### PR TITLE
LPD-43433 - FreeMarker syntax error in notifications with fields of related objects

### DIFF
--- a/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/internal/type/EmailNotificationType.java
+++ b/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/internal/type/EmailNotificationType.java
@@ -10,6 +10,7 @@ import com.liferay.account.service.AccountEntryOrganizationRelLocalService;
 import com.liferay.account.service.AccountEntryUserRelLocalService;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.InfoFieldValue;
+import com.liferay.info.field.type.RelationshipInfoFieldType;
 import com.liferay.info.item.InfoItemFieldValues;
 import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
@@ -74,6 +75,7 @@ import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.KeyValuePair;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -595,6 +597,20 @@ public class EmailNotificationType extends BaseNotificationType {
 						PortletDisplayTemplate.DISPLAY_STYLE_PREFIX)) {
 
 					continue;
+				}
+
+				if (Objects.equals(
+						infoField.getInfoFieldType(),
+						RelationshipInfoFieldType.INSTANCE) &&
+					(infoFieldValue.getValue() instanceof KeyValuePair)) {
+
+					KeyValuePair keyValuePair =
+						(KeyValuePair)infoFieldValue.getValue();
+
+					infoFieldValue = new InfoFieldValue<>(
+						infoField,
+						GetterUtil.getObject(
+							keyValuePair.getKey(), StringPool.BLANK));
 				}
 
 				TemplateNode templateNode =

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
@@ -315,7 +315,9 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 		executeNotificationObjectAction(
 			0,
 			_addNotificationTemplate(
-				"${testTemplateContextContributorKey}",
+				"${testTemplateContextContributorKey};\n${.data_model[\"" +
+					"ObjectRelationship#C_ParentObjectDefinition#oneToMany" +
+						"ObjectRelationship_textObjectField\"].getData()}",
 				NotificationTemplateConstants.EDITOR_TYPE_FREEMARKER,
 				Collections.singletonMap(
 					LocaleUtil.US, "[%CURRENT_USER_FIRST_NAME%]"),
@@ -324,7 +326,8 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 					LocaleUtil.US, user1.getEmailAddress())));
 
 		_assertNotificationQueueEntryBody(
-			"testTemplateContextContributorValue");
+			"testTemplateContextContributorValue;\n" +
+				parentObjectEntryValues.get("textObjectField"));
 	}
 
 	@Test

--- a/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
+++ b/modules/apps/notification/notification-test/src/testIntegration/java/com/liferay/notification/internal/type/test/EmailNotificationTypeTest.java
@@ -130,6 +130,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -312,22 +313,71 @@ public class EmailNotificationTypeTest extends BaseNotificationTypeTest {
 	public void testFreeMarkerNotificationTemplateContextContributor()
 		throws Exception {
 
-		executeNotificationObjectAction(
-			0,
-			_addNotificationTemplate(
-				"${testTemplateContextContributorKey};\n${.data_model[\"" +
-					"ObjectRelationship#C_ParentObjectDefinition#oneToMany" +
-						"ObjectRelationship_textObjectField\"].getData()}",
-				NotificationTemplateConstants.EDITOR_TYPE_FREEMARKER,
-				Collections.singletonMap(
-					LocaleUtil.US, "[%CURRENT_USER_FIRST_NAME%]"),
-				false,
-				Collections.singletonMap(
-					LocaleUtil.US, user1.getEmailAddress())));
+		NotificationTemplate notificationTemplate = _addNotificationTemplate(
+			StringBundler.concat(
+				"${testTemplateContextContributorKey};\n${.data_model[\"",
+				"ObjectRelationship#C_ParentObjectDefinition#oneToMany",
+				"ObjectRelationship_textObjectField\"].getData()}\n",
+				"${ObjectField_r_oneToManyObjectRelationship_c_",
+				"parentObjectDefinitionId.getData()}"),
+			NotificationTemplateConstants.EDITOR_TYPE_FREEMARKER,
+			Collections.singletonMap(
+				LocaleUtil.US, "[%CURRENT_USER_FIRST_NAME%]"),
+			false,
+			Collections.singletonMap(LocaleUtil.US, user1.getEmailAddress()));
+
+		ObjectAction objectAction = objectActionLocalService.addObjectAction(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			childObjectDefinition.getObjectDefinitionId(), true,
+			StringPool.BLANK, RandomTestUtil.randomString(),
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			RandomTestUtil.randomString(),
+			ObjectActionExecutorConstants.KEY_NOTIFICATION,
+			ObjectActionTriggerConstants.KEY_ON_AFTER_ADD,
+			UnicodePropertiesBuilder.put(
+				"notificationTemplateId",
+				notificationTemplate.getNotificationTemplateId()
+			).build(),
+			false);
+
+		ObjectEntry parentObjectEntry = objectEntryManager.addObjectEntry(
+			dtoConverterContext, parentObjectDefinition,
+			new ObjectEntry() {
+				{
+					properties = new LinkedHashMap<>(parentObjectEntryValues);
+				}
+			},
+			ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		long parentObjectEntryId = parentObjectEntry.getId();
+
+		ObjectEntry childObjectEntry = objectEntryManager.addObjectEntry(
+			dtoConverterContext, childObjectDefinition,
+			new ObjectEntry() {
+				{
+					properties = HashMapBuilder.putAll(
+						childObjectEntryValues
+					).put(
+						getObjectRelationshipObjectField2Name(),
+						parentObjectEntryId
+					).build();
+				}
+			},
+			group.getGroupKey());
 
 		_assertNotificationQueueEntryBody(
-			"testTemplateContextContributorValue;\n" +
-				parentObjectEntryValues.get("textObjectField"));
+			StringBundler.concat(
+				"testTemplateContextContributorValue;\n",
+				parentObjectEntryValues.get("textObjectField"), "\n",
+				parentObjectEntryId));
+
+		objectActionLocalService.deleteObjectAction(
+			objectAction.getObjectActionId());
+
+		_objectEntryLocalService.deleteObjectEntry(childObjectEntry.getId());
+
+		_objectEntryLocalService.deleteObjectEntry(parentObjectEntryId);
 	}
 
 	@Test

--- a/modules/apps/notification/notification-web/src/main/java/com/liferay/notification/web/internal/portlet/action/NotificationTemplateFTLElementsMVCResourceCommand.java
+++ b/modules/apps/notification/notification-web/src/main/java/com/liferay/notification/web/internal/portlet/action/NotificationTemplateFTLElementsMVCResourceCommand.java
@@ -168,6 +168,11 @@ public class NotificationTemplateFTLElementsMVCResourceCommand
 					String content = (String)jsonObject.get("name");
 
 					if (infoField) {
+						if (content.contains(StringPool.POUND)) {
+							content = StringBundler.concat(
+								".data_model[\"", content, "\"]");
+						}
+
 						content = StringBundler.concat(
 							"${", content, ".getData()}");
 					}


### PR DESCRIPTION
### Already evaluated and approved original PR from [bpm](https://github.com/liferay-bpm/liferay-portal/pull/3946)

Ticket: https://liferay.atlassian.net/browse/LPD-43433

### Motivation


The user wants to create an email notification template using FreeMarker as editor 
to populate the email with data from a parent Object of an One to Many relationship.

### Proposed Solution

In the construction of the namespace for related fields, we replace the pound `#` symbol for 
underlines `_` to avoid a parser error with FreeMarker. This approach impacts the `FragmentEntryLink` table 
as it saves this value in its `editableValues` column. To maintain the integrity of current clients, we propose an upgrade process to update this value.

### Testing

To test the FreeMarker scenario, you can follow the instructions described in the ticket.
To test the scenario affected by the upgrade to the `FragmentEntryLink` table, follow these steps:

1. Edit a Portal Page adding a Collection Display;
2. Select a collection provider from a Custom Object that is a child of a One to Many relationship;
3. Add a Heading to the Collection Display;
4. Map the Heading to a field of the parent Object;

Without the upgrade, the Heading would not be able to render its correct value after the changes proposed 
in this PR.

### Request help

If you feel its necessary to amplify this solution to other tables you may think that would also be affected,  please let me know.
