### PR TITLE
LPD-43562 Fix NullPointerException in LayoutModelListener during upgrade

### DIFF
--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/model/listener/LayoutModelListener.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/model/listener/LayoutModelListener.java
@@ -27,7 +27,6 @@ import com.liferay.site.navigation.model.SiteNavigationMenuItem;
 import com.liferay.site.navigation.service.SiteNavigationMenuItemLocalService;
 import com.liferay.site.navigation.service.SiteNavigationMenuLocalService;
 import com.liferay.site.navigation.type.SiteNavigationMenuItemType;
-import com.liferay.site.navigation.type.SiteNavigationMenuItemTypeRegistry;
 
 import java.util.List;
 import java.util.Objects;
@@ -148,10 +147,6 @@ public class LayoutModelListener extends BaseModelListener<Layout> {
 			return;
 		}
 
-		SiteNavigationMenuItemType siteNavigationMenuItemType =
-			_siteNavigationMenuItemTypeRegistry.getSiteNavigationMenuItemType(
-				SiteNavigationMenuItemTypeConstants.LAYOUT);
-
 		ServiceContext serviceContext =
 			ServiceContextThreadLocal.getServiceContext();
 
@@ -164,7 +159,7 @@ public class LayoutModelListener extends BaseModelListener<Layout> {
 				null, serviceContext.getUserId(), layout.getGroupId(),
 				siteNavigationMenuId, parentSiteNavigationMenuItemId,
 				SiteNavigationMenuItemTypeConstants.LAYOUT,
-				siteNavigationMenuItemType.getTypeSettingsFromLayout(layout),
+				_siteNavigationMenuItemType.getTypeSettingsFromLayout(layout),
 				serviceContext);
 		}
 		catch (PortalException portalException) {
@@ -271,9 +266,10 @@ public class LayoutModelListener extends BaseModelListener<Layout> {
 	private SiteNavigationMenuItemLocalService
 		_siteNavigationMenuItemLocalService;
 
-	@Reference
-	private SiteNavigationMenuItemTypeRegistry
-		_siteNavigationMenuItemTypeRegistry;
+	@Reference(
+		target = "(site.navigation.menu.item.type=" + SiteNavigationMenuItemTypeConstants.LAYOUT + ")"
+	)
+	private SiteNavigationMenuItemType _siteNavigationMenuItemType;
 
 	@Reference
 	private SiteNavigationMenuLocalService _siteNavigationMenuLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-43562

This issue arises when the module component LayoutModelListener executes before another module component, LayoutSiteNavigationMenuItemType, has been activated. By enforcing sequential activation, with LayoutSiteNavigationMenuItemType activating prior to LayoutModelListener, we ensure this timing conflict will not occur. 

While we cannot create a direct test case due to the lack of reproducible steps, **the affected logic is already covered by the test LayoutSiteNavigationMenuItemTypeTest.testAddToAutoMenuTrueToMenu**.