### PR TITLE
LPS-119572 Uses legacy selection mechanism since CategoriesSelector does some custom DOM-manipulation that requires specific legacy markup

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category_action.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category_action.jsp
@@ -94,47 +94,49 @@ AssetCategory category = (AssetCategory)row.getObject();
 </liferay-ui:icon-menu>
 
 <c:if test="<%= assetCategoriesDisplayContext.hasPermission(category, ActionKeys.UPDATE) %>">
-	<aui:script sandbox="<%= true %>">
+	<aui:script require="frontend-js-web/liferay/ItemSelectorDialog.es as ItemSelectorDialog">
 		var moveCategoryIcon = document.getElementById(
 			'<portlet:namespace /><%= row.getRowId() %>moveCategory'
 		);
 
 		if (moveCategoryIcon) {
 			moveCategoryIcon.addEventListener('click', function (event) {
-				Liferay.Util.openSelectionModal({
-					multiple: true,
-					onSelect: function (selectedItem) {
-						if (selectedItem) {
-							var parentCategoryId = 0;
-							var vocabularyId = 0;
-
-							for (var key in selectedItem) {
-								var item = selectedItem[key];
-
-								if (!item.unchecked) {
-									parentCategoryId = item.categoryId || 0;
-									vocabularyId = item.vocabularyId || 0;
-
-									break;
-								}
-							}
-
-							if (vocabularyId > 0 || parentCategoryId > 0) {
-								document.<portlet:namespace />moveCategoryFm.<portlet:namespace />categoryId.value =
-									'<%= category.getCategoryId() %>';
-								document.<portlet:namespace />moveCategoryFm.<portlet:namespace />parentCategoryId.value = parentCategoryId;
-								document.<portlet:namespace />moveCategoryFm.<portlet:namespace />vocabularyId.value = vocabularyId;
-
-								submitForm(
-									document.<portlet:namespace />moveCategoryFm
-								);
-							}
-						}
-					},
-					selectEventName: '<portlet:namespace />selectCategory',
+				var itemSelectorDialog = new ItemSelectorDialog.default({
+					eventName: '<portlet:namespace />selectCategory',
 					title:
 						'<liferay-ui:message arguments="<%= category.getTitle(locale) %>" key="move-x" />',
 					url: '<%= assetCategoriesDisplayContext.getSelectCategoryURL() %>',
+				});
+
+				itemSelectorDialog.open();
+
+				itemSelectorDialog.on('selectedItemChange', function (event) {
+					var selectedItem = event.selectedItem;
+
+					if (selectedItem) {
+						var parentCategoryId = 0;
+						var vocabularyId = 0;
+
+						for (var key in selectedItem) {
+							var item = selectedItem[key];
+
+							if (!item.unchecked) {
+								parentCategoryId = item.categoryId || 0;
+								vocabularyId = item.vocabularyId || 0;
+
+								break;
+							}
+						}
+
+						if (vocabularyId > 0 || parentCategoryId > 0) {
+							document.<portlet:namespace />moveCategoryFm.<portlet:namespace />categoryId.value =
+								'<%= category.getCategoryId() %>';
+							document.<portlet:namespace />moveCategoryFm.<portlet:namespace />parentCategoryId.value = parentCategoryId;
+							document.<portlet:namespace />moveCategoryFm.<portlet:namespace />vocabularyId.value = vocabularyId;
+
+							submitForm(document.<portlet:namespace />moveCategoryFm);
+						}
+					}
 				});
 			});
 		}


### PR DESCRIPTION
So, basically this is simply reverting the changes applied to this selection.

The problem is that `AssetCategoriesSelector` component and the asset selection jsp do a whole lot of manual DOM manipulation, so updating this would require reworking those as well. For now, we simply stick to the legacy dialogs for category selection.