### PR TITLE
LPD-40360

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageTemplateSetDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageTemplateSetDTOConverter.java
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.dto.v1_0.converter;
+
+import com.liferay.headless.admin.site.dto.v1_0.PageTemplateSet;
+import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Javier Moral
+ */
+@Component(
+	property = "dto.class.name=com.liferay.layout.page.template.model.LayoutPageTemplateCollection",
+	service = DTOConverter.class
+)
+public class PageTemplateSetDTOConverter
+	implements DTOConverter<LayoutPageTemplateCollection, PageTemplateSet> {
+
+	@Override
+	public String getContentType() {
+		return PageTemplateSet.class.getSimpleName();
+	}
+
+	@Override
+	public PageTemplateSet toDTO(
+			LayoutPageTemplateCollection layoutPageTemplateCollection)
+		throws Exception {
+
+		return new PageTemplateSet() {
+			{
+				setDateCreated(layoutPageTemplateCollection::getCreateDate);
+				setDateModified(layoutPageTemplateCollection::getModifiedDate);
+				setDescription(layoutPageTemplateCollection::getDescription);
+				setExternalReferenceCode(
+					layoutPageTemplateCollection::getExternalReferenceCode);
+				setName(layoutPageTemplateCollection::getName);
+			}
+		};
+	}
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
@@ -7,12 +7,16 @@ package com.liferay.headless.admin.site.internal.resource.v1_0;
 
 import com.liferay.headless.admin.site.dto.v1_0.PageTemplateSet;
 import com.liferay.headless.admin.site.resource.v1_0.PageTemplateSetResource;
+import com.liferay.headless.common.spi.service.context.ServiceContextBuilder;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateCollectionTypeConstants;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
 import com.liferay.layout.page.template.exception.NoSuchPageTemplateCollectionException;
 import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
 import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionService;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 
 import org.osgi.service.component.annotations.Component;
@@ -69,6 +73,56 @@ public class PageTemplateSetResourceImpl
 		}
 
 		return _toPageTemplateSet(layoutPageTemplateCollection);
+	}
+
+	@Override
+	public PageTemplateSet putSiteSiteByExternalReferenceCodePageTemplateSet(
+			String siteExternalReferenceCode,
+			String pageTemplateSetExternalReferenceCode,
+			PageTemplateSet pageTemplateSet)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
+			throw new UnsupportedOperationException();
+		}
+
+		Group group = _groupLocalService.getGroupByExternalReferenceCode(
+			siteExternalReferenceCode, contextCompany.getCompanyId());
+
+		LayoutPageTemplateCollection layoutPageTemplateCollection =
+			_layoutPageTemplateCollectionService.
+				fetchLayoutPageTemplateCollection(
+					pageTemplateSetExternalReferenceCode, group.getGroupId());
+
+		if (layoutPageTemplateCollection == null) {
+			ServiceContext serviceContext = ServiceContextBuilder.create(
+				group.getGroupId(), contextHttpServletRequest, null
+			).build();
+
+			serviceContext.setCreateDate(pageTemplateSet.getDateCreated());
+			serviceContext.setModifiedDate(pageTemplateSet.getDateModified());
+			serviceContext.setUuid(pageTemplateSet.getUuid());
+
+			return _toPageTemplateSet(
+				_layoutPageTemplateCollectionService.
+					addLayoutPageTemplateCollection(
+						pageTemplateSet.getExternalReferenceCode(),
+						group.getGroupId(),
+						LayoutPageTemplateConstants.
+							PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
+						pageTemplateSet.getName(),
+						pageTemplateSet.getDescription(),
+						LayoutPageTemplateCollectionTypeConstants.BASIC,
+						serviceContext));
+		}
+
+		return _toPageTemplateSet(
+			_layoutPageTemplateCollectionService.
+				updateLayoutPageTemplateCollection(
+					layoutPageTemplateCollection.
+						getLayoutPageTemplateCollectionId(),
+					pageTemplateSet.getName(),
+					pageTemplateSet.getDescription()));
 	}
 
 	private PageTemplateSet _toPageTemplateSet(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
@@ -5,11 +5,15 @@
 
 package com.liferay.headless.admin.site.internal.resource.v1_0;
 
+import com.liferay.headless.admin.site.dto.v1_0.PageTemplateSet;
 import com.liferay.headless.admin.site.resource.v1_0.PageTemplateSetResource;
+import com.liferay.layout.page.template.exception.NoSuchPageTemplateCollectionException;
+import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
 import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionService;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -42,11 +46,49 @@ public class PageTemplateSetResourceImpl
 			pageTemplateSetExternalReferenceCode, group.getGroupId());
 	}
 
+	@Override
+	public PageTemplateSet getSiteSiteByExternalReferenceCodePageTemplateSet(
+			String siteExternalReferenceCode,
+			String pageTemplateSetExternalReferenceCode)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
+			throw new UnsupportedOperationException();
+		}
+
+		Group group = _groupLocalService.getGroupByExternalReferenceCode(
+			siteExternalReferenceCode, contextCompany.getCompanyId());
+
+		LayoutPageTemplateCollection layoutPageTemplateCollection =
+			_layoutPageTemplateCollectionService.
+				fetchLayoutPageTemplateCollection(
+					pageTemplateSetExternalReferenceCode, group.getGroupId());
+
+		if (layoutPageTemplateCollection == null) {
+			throw new NoSuchPageTemplateCollectionException();
+		}
+
+		return _toPageTemplateSet(layoutPageTemplateCollection);
+	}
+
+	private PageTemplateSet _toPageTemplateSet(
+			LayoutPageTemplateCollection layoutPageTemplateCollection)
+		throws Exception {
+
+		return _pageTemplateSetDTOConverter.toDTO(layoutPageTemplateCollection);
+	}
+
 	@Reference
 	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private LayoutPageTemplateCollectionService
 		_layoutPageTemplateCollectionService;
+
+	@Reference(
+		target = "(component.name=com.liferay.headless.admin.site.internal.dto.v1_0.converter.PageTemplateSetDTOConverter)"
+	)
+	private DTOConverter<LayoutPageTemplateCollection, PageTemplateSet>
+		_pageTemplateSetDTOConverter;
 
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 
 import org.osgi.service.component.annotations.Component;
@@ -76,6 +77,43 @@ public class PageTemplateSetResourceImpl
 	}
 
 	@Override
+	public PageTemplateSet patchSiteSiteByExternalReferenceCodePageTemplateSet(
+			String siteExternalReferenceCode,
+			String pageTemplateSetExternalReferenceCode,
+			PageTemplateSet pageTemplateSet)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
+			throw new UnsupportedOperationException();
+		}
+
+		Group group = _groupLocalService.getGroupByExternalReferenceCode(
+			siteExternalReferenceCode, contextCompany.getCompanyId());
+
+		LayoutPageTemplateCollection layoutPageTemplateCollection =
+			_layoutPageTemplateCollectionService.
+				fetchLayoutPageTemplateCollection(
+					pageTemplateSetExternalReferenceCode, group.getGroupId());
+
+		if (layoutPageTemplateCollection == null) {
+			throw new NoSuchPageTemplateCollectionException();
+		}
+
+		PageTemplateSet existingPageTemplateSet = _toPageTemplateSet(
+			layoutPageTemplateCollection);
+
+		preparePatch(pageTemplateSet, existingPageTemplateSet);
+
+		return _toPageTemplateSet(
+			_layoutPageTemplateCollectionService.
+				updateLayoutPageTemplateCollection(
+					layoutPageTemplateCollection.
+						getLayoutPageTemplateCollectionId(),
+					existingPageTemplateSet.getName(),
+					existingPageTemplateSet.getDescription()));
+	}
+
+	@Override
 	public PageTemplateSet putSiteSiteByExternalReferenceCodePageTemplateSet(
 			String siteExternalReferenceCode,
 			String pageTemplateSetExternalReferenceCode,
@@ -123,6 +161,36 @@ public class PageTemplateSetResourceImpl
 						getLayoutPageTemplateCollectionId(),
 					pageTemplateSet.getName(),
 					pageTemplateSet.getDescription()));
+	}
+
+	@Override
+	protected void preparePatch(
+		PageTemplateSet pageTemplateSet,
+		PageTemplateSet existingPageTemplateSet) {
+
+		if (pageTemplateSet.getDateCreated() != null) {
+			existingPageTemplateSet.setDateCreated(
+				pageTemplateSet::getDateCreated);
+		}
+
+		if (pageTemplateSet.getDateModified() != null) {
+			existingPageTemplateSet.setDateModified(
+				pageTemplateSet::getDateModified);
+		}
+
+		if (Validator.isNotNull(pageTemplateSet.getDescription())) {
+			existingPageTemplateSet.setDescription(
+				pageTemplateSet::getDescription);
+		}
+
+		if (Validator.isNotNull(pageTemplateSet.getExternalReferenceCode())) {
+			existingPageTemplateSet.setExternalReferenceCode(
+				pageTemplateSet::getExternalReferenceCode);
+		}
+
+		if (Validator.isNotNull(pageTemplateSet.getName())) {
+			existingPageTemplateSet.setName(pageTemplateSet::getName);
+		}
 	}
 
 	private PageTemplateSet _toPageTemplateSet(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageTemplateSetResourceImpl.java
@@ -6,8 +6,13 @@
 package com.liferay.headless.admin.site.internal.resource.v1_0;
 
 import com.liferay.headless.admin.site.resource.v1_0.PageTemplateSetResource;
+import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionService;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 
 /**
@@ -19,4 +24,29 @@ import org.osgi.service.component.annotations.ServiceScope;
 )
 public class PageTemplateSetResourceImpl
 	extends BasePageTemplateSetResourceImpl {
+
+	@Override
+	public void deleteSiteSiteByExternalReferenceCodePageTemplateSet(
+			String siteExternalReferenceCode,
+			String pageTemplateSetExternalReferenceCode)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
+			throw new UnsupportedOperationException();
+		}
+
+		Group group = _groupLocalService.getGroupByExternalReferenceCode(
+			siteExternalReferenceCode, contextCompany.getCompanyId());
+
+		_layoutPageTemplateCollectionService.deleteLayoutPageTemplateCollection(
+			pageTemplateSetExternalReferenceCode, group.getGroupId());
+	}
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private LayoutPageTemplateCollectionService
+		_layoutPageTemplateCollectionService;
+
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/build.gradle
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	testIntegrationImplementation group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	testIntegrationImplementation project(":apps:headless:headless-admin-site:headless-admin-site-api")
 	testIntegrationImplementation project(":apps:headless:headless-admin-site:headless-admin-site-client")
+	testIntegrationImplementation project(":apps:layout:layout-page-template-api")
 	testIntegrationImplementation project(":apps:portal-odata:portal-odata-api")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateSetResourceTest.java
@@ -6,15 +6,208 @@
 package com.liferay.headless.admin.site.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageTemplateSet;
+import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionLocalService;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
 
+import org.junit.Assert;
 import org.junit.Ignore;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
  * @author Rubén Pulido
  */
-@Ignore
+@FeatureFlags("LPD-35443")
 @RunWith(Arquillian.class)
 public class PageTemplateSetResourceTest
 	extends BasePageTemplateSetResourceTestCase {
+
+	@Override
+	@Test
+	public void testDeleteSiteSiteByExternalReferenceCodePageTemplateSet()
+		throws Exception {
+
+		PageTemplateSet pageTemplateSet =
+			testGetSiteSiteByExternalReferenceCodePageTemplateSetsPage_addPageTemplateSet(
+				testGroup.getExternalReferenceCode(), randomPageTemplateSet());
+
+		pageTemplateSetResource.
+			deleteSiteSiteByExternalReferenceCodePageTemplateSet(
+				testGroup.getExternalReferenceCode(),
+				pageTemplateSet.getExternalReferenceCode());
+
+		Assert.assertNull(
+			_layoutPageTemplateCollectionLocalService.
+				fetchLayoutPageTemplateCollectionByExternalReferenceCode(
+					pageTemplateSet.getExternalReferenceCode(),
+					testGroup.getGroupId()));
+	}
+
+	@Override
+	@Test
+	public void testGetSiteSiteByExternalReferenceCodePageTemplateSet()
+		throws Exception {
+
+		PageTemplateSet pageTemplateSet =
+			testGetSiteSiteByExternalReferenceCodePageTemplateSetsPage_addPageTemplateSet(
+				testGroup.getExternalReferenceCode(), randomPageTemplateSet());
+
+		PageTemplateSet getPageTemplateSet =
+			pageTemplateSetResource.
+				getSiteSiteByExternalReferenceCodePageTemplateSet(
+					testGroup.getExternalReferenceCode(),
+					pageTemplateSet.getExternalReferenceCode());
+
+		assertEquals(pageTemplateSet, getPageTemplateSet);
+		assertValid(getPageTemplateSet);
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testGetSiteSiteByExternalReferenceCodePageTemplateSetPermissionsPage()
+		throws Exception {
+
+		super.
+			testGetSiteSiteByExternalReferenceCodePageTemplateSetPermissionsPage();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testGetSiteSiteByExternalReferenceCodePageTemplateSetsPage()
+		throws Exception {
+
+		super.testGetSiteSiteByExternalReferenceCodePageTemplateSetsPage();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testGetSiteSiteByExternalReferenceCodePageTemplateSetsPageWithPagination()
+		throws Exception {
+
+		super.
+			testGetSiteSiteByExternalReferenceCodePageTemplateSetsPageWithPagination();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testGetSiteSiteExternalReferenceCodePageTemplateSetPermissionsPage()
+		throws Exception {
+
+		super.
+			testGetSiteSiteExternalReferenceCodePageTemplateSetPermissionsPage();
+	}
+
+	@Override
+	@Test
+	public void testPatchSiteSiteByExternalReferenceCodePageTemplateSet()
+		throws Exception {
+
+		PageTemplateSet pageTemplateSet = randomPageTemplateSet();
+
+		pageTemplateSetResource.
+			putSiteSiteByExternalReferenceCodePageTemplateSet(
+				testGroup.getExternalReferenceCode(),
+				pageTemplateSet.getExternalReferenceCode(), pageTemplateSet);
+
+		pageTemplateSet.setName(RandomTestUtil.randomString());
+
+		PageTemplateSet patchPageTemplateSet =
+			pageTemplateSetResource.
+				patchSiteSiteByExternalReferenceCodePageTemplateSet(
+					testGroup.getExternalReferenceCode(),
+					pageTemplateSet.getExternalReferenceCode(),
+					pageTemplateSet);
+
+		assertEquals(pageTemplateSet, patchPageTemplateSet);
+		assertValid(patchPageTemplateSet);
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testPostSiteSiteByExternalReferenceCodePageTemplateSet()
+		throws Exception {
+
+		super.testPostSiteSiteByExternalReferenceCodePageTemplateSet();
+	}
+
+	@Override
+	@Test
+	public void testPutSiteSiteByExternalReferenceCodePageTemplateSet()
+		throws Exception {
+
+		PageTemplateSet pageTemplateSet = randomPageTemplateSet();
+
+		PageTemplateSet putPageTemplateSet =
+			pageTemplateSetResource.
+				putSiteSiteByExternalReferenceCodePageTemplateSet(
+					testGroup.getExternalReferenceCode(),
+					pageTemplateSet.getExternalReferenceCode(),
+					pageTemplateSet);
+
+		assertEquals(pageTemplateSet, putPageTemplateSet);
+		assertValid(putPageTemplateSet);
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testPutSiteSiteByExternalReferenceCodePageTemplateSetPermissionsPage()
+		throws Exception {
+
+		super.
+			testPutSiteSiteByExternalReferenceCodePageTemplateSetPermissionsPage();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testPutSiteSiteExternalReferenceCodePageTemplateSetPermissionsPage()
+		throws Exception {
+
+		super.
+			testPutSiteSiteExternalReferenceCodePageTemplateSetPermissionsPage();
+	}
+
+	@Override
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[] {"externalReferenceCode", "description", "name"};
+	}
+
+	@Override
+	protected PageTemplateSet
+			testGetSiteSiteByExternalReferenceCodePageTemplateSetsPage_addPageTemplateSet(
+				String siteExternalReferenceCode,
+				PageTemplateSet pageTemplateSet)
+		throws Exception {
+
+		return pageTemplateSetResource.
+			putSiteSiteByExternalReferenceCodePageTemplateSet(
+				siteExternalReferenceCode,
+				pageTemplateSet.getExternalReferenceCode(), pageTemplateSet);
+	}
+
+	@Override
+	protected PageTemplateSet
+			testPostSiteSiteByExternalReferenceCodePageTemplateSet_addPageTemplateSet(
+				PageTemplateSet pageTemplateSet)
+		throws Exception {
+
+		return pageTemplateSetResource.
+			putSiteSiteByExternalReferenceCodePageTemplateSet(
+				testGroup.getExternalReferenceCode(),
+				pageTemplateSet.getExternalReferenceCode(), pageTemplateSet);
+	}
+
+	@Inject
+	private LayoutPageTemplateCollectionLocalService
+		_layoutPageTemplateCollectionLocalService;
+
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-40360

Dear reviewer,
This pr implements operations for path "page-template-sets/{pageTemplateSetExternalReferenceCode}"

Considerations:
- PUT operation when modifying a PageTemplateSet object only updates fields name and description because LayoutPageTemplateCollectionService only contains an update method for those fields.
- In the tests, I did not include "dateCreated" and "dateModified" fields in the getAdditionalAssertFieldNames() although they are included in the DTO. The motivation for this is related with the previous point as the put tests failed when these date fields were not being updated. I had to include them in the DTO because the assertValid() method check if they exist.