### PR TITLE
[TS] LPS-140333

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/ColorPalette.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/ColorPalette.js
@@ -14,7 +14,6 @@
 
 import ClayButton from '@clayui/button';
 import classNames from 'classnames';
-import {capitalize} from 'data-engine-js-components-web';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -54,7 +53,7 @@ export default function ColorPalette({
 								displayType="unstyled"
 								onClick={(event) => onColorSelect(color, event)}
 								small
-								title={capitalize(color)}
+								title={color}
 							/>
 						</li>
 					))}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPP-42486
https://issues.liferay.com/browse/LPS-140333
https://issues.liferay.com/browse/PTR-2674

Hi Echo Team!

This is a ticket to address the UX issue in the Color Palette fragment where colors do not have a tooltip identifying them. Adding this tooltip now makes Color Palette act in a more similar fashion to Color Picker. I've included a link to PTR-2674 above where the issue was ruled as a bug.