### PR TITLE
LPD-43602 The search field of layout usage is not working

### DIFF
--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/LayoutClassedModelUsagesManagementToolbarDisplayContext.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/LayoutClassedModelUsagesManagementToolbarDisplayContext.java
@@ -31,6 +31,11 @@ public class LayoutClassedModelUsagesManagementToolbarDisplayContext
 	}
 
 	@Override
+	public String getSearchActionURL() {
+		return null;
+	}
+
+	@Override
 	public Boolean isSelectable() {
 		return false;
 	}


### PR DESCRIPTION
> [!Note]
> No tests needed

## Motivation

[LPD-43602](https://liferay.atlassian.net/browse/LPD-43602)

## Changes

In this case the search field of layout usage wasn't implemented so it doesn't make sense to allow the user to look for the elements.

## Steps to reproduce

1. Create a page “Page 1“.
2. Create Basic web content.
3. Add the web content to the Home Page and Page 1 using Content Display.
4. Check the usage of web content, and check that now you can't search.

<img width="1307" alt="image" src="https://github.com/user-attachments/assets/f377f7ab-fd18-4bff-b472-45de8161ce98">


[LPD-43602]: https://liferay.atlassian.net/browse/LPD-43602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ