### PR TITLE
LPD-40375 Allow Basic CRUD operations of a Display Page Templates Folder - delete, get and post

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/bnd.bnd
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Admin Site API
 Bundle-SymbolicName: com.liferay.headless.admin.site.api
-Bundle-Version: 2.0.1
+Bundle-Version: 2.1.0
 Export-Package:\
 	com.liferay.headless.admin.site.dto.v1_0,\
 	com.liferay.headless.admin.site.resource.v1_0

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/DisplayPageTemplateFolder.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/DisplayPageTemplateFolder.java
@@ -410,6 +410,62 @@ public class DisplayPageTemplateFolder implements Serializable {
 	private Supplier<String> _nameSupplier;
 
 	@Schema(
+		description = "The parent display page template folder's External Reference Code."
+	)
+	public String getParentDisplayPageTemplateFolderExternalReferenceCode() {
+		if (_parentDisplayPageTemplateFolderExternalReferenceCodeSupplier !=
+				null) {
+
+			parentDisplayPageTemplateFolderExternalReferenceCode =
+				_parentDisplayPageTemplateFolderExternalReferenceCodeSupplier.
+					get();
+
+			_parentDisplayPageTemplateFolderExternalReferenceCodeSupplier =
+				null;
+		}
+
+		return parentDisplayPageTemplateFolderExternalReferenceCode;
+	}
+
+	public void setParentDisplayPageTemplateFolderExternalReferenceCode(
+		String parentDisplayPageTemplateFolderExternalReferenceCode) {
+
+		this.parentDisplayPageTemplateFolderExternalReferenceCode =
+			parentDisplayPageTemplateFolderExternalReferenceCode;
+
+		_parentDisplayPageTemplateFolderExternalReferenceCodeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setParentDisplayPageTemplateFolderExternalReferenceCode(
+		UnsafeSupplier<String, Exception>
+			parentDisplayPageTemplateFolderExternalReferenceCodeUnsafeSupplier) {
+
+		_parentDisplayPageTemplateFolderExternalReferenceCodeSupplier = () -> {
+			try {
+				return parentDisplayPageTemplateFolderExternalReferenceCodeUnsafeSupplier.
+					get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The parent display page template folder's External Reference Code."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String parentDisplayPageTemplateFolderExternalReferenceCode;
+
+	@JsonIgnore
+	private Supplier<String>
+		_parentDisplayPageTemplateFolderExternalReferenceCodeSupplier;
+
+	@Schema(
 		description = "A valid external identifier to reference this page template folder."
 	)
 	public String getUuid() {
@@ -603,6 +659,25 @@ public class DisplayPageTemplateFolder implements Serializable {
 			sb.append("\"");
 
 			sb.append(_escape(name));
+
+			sb.append("\"");
+		}
+
+		String parentDisplayPageTemplateFolderExternalReferenceCode =
+			getParentDisplayPageTemplateFolderExternalReferenceCode();
+
+		if (parentDisplayPageTemplateFolderExternalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append(
+				"\"parentDisplayPageTemplateFolderExternalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				_escape(parentDisplayPageTemplateFolderExternalReferenceCode));
 
 			sb.append("\"");
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/resources/com/liferay/headless/admin/site/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/resources/com/liferay/headless/admin/site/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/DisplayPageTemplateFolder.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/DisplayPageTemplateFolder.java
@@ -194,6 +194,33 @@ public class DisplayPageTemplateFolder implements Cloneable, Serializable {
 
 	protected String name;
 
+	public String getParentDisplayPageTemplateFolderExternalReferenceCode() {
+		return parentDisplayPageTemplateFolderExternalReferenceCode;
+	}
+
+	public void setParentDisplayPageTemplateFolderExternalReferenceCode(
+		String parentDisplayPageTemplateFolderExternalReferenceCode) {
+
+		this.parentDisplayPageTemplateFolderExternalReferenceCode =
+			parentDisplayPageTemplateFolderExternalReferenceCode;
+	}
+
+	public void setParentDisplayPageTemplateFolderExternalReferenceCode(
+		UnsafeSupplier<String, Exception>
+			parentDisplayPageTemplateFolderExternalReferenceCodeUnsafeSupplier) {
+
+		try {
+			parentDisplayPageTemplateFolderExternalReferenceCode =
+				parentDisplayPageTemplateFolderExternalReferenceCodeUnsafeSupplier.
+					get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String parentDisplayPageTemplateFolderExternalReferenceCode;
+
 	public String getUuid() {
 		return uuid;
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/DisplayPageTemplateFolderSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/DisplayPageTemplateFolderSerDes.java
@@ -174,6 +174,27 @@ public class DisplayPageTemplateFolderSerDes {
 			sb.append("\"");
 		}
 
+		if (displayPageTemplateFolder.
+				getParentDisplayPageTemplateFolderExternalReferenceCode() !=
+					null) {
+
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append(
+				"\"parentDisplayPageTemplateFolderExternalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				_escape(
+					displayPageTemplateFolder.
+						getParentDisplayPageTemplateFolderExternalReferenceCode()));
+
+			sb.append("\"");
+		}
+
 		if (displayPageTemplateFolder.getUuid() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -289,6 +310,21 @@ public class DisplayPageTemplateFolderSerDes {
 				"name", String.valueOf(displayPageTemplateFolder.getName()));
 		}
 
+		if (displayPageTemplateFolder.
+				getParentDisplayPageTemplateFolderExternalReferenceCode() ==
+					null) {
+
+			map.put(
+				"parentDisplayPageTemplateFolderExternalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"parentDisplayPageTemplateFolderExternalReferenceCode",
+				String.valueOf(
+					displayPageTemplateFolder.
+						getParentDisplayPageTemplateFolderExternalReferenceCode()));
+		}
+
 		if (displayPageTemplateFolder.getUuid() == null) {
 			map.put("uuid", null);
 		}
@@ -341,6 +377,12 @@ public class DisplayPageTemplateFolderSerDes {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "name")) {
+				return false;
+			}
+			else if (Objects.equals(
+						jsonParserFieldName,
+						"parentDisplayPageTemplateFolderExternalReferenceCode")) {
+
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "uuid")) {
@@ -405,6 +447,16 @@ public class DisplayPageTemplateFolderSerDes {
 				if (jsonParserFieldValue != null) {
 					displayPageTemplateFolder.setName(
 						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName,
+						"parentDisplayPageTemplateFolderExternalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					displayPageTemplateFolder.
+						setParentDisplayPageTemplateFolderExternalReferenceCode(
+							(String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "uuid")) {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
@@ -425,6 +425,11 @@ components:
                     description:
                         The display page template folder's name.
                     type: string
+                parentDisplayPageTemplateFolderExternalReferenceCode:
+                    # @review
+                    description:
+                        The parent display page template folder's External Reference Code.
+                    type: string
                 uuid:
                     # @review
                     description:

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/DisplayPageTemplateFolderDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/DisplayPageTemplateFolderDTOConverter.java
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.dto.v1_0.converter;
+
+import com.liferay.headless.admin.site.dto.v1_0.DisplayPageTemplateFolder;
+import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
+import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionService;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Bárbara Cabrera
+ */
+@Component(
+	property = "dto.class.name=com.liferay.portal.kernel.model.LayoutPageTemplateCollection",
+	service = DTOConverter.class
+)
+public class DisplayPageTemplateFolderDTOConverter
+	implements DTOConverter
+		<LayoutPageTemplateCollection, DisplayPageTemplateFolder> {
+
+	@Override
+	public String getContentType() {
+		return DisplayPageTemplateFolder.class.getSimpleName();
+	}
+
+	@Override
+	public DisplayPageTemplateFolder toDTO(
+			DTOConverterContext dtoConverterContext,
+			LayoutPageTemplateCollection layoutPageTemplateCollection)
+		throws Exception {
+
+		return new DisplayPageTemplateFolder() {
+			{
+				setDateCreated(layoutPageTemplateCollection::getCreateDate);
+				setDateModified(layoutPageTemplateCollection::getModifiedDate);
+				setDescription(layoutPageTemplateCollection::getDescription);
+				setExternalReferenceCode(
+					layoutPageTemplateCollection::getExternalReferenceCode);
+				setKey(
+					layoutPageTemplateCollection::
+						getLayoutPageTemplateCollectionKey);
+				setName(layoutPageTemplateCollection::getName);
+				setParentDisplayPageTemplateFolderExternalReferenceCode(
+					() -> {
+						LayoutPageTemplateCollection
+							parentLayoutPageTemplateCollection =
+								_layoutPageTemplateCollectionService.
+									fetchLayoutPageTemplateCollection(
+										layoutPageTemplateCollection.
+											getParentLayoutPageTemplateCollectionId());
+
+						if (parentLayoutPageTemplateCollection == null) {
+							return null;
+						}
+
+						return parentLayoutPageTemplateCollection.
+							getExternalReferenceCode();
+					});
+				setUuid(layoutPageTemplateCollection::getUuid);
+			}
+		};
+	}
+
+	@Reference
+	private LayoutPageTemplateCollectionService
+		_layoutPageTemplateCollectionService;
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/graphql/query/v1_0/Query.java
@@ -403,7 +403,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {siteByExternalReferenceCodeDisplayPageTemplateFolder(displayPageTemplateFolderExternalReferenceCode: ___, siteExternalReferenceCode: ___){creator, creatorExternalReferenceCode, dateCreated, dateModified, description, externalReferenceCode, key, name, uuid}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {siteByExternalReferenceCodeDisplayPageTemplateFolder(displayPageTemplateFolderExternalReferenceCode: ___, siteExternalReferenceCode: ___){creator, creatorExternalReferenceCode, dateCreated, dateModified, description, externalReferenceCode, key, name, parentDisplayPageTemplateFolderExternalReferenceCode, uuid}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(
 		description = "Retrieves a specific display page template folder of a site."

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseDisplayPageTemplateFolderResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BaseDisplayPageTemplateFolderResourceImpl.java
@@ -155,7 +155,7 @@ public abstract class BaseDisplayPageTemplateFolderResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/display-page-template-folders' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "key": ___, "name": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/display-page-template-folders' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "key": ___, "name": ___, "parentDisplayPageTemplateFolderExternalReferenceCode": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Adds a new display page template folder."
@@ -397,7 +397,7 @@ public abstract class BaseDisplayPageTemplateFolderResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/display-page-template-folders/{displayPageTemplateFolderExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "key": ___, "name": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/display-page-template-folders/{displayPageTemplateFolderExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "key": ___, "name": ___, "parentDisplayPageTemplateFolderExternalReferenceCode": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates only the fields received in the request body, leaving any other fields untouched."
@@ -497,6 +497,16 @@ public abstract class BaseDisplayPageTemplateFolderResourceImpl
 				displayPageTemplateFolder.getName());
 		}
 
+		if (displayPageTemplateFolder.
+				getParentDisplayPageTemplateFolderExternalReferenceCode() !=
+					null) {
+
+			existingDisplayPageTemplateFolder.
+				setParentDisplayPageTemplateFolderExternalReferenceCode(
+					displayPageTemplateFolder.
+						getParentDisplayPageTemplateFolderExternalReferenceCode());
+		}
+
 		if (displayPageTemplateFolder.getUuid() != null) {
 			existingDisplayPageTemplateFolder.setUuid(
 				displayPageTemplateFolder.getUuid());
@@ -514,7 +524,7 @@ public abstract class BaseDisplayPageTemplateFolderResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/display-page-template-folders/{displayPageTemplateFolderExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "key": ___, "name": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/display-page-template-folders/{displayPageTemplateFolderExternalReferenceCode}' -d $'{"creatorExternalReferenceCode": ___, "dateCreated": ___, "dateModified": ___, "description": ___, "externalReferenceCode": ___, "key": ___, "name": ___, "parentDisplayPageTemplateFolderExternalReferenceCode": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates the display page template folder with the given external reference code, or creates it if it does not exist."

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
@@ -6,12 +6,18 @@
 package com.liferay.headless.admin.site.internal.resource.v1_0;
 
 import com.liferay.headless.admin.site.resource.v1_0.DisplayPageTemplateFolderResource;
+import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionService;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 
 /**
  * @author Rubén Pulido
+ * @author Bárbara Cabrera
  */
 @Component(
 	properties = "OSGI-INF/liferay/rest/v1_0/display-page-template-folder.properties",
@@ -20,4 +26,29 @@ import org.osgi.service.component.annotations.ServiceScope;
 )
 public class DisplayPageTemplateFolderResourceImpl
 	extends BaseDisplayPageTemplateFolderResourceImpl {
+
+	@Override
+	public void deleteSiteSiteByExternalReferenceCodeDisplayPageTemplateFolder(
+			String siteExternalReferenceCode,
+			String displayPageTemplateFolderExternalReferenceCode)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
+			throw new UnsupportedOperationException();
+		}
+
+		Group group = _groupLocalService.getGroupByExternalReferenceCode(
+			siteExternalReferenceCode, contextCompany.getCompanyId());
+
+		_layoutPageTemplateCollectionService.deleteLayoutPageTemplateCollection(
+			displayPageTemplateFolderExternalReferenceCode, group.getGroupId());
+	}
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private LayoutPageTemplateCollectionService
+		_layoutPageTemplateCollectionService;
+
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
@@ -5,11 +5,16 @@
 
 package com.liferay.headless.admin.site.internal.resource.v1_0;
 
+import com.liferay.headless.admin.site.dto.v1_0.DisplayPageTemplateFolder;
 import com.liferay.headless.admin.site.resource.v1_0.DisplayPageTemplateFolderResource;
+import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
 import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionService;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
+import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -43,6 +48,54 @@ public class DisplayPageTemplateFolderResourceImpl
 		_layoutPageTemplateCollectionService.deleteLayoutPageTemplateCollection(
 			displayPageTemplateFolderExternalReferenceCode, group.getGroupId());
 	}
+
+	@Override
+	public DisplayPageTemplateFolder
+			getSiteSiteByExternalReferenceCodeDisplayPageTemplateFolder(
+				String siteExternalReferenceCode,
+				String displayPageTemplateFolderExternalReferenceCode)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
+			throw new UnsupportedOperationException();
+		}
+
+		Group group = _groupLocalService.getGroupByExternalReferenceCode(
+			siteExternalReferenceCode, contextCompany.getCompanyId());
+
+		LayoutPageTemplateCollection layoutPageTemplateCollection =
+			_layoutPageTemplateCollectionService.
+				fetchLayoutPageTemplateCollection(
+					displayPageTemplateFolderExternalReferenceCode,
+					group.getGroupId());
+
+		return _toDisplayPageTemplateFolder(layoutPageTemplateCollection);
+	}
+
+	private DisplayPageTemplateFolder _toDisplayPageTemplateFolder(
+			LayoutPageTemplateCollection layoutPageTemplateCollection)
+		throws Exception {
+
+		return _displayPageTemplateFolderDTOConverter.toDTO(
+			new DefaultDTOConverterContext(
+				contextAcceptLanguage.isAcceptAllLanguages(), null,
+				_dtoConverterRegistry, contextHttpServletRequest,
+				layoutPageTemplateCollection.
+					getLayoutPageTemplateCollectionId(),
+				contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
+				contextUser),
+			layoutPageTemplateCollection);
+	}
+
+	@Reference(
+		target = "(component.name=com.liferay.headless.admin.site.internal.dto.v1_0.converter.DisplayPageTemplateFolderDTOConverter)"
+	)
+	private DTOConverter
+		<LayoutPageTemplateCollection, DisplayPageTemplateFolder>
+			_displayPageTemplateFolderDTOConverter;
+
+	@Reference
+	private DTOConverterRegistry _dtoConverterRegistry;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/DisplayPageTemplateFolderResourceImpl.java
@@ -7,6 +7,9 @@ package com.liferay.headless.admin.site.internal.resource.v1_0;
 
 import com.liferay.headless.admin.site.dto.v1_0.DisplayPageTemplateFolder;
 import com.liferay.headless.admin.site.resource.v1_0.DisplayPageTemplateFolderResource;
+import com.liferay.headless.common.spi.service.context.ServiceContextBuilder;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateCollectionTypeConstants;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
 import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionService;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
@@ -70,6 +73,53 @@ public class DisplayPageTemplateFolderResourceImpl
 					group.getGroupId());
 
 		return _toDisplayPageTemplateFolder(layoutPageTemplateCollection);
+	}
+
+	@Override
+	public DisplayPageTemplateFolder
+			postSiteSiteByExternalReferenceCodeDisplayPageTemplateFolder(
+				String siteExternalReferenceCode,
+				DisplayPageTemplateFolder displayPageTemplateFolder)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
+			throw new UnsupportedOperationException();
+		}
+
+		Group group = _groupLocalService.getGroupByExternalReferenceCode(
+			siteExternalReferenceCode, contextCompany.getCompanyId());
+
+		String parentDisplayPageTemplateFolderExternalReferenceCode =
+			displayPageTemplateFolder.
+				getParentDisplayPageTemplateFolderExternalReferenceCode();
+
+		long parentDisplayPageTemplateFolderId =
+			LayoutPageTemplateConstants.
+				PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT;
+
+		LayoutPageTemplateCollection parentLayoutPageTemplateCollection =
+			_layoutPageTemplateCollectionService.
+				fetchLayoutPageTemplateCollection(
+					parentDisplayPageTemplateFolderExternalReferenceCode,
+					group.getGroupId());
+
+		if (parentLayoutPageTemplateCollection != null) {
+			parentDisplayPageTemplateFolderId =
+				parentLayoutPageTemplateCollection.
+					getLayoutPageTemplateCollectionId();
+		}
+
+		return _toDisplayPageTemplateFolder(
+			_layoutPageTemplateCollectionService.
+				addLayoutPageTemplateCollection(
+					displayPageTemplateFolder.getExternalReferenceCode(),
+					group.getGroupId(), parentDisplayPageTemplateFolderId,
+					displayPageTemplateFolder.getName(),
+					displayPageTemplateFolder.getDescription(),
+					LayoutPageTemplateCollectionTypeConstants.DISPLAY_PAGE,
+					ServiceContextBuilder.create(
+						group.getGroupId(), contextHttpServletRequest, null
+					).build()));
 	}
 
 	private DisplayPageTemplateFolder _toDisplayPageTemplateFolder(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/build.gradle
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	testIntegrationImplementation group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	testIntegrationImplementation project(":apps:headless:headless-admin-site:headless-admin-site-api")
 	testIntegrationImplementation project(":apps:headless:headless-admin-site:headless-admin-site-client")
+	testIntegrationImplementation project(":apps:layout:layout-page-template-api")
 	testIntegrationImplementation project(":apps:portal-odata:portal-odata-api")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseDisplayPageTemplateFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BaseDisplayPageTemplateFolderResourceTestCase.java
@@ -181,6 +181,8 @@ public abstract class BaseDisplayPageTemplateFolderResourceTestCase {
 		displayPageTemplateFolder.setExternalReferenceCode(regex);
 		displayPageTemplateFolder.setKey(regex);
 		displayPageTemplateFolder.setName(regex);
+		displayPageTemplateFolder.
+			setParentDisplayPageTemplateFolderExternalReferenceCode(regex);
 		displayPageTemplateFolder.setUuid(regex);
 
 		String json = DisplayPageTemplateFolderSerDes.toJSON(
@@ -197,6 +199,10 @@ public abstract class BaseDisplayPageTemplateFolderResourceTestCase {
 			regex, displayPageTemplateFolder.getExternalReferenceCode());
 		Assert.assertEquals(regex, displayPageTemplateFolder.getKey());
 		Assert.assertEquals(regex, displayPageTemplateFolder.getName());
+		Assert.assertEquals(
+			regex,
+			displayPageTemplateFolder.
+				getParentDisplayPageTemplateFolderExternalReferenceCode());
 		Assert.assertEquals(regex, displayPageTemplateFolder.getUuid());
 	}
 
@@ -1067,6 +1073,20 @@ public abstract class BaseDisplayPageTemplateFolderResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals(
+					"parentDisplayPageTemplateFolderExternalReferenceCode",
+					additionalAssertFieldName)) {
+
+				if (displayPageTemplateFolder.
+						getParentDisplayPageTemplateFolderExternalReferenceCode() ==
+							null) {
+
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("uuid", additionalAssertFieldName)) {
 				if (displayPageTemplateFolder.getUuid() == null) {
 					valid = false;
@@ -1285,6 +1305,22 @@ public abstract class BaseDisplayPageTemplateFolderResourceTestCase {
 				if (!Objects.deepEquals(
 						displayPageTemplateFolder1.getName(),
 						displayPageTemplateFolder2.getName())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"parentDisplayPageTemplateFolderExternalReferenceCode",
+					additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						displayPageTemplateFolder1.
+							getParentDisplayPageTemplateFolderExternalReferenceCode(),
+						displayPageTemplateFolder2.
+							getParentDisplayPageTemplateFolderExternalReferenceCode())) {
 
 					return false;
 				}
@@ -1716,6 +1752,56 @@ public abstract class BaseDisplayPageTemplateFolderResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals(
+				"parentDisplayPageTemplateFolderExternalReferenceCode")) {
+
+			Object object =
+				displayPageTemplateFolder.
+					getParentDisplayPageTemplateFolderExternalReferenceCode();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("uuid")) {
 			Object object = displayPageTemplateFolder.getUuid();
 
@@ -1819,6 +1905,8 @@ public abstract class BaseDisplayPageTemplateFolderResourceTestCase {
 					RandomTestUtil.randomString());
 				key = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
+				parentDisplayPageTemplateFolderExternalReferenceCode =
+					StringUtil.toLowerCase(RandomTestUtil.randomString());
 				uuid = StringUtil.toLowerCase(RandomTestUtil.randomString());
 			}
 		};

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateFolderResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateFolderResourceTest.java
@@ -6,15 +6,407 @@
 package com.liferay.headless.admin.site.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.headless.admin.site.client.dto.v1_0.DisplayPageTemplateFolder;
+import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionService;
+import com.liferay.petra.function.UnsafeTriConsumer;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
 
+import java.util.Map;
+
+import org.junit.Assert;
 import org.junit.Ignore;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
  * @author Rubén Pulido
+ * @author Bárbara Cabrera
  */
-@Ignore
+@FeatureFlags("LPD-35443")
 @RunWith(Arquillian.class)
 public class DisplayPageTemplateFolderResourceTest
 	extends BaseDisplayPageTemplateFolderResourceTestCase {
+
+	@Override
+	@Test
+	public void testDeleteSiteSiteByExternalReferenceCodeDisplayPageTemplateFolder()
+		throws Exception {
+
+		DisplayPageTemplateFolder postDisplayPageTemplateFolder =
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPage_addDisplayPageTemplateFolder(
+				testGroup.getExternalReferenceCode(),
+				randomDisplayPageTemplateFolder());
+
+		displayPageTemplateFolderResource.
+			deleteSiteSiteByExternalReferenceCodeDisplayPageTemplateFolder(
+				testGroup.getExternalReferenceCode(),
+				postDisplayPageTemplateFolder.getExternalReferenceCode());
+
+		Assert.assertNull(
+			_layoutPageTemplateCollectionService.
+				fetchLayoutPageTemplateCollection(
+					postDisplayPageTemplateFolder.getExternalReferenceCode(),
+					testGroup.getGroupId()));
+	}
+
+	@Override
+	@Test
+	public void testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFolder()
+		throws Exception {
+
+		DisplayPageTemplateFolder postDisplayPageTemplateFolder =
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPage_addDisplayPageTemplateFolder(
+				testGroup.getExternalReferenceCode(),
+				randomDisplayPageTemplateFolder());
+
+		DisplayPageTemplateFolder getDisplayPageTemplateFolder =
+			displayPageTemplateFolderResource.
+				getSiteSiteByExternalReferenceCodeDisplayPageTemplateFolder(
+					testGroup.getExternalReferenceCode(),
+					postDisplayPageTemplateFolder.getExternalReferenceCode());
+
+		assertEquals(
+			postDisplayPageTemplateFolder, getDisplayPageTemplateFolder);
+		assertValid(getDisplayPageTemplateFolder);
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFolderPermissionsPage()
+		throws Exception {
+
+		super.
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFolderPermissionsPage();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPage()
+		throws Exception {
+
+		super.
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPage();
+	}
+
+	@Override
+	@Test
+	public void testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithFilterDateTimeEquals()
+		throws Exception {
+
+		super.
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithFilterDateTimeEquals();
+	}
+
+	@Override
+	@Test
+	public void testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithFilterDoubleEquals()
+		throws Exception {
+
+		super.
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithFilterDoubleEquals();
+	}
+
+	@Override
+	@Test
+	public void testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithFilterStringContains()
+		throws Exception {
+
+		super.
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithFilterStringContains();
+	}
+
+	@Override
+	@Test
+	public void testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithFilterStringEquals()
+		throws Exception {
+
+		super.
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithFilterStringEquals();
+	}
+
+	@Override
+	@Test
+	public void testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithFilterStringStartsWith()
+		throws Exception {
+
+		super.
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithFilterStringStartsWith();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithPagination()
+		throws Exception {
+
+		super.
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithPagination();
+	}
+
+	@Override
+	@Test
+	public void testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithSortDateTime()
+		throws Exception {
+
+		super.
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithSortDateTime();
+	}
+
+	@Override
+	@Test
+	public void testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithSortDouble()
+		throws Exception {
+
+		super.
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithSortDouble();
+	}
+
+	@Override
+	@Test
+	public void testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithSortInteger()
+		throws Exception {
+
+		super.
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithSortInteger();
+	}
+
+	@Override
+	@Test
+	public void testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithSortString()
+		throws Exception {
+
+		super.
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithSortString();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testGetSiteSiteExternalReferenceCodeDisplayPageTemplateFolderPermissionsPage()
+		throws Exception {
+
+		super.
+			testGetSiteSiteExternalReferenceCodeDisplayPageTemplateFolderPermissionsPage();
+	}
+
+	@Override
+	@Test
+	public void testGraphQLGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFolder()
+		throws Exception {
+
+		super.
+			testGraphQLGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFolder();
+	}
+
+	@Override
+	@Test
+	public void testGraphQLGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFolderNotFound()
+		throws Exception {
+
+		super.
+			testGraphQLGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFolderNotFound();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testPatchSiteSiteByExternalReferenceCodeDisplayPageTemplateFolder()
+		throws Exception {
+
+		super.
+			testPatchSiteSiteByExternalReferenceCodeDisplayPageTemplateFolder();
+	}
+
+	@Override
+	@Test
+	public void testPostSiteSiteByExternalReferenceCodeDisplayPageTemplateFolder()
+		throws Exception {
+
+		super.
+			testPostSiteSiteByExternalReferenceCodeDisplayPageTemplateFolder();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testPutSiteSiteByExternalReferenceCodeDisplayPageTemplateFolder()
+		throws Exception {
+
+		super.testPutSiteSiteByExternalReferenceCodeDisplayPageTemplateFolder();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testPutSiteSiteByExternalReferenceCodeDisplayPageTemplateFolderPermissionsPage()
+		throws Exception {
+
+		super.
+			testPutSiteSiteByExternalReferenceCodeDisplayPageTemplateFolderPermissionsPage();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testPutSiteSiteExternalReferenceCodeDisplayPageTemplateFolderPermissionsPage()
+		throws Exception {
+
+		super.
+			testPutSiteSiteExternalReferenceCodeDisplayPageTemplateFolderPermissionsPage();
+	}
+
+	@Override
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[] {
+			"description", "externalReferenceCode", "key", "name",
+			"parentDisplayPageTemplateFolderExternalReferenceCode", "uuid"
+		};
+	}
+
+	@Override
+	protected DisplayPageTemplateFolder randomDisplayPageTemplateFolder()
+		throws Exception {
+
+		return super.randomDisplayPageTemplateFolder();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	protected DisplayPageTemplateFolder
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFolderPermissionsPage_addDisplayPageTemplateFolder()
+		throws Exception {
+
+		return super.
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFolderPermissionsPage_addDisplayPageTemplateFolder();
+	}
+
+	@Override
+	protected DisplayPageTemplateFolder
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPage_addDisplayPageTemplateFolder(
+				String siteExternalReferenceCode,
+				DisplayPageTemplateFolder displayPageTemplateFolder)
+		throws Exception {
+
+		return testPostSiteSiteByExternalReferenceCodeDisplayPageTemplateFolder_addDisplayPageTemplateFolder(
+			displayPageTemplateFolder);
+	}
+
+	@Ignore
+	@Override
+	@Test
+	protected Map<String, Map<String, String>>
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPage_getExpectedActions(
+				String siteExternalReferenceCode)
+		throws Exception {
+
+		return super.
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPage_getExpectedActions(
+				siteExternalReferenceCode);
+	}
+
+	@Ignore
+	@Override
+	@Test
+	protected String
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPage_getIrrelevantSiteExternalReferenceCode()
+		throws Exception {
+
+		return super.
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPage_getIrrelevantSiteExternalReferenceCode();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	protected String
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPage_getSiteExternalReferenceCode()
+		throws Exception {
+
+		return super.
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPage_getSiteExternalReferenceCode();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	protected void
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithFilter(
+				String operator, EntityField.Type type)
+		throws Exception {
+
+		super.
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithFilter(
+				operator, type);
+	}
+
+	@Ignore
+	@Override
+	@Test
+	protected void
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithSort(
+				EntityField.Type type,
+				UnsafeTriConsumer
+					<EntityField, DisplayPageTemplateFolder,
+					 DisplayPageTemplateFolder, Exception> unsafeTriConsumer)
+		throws Exception {
+
+		super.
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplateFoldersPageWithSort(
+				type, unsafeTriConsumer);
+	}
+
+	@Ignore
+	@Override
+	@Test
+	protected DisplayPageTemplateFolder
+			testGetSiteSiteExternalReferenceCodeDisplayPageTemplateFolderPermissionsPage_addDisplayPageTemplateFolder()
+		throws Exception {
+
+		return super.
+			testGetSiteSiteExternalReferenceCodeDisplayPageTemplateFolderPermissionsPage_addDisplayPageTemplateFolder();
+	}
+
+	@Override
+	protected DisplayPageTemplateFolder
+			testPostSiteSiteByExternalReferenceCodeDisplayPageTemplateFolder_addDisplayPageTemplateFolder(
+				DisplayPageTemplateFolder displayPageTemplateFolder)
+		throws Exception {
+
+		return displayPageTemplateFolderResource.
+			postSiteSiteByExternalReferenceCodeDisplayPageTemplateFolder(
+				testGroup.getExternalReferenceCode(),
+				displayPageTemplateFolder);
+	}
+
+	@Ignore
+	@Override
+	@Test
+	protected DisplayPageTemplateFolder
+			testPutSiteSiteByExternalReferenceCodeDisplayPageTemplateFolderPermissionsPage_addDisplayPageTemplateFolder()
+		throws Exception {
+
+		return super.
+			testPutSiteSiteByExternalReferenceCodeDisplayPageTemplateFolderPermissionsPage_addDisplayPageTemplateFolder();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	protected DisplayPageTemplateFolder
+			testPutSiteSiteExternalReferenceCodeDisplayPageTemplateFolderPermissionsPage_addDisplayPageTemplateFolder()
+		throws Exception {
+
+		return super.
+			testPutSiteSiteExternalReferenceCodeDisplayPageTemplateFolderPermissionsPage_addDisplayPageTemplateFolder();
+	}
+
+	@Inject
+	private LayoutPageTemplateCollectionService
+		_layoutPageTemplateCollectionService;
+
 }


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPD-40375)

### Changes

Add the basic operations (delete, get and post) for the Display Page Templates Folders.

## How to test it

1. Create a Display Page Template Folder
2. Go to [http://localhost:8080/o/api?endpoint=http://localhost:8080/o/headless-admin-site/v1.0/openapi.json](http://localhost:8080/o/api?endpoint=http://localhost:8080/o/headless-admin-site/v1.0/openapi.json)
3. Test the Get using the `siteExternalReferenceCode`and the `displayPageTemplateFolderExternalReferenceCode`. Copy the response to use it in the Post operation.
4. Test the Delete using the same information, the `siteExternalReferenceCode`and the `displayPageTemplateFolderExternalReferenceCode`
5. Test the Post with the information obtained in the step 3.