### PR TITLE
LPD-45712 Removes smoke tests for all DB versions from acceptance and…

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -3078,16 +3078,10 @@
         #functional-tomcat-mysql57,\
         functional-smoke-jboss74-mysql57,\
         functional-smoke-tomcat90-mariadb102,\
-        functional-smoke-tomcat90-mysql57,\
         functional-smoke-tomcat90-mysql57-jdk17_zulu,\
         functional-smoke-tomcat90-mysql80,\
-        functional-smoke-tomcat90-postgresql121,\
-        functional-smoke-tomcat90-postgresql134,\
-        functional-smoke-tomcat90-postgresql144,\
-        functional-smoke-tomcat90-postgresql153,\
         functional-smoke-tomcat90-postgresql163,\
         functional-smoke-weblogic141-mysql57,\
-        functional-smoke-wildfly261-mariadb104,\
         functional-smoke-wildfly261-mariadb106,\
         functional-tomcat90-hypersonic20,\
         functional-tomcat90-mariadb102,\
@@ -3148,11 +3142,8 @@
 
     test.batch.names[acceptance-dxp]=\
         ${test.batch.names[acceptance-ce]},\
-        functional-smoke-tomcat90-db2111,\
         functional-smoke-tomcat90-db2115,\
         functional-smoke-tomcat90-oracle193,\
-        functional-smoke-tomcat90-sqlserver2017,\
-        functional-smoke-tomcat90-sqlserver2019,\
         functional-smoke-tomcat90-sqlserver2022,\
         functional-tomcat90-db2111,\
         functional-tomcat90-oracle193,\


### PR DESCRIPTION
… keep only the latest one, since we are already executing those tests on portal-release-acceptance