### PR TITLE
LPD-44231 Clean inline styles in fragment module to support style-src '[NONCE]' directive

### DIFF
--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/external-video/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/external-video/index.html
@@ -1,4 +1,11 @@
-<div style="display: flex; justify-content: ${configuration.align};">
+[@liferay_aui.style]
+	.external-video {
+		display: flex;
+		justify-content: ${configuration.align};
+	}
+[/@]
+
+<div class="external-video">
 	<div class="aspect-ratio aspect-ratio-16-to-9 video">
 		<div class="alert alert-info error-message" hidden role="alert">
 			<p>Please enter a valid video URL.</p>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/video/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/video/index.html
@@ -1,4 +1,11 @@
-<div style="display: flex; justify-content: ${configuration.align};">
+[@liferay_aui.style]
+	.video-url {
+		display: flex;
+		justify-content: ${configuration.align};
+	}
+[/@]
+
+<div class="video-url">
 	<div class="video">
 		<div class="alert alert-info error-message" hidden role="alert">
 			<p>Please enter a valid video URL.</p>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/rich-text-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/rich-text-input/index.html
@@ -2,6 +2,12 @@
 	showLabel = input.showLabel && input.label?has_content && (layoutMode == "edit" || input.readOnly)
 ]
 
+[@liferay_aui.style]
+	.cke-height {
+		height: 200px
+	}
+[/@]
+
 <div class="rich-text-input [#if !input.showLabel || !input.label?has_content]rich-text-input--hidden-label[/#if]">
 	<div class="form-group [#if input.errorMessage?has_content]has-error[/#if] mb-0">
 		<label class="[#if !showLabel]sr-only[/#if]" data-localizable="${input.localizable?string('true', 'false')}" id="${fragmentEntryLinkNamespace}-rich-text-input-label">
@@ -108,7 +114,7 @@
 							</div>
 						</div>
 
-					<div class="cke_contents cke_editable" style="height: 200px"></div>
+					<div class="cke_contents cke_editable cke-height"></div>
 					</div>
 				</div>
 			</div>

--- a/modules/apps/fragment/fragment-collection-filter-tags/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/fragment/fragment-collection-filter-tags/src/main/resources/META-INF/resources/init.jsp
@@ -7,7 +7,8 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
-<%@ taglib uri="http://liferay.com/tld/react" prefix="react" %>
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/react" prefix="react" %>
 
 <%@ page import="com.liferay.fragment.collection.filter.tags.display.context.FragmentCollectionFilterTagsDisplayContext" %>
 

--- a/modules/apps/fragment/fragment-collection-filter-tags/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/fragment/fragment-collection-filter-tags/src/main/resources/META-INF/resources/page.jsp
@@ -7,13 +7,19 @@
 
 <%@ include file="/init.jsp" %>
 
+<aui:style>
+	.tag-filter-input {
+		min-height: 2.125rem;
+	}
+</aui:style>
+
 <div class="form-group form-group-sm mb-0">
 	<div role="presentation">
 		<label class="control-label <%= fragmentCollectionFilterTagsDisplayContext.isShowLabel() ? "" : "sr-only" %>">
 			<%= fragmentCollectionFilterTagsDisplayContext.getLabel() %>
 		</label>
 
-		<input class="form-control form-control-select form-control-sm w-100" style="min-height: 2.125rem;" type="text" />
+		<input class="form-control form-control-select form-control-sm tag-filter-input w-100" type="text" />
 
 		<c:choose>
 			<c:when test="<%= fragmentCollectionFilterTagsDisplayContext.isShowHelpText() %>">

--- a/modules/apps/fragment/fragment-renderer-collection-filter-impl/src/main/resources/META-INF/resources/applied_filters.jsp
+++ b/modules/apps/fragment/fragment-renderer-collection-filter-impl/src/main/resources/META-INF/resources/applied_filters.jsp
@@ -13,8 +13,14 @@ CollectionAppliedFiltersFragmentRendererDisplayContext collectionAppliedFiltersF
 List<Map<String, String>> appliedFilters = collectionAppliedFiltersFragmentRendererDisplayContext.getAppliedFilters();
 %>
 
+<aui:style type="text/css">
+	.applied-filters-show-more-button {
+		line-height: 1.3125;
+	}
+</aui:style>
+
 <div class="align-items-sm-start align-items-stretch d-flex flex-column flex-sm-row py-1" id="<%= collectionAppliedFiltersFragmentRendererDisplayContext.getFragmentEntryLinkNamespace() %>">
-	<div class="flex-grow-1 overflow-hidden" id="<%= collectionAppliedFiltersFragmentRendererDisplayContext.getFragmentEntryLinkNamespace() %>_filterList" style="max-height: 4em;">
+	<div class="flex-grow-1 overflow-hidden" id="<%= collectionAppliedFiltersFragmentRendererDisplayContext.getFragmentEntryLinkNamespace() %>_filterList">
 		<c:choose>
 			<c:when test="<%= appliedFilters.isEmpty() && collectionAppliedFiltersFragmentRendererDisplayContext.isEditMode() %>">
 				<span class="text-secondary">
@@ -52,12 +58,11 @@ List<Map<String, String>> appliedFilters = collectionAppliedFiltersFragmentRende
 
 	<div class="d-flex flex-grow-1 flex-shrink-0 flex-sm-column-reverse flex-sm-grow-0 justify-content-between justify-content-sm-start ml-sm-2 mt-2 mt-sm-0">
 		<clay:button
-			cssClass="border-0 btn btn-link btn-sm d-none flex-shrink-0 mt-0 mt-sm-2 p-0 text-right text-secondary"
+			cssClass="applied-filters-show-more-button border-0 btn btn-link btn-sm d-none flex-shrink-0 mt-0 mt-sm-2 p-0 text-right text-secondary"
 			data-show-less-label='<%= LanguageUtil.get(request, "show-less") %>'
 			data-show-more-label='<%= LanguageUtil.get(request, "show-more") %>'
 			displayType="secondary"
 			id='<%= collectionAppliedFiltersFragmentRendererDisplayContext.getFragmentEntryLinkNamespace() + "_toggleExpand" %>'
-			style="line-height: 1.3125;"
 		>
 			<span class="inline-item-expand">
 				<liferay-ui:message key="show-more" />

--- a/modules/apps/fragment/fragment-renderer-collection-filter-impl/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/fragment/fragment-renderer-collection-filter-impl/src/main/resources/META-INF/resources/init.jsp
@@ -9,7 +9,8 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>


### PR DESCRIPTION
## Motivation

[LPD-44231](https://liferay.atlassian.net/browse/LPD-44231)

## Changes

Remove inline styles, so customers can define Content Security Policies with a restrictive directive.
In general, inline (those included inside an HTML tag) style attributes are discouraged when implementing CSPs → [CSP: style-src - HTTP | MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src#unsafe_inline_styles) so the goal of this epic is to extract all inline styles ingrained in the modiules' code to their own CSS files or, if that’s not possible, to an <aui:style> tag at the very least, so that it contains a CSP nonce attribute when rendered.

[Documentation](https://liferay.atlassian.net/wiki/spaces/ENGFRONTENDINFRA/pages/3222143001/LPD-18227+-+Ensure+the+support+of+CSP+directives+script-src+script-src-attr+style-src#Implementation)


[LPD-44230]: https://liferay.atlassian.net/browse/LPD-44230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LPD-44231]: https://liferay.atlassian.net/browse/LPD-44231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ