### PR TITLE
LPD-49245

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -1980,17 +1980,16 @@ public class ContentPageEditorDisplayContext {
 	}
 
 	private boolean _isSegmentsExperimentVariant() {
-		long segmentsExperienceId = getSegmentsExperienceId();
-
 		SegmentsExperience segmentsExperience =
 			segmentsExperienceLocalService.fetchSegmentsExperience(
-				segmentsExperienceId);
+				getSegmentsExperienceId());
 
 		if ((segmentsExperience != null) && !segmentsExperience.isActive()) {
 			List<SegmentsExperimentRel> segmentsExperimentRels =
 				_segmentsExperimentRelLocalService.
-					getSegmentsExperimentRelsBySegmentsExperienceId(
-						segmentsExperienceId);
+					getSegmentsExperimentRelsBySegmentsExperienceKey(
+						segmentsExperience.getSegmentsExperienceKey(),
+						themeDisplay.getPlid());
 
 			if (ListUtil.isNotEmpty(segmentsExperimentRels)) {
 				return true;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageLayoutEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageLayoutEditorDisplayContext.java
@@ -355,8 +355,9 @@ public class ContentPageLayoutEditorDisplayContext
 		if (segmentsExperience != null) {
 			List<SegmentsExperimentRel> segmentsExperimentRels =
 				_segmentsExperimentRelLocalService.
-					getSegmentsExperimentRelsBySegmentsExperienceId(
-						segmentsExperience.getSegmentsExperienceId());
+					getSegmentsExperimentRelsBySegmentsExperienceKey(
+						segmentsExperience.getSegmentsExperienceKey(),
+						themeDisplay.getPlid());
 
 			if (segmentsExperimentRels.isEmpty()) {
 				return false;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/segments/SegmentsExperienceUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/segments/SegmentsExperienceUtil.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.segments.constants.SegmentsExperimentConstants;
 import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.model.SegmentsExperiment;
+import com.liferay.segments.service.SegmentsExperienceLocalServiceUtil;
 import com.liferay.segments.service.SegmentsExperienceServiceUtil;
 import com.liferay.segments.service.SegmentsExperimentLocalServiceUtil;
 
@@ -308,9 +309,13 @@ public class SegmentsExperienceUtil {
 		Layout layout = LayoutLocalServiceUtil.getLayout(
 			draftLayout.getClassPK());
 
+		SegmentsExperience segmentsExperience =
+			SegmentsExperienceLocalServiceUtil.fetchSegmentsExperience(
+				segmentsExperienceId);
+
 		return SegmentsExperimentLocalServiceUtil.fetchSegmentsExperiment(
-			themeDisplay.getScopeGroupId(), segmentsExperienceId,
-			layout.getPlid());
+			themeDisplay.getScopeGroupId(),
+			segmentsExperience.getSegmentsExperienceKey(), layout.getPlid());
 	}
 
 	private static String _getSegmentsExperimentURL(
@@ -381,7 +386,8 @@ public class SegmentsExperienceUtil {
 
 			SegmentsExperiment segmentsExperiment =
 				SegmentsExperimentLocalServiceUtil.fetchSegmentsExperiment(
-					groupId, sourceSegmentsExperience.getSegmentsExperienceId(),
+					groupId,
+					sourceSegmentsExperience.getSegmentsExperienceKey(),
 					segmentsExperimentPlid);
 
 			if (Validator.isNull(

--- a/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/struts/GetLayoutReportsDataStrutsAction.java
+++ b/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/struts/GetLayoutReportsDataStrutsAction.java
@@ -154,12 +154,13 @@ public class GetLayoutReportsDataStrutsAction implements StrutsAction {
 	}
 
 	private SegmentsExperience _getParentSegmentsExperience(
-		SegmentsExperience segmentsExperience) {
+		SegmentsExperience segmentsExperience, ThemeDisplay themeDisplay) {
 
 		List<SegmentsExperimentRel> segmentsExperimentRels =
 			_segmentsExperimentRelLocalService.
-				getSegmentsExperimentRelsBySegmentsExperienceId(
-					segmentsExperience.getSegmentsExperienceId());
+				getSegmentsExperimentRelsBySegmentsExperienceKey(
+					segmentsExperience.getSegmentsExperienceKey(),
+					themeDisplay.getPlid());
 
 		if (segmentsExperimentRels.isEmpty()) {
 			return null;
@@ -321,7 +322,7 @@ public class GetLayoutReportsDataStrutsAction implements StrutsAction {
 		SegmentsExperience segmentsExperience, ThemeDisplay themeDisplay) {
 
 		SegmentsExperience parentSegmentsExperience =
-			_getParentSegmentsExperience(segmentsExperience);
+			_getParentSegmentsExperience(segmentsExperience, themeDisplay);
 
 		if (parentSegmentsExperience != null) {
 			segmentsExperience = parentSegmentsExperience;

--- a/modules/apps/segments/segments-api/bnd.bnd
+++ b/modules/apps/segments/segments-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Segments API
 Bundle-SymbolicName: com.liferay.segments.api
-Bundle-Version: 27.1.0
+Bundle-Version: 28.0.0
 Export-Package:\
 	com.liferay.segments,\
 	com.liferay.segments.configuration,\

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentLocalService.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentLocalService.java
@@ -125,7 +125,7 @@ public interface SegmentsExperimentLocalService
 		throws PortalException;
 
 	public SegmentsExperiment deleteSegmentsExperiment(
-			long groupId, long segmentsExperienceId, long plid)
+			long groupId, String segmentsExperienceKey, long plid)
 		throws PortalException;
 
 	/**
@@ -228,11 +228,11 @@ public interface SegmentsExperimentLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public SegmentsExperiment fetchSegmentsExperiment(
-		long groupId, long segmentsExperienceId, long plid);
+		long groupId, String segmentsExperimentKey);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public SegmentsExperiment fetchSegmentsExperiment(
-		long groupId, String segmentsExperimentKey);
+		long groupId, String segmentsExperienceKey, long plid);
 
 	/**
 	 * Returns the segments experiment matching the UUID and group.

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentLocalServiceUtil.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentLocalServiceUtil.java
@@ -115,11 +115,11 @@ public class SegmentsExperimentLocalServiceUtil {
 	}
 
 	public static SegmentsExperiment deleteSegmentsExperiment(
-			long groupId, long segmentsExperienceId, long plid)
+			long groupId, String segmentsExperienceKey, long plid)
 		throws PortalException {
 
 		return getService().deleteSegmentsExperiment(
-			groupId, segmentsExperienceId, plid);
+			groupId, segmentsExperienceKey, plid);
 	}
 
 	/**
@@ -239,17 +239,17 @@ public class SegmentsExperimentLocalServiceUtil {
 	}
 
 	public static SegmentsExperiment fetchSegmentsExperiment(
-		long groupId, long segmentsExperienceId, long plid) {
-
-		return getService().fetchSegmentsExperiment(
-			groupId, segmentsExperienceId, plid);
-	}
-
-	public static SegmentsExperiment fetchSegmentsExperiment(
 		long groupId, String segmentsExperimentKey) {
 
 		return getService().fetchSegmentsExperiment(
 			groupId, segmentsExperimentKey);
+	}
+
+	public static SegmentsExperiment fetchSegmentsExperiment(
+		long groupId, String segmentsExperienceKey, long plid) {
+
+		return getService().fetchSegmentsExperiment(
+			groupId, segmentsExperienceKey, plid);
 	}
 
 	/**

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentLocalServiceWrapper.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentLocalServiceWrapper.java
@@ -122,11 +122,11 @@ public class SegmentsExperimentLocalServiceWrapper
 
 	@Override
 	public SegmentsExperiment deleteSegmentsExperiment(
-			long groupId, long segmentsExperienceId, long plid)
+			long groupId, String segmentsExperienceKey, long plid)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _segmentsExperimentLocalService.deleteSegmentsExperiment(
-			groupId, segmentsExperienceId, plid);
+			groupId, segmentsExperienceKey, plid);
 	}
 
 	/**
@@ -271,18 +271,18 @@ public class SegmentsExperimentLocalServiceWrapper
 
 	@Override
 	public SegmentsExperiment fetchSegmentsExperiment(
-		long groupId, long segmentsExperienceId, long plid) {
-
-		return _segmentsExperimentLocalService.fetchSegmentsExperiment(
-			groupId, segmentsExperienceId, plid);
-	}
-
-	@Override
-	public SegmentsExperiment fetchSegmentsExperiment(
 		long groupId, String segmentsExperimentKey) {
 
 		return _segmentsExperimentLocalService.fetchSegmentsExperiment(
 			groupId, segmentsExperimentKey);
+	}
+
+	@Override
+	public SegmentsExperiment fetchSegmentsExperiment(
+		long groupId, String segmentsExperienceKey, long plid) {
+
+		return _segmentsExperimentLocalService.fetchSegmentsExperiment(
+			groupId, segmentsExperienceKey, plid);
 	}
 
 	/**

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentRelLocalService.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentRelLocalService.java
@@ -221,7 +221,7 @@ public interface SegmentsExperimentRelLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public SegmentsExperimentRel fetchSegmentsExperimentRel(
-		long segmentsExperimentId, long segmentsExperienceId);
+		long segmentsExperimentId, String segmentsExperienceKey);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ActionableDynamicQuery getActionableDynamicQuery();
@@ -258,7 +258,7 @@ public interface SegmentsExperimentRelLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public SegmentsExperimentRel getSegmentsExperimentRel(
-			long segmentsExperimentId, long segmentsExperienceId)
+			long segmentsExperimentId, String segmentsExperienceKey)
 		throws PortalException;
 
 	/**
@@ -282,8 +282,8 @@ public interface SegmentsExperimentRelLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<SegmentsExperimentRel>
-		getSegmentsExperimentRelsBySegmentsExperienceId(
-			long segmentsExperienceId);
+		getSegmentsExperimentRelsBySegmentsExperienceKey(
+			String segmentsExperienceKey, long plid);
 
 	/**
 	 * Returns the number of segments experiment rels.

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentRelLocalServiceUtil.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentRelLocalServiceUtil.java
@@ -237,10 +237,10 @@ public class SegmentsExperimentRelLocalServiceUtil {
 	}
 
 	public static SegmentsExperimentRel fetchSegmentsExperimentRel(
-		long segmentsExperimentId, long segmentsExperienceId) {
+		long segmentsExperimentId, String segmentsExperienceKey) {
 
 		return getService().fetchSegmentsExperimentRel(
-			segmentsExperimentId, segmentsExperienceId);
+			segmentsExperimentId, segmentsExperienceKey);
 	}
 
 	public static com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery
@@ -289,11 +289,11 @@ public class SegmentsExperimentRelLocalServiceUtil {
 	}
 
 	public static SegmentsExperimentRel getSegmentsExperimentRel(
-			long segmentsExperimentId, long segmentsExperienceId)
+			long segmentsExperimentId, String segmentsExperienceKey)
 		throws PortalException {
 
 		return getService().getSegmentsExperimentRel(
-			segmentsExperimentId, segmentsExperienceId);
+			segmentsExperimentId, segmentsExperienceKey);
 	}
 
 	/**
@@ -320,11 +320,11 @@ public class SegmentsExperimentRelLocalServiceUtil {
 	}
 
 	public static List<SegmentsExperimentRel>
-		getSegmentsExperimentRelsBySegmentsExperienceId(
-			long segmentsExperienceId) {
+		getSegmentsExperimentRelsBySegmentsExperienceKey(
+			String segmentsExperienceKey, long plid) {
 
-		return getService().getSegmentsExperimentRelsBySegmentsExperienceId(
-			segmentsExperienceId);
+		return getService().getSegmentsExperimentRelsBySegmentsExperienceKey(
+			segmentsExperienceKey, plid);
 	}
 
 	/**

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentRelLocalServiceWrapper.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentRelLocalServiceWrapper.java
@@ -269,10 +269,10 @@ public class SegmentsExperimentRelLocalServiceWrapper
 
 	@Override
 	public SegmentsExperimentRel fetchSegmentsExperimentRel(
-		long segmentsExperimentId, long segmentsExperienceId) {
+		long segmentsExperimentId, String segmentsExperienceKey) {
 
 		return _segmentsExperimentRelLocalService.fetchSegmentsExperimentRel(
-			segmentsExperimentId, segmentsExperienceId);
+			segmentsExperimentId, segmentsExperienceKey);
 	}
 
 	@Override
@@ -330,11 +330,11 @@ public class SegmentsExperimentRelLocalServiceWrapper
 
 	@Override
 	public SegmentsExperimentRel getSegmentsExperimentRel(
-			long segmentsExperimentId, long segmentsExperienceId)
+			long segmentsExperimentId, String segmentsExperienceKey)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _segmentsExperimentRelLocalService.getSegmentsExperimentRel(
-			segmentsExperimentId, segmentsExperienceId);
+			segmentsExperimentId, segmentsExperienceKey);
 	}
 
 	/**
@@ -366,12 +366,12 @@ public class SegmentsExperimentRelLocalServiceWrapper
 
 	@Override
 	public java.util.List<SegmentsExperimentRel>
-		getSegmentsExperimentRelsBySegmentsExperienceId(
-			long segmentsExperienceId) {
+		getSegmentsExperimentRelsBySegmentsExperienceKey(
+			String segmentsExperienceKey, long plid) {
 
 		return _segmentsExperimentRelLocalService.
-			getSegmentsExperimentRelsBySegmentsExperienceId(
-				segmentsExperienceId);
+			getSegmentsExperimentRelsBySegmentsExperienceKey(
+				segmentsExperienceKey, plid);
 	}
 
 	/**

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentRelService.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentRelService.java
@@ -63,7 +63,7 @@ public interface SegmentsExperimentRelService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public SegmentsExperimentRel getSegmentsExperimentRel(
-			long segmentsExperimentId, long segmentsExperienceId)
+			long segmentsExperimentId, String segmentsExperienceKey)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentRelServiceUtil.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentRelServiceUtil.java
@@ -57,11 +57,11 @@ public class SegmentsExperimentRelServiceUtil {
 	}
 
 	public static SegmentsExperimentRel getSegmentsExperimentRel(
-			long segmentsExperimentId, long segmentsExperienceId)
+			long segmentsExperimentId, String segmentsExperienceKey)
 		throws PortalException {
 
 		return getService().getSegmentsExperimentRel(
-			segmentsExperimentId, segmentsExperienceId);
+			segmentsExperimentId, segmentsExperienceKey);
 	}
 
 	public static List<SegmentsExperimentRel> getSegmentsExperimentRels(

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentRelServiceWrapper.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentRelServiceWrapper.java
@@ -60,11 +60,11 @@ public class SegmentsExperimentRelServiceWrapper
 
 	@Override
 	public SegmentsExperimentRel getSegmentsExperimentRel(
-			long segmentsExperimentId, long segmentsExperienceId)
+			long segmentsExperimentId, String segmentsExperienceKey)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _segmentsExperimentRelService.getSegmentsExperimentRel(
-			segmentsExperimentId, segmentsExperienceId);
+			segmentsExperimentId, segmentsExperienceKey);
 	}
 
 	@Override

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentService.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentService.java
@@ -65,12 +65,12 @@ public interface SegmentsExperimentService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public SegmentsExperiment fetchSegmentsExperiment(
-			long groupId, long segmentsExperienceId, long plid)
+			long groupId, String segmentsExperimentKey)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public SegmentsExperiment fetchSegmentsExperiment(
-			long groupId, String segmentsExperimentKey)
+			long groupId, String segmentsExperienceKey, long plid)
 		throws PortalException;
 
 	/**

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentServiceUtil.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentServiceUtil.java
@@ -63,19 +63,19 @@ public class SegmentsExperimentServiceUtil {
 	}
 
 	public static SegmentsExperiment fetchSegmentsExperiment(
-			long groupId, long segmentsExperienceId, long plid)
-		throws PortalException {
-
-		return getService().fetchSegmentsExperiment(
-			groupId, segmentsExperienceId, plid);
-	}
-
-	public static SegmentsExperiment fetchSegmentsExperiment(
 			long groupId, String segmentsExperimentKey)
 		throws PortalException {
 
 		return getService().fetchSegmentsExperiment(
 			groupId, segmentsExperimentKey);
+	}
+
+	public static SegmentsExperiment fetchSegmentsExperiment(
+			long groupId, String segmentsExperienceKey, long plid)
+		throws PortalException {
+
+		return getService().fetchSegmentsExperiment(
+			groupId, segmentsExperienceKey, plid);
 	}
 
 	/**

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentServiceWrapper.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperimentServiceWrapper.java
@@ -70,20 +70,20 @@ public class SegmentsExperimentServiceWrapper
 
 	@Override
 	public SegmentsExperiment fetchSegmentsExperiment(
-			long groupId, long segmentsExperienceId, long plid)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _segmentsExperimentService.fetchSegmentsExperiment(
-			groupId, segmentsExperienceId, plid);
-	}
-
-	@Override
-	public SegmentsExperiment fetchSegmentsExperiment(
 			long groupId, String segmentsExperimentKey)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _segmentsExperimentService.fetchSegmentsExperiment(
 			groupId, segmentsExperimentKey);
+	}
+
+	@Override
+	public SegmentsExperiment fetchSegmentsExperiment(
+			long groupId, String segmentsExperienceKey, long plid)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _segmentsExperimentService.fetchSegmentsExperiment(
+			groupId, segmentsExperienceKey, plid);
 	}
 
 	/**

--- a/modules/apps/segments/segments-api/src/main/resources/com/liferay/segments/service/packageinfo
+++ b/modules/apps/segments/segments-api/src/main/resources/com/liferay/segments/service/packageinfo
@@ -1,1 +1,1 @@
-version 14.1.0
+version 15.0.0

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/model/impl/SegmentsExperienceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/model/impl/SegmentsExperienceImpl.java
@@ -10,7 +10,9 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.segments.constants.SegmentsExperimentConstants;
+import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.model.SegmentsExperiment;
+import com.liferay.segments.service.SegmentsExperienceLocalServiceUtil;
 import com.liferay.segments.service.SegmentsExperimentLocalServiceUtil;
 
 import java.io.IOException;
@@ -38,9 +40,14 @@ public class SegmentsExperienceImpl extends SegmentsExperienceBaseImpl {
 
 	@Override
 	public boolean hasSegmentsExperiment() {
+		SegmentsExperience segmentsExperience =
+			SegmentsExperienceLocalServiceUtil.fetchSegmentsExperience(
+				getSegmentsExperienceId());
+
 		SegmentsExperiment segmentsExperiment =
 			SegmentsExperimentLocalServiceUtil.fetchSegmentsExperiment(
-				getGroupId(), getSegmentsExperienceId(), getPlid());
+				getGroupId(), segmentsExperience.getSegmentsExperienceKey(),
+				getPlid());
 
 		if ((segmentsExperiment == null) ||
 			!ArrayUtil.contains(

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/http/SegmentsExperimentRelServiceHttp.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/http/SegmentsExperimentRelServiceHttp.java
@@ -131,7 +131,7 @@ public class SegmentsExperimentRelServiceHttp {
 	public static com.liferay.segments.model.SegmentsExperimentRel
 			getSegmentsExperimentRel(
 				HttpPrincipal httpPrincipal, long segmentsExperimentId,
-				long segmentsExperienceId)
+				String segmentsExperienceKey)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -141,7 +141,7 @@ public class SegmentsExperimentRelServiceHttp {
 				_getSegmentsExperimentRelParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, segmentsExperimentId, segmentsExperienceId);
+				methodKey, segmentsExperimentId, segmentsExperienceKey);
 
 			Object returnObj = null;
 
@@ -313,7 +313,7 @@ public class SegmentsExperimentRelServiceHttp {
 	private static final Class<?>[]
 		_deleteSegmentsExperimentRelParameterTypes1 = new Class[] {long.class};
 	private static final Class<?>[] _getSegmentsExperimentRelParameterTypes2 =
-		new Class[] {long.class, long.class};
+		new Class[] {long.class, String.class};
 	private static final Class<?>[] _getSegmentsExperimentRelsParameterTypes3 =
 		new Class[] {long.class};
 	private static final Class<?>[]

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/http/SegmentsExperimentServiceHttp.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/http/SegmentsExperimentServiceHttp.java
@@ -215,7 +215,7 @@ public class SegmentsExperimentServiceHttp {
 	public static com.liferay.segments.model.SegmentsExperiment
 			fetchSegmentsExperiment(
 				HttpPrincipal httpPrincipal, long groupId,
-				long segmentsExperienceId, long plid)
+				String segmentsExperimentKey)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -224,7 +224,7 @@ public class SegmentsExperimentServiceHttp {
 				_fetchSegmentsExperimentParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, segmentsExperienceId, plid);
+				methodKey, groupId, segmentsExperimentKey);
 
 			Object returnObj = null;
 
@@ -257,7 +257,7 @@ public class SegmentsExperimentServiceHttp {
 	public static com.liferay.segments.model.SegmentsExperiment
 			fetchSegmentsExperiment(
 				HttpPrincipal httpPrincipal, long groupId,
-				String segmentsExperimentKey)
+				String segmentsExperienceKey, long plid)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -266,7 +266,7 @@ public class SegmentsExperimentServiceHttp {
 				_fetchSegmentsExperimentParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, segmentsExperimentKey);
+				methodKey, groupId, segmentsExperienceKey, plid);
 
 			Object returnObj = null;
 
@@ -702,9 +702,9 @@ public class SegmentsExperimentServiceHttp {
 	private static final Class<?>[] _deleteSegmentsExperimentParameterTypes3 =
 		new Class[] {String.class};
 	private static final Class<?>[] _fetchSegmentsExperimentParameterTypes4 =
-		new Class[] {long.class, long.class, long.class};
-	private static final Class<?>[] _fetchSegmentsExperimentParameterTypes5 =
 		new Class[] {long.class, String.class};
+	private static final Class<?>[] _fetchSegmentsExperimentParameterTypes5 =
+		new Class[] {long.class, String.class, long.class};
 	private static final Class<?>[] _getSegmentsExperimentParameterTypes6 =
 		new Class[] {long.class};
 	private static final Class<?>[] _getSegmentsExperimentParameterTypes7 =

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperimentLocalServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperimentLocalServiceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserNotificationDeliveryConstants;
 import com.liferay.portal.kernel.notifications.UserNotificationManagerUtil;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
@@ -156,12 +157,12 @@ public class SegmentsExperimentLocalServiceImpl
 
 	@Override
 	public SegmentsExperiment deleteSegmentsExperiment(
-			long groupId, long segmentsExperienceId, long plid)
+			long groupId, String segmentsExperienceKey, long plid)
 		throws PortalException {
 
 		SegmentsExperiment segmentsExperiment =
 			segmentsExperimentLocalService.fetchSegmentsExperiment(
-				groupId, segmentsExperienceId, plid);
+				groupId, segmentsExperienceKey, plid);
 
 		return segmentsExperimentLocalService.deleteSegmentsExperiment(
 			segmentsExperiment);
@@ -205,11 +206,27 @@ public class SegmentsExperimentLocalServiceImpl
 
 	@Override
 	public SegmentsExperiment fetchSegmentsExperiment(
-		long groupId, long segmentsExperienceId, long plid) {
+		long groupId, String segmentsExperimentKey) {
+
+		return segmentsExperimentPersistence.fetchByG_S(
+			groupId, segmentsExperimentKey);
+	}
+
+	@Override
+	public SegmentsExperiment fetchSegmentsExperiment(
+		long groupId, String segmentsExperienceKey, long plid) {
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				groupId, segmentsExperienceKey, _getPublishedLayoutPlid(plid));
+
+		if (segmentsExperience == null) {
+			return null;
+		}
 
 		for (SegmentsExperimentRel segmentsExperimentRel :
 				_segmentsExperimentRelPersistence.findBySegmentsExperienceId(
-					segmentsExperienceId)) {
+					segmentsExperience.getSegmentsExperienceId())) {
 
 			SegmentsExperiment segmentsExperiment =
 				segmentsExperimentPersistence.fetchByPrimaryKey(
@@ -223,14 +240,6 @@ public class SegmentsExperimentLocalServiceImpl
 		}
 
 		return null;
-	}
-
-	@Override
-	public SegmentsExperiment fetchSegmentsExperiment(
-		long groupId, String segmentsExperimentKey) {
-
-		return segmentsExperimentPersistence.fetchByG_S(
-			groupId, segmentsExperimentKey);
 	}
 
 	@Override
@@ -359,6 +368,16 @@ public class SegmentsExperimentLocalServiceImpl
 			segmentsExperimentPersistence.findByPrimaryKey(
 				segmentsExperimentId),
 			winnerSegmentsExperienceId, status);
+	}
+
+	private long _getPublishedLayoutPlid(long plid) {
+		Layout layout = _layoutLocalService.fetchLayout(plid);
+
+		if ((layout != null) && layout.isDraftLayout()) {
+			return layout.getClassPK();
+		}
+
+		return plid;
 	}
 
 	private DynamicQuery _getSegmentsExperienceIdsDynamicQuery(
@@ -518,10 +537,20 @@ public class SegmentsExperimentLocalServiceImpl
 			long winnerSegmentsExperienceId, int status)
 		throws PortalException {
 
+		SegmentsExperience winnerSegmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				winnerSegmentsExperienceId);
+
+		if (winnerSegmentsExperience == null) {
+			throw new WinnerSegmentsExperienceException(
+				"Winner segments experience " + winnerSegmentsExperienceId +
+					" no found");
+		}
+
 		SegmentsExperimentRel segmentsExperimentRel =
 			_segmentsExperimentRelLocalService.fetchSegmentsExperimentRel(
 				segmentsExperiment.getSegmentsExperimentId(),
-				winnerSegmentsExperienceId);
+				winnerSegmentsExperience.getSegmentsExperienceKey());
 
 		if (segmentsExperimentRel == null) {
 			throw new WinnerSegmentsExperienceException(
@@ -591,9 +620,13 @@ public class SegmentsExperimentLocalServiceImpl
 			long groupId, long segmentsExperienceId, long plid)
 		throws PortalException {
 
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.getSegmentsExperience(
+				segmentsExperienceId);
+
 		SegmentsExperiment segmentsExperiment =
 			segmentsExperimentLocalService.fetchSegmentsExperiment(
-				groupId, segmentsExperienceId, plid);
+				groupId, segmentsExperience.getSegmentsExperienceKey(), plid);
 
 		if (segmentsExperiment == null) {
 			return;
@@ -694,6 +727,9 @@ public class SegmentsExperimentLocalServiceImpl
 			throw new SegmentsExperimentTypeException();
 		}
 	}
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperimentRelLocalServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperimentRelLocalServiceImpl.java
@@ -7,8 +7,10 @@ package com.liferay.segments.service.impl;
 
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
@@ -142,19 +144,37 @@ public class SegmentsExperimentRelLocalServiceImpl
 
 	@Override
 	public SegmentsExperimentRel fetchSegmentsExperimentRel(
-		long segmentsExperimentId, long segmentsExperienceId) {
+		long segmentsExperimentId, String segmentsExperienceKey) {
+
+		SegmentsExperiment segmentsExperiment =
+			_segmentsExperimentPersistence.fetchByPrimaryKey(
+				segmentsExperimentId);
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				segmentsExperiment.getGroupId(), segmentsExperienceKey,
+				_getPublishedLayoutPlid(segmentsExperiment.getPlid()));
 
 		return segmentsExperimentRelPersistence.fetchByS_S(
-			segmentsExperimentId, segmentsExperienceId);
+			segmentsExperimentId, segmentsExperience.getSegmentsExperienceId());
 	}
 
 	@Override
 	public SegmentsExperimentRel getSegmentsExperimentRel(
-			long segmentsExperimentId, long segmentsExperienceId)
+			long segmentsExperimentId, String segmentsExperienceKey)
 		throws PortalException {
 
+		SegmentsExperiment segmentsExperiment =
+			_segmentsExperimentPersistence.fetchByPrimaryKey(
+				segmentsExperimentId);
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				segmentsExperiment.getGroupId(), segmentsExperienceKey,
+				_getPublishedLayoutPlid(segmentsExperiment.getPlid()));
+
 		return segmentsExperimentRelPersistence.findByS_S(
-			segmentsExperimentId, segmentsExperienceId);
+			segmentsExperimentId, segmentsExperience.getSegmentsExperienceId());
 	}
 
 	@Override
@@ -167,11 +187,18 @@ public class SegmentsExperimentRelLocalServiceImpl
 
 	@Override
 	public List<SegmentsExperimentRel>
-		getSegmentsExperimentRelsBySegmentsExperienceId(
-			long segmentsExperienceId) {
+		getSegmentsExperimentRelsBySegmentsExperienceKey(
+			String segmentsExperienceKey, long plid) {
+
+		Layout layout = _layoutLocalService.fetchLayout(plid);
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				layout.getGroupId(), segmentsExperienceKey,
+				_getPublishedLayoutPlid(layout.getPlid()));
 
 		return segmentsExperimentRelPersistence.findBySegmentsExperienceId(
-			segmentsExperienceId);
+			segmentsExperience.getSegmentsExperienceId());
 	}
 
 	@Override
@@ -228,6 +255,16 @@ public class SegmentsExperimentRelLocalServiceImpl
 		return segmentsExperimentRelPersistence.update(segmentsExperimentRel);
 	}
 
+	private long _getPublishedLayoutPlid(long plid) {
+		Layout layout = _layoutLocalService.fetchLayout(plid);
+
+		if ((layout != null) && layout.isDraftLayout()) {
+			return layout.getClassPK();
+		}
+
+		return plid;
+	}
+
 	private SegmentsExperimentRel _updateSegmentsExperimentRelSplit(
 			SegmentsExperimentRel segmentsExperimentRel, double split)
 		throws PortalException {
@@ -263,6 +300,9 @@ public class SegmentsExperimentRelLocalServiceImpl
 			throw new LockedSegmentsExperimentException(segmentsExperimentId);
 		}
 	}
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
 
 	@Reference
 	private SegmentsExperienceLocalService _segmentsExperienceLocalService;

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperimentRelServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperimentRelServiceImpl.java
@@ -79,12 +79,12 @@ public class SegmentsExperimentRelServiceImpl
 
 	@Override
 	public SegmentsExperimentRel getSegmentsExperimentRel(
-			long segmentsExperimentId, long segmentsExperienceId)
+			long segmentsExperimentId, String segmentsExperienceKey)
 		throws PortalException {
 
 		SegmentsExperimentRel segmentsExperimentRel =
 			segmentsExperimentRelLocalService.getSegmentsExperimentRel(
-				segmentsExperimentId, segmentsExperienceId);
+				segmentsExperimentId, segmentsExperienceKey);
 
 		_segmentsExperimentResourcePermission.check(
 			getPermissionChecker(), segmentsExperimentId, ActionKeys.VIEW);

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperimentServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperimentServiceImpl.java
@@ -97,12 +97,12 @@ public class SegmentsExperimentServiceImpl
 
 	@Override
 	public SegmentsExperiment fetchSegmentsExperiment(
-			long groupId, long segmentsExperienceId, long plid)
+			long groupId, String segmentsExperimentKey)
 		throws PortalException {
 
 		SegmentsExperiment segmentsExperiment =
 			segmentsExperimentLocalService.fetchSegmentsExperiment(
-				groupId, segmentsExperienceId, plid);
+				groupId, segmentsExperimentKey);
 
 		if ((segmentsExperiment != null) &&
 			_segmentsExperimentResourcePermission.contains(
@@ -116,12 +116,12 @@ public class SegmentsExperimentServiceImpl
 
 	@Override
 	public SegmentsExperiment fetchSegmentsExperiment(
-			long groupId, String segmentsExperimentKey)
+			long groupId, String segmentsExperienceKey, long plid)
 		throws PortalException {
 
 		SegmentsExperiment segmentsExperiment =
 			segmentsExperimentLocalService.fetchSegmentsExperiment(
-				groupId, segmentsExperimentKey);
+				groupId, segmentsExperienceKey, plid);
 
 		if ((segmentsExperiment != null) &&
 			_segmentsExperimentResourcePermission.contains(

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperimentLocalServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperimentLocalServiceTest.java
@@ -274,7 +274,7 @@ public class SegmentsExperimentLocalServiceTest {
 		Assert.assertNull(
 			_segmentsExperimentLocalService.fetchSegmentsExperiment(
 				_group.getGroupId(),
-				segmentsExperience.getSegmentsExperienceId(),
+				segmentsExperience.getSegmentsExperienceKey(),
 				segmentsExperience.getPlid()));
 	}
 
@@ -290,7 +290,7 @@ public class SegmentsExperimentLocalServiceTest {
 			SegmentsExperimentConstants.STATUS_RUNNING);
 
 		_segmentsExperimentLocalService.deleteSegmentsExperiment(
-			_group.getGroupId(), segmentsExperience.getSegmentsExperienceId(),
+			_group.getGroupId(), segmentsExperience.getSegmentsExperienceKey(),
 			segmentsExperience.getPlid());
 	}
 
@@ -301,13 +301,13 @@ public class SegmentsExperimentLocalServiceTest {
 		_addSegmentsExperiment(segmentsExperience);
 
 		_segmentsExperimentLocalService.deleteSegmentsExperiment(
-			_group.getGroupId(), segmentsExperience.getSegmentsExperienceId(),
+			_group.getGroupId(), segmentsExperience.getSegmentsExperienceKey(),
 			segmentsExperience.getPlid());
 
 		Assert.assertNull(
 			_segmentsExperimentLocalService.fetchSegmentsExperiment(
 				_group.getGroupId(),
-				segmentsExperience.getSegmentsExperienceId(),
+				segmentsExperience.getSegmentsExperienceKey(),
 				segmentsExperience.getPlid()));
 	}
 
@@ -352,7 +352,7 @@ public class SegmentsExperimentLocalServiceTest {
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		_segmentsExperimentLocalService.deleteSegmentsExperiment(
-			_group.getGroupId(), segmentsExperience.getSegmentsExperienceId(),
+			_group.getGroupId(), segmentsExperience.getSegmentsExperienceKey(),
 			segmentsExperience.getPlid());
 
 		Assert.assertNull(
@@ -384,12 +384,12 @@ public class SegmentsExperimentLocalServiceTest {
 		Assert.assertNotNull(
 			_segmentsExperimentLocalService.fetchSegmentsExperiment(
 				_group.getGroupId(),
-				segmentsExperience.getSegmentsExperienceId(),
+				segmentsExperience.getSegmentsExperienceKey(),
 				segmentsExperience.getPlid()));
 		Assert.assertNotNull(
 			_segmentsExperimentLocalService.fetchSegmentsExperiment(
 				_group.getGroupId(),
-				segmentsExperiment.getSegmentsExperienceId(),
+				segmentsExperiment.getSegmentsExperienceKey(),
 				segmentsExperience.getPlid()));
 	}
 
@@ -460,7 +460,7 @@ public class SegmentsExperimentLocalServiceTest {
 		SegmentsExperiment actualSegmentsExperiment =
 			_segmentsExperimentLocalService.fetchSegmentsExperiment(
 				_layout.getGroupId(),
-				segmentsExperience2.getSegmentsExperienceId(),
+				segmentsExperience2.getSegmentsExperienceKey(),
 				_layout.getPlid());
 
 		Assert.assertEquals(
@@ -489,12 +489,12 @@ public class SegmentsExperimentLocalServiceTest {
 		Assert.assertNotNull(
 			_segmentsExperimentLocalService.fetchSegmentsExperiment(
 				_group.getGroupId(),
-				segmentsExperience.getSegmentsExperienceId(),
+				segmentsExperience.getSegmentsExperienceKey(),
 				segmentsExperience.getPlid()));
 		Assert.assertNotNull(
 			_segmentsExperimentLocalService.fetchSegmentsExperiment(
 				_group.getGroupId(),
-				segmentsExperiment.getSegmentsExperienceId(),
+				segmentsExperiment.getSegmentsExperienceKey(),
 				segmentsExperience.getPlid()));
 	}
 
@@ -535,11 +535,11 @@ public class SegmentsExperimentLocalServiceTest {
 		SegmentsExperimentRel segmentsExperimentRel =
 			_segmentsExperimentRelLocalService.fetchSegmentsExperimentRel(
 				segmentsExperiment.getSegmentsExperimentId(),
-				segmentsExperiment.getSegmentsExperienceId());
+				segmentsExperiment.getSegmentsExperienceKey());
 		SegmentsExperimentRel variantSegmentsExperimentRel =
 			_segmentsExperimentRelLocalService.fetchSegmentsExperimentRel(
 				segmentsExperiment.getSegmentsExperimentId(),
-				variantSegmentsExperience.getSegmentsExperienceId());
+				variantSegmentsExperience.getSegmentsExperienceKey());
 
 		Assert.assertEquals(
 			segmentsExperienceIdSplitMap.get(

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperimentRelLocalServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperimentRelLocalServiceTest.java
@@ -235,7 +235,7 @@ public class SegmentsExperimentRelLocalServiceTest {
 		SegmentsExperimentRel segmentsExperimentRel =
 			_segmentsExperimentRelLocalService.getSegmentsExperimentRel(
 				segmentsExperiment.getSegmentsExperimentId(),
-				segmentsExperiment.getSegmentsExperienceId());
+				segmentsExperiment.getSegmentsExperienceKey());
 
 		_segmentsExperimentRelLocalService.updateSegmentsExperimentRel(
 			segmentsExperimentRel.getSegmentsExperimentRelId(),
@@ -280,7 +280,7 @@ public class SegmentsExperimentRelLocalServiceTest {
 		SegmentsExperimentRel segmentsExperimentRel =
 			_segmentsExperimentRelLocalService.getSegmentsExperimentRel(
 				segmentsExperiment.getSegmentsExperimentId(),
-				segmentsExperiment.getSegmentsExperienceId());
+				segmentsExperiment.getSegmentsExperienceKey());
 
 		_segmentsExperimentRelLocalService.updateSegmentsExperimentRel(
 			segmentsExperimentRel.getSegmentsExperimentRelId(),

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperimentServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperimentServiceTest.java
@@ -185,7 +185,7 @@ public class SegmentsExperimentServiceTest {
 			Assert.assertNull(
 				_segmentsExperimentService.fetchSegmentsExperiment(
 					layout.getGroupId(),
-					segmentsExperiment.getSegmentsExperienceId(),
+					segmentsExperiment.getSegmentsExperienceKey(),
 					layout.getPlid()));
 		}
 	}
@@ -205,7 +205,7 @@ public class SegmentsExperimentServiceTest {
 				segmentsExperiment,
 				_segmentsExperimentService.fetchSegmentsExperiment(
 					layout.getGroupId(),
-					segmentsExperiment.getSegmentsExperienceId(),
+					segmentsExperiment.getSegmentsExperienceKey(),
 					layout.getPlid()));
 		}
 	}

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsExperienceSelectorDisplayContext.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsExperienceSelectorDisplayContext.java
@@ -88,12 +88,13 @@ public class SegmentsExperienceSelectorDisplayContext {
 	}
 
 	private SegmentsExperience _getParentSegmentsExperience(
-		SegmentsExperience segmentsExperience) {
+		SegmentsExperience segmentsExperience, ThemeDisplay themeDisplay) {
 
 		List<SegmentsExperimentRel> segmentsExperimentRels =
 			_segmentsExperimentRelLocalService.
-				getSegmentsExperimentRelsBySegmentsExperienceId(
-					segmentsExperience.getSegmentsExperienceId());
+				getSegmentsExperimentRelsBySegmentsExperienceKey(
+					segmentsExperience.getSegmentsExperienceKey(),
+					themeDisplay.getPlid());
 
 		if (segmentsExperimentRels.isEmpty()) {
 			return null;
@@ -216,7 +217,7 @@ public class SegmentsExperienceSelectorDisplayContext {
 
 		if (segmentsExperience != null) {
 			SegmentsExperience parentSegmentsExperience =
-				_getParentSegmentsExperience(segmentsExperience);
+				_getParentSegmentsExperience(segmentsExperience, _themeDisplay);
 
 			if (parentSegmentsExperience != null) {
 				segmentsExperience = parentSegmentsExperience;

--- a/modules/dxp/apps/segments/segments-asah-connector-test/src/testIntegration/java/com/liferay/segments/asah/connector/internal/portlet/action/test/AddSegmentsExperimentMVCActionCommandTest.java
+++ b/modules/dxp/apps/segments/segments-asah-connector-test/src/testIntegration/java/com/liferay/segments/asah/connector/internal/portlet/action/test/AddSegmentsExperimentMVCActionCommandTest.java
@@ -36,6 +36,7 @@ import com.liferay.segments.exception.DuplicateSegmentsExperimentException;
 import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.model.SegmentsExperiment;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
 import com.liferay.segments.service.SegmentsExperimentLocalService;
 import com.liferay.segments.test.util.SegmentsTestUtil;
 
@@ -156,7 +157,7 @@ public class AddSegmentsExperimentMVCActionCommandTest {
 			SegmentsExperiment segmentsExperiment =
 				_segmentsExperimentLocalService.fetchSegmentsExperiment(
 					segmentsExperience.getGroupId(),
-					segmentsExperience.getSegmentsExperienceId(),
+					segmentsExperience.getSegmentsExperienceKey(),
 					segmentsExperience.getPlid());
 
 			Assert.assertEquals(
@@ -264,11 +265,15 @@ public class AddSegmentsExperimentMVCActionCommandTest {
 			JSONObject segmentsExperimentJSONObject =
 				(JSONObject)jsonObject.get("segmentsExperiment");
 
+			segmentsExperience =
+				_segmentsExperienceLocalService.fetchSegmentsExperience(
+					segmentsExperimentJSONObject.getLong(
+						"segmentsExperienceId"));
+
 			segmentsExperiment =
 				_segmentsExperimentLocalService.fetchSegmentsExperiment(
 					_group.getGroupId(),
-					segmentsExperimentJSONObject.getLong(
-						"segmentsExperienceId"),
+					segmentsExperience.getSegmentsExperienceKey(),
 					_layout.getPlid());
 
 			Assert.assertNotNull(segmentsExperiment);
@@ -326,11 +331,15 @@ public class AddSegmentsExperimentMVCActionCommandTest {
 				description,
 				segmentsExperimentJSONObject.getString("description"));
 
+			segmentsExperience =
+				_segmentsExperienceLocalService.fetchSegmentsExperience(
+					segmentsExperimentJSONObject.getLong(
+						"segmentsExperienceId"));
+
 			SegmentsExperiment segmentsExperiment =
 				_segmentsExperimentLocalService.fetchSegmentsExperiment(
 					_group.getGroupId(),
-					segmentsExperimentJSONObject.getLong(
-						"segmentsExperienceId"),
+					segmentsExperience.getSegmentsExperienceKey(),
 					_layout.getPlid());
 
 			Assert.assertEquals(
@@ -429,6 +438,9 @@ public class AddSegmentsExperimentMVCActionCommandTest {
 		filter = "mvc.command.name=/segments_experiment/add_segments_experiment"
 	)
 	private MVCActionCommand _mvcActionCommand;
+
+	@Inject
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
 
 	@Inject
 	private SegmentsExperimentLocalService _segmentsExperimentLocalService;

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/model/listener/LayoutModelListener.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/model/listener/LayoutModelListener.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.segments.asah.connector.internal.client.AsahFaroBackendClientImpl;
 import com.liferay.segments.asah.connector.internal.processor.AsahSegmentsExperimentProcessor;
 import com.liferay.segments.asah.connector.internal.util.AsahUtil;
+import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.model.SegmentsExperiment;
 import com.liferay.segments.service.SegmentsEntryLocalService;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
@@ -48,11 +49,14 @@ public class LayoutModelListener extends BaseModelListener<Layout> {
 				return;
 			}
 
+			SegmentsExperience segmentsExperience =
+				_segmentsExperienceLocalService.fetchDefaultSegmentsExperience(
+					layout.getPlid());
+
 			SegmentsExperiment segmentsExperiment =
 				_segmentsExperimentLocalService.fetchSegmentsExperiment(
 					layout.getGroupId(),
-					_segmentsExperienceLocalService.
-						fetchDefaultSegmentsExperienceId(layout.getPlid()),
+					segmentsExperience.getSegmentsExperienceKey(),
 					layout.getPlid());
 
 			if (segmentsExperiment != null) {

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/model/listener/SegmentsExperienceModelListener.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/model/listener/SegmentsExperienceModelListener.java
@@ -57,7 +57,7 @@ public class SegmentsExperienceModelListener
 			SegmentsExperiment segmentsExperiment =
 				_segmentsExperimentLocalService.fetchSegmentsExperiment(
 					segmentsExperience.getGroupId(),
-					segmentsExperience.getSegmentsExperienceId(),
+					segmentsExperience.getSegmentsExperienceKey(),
 					segmentsExperience.getPlid());
 
 			if (segmentsExperiment != null) {

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/portlet/action/AddSegmentsExperimentMVCActionCommand.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/portlet/action/AddSegmentsExperimentMVCActionCommand.java
@@ -135,9 +135,18 @@ public class AddSegmentsExperimentMVCActionCommand
 			actionRequest, "segmentsExperienceId");
 		long plid = ParamUtil.getLong(actionRequest, "plid");
 
-		SegmentsExperiment segmentsExperiment =
-			_segmentsExperimentService.fetchSegmentsExperiment(
-				serviceContext.getScopeGroupId(), segmentsExperienceId, plid);
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				segmentsExperienceId);
+
+		SegmentsExperiment segmentsExperiment = null;
+
+		if (segmentsExperience != null) {
+			segmentsExperiment =
+				_segmentsExperimentService.fetchSegmentsExperiment(
+					serviceContext.getScopeGroupId(),
+					segmentsExperience.getSegmentsExperienceKey(), plid);
+		}
 
 		if (segmentsExperiment != null) {
 			if (segmentsExperiment.getStatus() ==
@@ -190,7 +199,7 @@ public class AddSegmentsExperimentMVCActionCommand
 		SegmentsExperimentRel segmentsExperimentRel =
 			_segmentsExperimentRelService.getSegmentsExperimentRel(
 				segmentsExperiment.getSegmentsExperimentId(),
-				segmentsExperiment.getSegmentsExperienceId());
+				segmentsExperiment.getSegmentsExperienceKey());
 
 		return JSONUtil.put(
 			"segmentsExperiment",

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/portlet/action/GetDataMVCResourceCommand.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/portlet/action/GetDataMVCResourceCommand.java
@@ -42,6 +42,7 @@ import com.liferay.segments.constants.SegmentsExperimentConstants;
 import com.liferay.segments.constants.SegmentsPortletKeys;
 import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.model.SegmentsExperiment;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
 import com.liferay.segments.service.SegmentsExperienceService;
 import com.liferay.segments.service.SegmentsExperimentRelService;
 import com.liferay.segments.service.SegmentsExperimentService;
@@ -144,9 +145,13 @@ public class GetDataMVCResourceCommand extends BaseMVCResourceCommand {
 			long groupId, long plid, long segmentsExperienceId)
 		throws PortalException {
 
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				segmentsExperienceId);
+
 		SegmentsExperiment segmentsExperiment =
 			_segmentsExperimentService.fetchSegmentsExperiment(
-				groupId, segmentsExperienceId, plid);
+				groupId, segmentsExperience.getSegmentsExperienceKey(), plid);
 
 		if (segmentsExperiment == null) {
 			return null;
@@ -169,7 +174,7 @@ public class GetDataMVCResourceCommand extends BaseMVCResourceCommand {
 				segmentsExperiment.getStatus(), status.getValue())) {
 
 			if (experiment.getWinnerDXPVariantId() != null) {
-				SegmentsExperience segmentsExperience =
+				segmentsExperience =
 					_segmentsExperienceService.getSegmentsExperience(
 						segmentsExperiment.getGroupId(),
 						experiment.getWinnerDXPVariantId(),
@@ -194,8 +199,13 @@ public class GetDataMVCResourceCommand extends BaseMVCResourceCommand {
 			Layout layout, long segmentsExperienceId)
 		throws Exception {
 
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				segmentsExperienceId);
+
 		return _segmentsExperimentService.fetchSegmentsExperiment(
-			layout.getGroupId(), segmentsExperienceId, layout.getPlid());
+			layout.getGroupId(), segmentsExperience.getSegmentsExperienceKey(),
+			layout.getPlid());
 	}
 
 	private String _getContentPageEditorPortletNamespace() {
@@ -485,6 +495,9 @@ public class GetDataMVCResourceCommand extends BaseMVCResourceCommand {
 
 	@Reference
 	private PortletURLFactory _portletURLFactory;
+
+	@Reference
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
 
 	@Reference
 	private SegmentsExperienceService _segmentsExperienceService;

--- a/modules/dxp/apps/segments/segments-experiment-test/src/testIntegration/java/com/liferay/segments/experiment/web/internal/processor/test/SegmentsExperimentSegmentsExperienceRequestProcessorTest.java
+++ b/modules/dxp/apps/segments/segments-experiment-test/src/testIntegration/java/com/liferay/segments/experiment/web/internal/processor/test/SegmentsExperimentSegmentsExperienceRequestProcessorTest.java
@@ -116,14 +116,14 @@ public class SegmentsExperimentSegmentsExperienceRequestProcessorTest {
 				_segmentsExperienceRequestProcessor.getSegmentsExperienceIds(
 					_getMockHttpServletRequest(), new MockHttpServletResponse(),
 					_group.getGroupId(), _layout.getPlid(),
-					new long[] {segmentsExperience.getSegmentsEntryId()});
+					new long[] {segmentsExperience.getSegmentsExperienceId()});
 
 			Assert.assertEquals(
 				Arrays.toString(segmentsExperienceIds), 1,
 				segmentsExperienceIds.length);
 
 			Assert.assertEquals(
-				segmentsExperience.getSegmentsEntryId(),
+				segmentsExperience.getSegmentsExperienceId(),
 				segmentsExperienceIds[0]);
 		}
 	}
@@ -464,14 +464,14 @@ public class SegmentsExperimentSegmentsExperienceRequestProcessorTest {
 					_getMockHttpServletRequest(), new MockHttpServletResponse(),
 					_group.getGroupId(), _layout.getPlid(),
 					new long[] {segmentsEntry.getSegmentsEntryId()},
-					new long[] {segmentsExperience.getSegmentsEntryId()});
+					new long[] {segmentsExperience.getSegmentsExperienceId()});
 
 			Assert.assertEquals(
 				Arrays.toString(segmentsExperienceIds), 1,
 				segmentsExperienceIds.length);
 
 			Assert.assertEquals(
-				segmentsExperience.getSegmentsEntryId(),
+				segmentsExperience.getSegmentsExperienceId(),
 				segmentsExperienceIds[0]);
 		}
 	}

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/processor/SegmentsExperimentSegmentsExperienceRequestProcessor.java
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/processor/SegmentsExperimentSegmentsExperienceRequestProcessor.java
@@ -102,7 +102,8 @@ public class SegmentsExperimentSegmentsExperienceRequestProcessor
 		if (segmentsExperienceId != -1) {
 			SegmentsExperiment segmentsExperiment =
 				_segmentsExperimentLocalService.fetchSegmentsExperiment(
-					themeDisplay.getScopeGroupId(), segmentsExperienceId, plid);
+					themeDisplay.getScopeGroupId(),
+					_getSegmentsExperienceKey(segmentsExperienceId), plid);
 
 			if (segmentsExperiment != null) {
 				httpServletRequest.setAttribute(
@@ -136,7 +137,8 @@ public class SegmentsExperimentSegmentsExperienceRequestProcessor
 
 		SegmentsExperiment segmentsExperiment =
 			_segmentsExperimentLocalService.fetchSegmentsExperiment(
-				themeDisplay.getScopeGroupId(), segmentsExperienceId, plid);
+				themeDisplay.getScopeGroupId(),
+				_getSegmentsExperienceKey(segmentsExperienceId), plid);
 
 		if (segmentsExperiment == null) {
 			if (_log.isDebugEnabled()) {

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/product/navigation/control/menu/SegmentsExperimentProductNavigationControlMenuEntry.java
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/product/navigation/control/menu/SegmentsExperimentProductNavigationControlMenuEntry.java
@@ -43,6 +43,7 @@ import com.liferay.product.navigation.control.menu.constants.ProductNavigationCo
 import com.liferay.segments.constants.SegmentsPortletKeys;
 import com.liferay.segments.experiment.web.internal.constants.ProductNavigationControlMenuEntryConstants;
 import com.liferay.segments.manager.SegmentsExperienceManager;
+import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.model.SegmentsExperiment;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
 import com.liferay.segments.service.SegmentsExperimentService;
@@ -353,21 +354,21 @@ public class SegmentsExperimentProductNavigationControlMenuEntry
 			HttpServletRequest httpServletRequest, ThemeDisplay themeDisplay)
 		throws Exception {
 
-		long segmentsExperienceId = _getSelectedSegmentsExperienceId(
-			httpServletRequest);
-
-		Layout layout = themeDisplay.getLayout();
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				_getSelectedSegmentsExperienceId(httpServletRequest));
 
 		SegmentsExperiment segmentsExperiment =
 			_segmentsExperimentService.fetchSegmentsExperiment(
-				themeDisplay.getScopeGroupId(), segmentsExperienceId,
-				layout.getPlid());
+				themeDisplay.getScopeGroupId(),
+				segmentsExperience.getSegmentsExperienceKey(),
+				themeDisplay.getPlid());
 
 		if (segmentsExperiment != null) {
 			return segmentsExperiment.getSegmentsExperienceId();
 		}
 
-		return segmentsExperienceId;
+		return segmentsExperience.getSegmentsExperienceId();
 	}
 
 	private long _getSelectedSegmentsExperienceId(


### PR DESCRIPTION
## Motivation 💡

Right now draft and publish layouts are linked to the same Segments Experience. As part of LPD-45656, we are working on having different segments experiences for draft and publish layout, those segments experiences are going to share the same segments experience key. It is going to allow us to simplify Headless APIs, workflow, and other functionalities.

Related with Segments Experiment, when we create a segments experiment we are linking the segments experiment to the published layout, so, having different segments experiences for draft and publish layout is going to affect in how we are getting the segments experiment. In order to avoid problems, we should adapt the logic to take into account this new behavior.

[Link to the story](https://liferay.atlassian.net/browse/LPD-45656)

## Proposed Solution 🔧

Update all Segments Experiment services to accept segments experience key instead of segments experience id and used the publish layout plid to get the right segments experiment.
