### PR TITLE
LPD-49338 page-management part of LPD-47718

### DIFF
--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FormFragmentsConfiguration.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FormFragmentsConfiguration.js
@@ -7,12 +7,8 @@ import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayLayout from '@clayui/layout';
 import ClayTable from '@clayui/table';
-import {
-	createPortletURL,
-	getPortletId,
-	openSelectionModal,
-	sub,
-} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
+import {createPortletURL, getPortletId, sub} from 'frontend-js-web';
 import React, {useState} from 'react';
 
 export default function FormFragmentsConfiguration({

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCollectionDropdownPropsTransformer.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCollectionDropdownPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
 
 import openDeleteFragmentCollectionModal from './openDeleteFragmentCollectionModal';
 

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCompositionDropdownPropsTransformer.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCompositionDropdownPropsTransformer.js
@@ -6,8 +6,8 @@
 import {
 	openSelectionModal,
 	openSimpleInputModal,
-	setFormValues,
-} from 'frontend-js-web';
+} from 'frontend-js-components-web';
+import {setFormValues} from 'frontend-js-web';
 
 import openDeleteFragmentModal from './openDeleteFragmentModal';
 

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentEntryDropdownPropsTransformer.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentEntryDropdownPropsTransformer.js
@@ -9,8 +9,8 @@ import {
 	openConfirmModal,
 	openSelectionModal,
 	openSimpleInputModal,
-	setFormValues,
-} from 'frontend-js-web';
+} from 'frontend-js-components-web';
+import {setFormValues} from 'frontend-js-web';
 
 import openDeleteFragmentModal from './openDeleteFragmentModal';
 

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentServiceConfiguration.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentServiceConfiguration.js
@@ -6,7 +6,8 @@
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayCheckbox} from '@clayui/form';
 import ClayModal, {useModal} from '@clayui/modal';
-import {fetch, objectToFormData, openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch, objectToFormData} from 'frontend-js-web';
 import React, {useState} from 'react';
 
 const FEEDBACK_MESSAGES = {

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/MultiStepFormModal.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/MultiStepFormModal.js
@@ -6,7 +6,8 @@
 import ClayButton from '@clayui/button';
 import ClayForm from '@clayui/form';
 import ClayModal from '@clayui/modal';
-import {fetch, navigate, openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch, navigate} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useRef, useState} from 'react';
 

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/ViewFragmentEntriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/ViewFragmentEntriesManagementToolbarPropsTransformer.js
@@ -4,7 +4,8 @@
  */
 
 import {render} from '@liferay/frontend-js-react-web';
-import {getCheckedCheckboxes, openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
+import {getCheckedCheckboxes} from 'frontend-js-web';
 
 import AddFragmentModal from './AddFragmentModal';
 import openDeleteFragmentModal from './openDeleteFragmentModal';

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/actions.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/actions.js
@@ -3,7 +3,11 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal, openSelectionModal, openToast} from 'frontend-js-web';
+import {
+	openModal,
+	openSelectionModal,
+	openToast,
+} from 'frontend-js-components-web';
 
 import openDeleteFragmentCollectionModal from './openDeleteFragmentCollectionModal';
 

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/fragment-editor/EmbeddedWidgetsModal.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/fragment-editor/EmbeddedWidgetsModal.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal, sub} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 
 export default function EmbeddedWidgetsModal({learnMessageHTML, onPublish}) {
 	openModal({

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/fragment-editor/FragmentEditor.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/fragment-editor/FragmentEditor.js
@@ -7,7 +7,8 @@ import ClayForm from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayTabs from '@clayui/tabs';
 import {useIsMounted, usePrevious} from '@liferay/frontend-js-react-web';
-import {debounce, fetch, navigate, openToast, sub} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {debounce, fetch, navigate, sub} from 'frontend-js-web';
 import React, {useCallback, useEffect, useState} from 'react';
 
 import CodeMirrorEditor from './CodeMirrorEditor';

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/openDeleteFragmentCollectionModal.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/openDeleteFragmentCollectionModal.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal, sub} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 
 export default function openDeleteFragmentCollectionModal({
 	multiple = false,

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/openDeleteFragmentCollectionResourceModal.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/openDeleteFragmentCollectionResourceModal.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal, sub} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 
 export default function openDeleteFragmentCollectionResourceModal({
 	multiple = false,

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/openDeleteFragmentModal.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/openDeleteFragmentModal.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal, sub} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 
 export default function openDeleteFragmentModal({multiple = false, onDelete}) {
 	openModal({

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/AddLayout.ts
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/AddLayout.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {fetch, getOpener, openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch, getOpener} from 'frontend-js-web';
 
 import {checkFriendlyURL} from './checkFriendlyURL';
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/CustomizationSettingsActionDropdownPropsTransformer.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/CustomizationSettingsActionDropdownPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 
 const ACTIONS = {
 	resetCustomizationView(itemData) {

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/EditLayout.ts
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/EditLayout.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 
 import {checkFriendlyURL} from './checkFriendlyURL';
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LayoutPageTemplateEntryCard.tsx
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LayoutPageTemplateEntryCard.tsx
@@ -7,7 +7,8 @@ import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import ClayCard from '@clayui/card';
 import ClayIcon from '@clayui/icon';
 import ClayModal, {useModal} from '@clayui/modal';
-import {createPortletURL, fetch, openModal} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
+import {createPortletURL, fetch} from 'frontend-js-web';
 import {
 	KeyboardEvent,
 	MouseEvent,

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LayoutUtilityPageEntryDropdownPropsTransformer.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LayoutUtilityPageEntryDropdownPropsTransformer.js
@@ -8,7 +8,7 @@ import {
 	openModal,
 	openSelectionModal,
 	openSimpleInputModal,
-} from 'frontend-js-web';
+} from 'frontend-js-components-web';
 
 import openDeleteLayoutModal from './openDeleteLayoutModal';
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LayoutsManagementToolbarPropsTransformer.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LayoutsManagementToolbarPropsTransformer.js
@@ -4,15 +4,12 @@
  */
 
 import {
-	addParams,
-	fetch,
-	navigate,
 	openConfirmModal,
 	openModal,
 	openSelectionModal,
 	openToast,
-	sub,
-} from 'frontend-js-web';
+} from 'frontend-js-components-web';
+import {addParams, fetch, navigate, sub} from 'frontend-js-web';
 
 import openDeleteLayoutModal from './openDeleteLayoutModal';
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LookAndFeelThemeEdit.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LookAndFeelThemeEdit.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {fetch, objectToFormData, openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
+import {fetch, objectToFormData} from 'frontend-js-web';
 
 export default function ({
 	changeThemeButtonId,

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/OrphanPortletsManagementToolbarPropsTransformer.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/OrphanPortletsManagementToolbarPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/SelectLayoutUtilityPageEntryMasterLayoutVerticalCardPropsTransformer.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/SelectLayoutUtilityPageEntryMasterLayoutVerticalCardPropsTransformer.js
@@ -4,7 +4,7 @@
  */
 
 import {getSpritemap} from '@liferay/frontend-icons-web';
-import {openSimpleInputModal} from 'frontend-js-web';
+import {openSimpleInputModal} from 'frontend-js-components-web';
 
 export default function SelectLayoutPageTemplateEntryMasterLayoutVerticalCardPropsTransformer({
 	additionalProps: {

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/ThemeCSSReplacementSelector.tsx
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/ThemeCSSReplacementSelector.tsx
@@ -5,7 +5,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 import React, {useState} from 'react';
 
 export default function ThemeCSSReplacementSelector({

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/actions.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/actions.js
@@ -4,12 +4,11 @@
  */
 
 import {
-	fetch,
-	navigate,
 	openConfirmModal,
 	openModal,
 	openToast,
-} from 'frontend-js-web';
+} from 'frontend-js-components-web';
+import {fetch, navigate} from 'frontend-js-web';
 
 import openDeleteLayoutModal from './openDeleteLayoutModal';
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/Layout.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/Layout.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {fetch, navigate, openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch, navigate} from 'frontend-js-web';
 import React, {useContext, useEffect, useRef, useState} from 'react';
 
 import Breadcrumbs from '../breadcrumbs/Breadcrumbs';

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/look_and_feel/Favicon.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/look_and_feel/Favicon.js
@@ -5,7 +5,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 import React, {useState} from 'react';
 
 export default function Favicon({

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/look_and_feel/GlobalCSSCETsConfiguration.tsx
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/look_and_feel/GlobalCSSCETsConfiguration.tsx
@@ -7,7 +7,7 @@ import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayTable from '@clayui/table';
 import classNames from 'classnames';
-import {openSelectionModal, openToast} from 'frontend-js-web';
+import {openSelectionModal, openToast} from 'frontend-js-components-web';
 import React, {useMemo, useState} from 'react';
 
 import {GlobalCETOptionsDropDown} from './GlobalCETOptionsDropDown';

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/look_and_feel/GlobalJSCETsConfiguration.tsx
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/look_and_feel/GlobalJSCETsConfiguration.tsx
@@ -9,7 +9,7 @@ import {ClaySelectWithOption} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayTable from '@clayui/table';
 import classNames from 'classnames';
-import {openSelectionModal, openToast} from 'frontend-js-web';
+import {openSelectionModal, openToast} from 'frontend-js-components-web';
 import React, {useMemo, useState} from 'react';
 
 import {GlobalCETOptionsDropDown} from './GlobalCETOptionsDropDown';

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/look_and_feel/MasterLayoutConfiguration.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/look_and_feel/MasterLayoutConfiguration.js
@@ -7,7 +7,7 @@ import {ClayButtonWithIcon} from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 import React, {useEffect, useState} from 'react';
 
 const DEFAULT_MASTER_LAYOUT_PLID = '0';

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/look_and_feel/StyleBookConfiguration.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/look_and_feel/StyleBookConfiguration.js
@@ -5,7 +5,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 import React, {useState} from 'react';
 
 export default function StyleBookConfiguration({

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/look_and_feel/ThemeSpritemapCETsConfiguration.tsx
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/look_and_feel/ThemeSpritemapCETsConfiguration.tsx
@@ -6,7 +6,7 @@
 import ClayAlert from '@clayui/alert';
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 import React, {useState} from 'react';
 
 export default function ThemeSpritemapCETsConfiguration({

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/openDeleteLayoutModal.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/openDeleteLayoutModal.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal, sub} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 
 export default function openDeleteLayoutModal({
 	message,

--- a/modules/apps/layout/layout-admin-web/test/js/LayoutPageTemplateEntryCard.tsx
+++ b/modules/apps/layout/layout-admin-web/test/js/LayoutPageTemplateEntryCard.tsx
@@ -6,15 +6,19 @@
 import '@testing-library/jest-dom/extend-expect';
 import {act, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {fetch, openModal} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
+import {fetch} from 'frontend-js-web';
 import * as React from 'react';
 
 import LayoutPageTemplateEntryCard from '../../src/main/resources/META-INF/resources/js/LayoutPageTemplateEntryCard';
 
+jest.mock('frontend-js-components-web', () => ({
+	openModal: jest.fn(),
+}));
+
 jest.mock('frontend-js-web', () => ({
 	createPortletURL: jest.fn(),
 	fetch: jest.fn(),
-	openModal: jest.fn(),
 }));
 
 const openModalMock = openModal as jest.Mock<typeof openModal>;

--- a/modules/apps/layout/layout-admin-web/test/js/layout/look_and_feel/GlobalCSSCETsConfiguration.test.tsx
+++ b/modules/apps/layout/layout-admin-web/test/js/layout/look_and_feel/GlobalCSSCETsConfiguration.test.tsx
@@ -12,12 +12,12 @@ import {
 	screen,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 import * as React from 'react';
 
 import GlobalCSSCETsConfiguration from '../../../../src/main/resources/META-INF/resources/js/layout/look_and_feel/GlobalCSSCETsConfiguration';
 
-jest.mock('frontend-js-web', () => ({
+jest.mock('frontend-js-components-web', () => ({
 	openSelectionModal: jest.fn(),
 	openToast: () => {},
 }));

--- a/modules/apps/layout/layout-admin-web/test/js/layout/look_and_feel/GlobalJSCETsConfiguration.test.tsx
+++ b/modules/apps/layout/layout-admin-web/test/js/layout/look_and_feel/GlobalJSCETsConfiguration.test.tsx
@@ -11,12 +11,12 @@ import {
 	render,
 	screen,
 } from '@testing-library/react';
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 import * as React from 'react';
 
 import GlobalJSCETsConfiguration from '../../../../src/main/resources/META-INF/resources/js/layout/look_and_feel/GlobalJSCETsConfiguration';
 
-jest.mock('frontend-js-web', () => ({
+jest.mock('frontend-js-components-web', () => ({
 	openSelectionModal: jest.fn(),
 	openToast: () => {},
 }));

--- a/modules/apps/layout/layout-admin-web/test/js/layout/look_and_feel/ThemeCSSReplacementSelector.test.tsx
+++ b/modules/apps/layout/layout-admin-web/test/js/layout/look_and_feel/ThemeCSSReplacementSelector.test.tsx
@@ -6,12 +6,12 @@
 import '@testing-library/jest-dom/extend-expect';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 import * as React from 'react';
 
 import ThemeCSSReplacementSelector from '../../../../src/main/resources/META-INF/resources/js/ThemeCSSReplacementSelector';
 
-jest.mock('frontend-js-web', () => ({
+jest.mock('frontend-js-components-web', () => ({
 	openSelectionModal: jest.fn(),
 }));
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DiscardDraftButton.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DiscardDraftButton.tsx
@@ -4,7 +4,7 @@
  */
 
 import ClayButton from '@clayui/button';
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 import React from 'react';
 
 import {config} from '../config/index';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/MasterLayout.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/MasterLayout.js
@@ -4,7 +4,7 @@
  */
 
 import classNames from 'classnames';
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useMemo, useRef} from 'react';
 import {useDrop} from 'react-dnd';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/NetworkStatusBar.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/NetworkStatusBar.js
@@ -6,7 +6,7 @@
 import ClayIcon from '@clayui/icon';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {useEventListener} from '@liferay/frontend-js-react-web';
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 import React, {useEffect, useState} from 'react';
 
 import {SERVICE_NETWORK_STATUS_TYPES} from '../config/constants/serviceNetworkStatusTypes';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/ShortcutManager.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/ShortcutManager.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 import React, {useEffect, useRef, useState} from 'react';
 
 import {ITEM_ACTIVATION_ORIGINS} from '../config/constants/itemActivationOrigins';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Toolbar.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Toolbar.js
@@ -6,7 +6,7 @@
 import ClayLayout from '@clayui/layout';
 import {ReactPortal, useIsMounted} from '@liferay/frontend-js-react-web';
 import classNames from 'classnames';
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 import React, {useEffect, useState} from 'react';
 
 import ExperienceToolbarSection from '../../plugins/experience/components/ExperienceToolbarSection';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment_configuration_fields/HideFragmentField.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment_configuration_fields/HideFragmentField.js
@@ -6,7 +6,7 @@
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import ClayForm, {ClayCheckbox} from '@clayui/form';
 import {useControlledState} from '@liferay/layout-js-components-web';
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/keyboard_movement/KeyboardMovementManager.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/keyboard_movement/KeyboardMovementManager.js
@@ -4,7 +4,8 @@
  */
 
 import {useEventListener} from '@liferay/frontend-js-react-web';
-import {openToast, sub} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 import {useEffect, useRef} from 'react';
 
 import {FRAGMENT_ENTRY_TYPES} from '../../config/constants/fragmentEntryTypes';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/topper/TopperItemActions.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/topper/TopperItemActions.js
@@ -6,7 +6,7 @@
 import ClayButton from '@clayui/button';
 import ClayDropDown, {Align} from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
-import {openModal, openToast} from 'frontend-js-web';
+import {openModal, openToast} from 'frontend-js-components-web';
 import PropTypes from 'prop-types';
 import React, {useMemo, useState} from 'react';
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getAlloyEditorProcessor.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getAlloyEditorProcessor.js
@@ -4,7 +4,8 @@
  */
 
 import {isNullOrUndefined} from '@liferay/layout-js-components-web';
-import {debounce, openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
+import {debounce} from 'frontend-js-web';
 
 import {SPACE_KEY_CODE} from '../config/constants/keyboardCodes';
 import {config} from '../config/index';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/addFragmentComposition.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/addFragmentComposition.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openToast, sub} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 
 import addFragmentCompositionAction from '../actions/addFragmentComposition';
 import FragmentService from '../services/FragmentService';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/deleteItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/deleteItem.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 
 import deleteItemAction from '../actions/deleteItem';
 import {ITEM_ACTIVATION_ORIGINS} from '../config/constants/itemActivationOrigins';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/updateFormItemConfig.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/updateFormItemConfig.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 
 import updateFormItemConfigAction from '../actions/updateFormItemConfig';
 import FormService from '../services/FormService';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getPageContentDropdownItems.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getPageContentDropdownItems.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal, sub} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 
 export function getPageContentDropdownItems(pageContent, label = '') {
 	if (!pageContent) {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/isMovementValid.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/isMovementValid.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openToast, sub} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 
 import {LayoutData, LayoutDataItem} from '../../types/layout_data/LayoutData';
 import {FragmentEntryLinkMap} from '../actions/addFragmentEntryLinks';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/openConfirmModal.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/openConfirmModal.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
 
 type Props = {
 	buttonLabel: string;
@@ -11,7 +11,7 @@ type Props = {
 	onCancel?: () => void;
 	onConfirm?: () => void;
 	status: 'info' | 'warning';
-	text: string;
+	text?: string;
 	title: string;
 };
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/openImageSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/openImageSelector.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 
 import {config} from '../app/config/index';
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/openInfoFieldSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/openInfoFieldSelector.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {getPortletNamespace, openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
+import {getPortletNamespace} from 'frontend-js-web';
 
 import {config} from '../app/config/index';
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/openItemSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/openItemSelector.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 
 export function openItemSelector({
 	callback,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTreeNodeActions.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTreeNodeActions.js
@@ -8,7 +8,7 @@ import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import {FocusScope} from '@clayui/shared';
 import classNames from 'classnames';
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 import React, {useCallback, useMemo, useRef, useState} from 'react';
 import {flushSync} from 'react-dom';
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/VisibilityButton.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/VisibilityButton.js
@@ -6,7 +6,8 @@
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import classNames from 'classnames';
-import {openToast, sub} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/EditableActionPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/EditableActionPanel.js
@@ -5,8 +5,8 @@
 
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
-import {useId} from 'frontend-js-components-web';
-import {debounce, openToast, sub} from 'frontend-js-web';
+import {openToast, useId} from 'frontend-js-components-web';
+import {debounce, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useMemo, useState} from 'react';
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/FormGeneralPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/FormGeneralPanel.js
@@ -8,8 +8,7 @@ import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput, ClayToggle} from '@clayui/form';
 import ClayPanel from '@clayui/panel';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
-import {useId} from 'frontend-js-components-web';
-import {openToast} from 'frontend-js-web';
+import {openToast, useId} from 'frontend-js-components-web';
 import React, {useCallback, useEffect, useState} from 'react';
 
 import {CheckboxField} from '../../../../../../app/components/fragment_configuration_fields/CheckboxField';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/collection_general_panel/CollectionGeneralPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/collection_general_panel/CollectionGeneralPanel.js
@@ -8,8 +8,8 @@ import ClayButton from '@clayui/button';
 import ClayLabel from '@clayui/label';
 import ClayPanel from '@clayui/panel';
 import ClayPopover from '@clayui/popover';
-import {useId} from 'frontend-js-components-web';
-import {openConfirmModal, sub} from 'frontend-js-web';
+import {openConfirmModal, useId} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/comments/components/AddCommentForm.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/comments/components/AddCommentForm.js
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {useId} from 'frontend-js-components-web';
-import {openToast} from 'frontend-js-web';
+import {openToast, useId} from 'frontend-js-components-web';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/comments/components/EditCommentForm.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/comments/components/EditCommentForm.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/comments/components/FragmentComment.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/comments/components/FragmentComment.js
@@ -8,8 +8,8 @@ import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
 import classNames from 'classnames';
-import {useSessionState} from 'frontend-js-components-web';
-import {openToast, sub} from 'frontend-js-web';
+import {openToast, useSessionState} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/comments/components/ReplyCommentForm.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/comments/components/ReplyCommentForm.js
@@ -4,7 +4,7 @@
  */
 
 import ClayButton from '@clayui/button';
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceItem.js
@@ -10,7 +10,8 @@ import ClayLayout from '@clayui/layout';
 import ClayLink from '@clayui/link';
 import ClayList from '@clayui/list';
 import classNames from 'classnames';
-import {navigate, openConfirmModal, setSessionValue} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {navigate, setSessionValue} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
@@ -15,8 +15,8 @@ import {
 	useEventListener,
 	useIsMounted,
 } from '@liferay/frontend-js-react-web';
-import {useId, useSessionState} from 'frontend-js-components-web';
-import {COOKIE_TYPES, navigate, openToast} from 'frontend-js-web';
+import {openToast, useId, useSessionState} from 'frontend-js-components-web';
+import {COOKIE_TYPES, navigate} from 'frontend-js-web';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import {config} from '../../../app/config/index';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_rules/components/RulesList.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_rules/components/RulesList.js
@@ -9,7 +9,8 @@ import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
 import ClayList from '@clayui/list';
 import classNames from 'classnames';
-import {openToast, sub} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 import {useDispatch, useSelector} from '../../../app/contexts/StoreContext';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_rules/components/RulesModal.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_rules/components/RulesModal.js
@@ -10,8 +10,7 @@ import ClayIcon from '@clayui/icon';
 import ClayModal, {useModal} from '@clayui/modal';
 import {ScreenReaderAnnouncerContextProvider} from '@liferay/layout-js-components-web';
 import classNames from 'classnames';
-import {useId} from 'frontend-js-components-web';
-import {openToast} from 'frontend-js-web';
+import {openToast, useId} from 'frontend-js-components-web';
 import React, {useEffect, useRef, useState} from 'react';
 import {v4 as uuidv4} from 'uuid';
 

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/DiscardDraftButton.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/DiscardDraftButton.test.js
@@ -6,7 +6,7 @@
 import '@testing-library/jest-dom/extend-expect';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 import React from 'react';
 
 import DiscardDraftButton from '../../../../src/main/resources/META-INF/resources/page_editor/app/components/DiscardDraftButton';
@@ -17,8 +17,8 @@ jest.mock(
 	() => jest.fn(() => false)
 );
 
-jest.mock('frontend-js-web', () => ({
-	...jest.requireActual('frontend-js-web'),
+jest.mock('frontend-js-components-web', () => ({
+	...jest.requireActual('frontend-js-components-web'),
 	openConfirmModal: jest.fn(({onConfirm}) => onConfirm(true)),
 }));
 

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/ToolbarActionsDropdown.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/ToolbarActionsDropdown.test.js
@@ -6,7 +6,7 @@
 import '@testing-library/jest-dom/extend-expect';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 import React from 'react';
 
 import ToolbarActionsDropdown from '../../../../src/main/resources/META-INF/resources/page_editor/app/components/ToolbarActionsDropdown';
@@ -29,8 +29,8 @@ const INITIAL_STATE = {
 	undoHistory: [{}],
 };
 
-jest.mock('frontend-js-web', () => ({
-	...jest.requireActual('frontend-js-web'),
+jest.mock('frontend-js-components-web', () => ({
+	...jest.requireActual('frontend-js-components-web'),
 	openConfirmModal: jest.fn(({onConfirm}) => onConfirm(false)),
 }));
 

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page_rules/components/RulesModal.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page_rules/components/RulesModal.test.js
@@ -34,9 +34,12 @@ jest.mock(
 	() => jest.fn(() => [{id: 'condition-id'}])
 );
 
-jest.mock('frontend-js-web', () => ({
-	...jest.requireActual('frontend-js-web'),
+jest.mock('frontend-js-components-web', () => ({
+	...jest.requireActual('frontend-js-components-web'),
 	openToast: jest.fn(),
+}));
+
+jest.mock('frontend-js-web', () => ({
 	sub: jest.fn((langKey, arg) => langKey.replace('x', arg)),
 }));
 

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/common/openItemSelector.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/common/openItemSelector.test.js
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 
 import {openItemSelector} from '../../../src/main/resources/META-INF/resources/page_editor/common/openItemSelector';
 
-jest.mock('frontend-js-web');
+jest.mock('frontend-js-components-web');
 
 const openModal = ({
 	callback = () => {},

--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/import/Import.tsx
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/import/Import.tsx
@@ -9,8 +9,8 @@ import ClayLayout from '@clayui/layout';
 import ClayLink from '@clayui/link';
 import ClayToolbar from '@clayui/toolbar';
 import classNames from 'classnames';
-import {useId} from 'frontend-js-components-web';
-import {fetch, navigate, openToast, sub} from 'frontend-js-web';
+import {openToast, useId} from 'frontend-js-components-web';
+import {fetch, navigate, sub} from 'frontend-js-web';
 import React, {useRef, useState} from 'react';
 
 import isNullOrUndefined from '../../utils/isNullOrUndefined';

--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/modals/CopyFragmentModal.tsx
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/modals/CopyFragmentModal.tsx
@@ -7,7 +7,8 @@ import ClayAlert from '@clayui/alert';
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput, ClaySelectWithOption} from '@clayui/form';
 import ClayModal, {useModal} from '@clayui/modal';
-import {fetch, navigate, openToast, sub} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch, navigate, sub} from 'frontend-js-web';
 import React, {FormEvent, useMemo, useState} from 'react';
 
 import FormField from './FormField';

--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/page_template_modal/PageTemplateModal.tsx
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/page_template_modal/PageTemplateModal.tsx
@@ -7,7 +7,8 @@ import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput, ClaySelectWithOption} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayModal, {useModal} from '@clayui/modal';
-import {fetch, openToast, sub} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch, sub} from 'frontend-js-web';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {flushSync} from 'react-dom';
 

--- a/modules/apps/layout/layout-js-components-web/test/components/page_template_modal/PageTemplateModal.test.tsx
+++ b/modules/apps/layout/layout-js-components-web/test/components/page_template_modal/PageTemplateModal.test.tsx
@@ -12,13 +12,16 @@ import PageTemplateModal from '../../../src/main/resources/META-INF/resources/js
 
 import '@testing-library/jest-dom/extend-expect';
 
+jest.mock('frontend-js-components-web', () => ({
+	openToast: jest.fn(),
+}));
+
 jest.mock('frontend-js-web', () => {
 	const actual = jest.requireActual('frontend-js-web');
 
 	return {
 		...actual,
 		fetch: jest.fn(() => Promise.resolve({json: () => {}})),
-		openToast: jest.fn(),
 		sub: jest.fn((langKey, arg) => langKey.replace('x', arg)),
 	};
 });

--- a/modules/apps/layout/layout-locked-layouts-web/package.json
+++ b/modules/apps/layout/layout-locked-layouts-web/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*"
 	},
 	"main": "js/index.ts",

--- a/modules/apps/layout/layout-locked-layouts-web/src/main/resources/META-INF/resources/js/openUnlockLayoutsModal.ts
+++ b/modules/apps/layout/layout-locked-layouts-web/src/main/resources/META-INF/resources/js/openUnlockLayoutsModal.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
 
 export default function openUnlockLayoutsModal({
 	onUnlock,

--- a/modules/apps/layout/layout-locked-layouts-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/layout/layout-locked-layouts-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "140c5f1be5b58dd936a70cb37200950f934f1437",
+	"@generated": "85013f1cbc1c96cd97b005373606c7f9b906250a",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}

--- a/modules/apps/layout/layout-page-template-admin-web/package.json
+++ b/modules/apps/layout/layout-page-template-admin-web/package.json
@@ -8,6 +8,7 @@
 		"@liferay/frontend-js-react-web": "*",
 		"@liferay/layout-js-components-web": "*",
 		"classnames": "2.3.1",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "18.2.0",

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/ActionsComponentPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
 
 import openDeletePageTemplateModal from './commands/openDeletePageTemplateModal';
 

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/commands/openDeletePageTemplateModal.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/commands/openDeletePageTemplateModal.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal, sub} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 
 export default function openDeletePageTemplateModal({
 	message,

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/commands/openInUseModal.ts
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/commands/openInUseModal.ts
@@ -3,12 +3,13 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {navigate, openModal, sub} from 'frontend-js-web';
+import {ModalStatus, openModal} from 'frontend-js-components-web';
+import {navigate, sub} from 'frontend-js-web';
 
 type Props = {
 	assetType: string;
 	onCancel?: () => void;
-	status: string;
+	status: ModalStatus;
 	viewUsagesURL: string;
 };
 

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/components/ContentTypeModal.tsx
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/components/ContentTypeModal.tsx
@@ -6,7 +6,8 @@
 import ClayAlert from '@clayui/alert';
 import ClayButton from '@clayui/button';
 import ClayModal, {useModal} from '@clayui/modal';
-import {fetch, navigate, openModal} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
+import {fetch, navigate} from 'frontend-js-web';
 import React, {useCallback, useRef, useState} from 'react';
 
 import openInUseModal from '../commands/openInUseModal';

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/AssetDisplayPageUsagesManagementToolbarPropsTransformer.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/AssetDisplayPageUsagesManagementToolbarPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	const deleteAssetDisplayPageEntry = (itemData) => {

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/DisplayPageDropdownPropsTransformer.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/DisplayPageDropdownPropsTransformer.js
@@ -9,9 +9,8 @@ import {
 	openModal,
 	openSelectionModal,
 	openSimpleInputModal,
-	setFormValues,
-	sub,
-} from 'frontend-js-web';
+} from 'frontend-js-components-web';
+import {setFormValues, sub} from 'frontend-js-web';
 
 import openContentTypeModal from '../commands/openContentTypeModal';
 import openDeletePageTemplateModal from '../commands/openDeletePageTemplateModal';

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/DisplayPageManagementToolbarPropsTransformer.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/DisplayPageManagementToolbarPropsTransformer.js
@@ -7,11 +7,8 @@ import {
 	CreationModal,
 	openModalComponent,
 } from '@liferay/layout-js-components-web';
-import {
-	getCheckedCheckboxes,
-	openSelectionModal,
-	setFormValues,
-} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
+import {getCheckedCheckboxes, setFormValues} from 'frontend-js-web';
 
 import openDeletePageTemplateModal from '../commands/openDeletePageTemplateModal';
 

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/LayoutPageTemplateCollectionPropsTransformer.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/LayoutPageTemplateCollectionPropsTransformer.js
@@ -7,12 +7,8 @@ import {
 	CreationModal,
 	openModalComponent,
 } from '@liferay/layout-js-components-web';
-import {
-	openModal,
-	openSelectionModal,
-	setFormValues,
-	sub,
-} from 'frontend-js-web';
+import {openModal, openSelectionModal} from 'frontend-js-components-web';
+import {setFormValues, sub} from 'frontend-js-web';
 
 import openDeletePageTemplateModal from '../commands/openDeletePageTemplateModal';
 

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/LayoutPageTemplateEntryManagementToolbarPropsTransformer.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/LayoutPageTemplateEntryManagementToolbarPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openSimpleInputModal} from 'frontend-js-web';
+import {openSimpleInputModal} from 'frontend-js-components-web';
 
 import openDeletePageTemplateModal from '../commands/openDeletePageTemplateModal';
 

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/LayoutPageTemplateEntryPropsTransformer.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/LayoutPageTemplateEntryPropsTransformer.js
@@ -4,12 +4,12 @@
  */
 
 import {
-	createPortletURL,
 	openConfirmModal,
 	openModal,
 	openSelectionModal,
 	openSimpleInputModal,
-} from 'frontend-js-web';
+} from 'frontend-js-components-web';
+import {createPortletURL} from 'frontend-js-web';
 
 import openDeletePageTemplateModal from '../commands/openDeletePageTemplateModal';
 

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/LayoutPrototypeDropdownPropsTransformer.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/LayoutPrototypeDropdownPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
 
 import openDeletePageTemplateModal from '../commands/openDeletePageTemplateModal';
 

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/ManagePermissionsPropsTransformer.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/ManagePermissionsPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
 
 export default function ({additionalProps, ...props}) {
 	return {

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/MasterLayoutDropdownPropsTransformer.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/MasterLayoutDropdownPropsTransformer.js
@@ -8,7 +8,7 @@ import {
 	openModal,
 	openSelectionModal,
 	openSimpleInputModal,
-} from 'frontend-js-web';
+} from 'frontend-js-components-web';
 
 import openDeletePageTemplateModal from '../commands/openDeletePageTemplateModal';
 

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/MasterLayoutManagementToolbarPropsTransformer.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/MasterLayoutManagementToolbarPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openSimpleInputModal} from 'frontend-js-web';
+import {openSimpleInputModal} from 'frontend-js-components-web';
 
 import openDeletePageTemplateModal from '../commands/openDeletePageTemplateModal';
 

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/SelectLayoutPageTemplateEntryMasterLayoutVerticalCardPropsTransformer.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/SelectLayoutPageTemplateEntryMasterLayoutVerticalCardPropsTransformer.js
@@ -4,7 +4,7 @@
  */
 
 import {getSpritemap} from '@liferay/frontend-icons-web';
-import {openSimpleInputModal} from 'frontend-js-web';
+import {openSimpleInputModal} from 'frontend-js-components-web';
 
 export default function SelectLayoutPageTemplateEntryMasterLayoutVerticalCardPropsTransformer({
 	additionalProps: {

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "6dfe577ef1d963d40a4e42d57d663e9e50e01be7",
+	"@generated": "dd36546ef7c18103c4d246027515e9493aeadef9",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -20,6 +20,9 @@
 			],
 			"@liferay/layout-js-components-web": [
 				"../../../../../../layout-js-components-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
@@ -49,6 +52,9 @@
 		},
 		{
 			"path": "../../../../../../layout-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/apps/layout/layout-seo-web/package.json
+++ b/modules/apps/layout/layout-seo-web/package.json
@@ -4,6 +4,7 @@
 		"@clayui/form": "3.125.0",
 		"@liferay/frontend-js-react-web": "*",
 		"classnames": "2.3.1",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "18.2.0"

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/openGraph.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/openGraph.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openSelectionModal, toggleDisabled} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
+import {toggleDisabled} from 'frontend-js-web';
 
 import {previewSeoFireChange} from './PreviewSeoEvents';
 

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/openGraphSettings.js
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/js/seo/openGraphSettings.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openSelectionModal, toggleDisabled} from 'frontend-js-web';
+import {openSelectionModal} from 'frontend-js-components-web';
+import {toggleDisabled} from 'frontend-js-web';
 
 export default function ({namespace, uploadOpenGraphImageURL}) {
 	const openGraphImageButton = document.getElementById(

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "d005d0dac0c67803df23fbc4bc38576821dfeb14",
+	"@generated": "2464c2f98c93ac9433bfd3759666c6bd7761d06d",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -14,6 +14,9 @@
 		"paths": {
 			"@liferay/frontend-js-react-web": [
 				"../../../../../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
 			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
@@ -37,6 +40,9 @@
 	"references": [
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/apps/layout/layout-taglib/package.json
+++ b/modules/apps/layout/layout-taglib/package.json
@@ -10,6 +10,7 @@
 		"@clayui/pagination": "3.127.0",
 		"@clayui/table": "3.111.0",
 		"classnames": "2.3.1",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "18.2.0"

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/js/layout_classed_model_usages_view/ViewUsages.js
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/js/layout_classed_model_usages_view/ViewUsages.js
@@ -7,7 +7,8 @@ import {ClayButtonWithIcon} from '@clayui/button';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {ClayPaginationWithBasicItems} from '@clayui/pagination';
 import ClayTable from '@clayui/table';
-import {fetch, openModal, openToast} from 'frontend-js-web';
+import {openModal, openToast} from 'frontend-js-components-web';
+import {fetch} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 export default function ViewUsages({getUsagesURL}) {

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/js/render_layout_structure/InfoItemActionHandler.js
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/js/render_layout_structure/InfoItemActionHandler.js
@@ -3,12 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {
-	escapeHTML,
-	navigate,
-	objectToFormData,
-	openToast,
-} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {escapeHTML, navigate, objectToFormData} from 'frontend-js-web';
 
 const INTERACTION_NOTIFICATION = 'notification';
 const INTERACTION_PAGE = 'page';

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/js/select_layout/SelectLayoutTree.js
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/js/select_layout/SelectLayoutTree.js
@@ -10,7 +10,8 @@ import {ClayCheckbox} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import classNames from 'classnames';
-import {debounce, fetch, getOpener, openToast, sub} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {debounce, fetch, getOpener, sub} from 'frontend-js-web';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 export default function SelectLayoutTree({

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "41d29840e3572a1f4296eb011b7fbfb87a7de0dc",
+	"@generated": "0d4f2d269ca183529e447dd7d255c5ec32e2a0f6",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/package.json
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*"
 	},
 	"main": "js/index.js",

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/src/main/resources/META-INF/resources/js/index.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openAlertModal} from 'frontend-js-web';
+import {openAlertModal} from 'frontend-js-components-web';
 
 export function DisagreeButtonPropsTransformer({...props}) {
 	return {

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "77e5ca1500d78a8132ea17fdffa36df6fc9d29c5",
+	"@generated": "6a3579e24bc2e98bc3f4223ac8e35dece2d2d006",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}

--- a/modules/apps/portlet-configuration/portlet-configuration-web/package.json
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/package.json
@@ -1,6 +1,7 @@
 {
 	"dependencies": {
 		"@clayui/form": "3.125.0",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "18.2.0"

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/js/ArchivedSetuptsDropdownDefaultEventHandler.js
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/js/ArchivedSetuptsDropdownDefaultEventHandler.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {DefaultEventHandler, openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
+import {DefaultEventHandler} from 'frontend-js-web';
 
 class ArchivedSetuptsDropdownDefaultEventHandler extends DefaultEventHandler {
 	deleteArchivedSetups(itemData) {

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/js/ArchivedSetuptsDropdownDefaultPropsTransformer.js
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/js/ArchivedSetuptsDropdownDefaultPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 
 const ACTIONS = {
 	deleteArchivedSetups(itemData) {

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/js/ManagementToolbarPropsTransformer.js
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/js/ManagementToolbarPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openConfirmModal} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "289e3cf9bd9281c438a48e3e70d6a26806f14430",
+	"@generated": "f55c66b696f957ca1eced7348358b4e3e2244ec1",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}

--- a/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/InformationTemplatesDropdownPropsTransformer.js
+++ b/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/InformationTemplatesDropdownPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
 
 import openDeleteTemplateModal from './modal/openDeleteTemplateModal';
 

--- a/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/WidgetTemplatesDropdownPropsTransformer.js
+++ b/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/WidgetTemplatesDropdownPropsTransformer.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal, sub} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 
 import openDeleteTemplateModal from './modal/openDeleteTemplateModal';
 

--- a/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/configuration/icon/ImportScript.js
+++ b/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/configuration/icon/ImportScript.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
 
 export default function ({namespace}) {
 	const fileInput = document.getElementById(`${namespace}importScriptInput`);

--- a/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/ddm_template_editor/components/Editor.js
+++ b/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/ddm_template_editor/components/Editor.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {fetch, navigate, openToast, sub} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch, navigate, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useContext, useEffect, useRef, useState} from 'react';
 

--- a/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/modal/openDeleteTemplateModal.js
+++ b/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/modal/openDeleteTemplateModal.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal, sub} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 
 export default function openDeleteTemplateModal({
 	message,


### PR DESCRIPTION
Hi team :wave: 

This PR is part of [LPD-47718](https://liferay.atlassian.net/browse/LPD-47718).

It refactors your code to import `openModal`, `openToast`, etc. from `frontend-js-components-web` instead of `frontend-js-web`.

The final goal is to remove those methods from `frontend-js-web` so that whenever that module is imported the browser doesn't need to pull React and Clay simply because those methods existed there. This will enhance the performance of sites that don't need React or Clay.

Internally, for now, we are only [re-exporting those methods](https://github.com/brianchandotcom/liferay-portal/pull/159020/commits/3c4231e573b72d8775583af87224810fe42de532) from `frontend-js-components-web`, but once all PRs like this one sent to teams are merged, we (Frontend Infra) will send another final PR to move the methods and remove them completely from `frontend-js-web`.

The code in this PR (as well as the one we will send to other teams) has been thoroughly tested in [this PR](https://github.com/liferay-frontend/liferay-portal/pull/4720#) but we want to make sure that it doesn't break anything and that's why we send it to you for review.

The expectations are that you run the tests suites you think apply and if nothing breaks you just simply forward the PR to Brian. 

Also, it would be great if any new code you write that uses those methods imports them from `frontend-js-components-web` instead of `frontend-js-web` so that we don't have to repeat this process again :grimacing: .

For reference, here is the list of moved methods:

1. openAlertModal
2. openCategorySelectionModal
3. openConfirmModal
4. openModal
5. openPortletModal
6. openPortletWindow
7. openSelectionModal
8. openSimpleInputModal
9. openTagSelectionModal
10. openToast