### PR TITLE
LPS-190826 Add value field to grid response

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
@@ -55,6 +55,7 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -217,6 +218,55 @@ public class ContentFieldUtil {
 								longitude = jsonObject.getDouble("longitude");
 							}
 						};
+					}
+				};
+			}
+			else if (Objects.equals(
+						DDMFormFieldTypeConstants.GRID,
+						ddmFormField.getType())) {
+
+				Map<String, Object> properties = ddmFormField.getProperties();
+
+				DDMFormFieldOptions rowsDDMFormFieldOptions =
+					(DDMFormFieldOptions)properties.get("rows");
+				DDMFormFieldOptions columnsDDMFormFieldOptions =
+					(DDMFormFieldOptions)properties.get("columns");
+
+				JSONObject localizedSelectedDataJSONObject =
+					JSONFactoryUtil.createJSONObject();
+				JSONObject selectedValuesJSONObject =
+					JSONFactoryUtil.createJSONObject();
+
+				JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+					valueString);
+
+				Iterator<String> iterator = jsonObject.keys();
+
+				while (iterator.hasNext()) {
+					String key = iterator.next();
+
+					LocalizedValue optionKeyLabelsLocalizedValue =
+						rowsDDMFormFieldOptions.getOptionLabels(key);
+
+					String value = jsonObject.getString(key);
+
+					LocalizedValue optionValueLabelsLocalizedValue =
+						columnsDDMFormFieldOptions.getOptionLabels(value);
+
+					localizedSelectedDataJSONObject.put(
+						optionKeyLabelsLocalizedValue.getString(locale),
+						optionValueLabelsLocalizedValue.getString(locale));
+
+					selectedValuesJSONObject.put(
+						rowsDDMFormFieldOptions.getOptionReference(key),
+						columnsDDMFormFieldOptions.getOptionReference(value));
+				}
+
+				return new ContentFieldValue() {
+					{
+						setData(
+							JSONUtil.toString(localizedSelectedDataJSONObject));
+						setValue(JSONUtil.toString(selectedValuesJSONObject));
 					}
 				};
 			}


### PR DESCRIPTION

Motivation
=======
An impedibug was raised when testing a relates story as when the user customizes the option labels available in the grid sections in a web content, those new names are not shown properly. (Please for more info go to the original [Story](https://liferay.atlassian.net/browse/LPS-190826) ) 

Proposed Solution
========
In order to keep showing accurate information when a graphQL query is executed, information like the customized field reference value (label) and the original reference will be added to the response.

Steps to Verify
========

1. Add a web content structure with a Grid field
2. Add row and column options with customized field reference for Grid
3. Add a web content based on new structure
4. Get the id of structuredContent via getSiteStructuredContentsPage
5. Navigate to the GraphQL
6. Get the structuredContent with contentFieldValue

 ```

{
  structuredContent(structuredContentId: {structuredContentId}) {
    contentFields {
			contentFieldValue {
			  data
			  value
			}
    }
  }
}
```
7. Expected result as follows:
<img width="1053" alt="GridExpectedResult" src="https://github.com/liferay-echo/liferay-portal/assets/85171101/64b023f1-9e4d-42b8-8561-ed58eb703b39">



COMMITS:
-------------------
LPS-190226 Add value field to grid response

