### PR TITLE
LPD-29534 Use current company instead of fragmentEntryLink company

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker/src/main/java/com/liferay/fragment/entry/processor/freemarker/FreeMarkerFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker/src/main/java/com/liferay/fragment/entry/processor/freemarker/FreeMarkerFragmentEntryProcessor.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.template.StringTemplateResource;
 import com.liferay.portal.kernel.template.Template;
 import com.liferay.portal.kernel.template.TemplateConstants;
@@ -78,7 +79,7 @@ public class FreeMarkerFragmentEntryProcessor
 			freeMarkerFragmentEntryProcessorConfiguration =
 				_configurationProvider.getCompanyConfiguration(
 					FreeMarkerFragmentEntryProcessorConfiguration.class,
-					fragmentEntryLink.getCompanyId());
+					CompanyThreadLocal.getCompanyId());
 
 		if (!freeMarkerFragmentEntryProcessorConfiguration.enable() &&
 			Validator.isNull(fragmentEntryLink.getRendererKey()) &&


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-29534

Hello, there is an issue when adding a new site in a publication in a virtual instance with db partition enabled. When creating the new site the 404 and 500 utility pages get added and the `fragmentEntryLink.getCompanyId()` returns the default company which leads to a CT transaction validation failure so I have proposed getting the companyId from the current company instead. This was caught with multiple functional tests in the "ci:test:publications-db-partition" test suite and can be also be seen here: [PublicationsSites#PublishSiteCreatedInPublication](https://testray.liferay.com/#/project/34754/routines/34756/build/24934322/case-result/24965140). Could you please check if this is ok or if it breaks anything? Thank you! 