### PR TITLE
LPD-41264 Modify template infrastructure to support disable a template handler

### DIFF
--- a/modules/apps/portlet-display-template/portlet-display-template-impl/src/main/java/com/liferay/portlet/display/template/internal/PortletDisplayTemplateImpl.java
+++ b/modules/apps/portlet-display-template/portlet-display-template-impl/src/main/java/com/liferay/portlet/display/template/internal/PortletDisplayTemplateImpl.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.servlet.PipingServletResponse;
@@ -230,6 +231,10 @@ public class PortletDisplayTemplateImpl implements PortletDisplayTemplate {
 			TemplateHandlerRegistryUtil.getTemplateHandlers();
 
 		for (TemplateHandler templateHandler : templateHandlers) {
+			if (!templateHandler.isEnabled(CompanyThreadLocal.getCompanyId())) {
+				continue;
+			}
+
 			if (templateHandler instanceof BasePortletDisplayTemplateHandler) {
 				portletDisplayTemplateHandlers.add(templateHandler);
 			}

--- a/modules/apps/portlet-display-template/portlet-display-template-test/bnd.bnd
+++ b/modules/apps/portlet-display-template/portlet-display-template-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Portlet Display Template Test
+Bundle-SymbolicName: com.liferay.portlet.display.template.test
+Bundle-Version: 1.0.0

--- a/modules/apps/portlet-display-template/portlet-display-template-test/build.gradle
+++ b/modules/apps/portlet-display-template/portlet-display-template-test/build.gradle
@@ -1,0 +1,9 @@
+dependencies {
+	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	testIntegrationImplementation group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	testIntegrationImplementation group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	testIntegrationImplementation group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	testIntegrationImplementation project(":apps:layout:layout-test-util")
+	testIntegrationImplementation project(":apps:portlet-display-template:portlet-display-template-api")
+	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/portlet-display-template/portlet-display-template-test/src/testIntegration/java/com/liferay/portlet/display/template/test/PortletDisplayTemplateTest.java
+++ b/modules/apps/portlet-display-template/portlet-display-template-test/src/testIntegration/java/com/liferay/portlet/display/template/test/PortletDisplayTemplateTest.java
@@ -1,0 +1,146 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portlet.display.template.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.template.TemplateHandler;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portlet.display.template.BasePortletDisplayTemplateHandler;
+import com.liferay.portlet.display.template.PortletDisplayTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Mikel Lorza
+ */
+@RunWith(Arquillian.class)
+public class PortletDisplayTemplateTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testGetPortletDisplayTemplateHandlers() {
+		List<ServiceRegistration<?>> serviceRegistrations = new ArrayList<>();
+
+		try {
+			Bundle bundle = FrameworkUtil.getBundle(getClass());
+
+			BundleContext bundleContext = bundle.getBundleContext();
+
+			String className1 = RandomTestUtil.randomString();
+
+			TestTemplateHandler disabledTestTemplateHandler =
+				new TestTemplateHandler(className1, false);
+
+			serviceRegistrations.add(
+				bundleContext.registerService(
+					TemplateHandler.class, disabledTestTemplateHandler,
+					MapUtil.singletonDictionary(
+						"javax.portlet.name", RandomTestUtil.randomString())));
+
+			Assert.assertFalse(
+				_contains(
+					className1,
+					_portletDisplayTemplate.
+						getPortletDisplayTemplateHandlers()));
+
+			String className2 = RandomTestUtil.randomString();
+
+			TestTemplateHandler enabledTestTemplateHandler =
+				new TestTemplateHandler(className2, true);
+
+			serviceRegistrations.add(
+				bundleContext.registerService(
+					TemplateHandler.class, enabledTestTemplateHandler,
+					MapUtil.singletonDictionary(
+						"javax.portlet.name", RandomTestUtil.randomString())));
+
+			Assert.assertTrue(
+				_contains(
+					className2,
+					_portletDisplayTemplate.
+						getPortletDisplayTemplateHandlers()));
+		}
+		finally {
+			for (ServiceRegistration<?> serviceRegistration :
+					serviceRegistrations) {
+
+				serviceRegistration.unregister();
+			}
+		}
+	}
+
+	private boolean _contains(
+		String className, List<TemplateHandler> templateHandlers) {
+
+		for (TemplateHandler templateHandler : templateHandlers) {
+			if (Objects.equals(templateHandler.getClassName(), className)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	@Inject
+	private PortletDisplayTemplate _portletDisplayTemplate;
+
+	private class TestTemplateHandler
+		extends BasePortletDisplayTemplateHandler {
+
+		@Override
+		public String getClassName() {
+			return _className;
+		}
+
+		@Override
+		public String getName(Locale locale) {
+			return StringPool.BLANK;
+		}
+
+		@Override
+		public String getResourceName() {
+			return StringPool.BLANK;
+		}
+
+		@Override
+		public boolean isEnabled(long companyId) {
+			return _enabled;
+		}
+
+		private TestTemplateHandler(String className, boolean enabled) {
+			_className = className;
+			_enabled = enabled;
+		}
+
+		private final String _className;
+		private final boolean _enabled;
+
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/template/TemplateHandler.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/template/TemplateHandler.java
@@ -151,4 +151,16 @@ public interface TemplateHandler {
 	 */
 	public boolean isDisplayTemplateHandler();
 
+	/**
+	 * Returns <code>true</code> if the template handler is enabled for the
+	 * companyId.
+	 *
+	 * @return <code>true</code> if the template handler is enabled for the
+	 * companyId;
+	 *         <code>false</code> otherwise
+	 */
+	public default boolean isEnabled(long companyId) {
+		return true;
+	}
+
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/template/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/template/packageinfo
@@ -1,1 +1,1 @@
-version 16.0.0
+version 16.1.0


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-41264

Hi team,

Working on deprecating wiki from the portal, we have the need to hide wiki from wiki template creation. So, this PR include all necessary changes to support disable a template handler in order to do not disabled template entries.

# How am I fixing it?

 Hiding TemplateHandler from getPortletDisplayTemplateHandlers List if it is disabled

# How can you verify that it works?

Run included tests.