### PR TITLE
[TS] LPS-141276 | Multiple associated asset types are rolled back to single in Vocabulary if saved without adding newone

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/edit_vocabulary_settings.jspf
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/edit_vocabulary_settings.jspf
@@ -128,7 +128,7 @@ if (vocabulary != null) {
 	}
 	%>
 
-	<aui:input name="indexes" type="hidden" value="<%= indexes.toString() %>" />
+	<aui:input name="indexes" type="hidden" value="<%= StringUtil.merge(indexes) %>" />
 </liferay-frontend:fieldset>
 
 <aui:script use="liferay-auto-fields">


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-141276
Thank you!