### PR TITLE
LPD-46225 Add the deprecation feature flag to Widget Setting Scope in dropdown

### DIFF
--- a/modules/apps/application-list/application-list-taglib/build.gradle
+++ b/modules/apps/application-list/application-list-taglib/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	compileOnly project(":apps:application-list:application-list-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")

--- a/modules/apps/application-list/application-list-taglib/package.json
+++ b/modules/apps/application-list/application-list-taglib/package.json
@@ -1,4 +1,10 @@
 {
+	"dependencies": {
+		"@clayui/badge": "3.111.0",
+		"@clayui/button": "3.116.0",
+		"@clayui/drop-down": "3.124.0",
+		"react": "18.2.0"
+	},
 	"main": "js/index.ts",
 	"name": "@liferay/application-list-taglib",
 	"scripts": {

--- a/modules/apps/application-list/application-list-taglib/src/main/java/com/liferay/application/list/taglib/internal/display/context/ContentPanelCategoryDisplayContext.java
+++ b/modules/apps/application-list/application-list-taglib/src/main/java/com/liferay/application/list/taglib/internal/display/context/ContentPanelCategoryDisplayContext.java
@@ -101,6 +101,7 @@ public class ContentPanelCategoryDisplayContext {
 
 			dropdownItems.add(
 				dropdownItem -> {
+					dropdownItem.setDeprecated(true);
 					dropdownItem.setHref(layoutItemPortletURL);
 					dropdownItem.setLabel(
 						LanguageUtil.get(

--- a/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/js/ScopeDropdown.tsx
+++ b/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/js/ScopeDropdown.tsx
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayBadge from '@clayui/badge';
+import {ClayButtonWithIcon} from '@clayui/button';
+import ClayDropDown from '@clayui/drop-down';
+import React from 'react';
+
+interface ScopeDropdownItem {
+	deprecated?: boolean;
+	href?: string;
+	label: string;
+}
+
+interface ScopeDropdownProps {
+	items: ScopeDropdownItem[];
+}
+
+export default function ScopeDropdown({
+	items,
+}: ScopeDropdownProps): JSX.Element {
+	return (
+		<ClayDropDown
+			closeOnClick
+			items={items}
+			trigger={
+				<ClayButtonWithIcon
+					aria-label={Liferay.Util.sub(
+						Liferay.Language.get('choose-x'),
+						Liferay.Language.get('scope')
+					)}
+					borderless={true}
+					className="text-light"
+					displayType="secondary"
+					monospaced={true}
+					symbol="cog"
+					title={Liferay.Util.sub(
+						Liferay.Language.get('choose-x'),
+						Liferay.Language.get('scope')
+					)}
+				/>
+			}
+		>
+			{(item: ScopeDropdownItem) => (
+				<ClayDropDown.Item href={item.href}>
+					{item.label}
+
+					{item.deprecated && (
+						<ClayBadge
+							className="c-ml-2 text-uppercase"
+							displayType="warning"
+							label="deprecated"
+							translucent
+						/>
+					)}
+				</ClayDropDown.Item>
+			)}
+		</ClayDropDown>
+	);
+}

--- a/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/js/index.ts
@@ -4,3 +4,4 @@
  */
 
 export {default as PanelKeyboardHandler} from './PanelKeyboardHandler';
+export {default as ScopeDropdown} from './ScopeDropdown';

--- a/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/panel/init.jsp
+++ b/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/panel/init.jsp
@@ -6,3 +6,7 @@
 --%>
 
 <%@ include file="/init.jsp" %>
+
+<%@ taglib uri="http://liferay.com/tld/react" prefix="react" %>
+
+<%@ page import="com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil" %>

--- a/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/panel/page.jsp
+++ b/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/panel/page.jsp
@@ -71,7 +71,7 @@ PanelCategoryHelper panelCategoryHelper = new PanelCategoryHelper(panelAppRegist
 
 						<div class="collapse <%= active ? "show" : StringPool.BLANK %>" id="<%= id %>">
 							<div class="list-group-item">
-								<c:if test="<%= childPanelCategory.isAllowScopeLayouts() %>">
+								<c:if test='<%= FeatureFlagManagerUtil.isEnabled("LPD-11131") && childPanelCategory.isAllowScopeLayouts() %>'>
 
 									<%
 									Group curSite = themeDisplay.getSiteGroup();
@@ -109,14 +109,16 @@ PanelCategoryHelper panelCategoryHelper = new PanelCategoryHelper(panelAppRegist
 												%>
 
 												<clay:content-col>
-													<clay:dropdown-menu
-														borderless="<%= true %>"
-														cssClass="text-light"
-														displayType="secondary"
-														dropdownItems="<%= contentPanelCategoryDisplayContext.getScopesDropdownItemList() %>"
-														icon="cog"
-														monospaced="<%= true %>"
-													/>
+													<div>
+														<react:component
+															module="{ScopeDropdown} from application-list-taglib"
+															props='<%=
+																HashMapBuilder.<String, Object>put(
+																	"items", contentPanelCategoryDisplayContext.getScopesDropdownItemList()
+																).build()
+															%>'
+														/>
+													</div>
 												</clay:content-col>
 											</clay:content-row>
 										</div>

--- a/modules/test/playwright/tests/layout-content-page-editor-web/widgets.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/widgets.spec.ts
@@ -13,6 +13,7 @@ import {loginTest} from '../../fixtures/loginTest';
 import {masterPagesPagesTest} from '../../fixtures/masterPagesPagesTest';
 import {pageEditorPagesTest} from '../../fixtures/pageEditorPagesTest';
 import {pageManagementSiteTest} from '../../fixtures/pageManagementSiteTest';
+import {productMenuPageTest} from '../../fixtures/productMenuPageTest';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../utils/getRandomString';
 import {performLogout} from '../../utils/performLogin';
@@ -34,7 +35,8 @@ const test = mergeTests(
 	loginTest(),
 	masterPagesPagesTest,
 	pageEditorPagesTest,
-	pageManagementSiteTest
+	pageManagementSiteTest,
+	productMenuPageTest
 );
 
 test(
@@ -448,5 +450,74 @@ test(
 				)
 				.first()
 		).toBeVisible();
+	}
+);
+
+test(
+	'Check that the scope dropdown in Product Menu have the deprecation badge and that the page is set as scope',
+	{
+		tag: ['@LPD-46225'],
+	},
+	async ({apiHelpers, page, pageEditorPage, productMenuPage, site}) => {
+
+		// Create a page with a Web Content Display Widget
+
+		const widgetId = getRandomString();
+
+		const widgetDefinition = getWidgetDefinition({
+			id: widgetId,
+			widgetName:
+				'com_liferay_journal_content_web_portlet_JournalContentPortlet',
+		});
+
+		const layoutTitle = getRandomString();
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([widgetDefinition]),
+			siteId: site.id,
+			title: layoutTitle,
+		});
+
+		// Access to the widget configuration
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.goToWidgetConfiguration(widgetId);
+
+		// Create a new scope and publish the page
+
+		const configurationIFrame = page.frameLocator(
+			'iframe[title="Configuration"]'
+		);
+
+		await configurationIFrame.getByRole('link', {name: 'Scope'}).click();
+
+		await configurationIFrame
+			.getByLabel('Scope', {exact: true})
+			.selectOption(layoutTitle + ' (Create New)');
+
+		await configurationIFrame.getByRole('button', {name: 'Save'}).click();
+
+		await page.getByLabel('close', {exact: true}).click();
+
+		await pageEditorPage.publishPage();
+
+		// Check the label in the dropdown at the Product Menu
+
+		await productMenuPage.openProductMenuButton.click();
+
+		await productMenuPage.contentAndDataButton.click();
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page.getByRole('menuitem', {
+				name: layoutTitle + ' deprecated',
+			}),
+			trigger: page.getByLabel('Choose Scope'),
+		});
+
+		// Check that the page is set as scope
+
+		await expect(page.getByText(layoutTitle + ' (Scope)')).toBeVisible();
 	}
 );


### PR DESCRIPTION
> [!NOTE]
> Activate the Feature Flag: LPD-11131

## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPD-46225)

### Changes

Replace the existent dropdown with a new component to add the deprecation label when the items are deprecated.

## How to test it:

- Create a page
- Add a Web Content Display widget
- Go to the configuration
- Check the scope tag
- Create a new scope based on the page using the selector and save
- Go to the Product Menu and go to Content & Data
- Click on the 'cog' button
- Check that the label appears and that the dropdown works as expected

https://github.com/user-attachments/assets/e742e236-f50e-419a-9bca-65d5586b9e60
