### PR TITLE
LPD-44634 Clean inline styles to support style-src '[NONCE]' directive

### DIFF
--- a/modules/apps/nested-portlets/nested-portlets-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/nested-portlets/nested-portlets-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -43,8 +43,14 @@
 							<label>
 								<aui:input checked="<%= layoutTemplateId.equals(layoutTemplate.getLayoutTemplateId()) %>" label="" name="preferences--layoutTemplateId--" type="radio" value="<%= layoutTemplate.getLayoutTemplateId() %>" />
 
+								<aui:style>
+									.card-background-image-<%= layoutTemplate.getLayoutTemplateId() %> {
+										background-image: url('<%= layoutTemplate.getStaticResourcePath() + HtmlUtil.escapeAttribute(layoutTemplate.getThumbnailPath()) %>') !important;
+									}
+								</aui:style>
+
 								<div class="card">
-									<div class="aspect-ratio aspect-ratio-bg-cover" style="background-image: url('<%= layoutTemplate.getStaticResourcePath() + HtmlUtil.escapeAttribute(layoutTemplate.getThumbnailPath()) %>');">
+									<div class="aspect-ratio aspect-ratio-bg-cover card-background-image-<%= layoutTemplate.getLayoutTemplateId() %>">
 									</div>
 
 									<div class="card-body">

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/color_picker_input.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/color_picker_input.jsp
@@ -23,7 +23,7 @@ String name = ParamUtil.getString(request, "name");
 			<div class="clay-color input-group">
 				<div class="input-group-item input-group-item-shrink input-group-prepend">
 					<div class="input-group-text">
-						<button class="btn clay-color-btn dropdown-toggle" style="border-width: 0px; height: 28px; width: 28px;" title="<%= color %>" type="button" />
+						<button class="btn clay-color-btn clay-color-btn-bordered dropdown-toggle" title="<%= color %>" type="button" />
 					</div>
 				</div>
 


### PR DESCRIPTION
## Motivation

[LPD-44634](https://liferay.atlassian.net/browse/LPD-44634)

## Changes

Remove inline styles, so customers can define Content Security Policies with a restrictive directive.
In general, inline (those included inside an HTML tag) style attributes are discouraged when implementing CSPs → [CSP: style-src - HTTP | MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src#unsafe_inline_styles) so the goal of this epic is to extract all inline styles ingrained in the modiules' code to their own CSS files or, if that’s not possible, to an <aui:style> tag at the very least, so that it contains a CSP nonce attribute when rendered.

[Documentation](https://liferay.atlassian.net/wiki/spaces/ENGFRONTENDINFRA/pages/3222143001/LPD-18227+-+Ensure+the+support+of+CSP+directives+script-src+script-src-attr+style-src#Implementation)



[LPD-44634]: https://liferay.atlassian.net/browse/LPD-44634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ