### PR TITLE
LPD-41551 Get endpoint for Page Specifications

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/ContentPageSpecification.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/ContentPageSpecification.java
@@ -176,6 +176,22 @@ public class ContentPageSpecification
 			sb.append(String.valueOf(settings));
 		}
 
+		Status status = getStatus();
+
+		if (status != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"status\": ");
+
+			sb.append("\"");
+
+			sb.append(status);
+
+			sb.append("\"");
+		}
+
 		Type type = getType();
 
 		if (type != null) {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/DisplayPageTemplate.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/DisplayPageTemplate.java
@@ -649,7 +649,7 @@ public class DisplayPageTemplate implements Serializable {
 	private Supplier<String> _nameSupplier;
 
 	@Schema(
-		description = "The display page template's specifications. A display page template may contain 0 or 1 page specifications in draft status and 0 or 1 page specifications in published status."
+		description = "The display page template's specifications. A display page template may contain 0 or 1 page specifications in draft status and 0 or 1 page specifications in published status. This field is not returned by default. It can be requested via nestedFields."
 	)
 	@Valid
 	public PageSpecification[] getPageSpecifications() {
@@ -687,7 +687,7 @@ public class DisplayPageTemplate implements Serializable {
 	}
 
 	@GraphQLField(
-		description = "The display page template's specifications. A display page template may contain 0 or 1 page specifications in draft status and 0 or 1 page specifications in published status."
+		description = "The display page template's specifications. A display page template may contain 0 or 1 page specifications in draft status and 0 or 1 page specifications in published status. This field is not returned by default. It can be requested via nestedFields."
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected PageSpecification[] pageSpecifications;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/MasterPage.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/MasterPage.java
@@ -540,7 +540,7 @@ public class MasterPage implements Serializable {
 	private Supplier<String> _nameSupplier;
 
 	@Schema(
-		description = "The master page's specifications. A master page may contain 0 or 1 page specifications in draft status and 0 or 1 page specifications in published status."
+		description = "The master page's specifications. A master page may contain 0 or 1 page specifications in draft status and 0 or 1 page specifications in published status. This field is not returned by default. It can be requested via nestedFields."
 	)
 	@Valid
 	public PageSpecification[] getPageSpecifications() {
@@ -578,7 +578,7 @@ public class MasterPage implements Serializable {
 	}
 
 	@GraphQLField(
-		description = "The master page's specifications. A master page may contain 0 or 1 page specifications in draft status and 0 or 1 page specifications in published status."
+		description = "The master page's specifications. A master page may contain 0 or 1 page specifications in draft status and 0 or 1 page specifications in published status. This field is not returned by default. It can be requested via nestedFields."
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected PageSpecification[] pageSpecifications;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageSpecification.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageSpecification.java
@@ -161,6 +161,60 @@ public abstract class PageSpecification implements Serializable {
 	@JsonIgnore
 	private Supplier<Settings> _settingsSupplier;
 
+	@JsonGetter("status")
+	@Schema(description = "The status of the page specification.")
+	@Valid
+	public Status getStatus() {
+		if (_statusSupplier != null) {
+			status = _statusSupplier.get();
+
+			_statusSupplier = null;
+		}
+
+		return status;
+	}
+
+	@JsonIgnore
+	public String getStatusAsString() {
+		Status status = getStatus();
+
+		if (status == null) {
+			return null;
+		}
+
+		return status.toString();
+	}
+
+	public void setStatus(Status status) {
+		this.status = status;
+
+		_statusSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setStatus(
+		UnsafeSupplier<Status, Exception> statusUnsafeSupplier) {
+
+		_statusSupplier = () -> {
+			try {
+				return statusUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(description = "The status of the page specification.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Status status;
+
+	@JsonIgnore
+	private Supplier<Status> _statusSupplier;
+
 	@JsonGetter("type")
 	@Schema(description = "The type of the page specification.")
 	@Valid
@@ -268,6 +322,22 @@ public abstract class PageSpecification implements Serializable {
 			sb.append(String.valueOf(settings));
 		}
 
+		Status status = getStatus();
+
+		if (status != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"status\": ");
+
+			sb.append("\"");
+
+			sb.append(status);
+
+			sb.append("\"");
+		}
+
 		Type type = getType();
 
 		if (type != null) {
@@ -295,6 +365,44 @@ public abstract class PageSpecification implements Serializable {
 		name = "x-class-name"
 	)
 	public String xClassName;
+
+	@GraphQLName("Status")
+	public static enum Status {
+
+		APPROVED("Approved"), DRAFT("Draft");
+
+		@JsonCreator
+		public static Status create(String value) {
+			if ((value == null) || value.equals("")) {
+				return null;
+			}
+
+			for (Status status : values()) {
+				if (Objects.equals(status.getValue(), value)) {
+					return status;
+				}
+			}
+
+			throw new IllegalArgumentException("Invalid enum value: " + value);
+		}
+
+		@JsonValue
+		public String getValue() {
+			return _value;
+		}
+
+		@Override
+		public String toString() {
+			return _value;
+		}
+
+		private Status(String value) {
+			_value = value;
+		}
+
+		private final String _value;
+
+	}
 
 	@GraphQLName("Type")
 	public static enum Type {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageTemplate.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageTemplate.java
@@ -507,7 +507,7 @@ public abstract class PageTemplate implements Serializable {
 	private Supplier<String> _nameSupplier;
 
 	@Schema(
-		description = "The page template's specifications. A page template of type content may contain 0 or 1 page specifications in draft status and 0 or 1 page specifications in published status. A page template of type widget contains only 1 page specification in published status."
+		description = "The page template's specifications. A page template of type content may contain 0 or 1 page specifications in draft status and 0 or 1 page specifications in published status. A page template of type widget contains only 1 page specification in published status. This field is not returned by default. It can be requested via nestedFields."
 	)
 	@Valid
 	public PageSpecification[] getPageSpecifications() {
@@ -545,7 +545,7 @@ public abstract class PageTemplate implements Serializable {
 	}
 
 	@GraphQLField(
-		description = "The page template's specifications. A page template of type content may contain 0 or 1 page specifications in draft status and 0 or 1 page specifications in published status. A page template of type widget contains only 1 page specification in published status."
+		description = "The page template's specifications. A page template of type content may contain 0 or 1 page specifications in draft status and 0 or 1 page specifications in published status. A page template of type widget contains only 1 page specification in published status. This field is not returned by default. It can be requested via nestedFields."
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected PageSpecification[] pageSpecifications;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/Settings.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/Settings.java
@@ -317,32 +317,35 @@ public class Settings implements Serializable {
 	private Supplier<String> _javascriptSupplier;
 
 	@Schema(
-		description = "The page specification's master page. This property is not applied if the page specification belongs to a master page."
+		description = "The page specification's master page external reference code. This property is not applied if the page specification belongs to a master page."
 	)
-	@Valid
-	public MasterPage getMasterPage() {
-		if (_masterPageSupplier != null) {
-			masterPage = _masterPageSupplier.get();
+	public String getMasterPageExternalReferenceCode() {
+		if (_masterPageExternalReferenceCodeSupplier != null) {
+			masterPageExternalReferenceCode =
+				_masterPageExternalReferenceCodeSupplier.get();
 
-			_masterPageSupplier = null;
+			_masterPageExternalReferenceCodeSupplier = null;
 		}
 
-		return masterPage;
+		return masterPageExternalReferenceCode;
 	}
 
-	public void setMasterPage(MasterPage masterPage) {
-		this.masterPage = masterPage;
+	public void setMasterPageExternalReferenceCode(
+		String masterPageExternalReferenceCode) {
 
-		_masterPageSupplier = null;
+		this.masterPageExternalReferenceCode = masterPageExternalReferenceCode;
+
+		_masterPageExternalReferenceCodeSupplier = null;
 	}
 
 	@JsonIgnore
-	public void setMasterPage(
-		UnsafeSupplier<MasterPage, Exception> masterPageUnsafeSupplier) {
+	public void setMasterPageExternalReferenceCode(
+		UnsafeSupplier<String, Exception>
+			masterPageExternalReferenceCodeUnsafeSupplier) {
 
-		_masterPageSupplier = () -> {
+		_masterPageExternalReferenceCodeSupplier = () -> {
 			try {
-				return masterPageUnsafeSupplier.get();
+				return masterPageExternalReferenceCodeUnsafeSupplier.get();
 			}
 			catch (RuntimeException runtimeException) {
 				throw runtimeException;
@@ -354,13 +357,13 @@ public class Settings implements Serializable {
 	}
 
 	@GraphQLField(
-		description = "The page specification's master page. This property is not applied if the page specification belongs to a master page."
+		description = "The page specification's master page external reference code. This property is not applied if the page specification belongs to a master page."
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected MasterPage masterPage;
+	protected String masterPageExternalReferenceCode;
 
 	@JsonIgnore
-	private Supplier<MasterPage> _masterPageSupplier;
+	private Supplier<String> _masterPageExternalReferenceCodeSupplier;
 
 	@Schema(
 		description = "The style book that is applied to the page specification."
@@ -733,16 +736,21 @@ public class Settings implements Serializable {
 			sb.append("\"");
 		}
 
-		MasterPage masterPage = getMasterPage();
+		String masterPageExternalReferenceCode =
+			getMasterPageExternalReferenceCode();
 
-		if (masterPage != null) {
+		if (masterPageExternalReferenceCode != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
 			}
 
-			sb.append("\"masterPage\": ");
+			sb.append("\"masterPageExternalReferenceCode\": ");
 
-			sb.append(String.valueOf(masterPage));
+			sb.append("\"");
+
+			sb.append(_escape(masterPageExternalReferenceCode));
+
+			sb.append("\"");
 		}
 
 		StyleBook styleBook = getStyleBook();

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/SitePage.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/SitePage.java
@@ -686,7 +686,7 @@ public class SitePage implements Serializable {
 	private Supplier<PageSettings> _pageSettingsSupplier;
 
 	@Schema(
-		description = "The page's specifications. A page may contain 0 or 1 page specifications in draft status and 0 or 1 page specifications in published status."
+		description = "The page's specifications. A page may contain 0 or 1 page specifications in draft status and 0 or 1 page specifications in published status. This field is not returned by default. It can be requested via nestedFields."
 	)
 	@Valid
 	public PageSpecification[] getPageSpecifications() {
@@ -724,7 +724,7 @@ public class SitePage implements Serializable {
 	}
 
 	@GraphQLField(
-		description = "The page's specifications. A page may contain 0 or 1 page specifications in draft status and 0 or 1 page specifications in published status."
+		description = "The page's specifications. A page may contain 0 or 1 page specifications in draft status and 0 or 1 page specifications in published status. This field is not returned by default. It can be requested via nestedFields."
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected PageSpecification[] pageSpecifications;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/UtilityPage.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/UtilityPage.java
@@ -498,7 +498,7 @@ public class UtilityPage implements Serializable {
 	private Supplier<String> _nameSupplier;
 
 	@Schema(
-		description = "The utility page's specifications. A utility page may contain 0 or 1 page specifications in draft status and 0 or 1 page specifications in published status."
+		description = "The utility page's specifications. A utility page may contain 0 or 1 page specifications in draft status and 0 or 1 page specifications in published status. This field is not returned by default. It can be requested via nestedFields."
 	)
 	@Valid
 	public PageSpecification[] getPageSpecifications() {
@@ -536,7 +536,7 @@ public class UtilityPage implements Serializable {
 	}
 
 	@GraphQLField(
-		description = "The utility page's specifications. A utility page may contain 0 or 1 page specifications in draft status and 0 or 1 page specifications in published status."
+		description = "The utility page's specifications. A utility page may contain 0 or 1 page specifications in draft status and 0 or 1 page specifications in published status. This field is not returned by default. It can be requested via nestedFields."
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected PageSpecification[] pageSpecifications;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/WidgetPageSpecification.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/WidgetPageSpecification.java
@@ -176,6 +176,22 @@ public class WidgetPageSpecification
 			sb.append(String.valueOf(settings));
 		}
 
+		Status status = getStatus();
+
+		if (status != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"status\": ");
+
+			sb.append("\"");
+
+			sb.append(status);
+
+			sb.append("\"");
+		}
+
 		Type type = getType();
 
 		if (type != null) {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageSpecification.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/PageSpecification.java
@@ -67,6 +67,35 @@ public abstract class PageSpecification implements Cloneable, Serializable {
 
 	protected Settings settings;
 
+	public Status getStatus() {
+		return status;
+	}
+
+	public String getStatusAsString() {
+		if (status == null) {
+			return null;
+		}
+
+		return status.toString();
+	}
+
+	public void setStatus(Status status) {
+		this.status = status;
+	}
+
+	public void setStatus(
+		UnsafeSupplier<Status, Exception> statusUnsafeSupplier) {
+
+		try {
+			status = statusUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Status status;
+
 	public Type getType() {
 		return type;
 	}
@@ -123,6 +152,39 @@ public abstract class PageSpecification implements Cloneable, Serializable {
 
 	public String toString() {
 		return PageSpecificationSerDes.toJSON(this);
+	}
+
+	public static enum Status {
+
+		APPROVED("Approved"), DRAFT("Draft");
+
+		public static Status create(String value) {
+			for (Status status : values()) {
+				if (Objects.equals(status.getValue(), value) ||
+					Objects.equals(status.name(), value)) {
+
+					return status;
+				}
+			}
+
+			return null;
+		}
+
+		public String getValue() {
+			return _value;
+		}
+
+		@Override
+		public String toString() {
+			return _value;
+		}
+
+		private Status(String value) {
+			_value = value;
+		}
+
+		private final String _value;
+
 	}
 
 	public static enum Type {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/Settings.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/Settings.java
@@ -157,26 +157,30 @@ public class Settings implements Cloneable, Serializable {
 
 	protected String javascript;
 
-	public MasterPage getMasterPage() {
-		return masterPage;
+	public String getMasterPageExternalReferenceCode() {
+		return masterPageExternalReferenceCode;
 	}
 
-	public void setMasterPage(MasterPage masterPage) {
-		this.masterPage = masterPage;
+	public void setMasterPageExternalReferenceCode(
+		String masterPageExternalReferenceCode) {
+
+		this.masterPageExternalReferenceCode = masterPageExternalReferenceCode;
 	}
 
-	public void setMasterPage(
-		UnsafeSupplier<MasterPage, Exception> masterPageUnsafeSupplier) {
+	public void setMasterPageExternalReferenceCode(
+		UnsafeSupplier<String, Exception>
+			masterPageExternalReferenceCodeUnsafeSupplier) {
 
 		try {
-			masterPage = masterPageUnsafeSupplier.get();
+			masterPageExternalReferenceCode =
+				masterPageExternalReferenceCodeUnsafeSupplier.get();
 		}
 		catch (Exception e) {
 			throw new RuntimeException(e);
 		}
 	}
 
-	protected MasterPage masterPage;
+	protected String masterPageExternalReferenceCode;
 
 	public StyleBook getStyleBook() {
 		return styleBook;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/ContentPageSpecificationSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/ContentPageSpecificationSerDes.java
@@ -101,6 +101,20 @@ public class ContentPageSpecificationSerDes {
 			sb.append(String.valueOf(contentPageSpecification.getSettings()));
 		}
 
+		if (contentPageSpecification.getStatus() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"status\": ");
+
+			sb.append("\"");
+
+			sb.append(contentPageSpecification.getStatus());
+
+			sb.append("\"");
+		}
+
 		if (contentPageSpecification.getType() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -164,6 +178,14 @@ public class ContentPageSpecificationSerDes {
 				String.valueOf(contentPageSpecification.getSettings()));
 		}
 
+		if (contentPageSpecification.getStatus() == null) {
+			map.put("status", null);
+		}
+		else {
+			map.put(
+				"status", String.valueOf(contentPageSpecification.getStatus()));
+		}
+
 		if (contentPageSpecification.getType() == null) {
 			map.put("type", null);
 		}
@@ -198,6 +220,9 @@ public class ContentPageSpecificationSerDes {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "settings")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "status")) {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "type")) {
@@ -241,6 +266,13 @@ public class ContentPageSpecificationSerDes {
 				if (jsonParserFieldValue != null) {
 					contentPageSpecification.setSettings(
 						SettingsSerDes.toDTO((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "status")) {
+				if (jsonParserFieldValue != null) {
+					contentPageSpecification.setStatus(
+						ContentPageSpecification.Status.create(
+							(String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "type")) {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageSpecificationSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/PageSpecificationSerDes.java
@@ -99,6 +99,13 @@ public class PageSpecificationSerDes {
 				"settings", String.valueOf(pageSpecification.getSettings()));
 		}
 
+		if (pageSpecification.getStatus() == null) {
+			map.put("status", null);
+		}
+		else {
+			map.put("status", String.valueOf(pageSpecification.getStatus()));
+		}
+
 		if (pageSpecification.getType() == null) {
 			map.put("type", null);
 		}
@@ -128,6 +135,9 @@ public class PageSpecificationSerDes {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "settings")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "status")) {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "type")) {
@@ -177,6 +187,13 @@ public class PageSpecificationSerDes {
 				if (jsonParserFieldValue != null) {
 					pageSpecification.setSettings(
 						SettingsSerDes.toDTO((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "status")) {
+				if (jsonParserFieldValue != null) {
+					pageSpecification.setStatus(
+						PageSpecification.Status.create(
+							(String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "type")) {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/SettingsSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/SettingsSerDes.java
@@ -150,14 +150,18 @@ public class SettingsSerDes {
 			sb.append("\"");
 		}
 
-		if (settings.getMasterPage() != null) {
+		if (settings.getMasterPageExternalReferenceCode() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
 			}
 
-			sb.append("\"masterPage\": ");
+			sb.append("\"masterPageExternalReferenceCode\": ");
 
-			sb.append(String.valueOf(settings.getMasterPage()));
+			sb.append("\"");
+
+			sb.append(_escape(settings.getMasterPageExternalReferenceCode()));
+
+			sb.append("\"");
 		}
 
 		if (settings.getStyleBook() != null) {
@@ -288,11 +292,13 @@ public class SettingsSerDes {
 			map.put("javascript", String.valueOf(settings.getJavascript()));
 		}
 
-		if (settings.getMasterPage() == null) {
-			map.put("masterPage", null);
+		if (settings.getMasterPageExternalReferenceCode() == null) {
+			map.put("masterPageExternalReferenceCode", null);
 		}
 		else {
-			map.put("masterPage", String.valueOf(settings.getMasterPage()));
+			map.put(
+				"masterPageExternalReferenceCode",
+				String.valueOf(settings.getMasterPageExternalReferenceCode()));
 		}
 
 		if (settings.getStyleBook() == null) {
@@ -374,7 +380,10 @@ public class SettingsSerDes {
 			else if (Objects.equals(jsonParserFieldName, "javascript")) {
 				return false;
 			}
-			else if (Objects.equals(jsonParserFieldName, "masterPage")) {
+			else if (Objects.equals(
+						jsonParserFieldName,
+						"masterPageExternalReferenceCode")) {
+
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "styleBook")) {
@@ -469,10 +478,13 @@ public class SettingsSerDes {
 					settings.setJavascript((String)jsonParserFieldValue);
 				}
 			}
-			else if (Objects.equals(jsonParserFieldName, "masterPage")) {
+			else if (Objects.equals(
+						jsonParserFieldName,
+						"masterPageExternalReferenceCode")) {
+
 				if (jsonParserFieldValue != null) {
-					settings.setMasterPage(
-						MasterPageSerDes.toDTO((String)jsonParserFieldValue));
+					settings.setMasterPageExternalReferenceCode(
+						(String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "styleBook")) {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/WidgetPageSpecificationSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/WidgetPageSpecificationSerDes.java
@@ -102,6 +102,20 @@ public class WidgetPageSpecificationSerDes {
 			sb.append(String.valueOf(widgetPageSpecification.getSettings()));
 		}
 
+		if (widgetPageSpecification.getStatus() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"status\": ");
+
+			sb.append("\"");
+
+			sb.append(widgetPageSpecification.getStatus());
+
+			sb.append("\"");
+		}
+
 		if (widgetPageSpecification.getType() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -166,6 +180,14 @@ public class WidgetPageSpecificationSerDes {
 				String.valueOf(widgetPageSpecification.getSettings()));
 		}
 
+		if (widgetPageSpecification.getStatus() == null) {
+			map.put("status", null);
+		}
+		else {
+			map.put(
+				"status", String.valueOf(widgetPageSpecification.getStatus()));
+		}
+
 		if (widgetPageSpecification.getType() == null) {
 			map.put("type", null);
 		}
@@ -200,6 +222,9 @@ public class WidgetPageSpecificationSerDes {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "settings")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "status")) {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "type")) {
@@ -244,6 +269,13 @@ public class WidgetPageSpecificationSerDes {
 				if (jsonParserFieldValue != null) {
 					widgetPageSpecification.setSettings(
 						SettingsSerDes.toDTO((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "status")) {
+				if (jsonParserFieldValue != null) {
+					widgetPageSpecification.setStatus(
+						WidgetPageSpecification.Status.create(
+							(String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "type")) {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/build.gradle
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/build.gradle
@@ -11,6 +11,8 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:client-extension:client-extension-api")
+	compileOnly project(":apps:client-extension:client-extension-type-api")
 	compileOnly project(":apps:friendly-url:friendly-url-api")
 	compileOnly project(":apps:headless:headless-admin-site:headless-admin-site-api")
 	compileOnly project(":apps:headless:headless-admin-taxonomy:headless-admin-taxonomy-api")
@@ -24,6 +26,7 @@ dependencies {
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:segments:segments-api")
 	compileOnly project(":apps:site:site-api")
+	compileOnly project(":apps:style-book:style-book-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
@@ -362,7 +362,8 @@ components:
                     # @review
                     description:
                         The display page template's specifications. A display page template may contain 0 or 1 page
-                        specifications in draft status and 0 or 1 page specifications in published status.
+                        specifications in draft status and 0 or 1 page specifications in published status. This field is
+                        not returned by default. It can be requested via nestedFields.
                     items:
                         $ref: "#/components/schemas/PageSpecification"
                     type: array
@@ -1201,7 +1202,8 @@ components:
                     # @review
                     description:
                         The master page's specifications. A master page may contain 0 or 1 page specifications in draft
-                        status and 0 or 1 page specifications in published status.
+                        status and 0 or 1 page specifications in published status. This field is not returned by
+                        default. It can be requested via nestedFields.
                     items:
                         $ref: "#/components/schemas/PageSpecification"
                     type: array
@@ -2249,7 +2251,8 @@ components:
                     description:
                         The page template's specifications. A page template of type content may contain 0 or 1 page
                         specifications in draft status and 0 or 1 page specifications in published status. A page
-                        template of type widget contains only 1 page specification in published status.
+                        template of type widget contains only 1 page specification in published status. This field is
+                        not returned by default. It can be requested via nestedFields.
                     items:
                         $ref: "#/components/schemas/PageSpecification"
                     type: array
@@ -2699,7 +2702,8 @@ components:
                     # @review
                     description:
                         The page's specifications. A page may contain 0 or 1 page specifications in draft status and 0
-                        or 1 page specifications in published status.
+                        or 1 page specifications in published status. This field is not returned by default. It can be
+                        requested via nestedFields.
                     items:
                         $ref: "#/components/schemas/PageSpecification"
                     type: array
@@ -2860,7 +2864,8 @@ components:
                     # @review
                     description:
                         The utility page's specifications. A utility page may contain 0 or 1 page specifications in
-                        draft status and 0 or 1 page specifications in published status.
+                        draft status and 0 or 1 page specifications in published status. This field is not returned by
+                        default. It can be requested via nestedFields.
                     items:
                         $ref: "#/components/schemas/PageSpecification"
                     type: array

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
@@ -2162,6 +2162,14 @@ components:
                     type: string
                 settings:
                     $ref: "#/components/schemas/Settings"
+                status:
+                    # @review
+                    description:
+                        The status of the page specification.
+                    enum:
+                        - Approved
+                        - Draft
+                    type: string
                 type:
                     # @review
                     description:

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
@@ -2559,12 +2559,12 @@ components:
                     description:
                         The page specification's JavaScript.
                     type: string
-                masterPage:
-                    $ref: "#/components/schemas/MasterPage"
+                masterPageExternalReferenceCode:
                     # @review
                     description:
-                        The page specification's master page. This property is not applied if the page specification
-                        belongs to a master page.
+                        The page specification's master page external reference code. This property is not applied if
+                        the page specification belongs to a master page.
+                    type: string
                 styleBook:
                     # @review
                     description:

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageSpecificationDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageSpecificationDTOConverter.java
@@ -62,6 +62,14 @@ public class PageSpecificationDTOConverter
 			{
 				setExternalReferenceCode(layout::getExternalReferenceCode);
 				setSettings(() -> _setSettings(layout));
+				setStatus(
+					() -> {
+						if (!layout.isDraftLayout()) {
+							return Status.APPROVED;
+						}
+
+						return Status.DRAFT;
+					});
 				setType(
 					() -> {
 						if (layout.isTypeAssetDisplay() ||

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageSpecificationDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageSpecificationDTOConverter.java
@@ -5,25 +5,34 @@
 
 package com.liferay.headless.admin.site.internal.dto.v1_0.converter;
 
+import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
+import com.liferay.client.extension.model.ClientExtensionEntryRel;
+import com.liferay.client.extension.service.ClientExtensionEntryRelLocalService;
 import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.headless.admin.site.dto.v1_0.ClientExtension;
 import com.liferay.headless.admin.site.dto.v1_0.ItemExternalReference;
 import com.liferay.headless.admin.site.dto.v1_0.PageSpecification;
 import com.liferay.headless.admin.site.dto.v1_0.Settings;
 import com.liferay.headless.admin.site.dto.v1_0.StyleBook;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.model.ColorScheme;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Theme;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ThemeLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.style.book.model.StyleBookEntry;
 import com.liferay.style.book.service.StyleBookEntryLocalService;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
@@ -67,7 +76,74 @@ public class PageSpecificationDTOConverter
 		};
 	}
 
+	private ClientExtension _getClientExtension(
+		ClientExtensionEntryRel clientExtensionEntryRel) {
+
+		if (clientExtensionEntryRel == null) {
+			return null;
+		}
+
+		return new ClientExtension() {
+			{
+				setClientExtensionConfig(
+					() -> _getClientExtensionConfig(clientExtensionEntryRel));
+				setExternalReferenceCode(
+					clientExtensionEntryRel::getCETExternalReferenceCode);
+			}
+		};
+	}
+
+	private ClientExtension _getClientExtension(
+		long classNameId, long classPK, String type) {
+
+		return _getClientExtension(
+			_clientExtensionEntryRelLocalService.fetchClientExtensionEntryRel(
+				classNameId, classPK, type));
+	}
+
+	private Map<String, String> _getClientExtensionConfig(
+		ClientExtensionEntryRel clientExtensionEntryRel) {
+
+		if (clientExtensionEntryRel == null) {
+			return null;
+		}
+
+		UnicodeProperties unicodeProperties = UnicodePropertiesBuilder.fastLoad(
+			clientExtensionEntryRel.getTypeSettings()
+		).build();
+
+		if (unicodeProperties.isEmpty()) {
+			return null;
+		}
+
+		Map<String, String> clientExtensionConfig = new HashMap<>();
+
+		for (Map.Entry<String, String> entry : unicodeProperties.entrySet()) {
+			clientExtensionConfig.put(entry.getKey(), entry.getValue());
+		}
+
+		return clientExtensionConfig;
+	}
+
+	private ClientExtension[] _getClientExtensions(
+		long classNameId, long classPK, String type) {
+
+		ClientExtension[] clientExtensions = TransformUtil.transformToArray(
+			_clientExtensionEntryRelLocalService.getClientExtensionEntryRels(
+				classNameId, classPK, type),
+			clientExtensionEntryRel -> _getClientExtension(
+				clientExtensionEntryRel),
+			ClientExtension.class);
+
+		if (ArrayUtil.isEmpty(clientExtensions)) {
+			return null;
+		}
+
+		return clientExtensions;
+	}
+
 	private Settings _setSettings(Layout layout) throws Exception {
+		long classNameId = _portal.getClassNameId(Layout.class.getName());
 		UnicodeProperties unicodeProperties =
 			layout.getTypeSettingsProperties();
 
@@ -102,12 +178,23 @@ public class PageSpecificationDTOConverter
 					});
 				setFavIcon(
 					() -> {
-						if (layout.getFaviconFileEntryId() == 0) {
+						ClientExtension clientExtension = _getClientExtension(
+							classNameId, layout.getPlid(),
+							ClientExtensionEntryConstants.TYPE_THEME_FAVICON);
+
+						if (clientExtension != null) {
+							return clientExtension;
+						}
+
+						long faviconFileEntryId =
+							layout.getFaviconFileEntryId();
+
+						if (faviconFileEntryId == 0) {
 							return null;
 						}
 
 						FileEntry fileEntry = _dlAppService.getFileEntry(
-							layout.getFaviconFileEntryId());
+							faviconFileEntryId);
 
 						if (fileEntry == null) {
 							return null;
@@ -122,6 +209,14 @@ public class PageSpecificationDTOConverter
 							}
 						};
 					});
+				setGlobalCSSClientExtensions(
+					() -> _getClientExtensions(
+						classNameId, layout.getPlid(),
+						ClientExtensionEntryConstants.TYPE_GLOBAL_CSS));
+				setGlobalJSClientExtensions(
+					() -> _getClientExtensions(
+						classNameId, layout.getPlid(),
+						ClientExtensionEntryConstants.TYPE_GLOBAL_JS));
 				setJavascript(
 					() -> unicodeProperties.getProperty("javascript", null));
 				setMasterPageExternalReferenceCode(
@@ -161,6 +256,10 @@ public class PageSpecificationDTOConverter
 							}
 						};
 					});
+				setThemeCSSClientExtension(
+					() -> _getClientExtension(
+						classNameId, layout.getPlid(),
+						ClientExtensionEntryConstants.TYPE_THEME_CSS));
 				setThemeName(
 					() -> {
 						if (Validator.isNull(layout.getThemeId())) {
@@ -198,9 +297,17 @@ public class PageSpecificationDTOConverter
 
 						return themeSettingsUnicodeProperties;
 					});
+				setThemeSpritemapClientExtension(
+					() -> _getClientExtension(
+						classNameId, layout.getPlid(),
+						ClientExtensionEntryConstants.TYPE_THEME_SPRITEMAP));
 			}
 		};
 	}
+
+	@Reference
+	private ClientExtensionEntryRelLocalService
+		_clientExtensionEntryRelLocalService;
 
 	@Reference
 	private DLAppService _dlAppService;
@@ -208,6 +315,9 @@ public class PageSpecificationDTOConverter
 	@Reference
 	private LayoutPageTemplateEntryLocalService
 		_layoutPageTemplateEntryLocalService;
+
+	@Reference
+	private Portal _portal;
 
 	@Reference
 	private StyleBookEntryLocalService _styleBookEntryLocalService;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageSpecificationDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageSpecificationDTOConverter.java
@@ -5,12 +5,29 @@
 
 package com.liferay.headless.admin.site.internal.dto.v1_0.converter;
 
+import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.headless.admin.site.dto.v1_0.ItemExternalReference;
 import com.liferay.headless.admin.site.dto.v1_0.PageSpecification;
+import com.liferay.headless.admin.site.dto.v1_0.Settings;
+import com.liferay.headless.admin.site.dto.v1_0.StyleBook;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
+import com.liferay.portal.kernel.model.ColorScheme;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.Theme;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.ThemeLocalService;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
+import com.liferay.style.book.model.StyleBookEntry;
+import com.liferay.style.book.service.StyleBookEntryLocalService;
+
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Lourdes Fernández Besada
@@ -35,6 +52,7 @@ public class PageSpecificationDTOConverter
 		return new PageSpecification() {
 			{
 				setExternalReferenceCode(layout::getExternalReferenceCode);
+				setSettings(() -> _setSettings(layout));
 				setType(
 					() -> {
 						if (layout.isTypeAssetDisplay() ||
@@ -48,5 +66,153 @@ public class PageSpecificationDTOConverter
 			}
 		};
 	}
+
+	private Settings _setSettings(Layout layout) throws Exception {
+		UnicodeProperties unicodeProperties =
+			layout.getTypeSettingsProperties();
+
+		return new Settings() {
+			{
+				setColorSchemeName(
+					() -> {
+						if (Validator.isNull(layout.getColorSchemeId()) ||
+							Validator.isNull(layout.getThemeId())) {
+
+							return null;
+						}
+
+						ColorScheme colorScheme =
+							_themeLocalService.getColorScheme(
+								layout.getCompanyId(), layout.getThemeId(),
+								layout.getColorSchemeId());
+
+						if (colorScheme == null) {
+							return null;
+						}
+
+						return colorScheme.getName();
+					});
+				setCss(
+					() -> {
+						if (Validator.isNull(layout.getCss())) {
+							return null;
+						}
+
+						return layout.getCss();
+					});
+				setFavIcon(
+					() -> {
+						if (layout.getFaviconFileEntryId() == 0) {
+							return null;
+						}
+
+						FileEntry fileEntry = _dlAppService.getFileEntry(
+							layout.getFaviconFileEntryId());
+
+						if (fileEntry == null) {
+							return null;
+						}
+
+						return new ItemExternalReference() {
+							{
+								setClassName(() -> FileEntry.class.getName());
+								setCollectionType(CollectionType.COLLECTION);
+								setExternalReferenceCode(
+									fileEntry::getExternalReferenceCode);
+							}
+						};
+					});
+				setJavascript(
+					() -> unicodeProperties.getProperty("javascript", null));
+				setMasterPageExternalReferenceCode(
+					() -> {
+						if (layout.getMasterLayoutPlid() == 0) {
+							return null;
+						}
+
+						LayoutPageTemplateEntry layoutPageTemplateEntry =
+							_layoutPageTemplateEntryLocalService.
+								fetchLayoutPageTemplateEntryByPlid(
+									layout.getMasterLayoutPlid());
+
+						if (layoutPageTemplateEntry == null) {
+							return null;
+						}
+
+						return layoutPageTemplateEntry.
+							getExternalReferenceCode();
+					});
+				setStyleBook(
+					() -> {
+						StyleBookEntry styleBookEntry =
+							_styleBookEntryLocalService.fetchStyleBookEntry(
+								layout.getStyleBookEntryId());
+
+						if (styleBookEntry == null) {
+							return null;
+						}
+
+						return new StyleBook() {
+							{
+								setKey(
+									() ->
+										styleBookEntry.getStyleBookEntryKey());
+								setName(styleBookEntry::getName);
+							}
+						};
+					});
+				setThemeName(
+					() -> {
+						if (Validator.isNull(layout.getThemeId())) {
+							return null;
+						}
+
+						Theme theme = _themeLocalService.fetchTheme(
+							layout.getCompanyId(), layout.getThemeId());
+
+						if (theme == null) {
+							return null;
+						}
+
+						return theme.getName();
+					});
+				setThemeSettings(
+					() -> {
+						UnicodeProperties themeSettingsUnicodeProperties =
+							new UnicodeProperties();
+
+						for (Map.Entry<String, String> entry :
+								unicodeProperties.entrySet()) {
+
+							String key = entry.getKey();
+
+							if (key.startsWith("lfr-theme:")) {
+								themeSettingsUnicodeProperties.setProperty(
+									key, entry.getValue());
+							}
+						}
+
+						if (themeSettingsUnicodeProperties.isEmpty()) {
+							return null;
+						}
+
+						return themeSettingsUnicodeProperties;
+					});
+			}
+		};
+	}
+
+	@Reference
+	private DLAppService _dlAppService;
+
+	@Reference
+	private LayoutPageTemplateEntryLocalService
+		_layoutPageTemplateEntryLocalService;
+
+	@Reference
+	private StyleBookEntryLocalService _styleBookEntryLocalService;
+
+	@Reference
+	private ThemeLocalService _themeLocalService;
 
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageSpecificationDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageSpecificationDTOConverter.java
@@ -10,10 +10,12 @@ import com.liferay.client.extension.model.ClientExtensionEntryRel;
 import com.liferay.client.extension.service.ClientExtensionEntryRelLocalService;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.headless.admin.site.dto.v1_0.ClientExtension;
+import com.liferay.headless.admin.site.dto.v1_0.ContentPageSpecification;
 import com.liferay.headless.admin.site.dto.v1_0.ItemExternalReference;
 import com.liferay.headless.admin.site.dto.v1_0.PageSpecification;
 import com.liferay.headless.admin.site.dto.v1_0.Settings;
 import com.liferay.headless.admin.site.dto.v1_0.StyleBook;
+import com.liferay.headless.admin.site.dto.v1_0.WidgetPageSpecification;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
@@ -58,30 +60,11 @@ public class PageSpecificationDTOConverter
 			DTOConverterContext dtoConverterContext, Layout layout)
 		throws Exception {
 
-		return new PageSpecification() {
-			{
-				setExternalReferenceCode(layout::getExternalReferenceCode);
-				setSettings(() -> _setSettings(layout));
-				setStatus(
-					() -> {
-						if (!layout.isDraftLayout()) {
-							return Status.APPROVED;
-						}
+		if (layout.isTypeAssetDisplay() || layout.isTypeContent()) {
+			return _toContentPageSpecification(layout);
+		}
 
-						return Status.DRAFT;
-					});
-				setType(
-					() -> {
-						if (layout.isTypeAssetDisplay() ||
-							layout.isTypeContent()) {
-
-							return Type.CONTENT_PAGE_SPECIFICATION;
-						}
-
-						return Type.WIDGET_PAGE_SPECIFICATION;
-					});
-			}
-		};
+		return _toWidgetPageSpecification(layout);
 	}
 
 	private ClientExtension _getClientExtension(
@@ -309,6 +292,35 @@ public class PageSpecificationDTOConverter
 					() -> _getClientExtension(
 						classNameId, layout.getPlid(),
 						ClientExtensionEntryConstants.TYPE_THEME_SPRITEMAP));
+			}
+		};
+	}
+
+	private PageSpecification _toContentPageSpecification(Layout layout) {
+		return new ContentPageSpecification() {
+			{
+				setExternalReferenceCode(layout::getExternalReferenceCode);
+				setSettings(() -> _setSettings(layout));
+				setStatus(
+					() -> {
+						if (!layout.isDraftLayout()) {
+							return Status.APPROVED;
+						}
+
+						return Status.DRAFT;
+					});
+				setType(() -> Type.CONTENT_PAGE_SPECIFICATION);
+			}
+		};
+	}
+
+	private PageSpecification _toWidgetPageSpecification(Layout layout) {
+		return new WidgetPageSpecification() {
+			{
+				setExternalReferenceCode(layout::getExternalReferenceCode);
+				setSettings(() -> _setSettings(layout));
+				setStatus(() -> Status.APPROVED);
+				setType(() -> Type.WIDGET_PAGE_SPECIFICATION);
 			}
 		};
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageSpecificationDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/PageSpecificationDTOConverter.java
@@ -12,12 +12,17 @@ import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.headless.admin.site.dto.v1_0.ClientExtension;
 import com.liferay.headless.admin.site.dto.v1_0.ContentPageSpecification;
 import com.liferay.headless.admin.site.dto.v1_0.ItemExternalReference;
+import com.liferay.headless.admin.site.dto.v1_0.PageExperience;
 import com.liferay.headless.admin.site.dto.v1_0.PageSpecification;
 import com.liferay.headless.admin.site.dto.v1_0.Settings;
 import com.liferay.headless.admin.site.dto.v1_0.StyleBook;
 import com.liferay.headless.admin.site.dto.v1_0.WidgetPageSpecification;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRel;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.model.ColorScheme;
 import com.liferay.portal.kernel.model.Layout;
@@ -31,6 +36,7 @@ import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
+import com.liferay.segments.service.SegmentsExperienceService;
 import com.liferay.style.book.model.StyleBookEntry;
 import com.liferay.style.book.service.StyleBookEntryLocalService;
 
@@ -61,7 +67,7 @@ public class PageSpecificationDTOConverter
 		throws Exception {
 
 		if (layout.isTypeAssetDisplay() || layout.isTypeContent()) {
-			return _toContentPageSpecification(layout);
+			return _toContentPageSpecification(dtoConverterContext, layout);
 		}
 
 		return _toWidgetPageSpecification(layout);
@@ -131,6 +137,37 @@ public class PageSpecificationDTOConverter
 		}
 
 		return clientExtensions;
+	}
+
+	private PageExperience[] _getPageExperiences(
+			DTOConverterContext dtoConverterContext, Layout layout)
+		throws Exception {
+
+		return TransformUtil.transformToArray(
+			_segmentsExperienceService.getSegmentsExperiences(
+				layout.getGroupId(), layout.getPlid(), true),
+			segmentsExperience -> {
+				LayoutPageTemplateStructure layoutPageTemplateStructure =
+					_layoutPageTemplateStructureLocalService.
+						fetchLayoutPageTemplateStructure(
+							segmentsExperience.getGroupId(),
+							segmentsExperience.getPlid());
+
+				LayoutPageTemplateStructureRel layoutPageTemplateStructureRel =
+					_layoutPageTemplateStructureRelLocalService.
+						fetchLayoutPageTemplateStructureRel(
+							layoutPageTemplateStructure.
+								getLayoutPageTemplateStructureId(),
+							segmentsExperience.getSegmentsExperienceId());
+
+				if (layoutPageTemplateStructureRel == null) {
+					throw new UnsupportedOperationException();
+				}
+
+				return _pageExperienceDTOConverter.toDTO(
+					dtoConverterContext, layoutPageTemplateStructureRel);
+			},
+			PageExperience.class);
 	}
 
 	private Settings _setSettings(Layout layout) throws Exception {
@@ -296,10 +333,14 @@ public class PageSpecificationDTOConverter
 		};
 	}
 
-	private PageSpecification _toContentPageSpecification(Layout layout) {
+	private PageSpecification _toContentPageSpecification(
+		DTOConverterContext dtoConverterContext, Layout layout) {
+
 		return new ContentPageSpecification() {
 			{
 				setExternalReferenceCode(layout::getExternalReferenceCode);
+				setPageExperiences(
+					() -> _getPageExperiences(dtoConverterContext, layout));
 				setSettings(() -> _setSettings(layout));
 				setStatus(
 					() -> {
@@ -337,7 +378,24 @@ public class PageSpecificationDTOConverter
 		_layoutPageTemplateEntryLocalService;
 
 	@Reference
+	private LayoutPageTemplateStructureLocalService
+		_layoutPageTemplateStructureLocalService;
+
+	@Reference
+	private LayoutPageTemplateStructureRelLocalService
+		_layoutPageTemplateStructureRelLocalService;
+
+	@Reference(
+		target = "(component.name=com.liferay.headless.admin.site.internal.dto.v1_0.converter.PageExperienceDTOConverter)"
+	)
+	private DTOConverter<LayoutPageTemplateStructureRel, PageExperience>
+		_pageExperienceDTOConverter;
+
+	@Reference
 	private Portal _portal;
+
+	@Reference
+	private SegmentsExperienceService _segmentsExperienceService;
 
 	@Reference
 	private StyleBookEntryLocalService _styleBookEntryLocalService;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/graphql/query/v1_0/Query.java
@@ -1026,7 +1026,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {siteByExternalReferenceCodePageSpecification(pageSpecificationExternalReferenceCode: ___, siteExternalReferenceCode: ___){externalReferenceCode, settings, type}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {siteByExternalReferenceCodePageSpecification(pageSpecificationExternalReferenceCode: ___, siteExternalReferenceCode: ___){externalReferenceCode, settings, status, type}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(
 		description = "Retrieves a page specification of a site page."

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageSpecificationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageSpecificationResourceImpl.java
@@ -298,7 +298,7 @@ public abstract class BasePageSpecificationResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-specifications/{pageSpecificationExternalReferenceCode}' -d $'{"externalReferenceCode": ___, "settings": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-specifications/{pageSpecificationExternalReferenceCode}' -d $'{"externalReferenceCode": ___, "settings": ___, "status": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates a page specification of a site page. Updates only the fields received in the request body, leaving any other fields untouched."
@@ -362,6 +362,10 @@ public abstract class BasePageSpecificationResourceImpl
 				pageSpecification.getExternalReferenceCode());
 		}
 
+		if (pageSpecification.getStatus() != null) {
+			existingPageSpecification.setStatus(pageSpecification.getStatus());
+		}
+
 		if (pageSpecification.getType() != null) {
 			existingPageSpecification.setType(pageSpecification.getType());
 		}
@@ -376,7 +380,7 @@ public abstract class BasePageSpecificationResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-specifications/{pageSpecificationExternalReferenceCode}' -d $'{"externalReferenceCode": ___, "settings": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-specifications/{pageSpecificationExternalReferenceCode}' -d $'{"externalReferenceCode": ___, "settings": ___, "status": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates a page specification of a site page."

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageSpecificationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageSpecificationResourceImpl.java
@@ -5,9 +5,16 @@
 
 package com.liferay.headless.admin.site.internal.resource.v1_0;
 
+import com.liferay.headless.admin.site.dto.v1_0.PageSpecification;
+import com.liferay.headless.admin.site.internal.resource.util.GroupUtil;
 import com.liferay.headless.admin.site.resource.v1_0.PageSpecificationResource;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.LayoutService;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ServiceScope;
 
 /**
@@ -19,4 +26,33 @@ import org.osgi.service.component.annotations.ServiceScope;
 )
 public class PageSpecificationResourceImpl
 	extends BasePageSpecificationResourceImpl {
+
+	@Override
+	public PageSpecification
+			getSiteSiteByExternalReferenceCodePageSpecification(
+				String siteExternalReferenceCode,
+				String pageSpecificationExternalReferenceCode)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-35443")) {
+			throw new UnsupportedOperationException();
+		}
+
+		return _pageSpecificationDTOConverter.toDTO(
+			_layoutService.getLayoutByExternalReferenceCode(
+				pageSpecificationExternalReferenceCode,
+				GroupUtil.getGroupId(
+					true, true, contextCompany.getCompanyId(),
+					siteExternalReferenceCode)));
+	}
+
+	@Reference
+	private LayoutService _layoutService;
+
+	@Reference(
+		target = "(component.name=com.liferay.headless.admin.site.internal.dto.v1_0.converter.PageSpecificationDTOConverter)"
+	)
+	private DTOConverter<Layout, PageSpecification>
+		_pageSpecificationDTOConverter;
+
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageSpecificationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageSpecificationResourceImpl.java
@@ -11,6 +11,7 @@ import com.liferay.headless.admin.site.resource.v1_0.PageSpecificationResource;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.LayoutService;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 
 import org.osgi.service.component.annotations.Component;
@@ -38,12 +39,49 @@ public class PageSpecificationResourceImpl
 			throw new UnsupportedOperationException();
 		}
 
-		return _pageSpecificationDTOConverter.toDTO(
-			_layoutService.getLayoutByExternalReferenceCode(
-				pageSpecificationExternalReferenceCode,
-				GroupUtil.getGroupId(
-					true, true, contextCompany.getCompanyId(),
-					siteExternalReferenceCode)));
+		Layout layout = _layoutService.getLayoutByExternalReferenceCode(
+			pageSpecificationExternalReferenceCode,
+			GroupUtil.getGroupId(
+				true, true, contextCompany.getCompanyId(),
+				siteExternalReferenceCode));
+
+		if (!_isPageSpecificationSupported(layout)) {
+			throw new UnsupportedOperationException();
+		}
+
+		return _pageSpecificationDTOConverter.toDTO(layout);
+	}
+
+	private boolean _isPageSpecificationSupported(Layout layout) {
+		if (_isPublished(layout)) {
+			if (!layout.isApproved() || !layout.isDraftLayout()) {
+				return true;
+			}
+
+			return false;
+		}
+
+		if (layout.isDraftLayout()) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isPublished(Layout layout) {
+		if (!layout.isTypeAssetDisplay() && !layout.isTypeContent()) {
+			return true;
+		}
+
+		if (layout.isDraftLayout()) {
+			return GetterUtil.getBoolean(
+				layout.getTypeSettingsProperty("published"));
+		}
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		return GetterUtil.getBoolean(
+			draftLayout.getTypeSettingsProperty("published"));
 	}
 
 	@Reference

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/build.gradle
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:headless:headless-admin-site:headless-admin-site-api")
 	testIntegrationImplementation project(":apps:headless:headless-admin-site:headless-admin-site-client")
 	testIntegrationImplementation project(":apps:info:info-api")
+	testIntegrationImplementation project(":apps:layout:layout-api")
 	testIntegrationImplementation project(":apps:layout:layout-page-template-api")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
 	testIntegrationImplementation project(":apps:layout:layout-utility-page-api")
@@ -14,5 +15,6 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationImplementation project(":apps:segments:segments-api")
 	testIntegrationImplementation project(":apps:segments:segments-test-util")
+	testIntegrationImplementation project(":apps:style-book:style-book-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageSpecificationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/BasePageSpecificationResourceTestCase.java
@@ -1018,6 +1018,14 @@ public abstract class BasePageSpecificationResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("status", additionalAssertFieldName)) {
+				if (pageSpecification.getStatus() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("type", additionalAssertFieldName)) {
 				if (pageSpecification.getType() == null) {
 					valid = false;
@@ -1194,6 +1202,17 @@ public abstract class BasePageSpecificationResourceTestCase {
 				if (!Objects.deepEquals(
 						pageSpecification1.getSettings(),
 						pageSpecification2.getSettings())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("status", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						pageSpecification1.getStatus(),
+						pageSpecification2.getStatus())) {
 
 					return false;
 				}
@@ -1407,6 +1426,11 @@ public abstract class BasePageSpecificationResourceTestCase {
 		}
 
 		if (entityFieldName.equals("settings")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("status")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
@@ -229,7 +229,9 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 					patchSiteSiteByExternalReferenceCodeMasterPage(
 						testGroup.getExternalReferenceCode(),
 						liveGroupMasterPage.getExternalReferenceCode(),
-						liveGroupMasterPage));
+						_getMasterPage(
+							null,
+							liveGroupMasterPage.getExternalReferenceCode())));
 	}
 
 	@Ignore
@@ -263,7 +265,9 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 			() ->
 				masterPageResource.putSiteSiteByExternalReferenceCodeMasterPage(
 					testGroup.getExternalReferenceCode(),
-					masterPage.getExternalReferenceCode(), masterPage));
+					masterPage.getExternalReferenceCode(),
+					_getMasterPage(
+						null, masterPage.getExternalReferenceCode())));
 	}
 
 	@Ignore

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
@@ -175,6 +175,13 @@ public class PageSpecificationResourceTest
 		super.testPutSiteSiteByExternalReferenceCodePageSpecification();
 	}
 
+	@Override
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[] {
+			"externalReferenceCode", "settings", "status", "type"
+		};
+	}
+
 	private Layout _addLayout(String type, ServiceContext serviceContext)
 		throws Exception {
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
@@ -6,15 +6,212 @@
 package com.liferay.headless.admin.site.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageSpecification;
+import com.liferay.headless.admin.site.client.dto.v1_0.Settings;
+import com.liferay.headless.admin.site.client.dto.v1_0.StyleBook;
+import com.liferay.headless.admin.site.client.dto.v1_0.WidgetPageSpecification;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.ColorScheme;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.Theme;
+import com.liferay.portal.kernel.service.ThemeLocalService;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.style.book.model.StyleBookEntry;
+import com.liferay.style.book.service.StyleBookEntryLocalService;
 
-import org.junit.Ignore;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
  * @author Rubén Pulido
  */
-@Ignore
+@FeatureFlags("LPD-35443")
 @RunWith(Arquillian.class)
 public class PageSpecificationResourceTest
 	extends BasePageSpecificationResourceTestCase {
+
+	@Override
+	@Test
+	public void testGetSiteSiteByExternalReferenceCodePageSpecification()
+		throws Exception {
+
+		_testGetSiteSiteByExternalReferenceCodePageSpecification(
+			LayoutTestUtil.addTypePortletLayout(testGroup));
+	}
+
+	private void _assertPageSpecificationSetting(
+			Layout layout, Settings settings)
+		throws Exception {
+
+		if (Validator.isNull(layout.getThemeId()) ||
+			Validator.isNull(layout.getThemeId())) {
+
+			Assert.assertTrue(Validator.isNull(settings.getColorSchemeName()));
+		}
+		else {
+			ColorScheme colorScheme = _themeLocalService.getColorScheme(
+				layout.getCompanyId(), layout.getThemeId(),
+				layout.getColorSchemeId());
+
+			Assert.assertEquals(
+				colorScheme.getName(), settings.getColorSchemeName());
+		}
+
+		if (Validator.isNull(layout.getCss())) {
+			Assert.assertTrue(Validator.isNull(settings.getCss()));
+		}
+		else {
+			Assert.assertEquals(layout.getCss(), settings.getCss());
+		}
+
+		UnicodeProperties unicodeProperties =
+			layout.getTypeSettingsProperties();
+
+		Assert.assertEquals(
+			unicodeProperties.getProperty("javascript", null),
+			settings.getJavascript());
+
+		if (layout.getMasterLayoutPlid() == 0) {
+			Assert.assertNull(settings.getMasterPageExternalReferenceCode());
+		}
+		else {
+			LayoutPageTemplateEntry layoutPageTemplateEntry =
+				_layoutPageTemplateEntryLocalService.
+					fetchLayoutPageTemplateEntryByPlid(
+						layout.getMasterLayoutPlid());
+
+			Assert.assertEquals(
+				layoutPageTemplateEntry.getExternalReferenceCode(),
+				settings.getMasterPageExternalReferenceCode());
+		}
+
+		if (layout.getStyleBookEntryId() == 0) {
+			Assert.assertNull(settings.getStyleBook());
+		}
+		else {
+			StyleBookEntry styleBookEntry =
+				_styleBookEntryLocalService.getStyleBookEntry(
+					layout.getStyleBookEntryId());
+
+			StyleBook styleBook = settings.getStyleBook();
+
+			Assert.assertEquals(
+				styleBookEntry.getStyleBookEntryKey(), styleBook.getKey());
+			Assert.assertEquals(styleBookEntry.getName(), styleBook.getName());
+		}
+
+		if (Validator.isNull(layout.getThemeId())) {
+			Assert.assertTrue(Validator.isNull(settings.getThemeName()));
+		}
+		else {
+			Theme theme = _themeLocalService.getTheme(
+				layout.getCompanyId(), layout.getThemeId());
+
+			Assert.assertEquals(theme.getName(), settings.getThemeName());
+		}
+
+		UnicodeProperties themeSettingsUnicodeProperties =
+			_getThemeSettingsUnicodeProperties(unicodeProperties);
+
+		if (themeSettingsUnicodeProperties.size() == 0) {
+			Assert.assertNull(settings.getThemeSettings());
+		}
+		else {
+			JSONObject jsonObject = _jsonFactory.createJSONObject(
+				(String)settings.getThemeSettings());
+
+			Assert.assertEquals(
+				themeSettingsUnicodeProperties.size(), jsonObject.length());
+
+			for (Map.Entry<String, String> entry :
+					themeSettingsUnicodeProperties.entrySet()) {
+
+				Assert.assertEquals(
+					entry.getValue(), jsonObject.getString(entry.getKey()));
+			}
+		}
+	}
+
+	private void _assertWidgetPageSpecification(
+		WidgetPageSpecification widgetPageSpecification) {
+
+		Assert.assertEquals(
+			PageSpecification.Type.WIDGET_PAGE_SPECIFICATION,
+			widgetPageSpecification.getType());
+
+		Assert.assertNull(widgetPageSpecification.getWidgetPageSections());
+	}
+
+	private UnicodeProperties _getThemeSettingsUnicodeProperties(
+		UnicodeProperties unicodeProperties) {
+
+		UnicodeProperties themeSettingsUnicodeProperties =
+			new UnicodeProperties();
+
+		for (Map.Entry<String, String> entry : unicodeProperties.entrySet()) {
+			String key = entry.getKey();
+
+			if (key.startsWith("lfr-theme:")) {
+				themeSettingsUnicodeProperties.setProperty(
+					key, entry.getValue());
+			}
+		}
+
+		return themeSettingsUnicodeProperties;
+	}
+
+	private void _testGetSiteSiteByExternalReferenceCodePageSpecification(
+			Layout layout)
+		throws Exception {
+
+		PageSpecification pageSpecification =
+			pageSpecificationResource.
+				getSiteSiteByExternalReferenceCodePageSpecification(
+					testGroup.getExternalReferenceCode(),
+					layout.getExternalReferenceCode());
+
+		Assert.assertEquals(
+			layout.getExternalReferenceCode(),
+			pageSpecification.getExternalReferenceCode());
+
+		_assertPageSpecificationSetting(
+			layout, pageSpecification.getSettings());
+
+		if (layout.isDraftLayout()) {
+			Assert.assertEquals(
+				PageSpecification.Status.DRAFT, pageSpecification.getStatus());
+		}
+		else {
+			Assert.assertEquals(
+				PageSpecification.Status.APPROVED,
+				pageSpecification.getStatus());
+		}
+
+		_assertWidgetPageSpecification(
+			(WidgetPageSpecification)pageSpecification);
+	}
+
+	@Inject
+	private JSONFactory _jsonFactory;
+
+	@Inject
+	private LayoutPageTemplateEntryLocalService
+		_layoutPageTemplateEntryLocalService;
+
+	@Inject
+	private StyleBookEntryLocalService _styleBookEntryLocalService;
+
+	@Inject
+	private ThemeLocalService _themeLocalService;
+
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
@@ -13,11 +13,17 @@ import com.liferay.headless.admin.site.client.dto.v1_0.Settings;
 import com.liferay.headless.admin.site.client.dto.v1_0.StyleBook;
 import com.liferay.headless.admin.site.client.dto.v1_0.WidgetPageSpecification;
 import com.liferay.headless.admin.site.client.problem.Problem;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateCollectionTypeConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
+import com.liferay.layout.utility.page.kernel.constants.LayoutUtilityPageEntryConstants;
+import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
+import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -32,6 +38,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
@@ -111,32 +118,21 @@ public class PageSpecificationResourceTest
 		_testGetSiteSiteByExternalReferenceCodePageSpecification(
 			_addLayout(LayoutConstants.TYPE_PORTLET, serviceContext));
 
-		Layout layout = _addLayout(
-			LayoutConstants.TYPE_CONTENT, serviceContext);
+		_testGetSiteSiteByExternalReferenceCodePageSpecificationWithLayoutWithDraftLayout(
+			_addLayout(LayoutConstants.TYPE_CONTENT, serviceContext),
+			serviceContext);
 
-		_assertProblemException(layout);
-
-		Layout draftLayout = layout.fetchDraftLayout();
-
-		_testGetSiteSiteByExternalReferenceCodePageSpecification(draftLayout);
-
-		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
-
-		_assertProblemException(draftLayout);
-
-		_testGetSiteSiteByExternalReferenceCodePageSpecification(layout);
-
-		_layoutLocalService.updateStatus(
-			TestPropsValues.getUserId(), draftLayout.getPlid(),
-			WorkflowConstants.STATUS_DRAFT, serviceContext);
-
-		_testGetSiteSiteByExternalReferenceCodePageSpecification(draftLayout);
-		_testGetSiteSiteByExternalReferenceCodePageSpecification(layout);
-
-		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
-
-		_assertProblemException(draftLayout);
-		_testGetSiteSiteByExternalReferenceCodePageSpecification(layout);
+		_testGetSiteSiteByExternalReferenceCodePageSpecificationWithLayoutWithDraftLayout(
+			_getBasicLayoutPageTemplateEntryLayout(serviceContext),
+			serviceContext);
+		_testGetSiteSiteByExternalReferenceCodePageSpecificationWithLayoutWithDraftLayout(
+			_getDisplayPageLayoutPageTemplateEntryLayout(serviceContext),
+			serviceContext);
+		_testGetSiteSiteByExternalReferenceCodePageSpecificationWithLayoutWithDraftLayout(
+			_getLayoutUtilityPageEntryLayout(serviceContext), serviceContext);
+		_testGetSiteSiteByExternalReferenceCodePageSpecificationWithLayoutWithDraftLayout(
+			_getMasterLayoutPageTemplateEntryLayout(serviceContext),
+			serviceContext);
 	}
 
 	@Ignore
@@ -354,6 +350,86 @@ public class PageSpecificationResourceTest
 		Assert.assertNull(widgetPageSpecification.getWidgetPageSections());
 	}
 
+	private Layout _getBasicLayoutPageTemplateEntryLayout(
+			ServiceContext serviceContext)
+		throws Exception {
+
+		LayoutPageTemplateCollection layoutPageTemplateCollection =
+			_layoutPageTemplateCollectionLocalService.
+				addLayoutPageTemplateCollection(
+					null, TestPropsValues.getUserId(),
+					serviceContext.getScopeGroupId(),
+					LayoutPageTemplateConstants.
+						PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
+					RandomTestUtil.randomString(),
+					RandomTestUtil.randomString(),
+					LayoutPageTemplateCollectionTypeConstants.BASIC,
+					serviceContext);
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
+				null, TestPropsValues.getUserId(),
+				serviceContext.getScopeGroupId(),
+				layoutPageTemplateCollection.
+					getLayoutPageTemplateCollectionId(),
+				RandomTestUtil.randomString(),
+				LayoutPageTemplateEntryTypeConstants.BASIC, 0,
+				WorkflowConstants.STATUS_DRAFT, serviceContext);
+
+		return _layoutLocalService.getLayout(layoutPageTemplateEntry.getPlid());
+	}
+
+	private Layout _getDisplayPageLayoutPageTemplateEntryLayout(
+			ServiceContext serviceContext)
+		throws Exception {
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
+				null, TestPropsValues.getUserId(),
+				serviceContext.getScopeGroupId(),
+				LayoutPageTemplateConstants.
+					PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
+				_portal.getClassNameId(
+					"com.liferay.asset.kernel.model.AssetCategory"),
+				0, RandomTestUtil.randomString(),
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE, 0,
+				WorkflowConstants.STATUS_DRAFT, serviceContext);
+
+		return _layoutLocalService.getLayout(layoutPageTemplateEntry.getPlid());
+	}
+
+	private Layout _getLayoutUtilityPageEntryLayout(
+			ServiceContext serviceContext)
+		throws Exception {
+
+		LayoutUtilityPageEntry layoutUtilityPageEntry =
+			_layoutUtilityPageEntryLocalService.addLayoutUtilityPageEntry(
+				null, TestPropsValues.getUserId(),
+				serviceContext.getScopeGroupId(), 0, 0, false,
+				RandomTestUtil.randomString(),
+				LayoutUtilityPageEntryConstants.TYPE_SC_INTERNAL_SERVER_ERROR,
+				0, serviceContext);
+
+		return _layoutLocalService.getLayout(layoutUtilityPageEntry.getPlid());
+	}
+
+	private Layout _getMasterLayoutPageTemplateEntryLayout(
+			ServiceContext serviceContext)
+		throws Exception {
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
+				null, TestPropsValues.getUserId(),
+				serviceContext.getScopeGroupId(),
+				LayoutPageTemplateConstants.
+					PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
+				RandomTestUtil.randomString(),
+				LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT, 0,
+				WorkflowConstants.STATUS_DRAFT, serviceContext);
+
+		return _layoutLocalService.getLayout(layoutPageTemplateEntry.getPlid());
+	}
+
 	private long _getMasterLayoutPlid(ServiceContext serviceContext)
 		throws Exception {
 
@@ -441,6 +517,36 @@ public class PageSpecificationResourceTest
 		}
 	}
 
+	private void
+			_testGetSiteSiteByExternalReferenceCodePageSpecificationWithLayoutWithDraftLayout(
+				Layout layout, ServiceContext serviceContext)
+		throws Exception {
+
+		_assertProblemException(layout);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		_testGetSiteSiteByExternalReferenceCodePageSpecification(draftLayout);
+
+		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
+
+		_assertProblemException(draftLayout);
+
+		_testGetSiteSiteByExternalReferenceCodePageSpecification(layout);
+
+		_layoutLocalService.updateStatus(
+			TestPropsValues.getUserId(), draftLayout.getPlid(),
+			WorkflowConstants.STATUS_DRAFT, serviceContext);
+
+		_testGetSiteSiteByExternalReferenceCodePageSpecification(draftLayout);
+		_testGetSiteSiteByExternalReferenceCodePageSpecification(layout);
+
+		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
+
+		_assertProblemException(draftLayout);
+		_testGetSiteSiteByExternalReferenceCodePageSpecification(layout);
+	}
+
 	@Inject
 	private JSONFactory _jsonFactory;
 
@@ -448,8 +554,19 @@ public class PageSpecificationResourceTest
 	private LayoutLocalService _layoutLocalService;
 
 	@Inject
+	private LayoutPageTemplateCollectionLocalService
+		_layoutPageTemplateCollectionLocalService;
+
+	@Inject
 	private LayoutPageTemplateEntryLocalService
 		_layoutPageTemplateEntryLocalService;
+
+	@Inject
+	private LayoutUtilityPageEntryLocalService
+		_layoutUtilityPageEntryLocalService;
+
+	@Inject
+	private Portal _portal;
 
 	@Inject
 	private SegmentsExperienceService _segmentsExperienceService;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
@@ -6,10 +6,13 @@
 package com.liferay.headless.admin.site.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.headless.admin.site.client.dto.v1_0.ContentPageSpecification;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageExperience;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageSpecification;
 import com.liferay.headless.admin.site.client.dto.v1_0.Settings;
 import com.liferay.headless.admin.site.client.dto.v1_0.StyleBook;
 import com.liferay.headless.admin.site.client.dto.v1_0.WidgetPageSpecification;
+import com.liferay.headless.admin.site.client.problem.Problem;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
@@ -24,6 +27,7 @@ import com.liferay.portal.kernel.model.Theme;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ThemeLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -33,13 +37,19 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.segments.service.SegmentsExperienceService;
 import com.liferay.style.book.model.StyleBookEntry;
 import com.liferay.style.book.service.StyleBookEntryLocalService;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
 import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -51,27 +61,62 @@ import org.junit.runner.RunWith;
 public class PageSpecificationResourceTest
 	extends BasePageSpecificationResourceTestCase {
 
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
 	@Override
 	@Test
 	public void testGetSiteSiteByExternalReferenceCodePageSpecification()
 		throws Exception {
 
-		_testGetSiteSiteByExternalReferenceCodePageSpecification(_addLayout());
-	}
-
-	private Layout _addLayout() throws Exception {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
 				testGroup.getGroupId(), TestPropsValues.getUserId());
+
+		_testGetSiteSiteByExternalReferenceCodePageSpecification(
+			_addLayout(LayoutConstants.TYPE_PORTLET, serviceContext));
+
+		Layout layout = _addLayout(
+			LayoutConstants.TYPE_CONTENT, serviceContext);
+
+		_assertProblemException(layout);
+		_testGetSiteSiteByExternalReferenceCodePageSpecification(
+			layout.fetchDraftLayout());
+	}
+
+	private Layout _addLayout(String type, ServiceContext serviceContext)
+		throws Exception {
 
 		return _layoutLocalService.addLayout(
 			null, TestPropsValues.getUserId(), testGroup.getGroupId(), false,
 			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID, 0, 0,
 			RandomTestUtil.randomLocaleStringMap(), Collections.emptyMap(),
 			Collections.emptyMap(), Collections.emptyMap(),
-			Collections.emptyMap(), LayoutConstants.TYPE_PORTLET,
-			_getTypeSettings(), false, false, Collections.emptyMap(),
-			_getMasterLayoutPlid(serviceContext), serviceContext);
+			Collections.emptyMap(), type, _getTypeSettings(), false, false,
+			Collections.emptyMap(), _getMasterLayoutPlid(serviceContext),
+			serviceContext);
+	}
+
+	private void _assertContentPageSpecification(
+			ContentPageSpecification contentPageSpecification, Layout layout)
+		throws Exception {
+
+		Assert.assertEquals(
+			PageSpecification.Type.CONTENT_PAGE_SPECIFICATION,
+			contentPageSpecification.getType());
+
+		PageExperience[] pageExperiences =
+			contentPageSpecification.getPageExperiences();
+
+		Assert.assertEquals(
+			Arrays.toString(pageExperiences),
+			_segmentsExperienceService.getSegmentsExperiencesCount(
+				layout.getGroupId(), layout.getPlid(), true),
+			pageExperiences.length);
 	}
 
 	private void _assertPageSpecificationSetting(
@@ -167,6 +212,23 @@ public class PageSpecificationResourceTest
 		}
 	}
 
+	private void _assertProblemException(Layout layout) throws Exception {
+		try {
+			pageSpecificationResource.
+				getSiteSiteByExternalReferenceCodePageSpecification(
+					testGroup.getExternalReferenceCode(),
+					layout.getExternalReferenceCode());
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("BAD_REQUEST", problem.getStatus());
+			Assert.assertNull(problem.getTitle());
+		}
+	}
+
 	private void _assertWidgetPageSpecification(
 		WidgetPageSpecification widgetPageSpecification) {
 
@@ -254,8 +316,14 @@ public class PageSpecificationResourceTest
 				pageSpecification.getStatus());
 		}
 
-		_assertWidgetPageSpecification(
-			(WidgetPageSpecification)pageSpecification);
+		if (layout.isTypeAssetDisplay() || layout.isTypeContent()) {
+			_assertContentPageSpecification(
+				(ContentPageSpecification)pageSpecification, layout);
+		}
+		else {
+			_assertWidgetPageSpecification(
+				(WidgetPageSpecification)pageSpecification);
+		}
 	}
 
 	@Inject
@@ -267,6 +335,9 @@ public class PageSpecificationResourceTest
 	@Inject
 	private LayoutPageTemplateEntryLocalService
 		_layoutPageTemplateEntryLocalService;
+
+	@Inject
+	private SegmentsExperienceService _segmentsExperienceService;
 
 	@Inject
 	private StyleBookEntryLocalService _styleBookEntryLocalService;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
@@ -17,6 +17,7 @@ import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -114,8 +115,28 @@ public class PageSpecificationResourceTest
 			LayoutConstants.TYPE_CONTENT, serviceContext);
 
 		_assertProblemException(layout);
-		_testGetSiteSiteByExternalReferenceCodePageSpecification(
-			layout.fetchDraftLayout());
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		_testGetSiteSiteByExternalReferenceCodePageSpecification(draftLayout);
+
+		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
+
+		_assertProblemException(draftLayout);
+
+		_testGetSiteSiteByExternalReferenceCodePageSpecification(layout);
+
+		_layoutLocalService.updateStatus(
+			TestPropsValues.getUserId(), draftLayout.getPlid(),
+			WorkflowConstants.STATUS_DRAFT, serviceContext);
+
+		_testGetSiteSiteByExternalReferenceCodePageSpecification(draftLayout);
+		_testGetSiteSiteByExternalReferenceCodePageSpecification(layout);
+
+		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
+
+		_assertProblemException(draftLayout);
+		_testGetSiteSiteByExternalReferenceCodePageSpecification(layout);
 	}
 
 	@Ignore

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
@@ -10,22 +10,33 @@ import com.liferay.headless.admin.site.client.dto.v1_0.PageSpecification;
 import com.liferay.headless.admin.site.client.dto.v1_0.Settings;
 import com.liferay.headless.admin.site.client.dto.v1_0.StyleBook;
 import com.liferay.headless.admin.site.client.dto.v1_0.WidgetPageSpecification;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
-import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.ColorScheme;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.Theme;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ThemeLocalService;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.style.book.model.StyleBookEntry;
 import com.liferay.style.book.service.StyleBookEntryLocalService;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -45,8 +56,22 @@ public class PageSpecificationResourceTest
 	public void testGetSiteSiteByExternalReferenceCodePageSpecification()
 		throws Exception {
 
-		_testGetSiteSiteByExternalReferenceCodePageSpecification(
-			LayoutTestUtil.addTypePortletLayout(testGroup));
+		_testGetSiteSiteByExternalReferenceCodePageSpecification(_addLayout());
+	}
+
+	private Layout _addLayout() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				testGroup.getGroupId(), TestPropsValues.getUserId());
+
+		return _layoutLocalService.addLayout(
+			null, TestPropsValues.getUserId(), testGroup.getGroupId(), false,
+			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID, 0, 0,
+			RandomTestUtil.randomLocaleStringMap(), Collections.emptyMap(),
+			Collections.emptyMap(), Collections.emptyMap(),
+			Collections.emptyMap(), LayoutConstants.TYPE_PORTLET,
+			_getTypeSettings(), false, false, Collections.emptyMap(),
+			_getMasterLayoutPlid(serviceContext), serviceContext);
 	}
 
 	private void _assertPageSpecificationSetting(
@@ -152,6 +177,26 @@ public class PageSpecificationResourceTest
 		Assert.assertNull(widgetPageSpecification.getWidgetPageSections());
 	}
 
+	private long _getMasterLayoutPlid(ServiceContext serviceContext)
+		throws Exception {
+
+		if (RandomTestUtil.randomBoolean()) {
+			return 0;
+		}
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
+				null, TestPropsValues.getUserId(),
+				serviceContext.getScopeGroupId(),
+				LayoutPageTemplateConstants.
+					PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
+				RandomTestUtil.randomString(),
+				LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT, 0,
+				WorkflowConstants.STATUS_APPROVED, serviceContext);
+
+		return layoutPageTemplateEntry.getPlid();
+	}
+
 	private UnicodeProperties _getThemeSettingsUnicodeProperties(
 		UnicodeProperties unicodeProperties) {
 
@@ -168,6 +213,18 @@ public class PageSpecificationResourceTest
 		}
 
 		return themeSettingsUnicodeProperties;
+	}
+
+	private String _getTypeSettings() throws Exception {
+		if (RandomTestUtil.randomBoolean()) {
+			return StringPool.BLANK;
+		}
+
+		return UnicodePropertiesBuilder.put(
+			"javascript", RandomTestUtil.randomString()
+		).put(
+			"lfr-theme:regular:show-maximize-minimize-application-links", true
+		).buildString();
 	}
 
 	private void _testGetSiteSiteByExternalReferenceCodePageSpecification(
@@ -203,6 +260,9 @@ public class PageSpecificationResourceTest
 
 	@Inject
 	private JSONFactory _jsonFactory;
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
 
 	@Inject
 	private LayoutPageTemplateEntryLocalService

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
@@ -49,6 +49,7 @@ import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -68,6 +69,35 @@ public class PageSpecificationResourceTest
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
 
+	@Ignore
+	@Override
+	@Test
+	public void testDeleteSiteSiteByExternalReferenceCodePageSpecification()
+		throws Exception {
+
+		super.testDeleteSiteSiteByExternalReferenceCodePageSpecification();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testGetSiteSiteByExternalReferenceCodeDisplayPageTemplatePageSpecificationsPage()
+		throws Exception {
+
+		super.
+			testGetSiteSiteByExternalReferenceCodeDisplayPageTemplatePageSpecificationsPage();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testGetSiteSiteByExternalReferenceCodeMasterPagePageSpecificationsPage()
+		throws Exception {
+
+		super.
+			testGetSiteSiteByExternalReferenceCodeMasterPagePageSpecificationsPage();
+	}
+
 	@Override
 	@Test
 	public void testGetSiteSiteByExternalReferenceCodePageSpecification()
@@ -86,6 +116,63 @@ public class PageSpecificationResourceTest
 		_assertProblemException(layout);
 		_testGetSiteSiteByExternalReferenceCodePageSpecification(
 			layout.fetchDraftLayout());
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testGetSiteSiteByExternalReferenceCodePageTemplatePageSpecificationsPage()
+		throws Exception {
+
+		super.
+			testGetSiteSiteByExternalReferenceCodePageTemplatePageSpecificationsPage();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testGetSiteSiteByExternalReferenceCodeSitePagePageSpecificationsPage()
+		throws Exception {
+
+		super.
+			testGetSiteSiteByExternalReferenceCodeSitePagePageSpecificationsPage();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testGetSiteSiteByExternalReferenceCodeUtilityPagePageSpecificationsPage()
+		throws Exception {
+
+		super.
+			testGetSiteSiteByExternalReferenceCodeUtilityPagePageSpecificationsPage();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testPatchSiteSiteByExternalReferenceCodePageSpecification()
+		throws Exception {
+
+		super.testPatchSiteSiteByExternalReferenceCodePageSpecification();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testPostSiteSiteByExternalReferenceCodePageSpecificationPublish()
+		throws Exception {
+
+		super.testPostSiteSiteByExternalReferenceCodePageSpecificationPublish();
+	}
+
+	@Ignore
+	@Override
+	@Test
+	public void testPutSiteSiteByExternalReferenceCodePageSpecification()
+		throws Exception {
+
+		super.testPutSiteSiteByExternalReferenceCodePageSpecification();
 	}
 
 	private Layout _addLayout(String type, ServiceContext serviceContext)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-41551

Dear reviewer :heart: 

This PR implements the endpoint `/sites/{siteExternalReferenceCode}/page-specifications/{pageSpecificationExternalReferenceCode}` for all types of page specifications, but it will fail for WidgetPageTemplate types because their layout does not belong to the site's group but to a separate group created for that layout. We will address this issue in future PRs.

Thank you!