### PR TITLE
LPD-49551

### DIFF
--- a/modules/apps/portal/portal-events-test/src/testIntegration/java/com/liferay/portal/events/test/ServicePreActionTest.java
+++ b/modules/apps/portal/portal-events-test/src/testIntegration/java/com/liferay/portal/events/test/ServicePreActionTest.java
@@ -27,7 +27,6 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalService;
-import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -596,9 +595,6 @@ public class ServicePreActionTest {
 
 	@Inject
 	private Portal _portal;
-
-	@Inject
-	private ResourceActionLocalService _resourceActionLocalService;
 
 	@Inject
 	private ResourcePermissionLocalService _resourcePermissionLocalService;

--- a/modules/apps/portal/portal-events-test/src/testIntegration/java/com/liferay/portal/events/test/ServicePreActionTest.java
+++ b/modules/apps/portal/portal-events-test/src/testIntegration/java/com/liferay/portal/events/test/ServicePreActionTest.java
@@ -86,13 +86,13 @@ public class ServicePreActionTest {
 	public static void setUpClass() throws Exception {
 		_company = CompanyTestUtil.addCompany();
 
-		_safeCloseable = CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-			_company.getCompanyId());
-
 		Role role = _roleLocalService.getRole(
 			_company.getCompanyId(), RoleConstants.GUEST);
 
 		_guestRoleId = role.getRoleId();
+
+		_safeCloseable = CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+			_company.getCompanyId());
 	}
 
 	@AfterClass
@@ -187,7 +187,7 @@ public class ServicePreActionTest {
 		long plid = _getThemeDisplayPlid(true, false);
 
 		Object viewableLayoutComposite = _getViewableLayoutComposite(
-			"/nonexistent_page", false);
+			false, "/nonexistent_page");
 
 		Layout layout = _getLayout(viewableLayoutComposite);
 
@@ -199,7 +199,7 @@ public class ServicePreActionTest {
 	}
 
 	@Test
-	public void testHiddenLayoutsVirtualHostLayoutCompositeWithoutPublicPath()
+	public void testHiddenLayoutsVirtualHostLayoutCompositeWithNonpublicPath()
 		throws Exception {
 
 		long plid = _getThemeDisplayPlid(true, false);
@@ -208,7 +208,7 @@ public class ServicePreActionTest {
 				_setLayoutsToHiddenAndDefaultLayoutToNotGuestViewable(plid)) {
 
 			Object viewableLayoutComposite = _getViewableLayoutComposite(
-				"/non/public/path", true);
+				true, "/non/public/path");
 
 			Layout layout = _getLayout(viewableLayoutComposite);
 
@@ -233,7 +233,7 @@ public class ServicePreActionTest {
 				_setLayoutsToHiddenAndDefaultLayoutToNotGuestViewable(plid)) {
 
 			Object viewableLayoutComposite = _getViewableLayoutComposite(
-				"/portal/saml/metadata", true);
+				true, "/portal/saml/metadata");
 
 			Layout layout = _getLayout(viewableLayoutComposite);
 
@@ -424,7 +424,7 @@ public class ServicePreActionTest {
 	}
 
 	private Object _getViewableLayoutComposite(
-		String requestURI, boolean prependPathMain) {
+		boolean prependPathMain, String requestURI) {
 
 		_mockHttpServletRequest.setPathInfo(requestURI);
 

--- a/modules/apps/portal/portal-events-test/src/testIntegration/java/com/liferay/portal/events/test/ServicePreActionTest.java
+++ b/modules/apps/portal/portal-events-test/src/testIntegration/java/com/liferay/portal/events/test/ServicePreActionTest.java
@@ -12,6 +12,8 @@ import com.liferay.portal.events.ServicePreAction;
 import com.liferay.portal.kernel.events.ActionException;
 import com.liferay.portal.kernel.events.LifecycleAction;
 import com.liferay.portal.kernel.events.LifecycleEvent;
+import com.liferay.portal.kernel.exception.LayoutPermissionException;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -31,6 +33,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
@@ -52,6 +55,7 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsUtil;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
@@ -206,6 +210,95 @@ public class ServicePreActionTest {
 		Assert.assertEquals(layout.getPlid(), plid);
 
 		Assert.assertEquals(layouts.toString(), 1, layouts.size());
+	}
+
+	@Test
+	public void testHiddenLayoutsVirtualHostLayoutCompositeWithoutPublicPath()
+		throws Exception {
+
+		String path = "/non/public/path";
+
+		_mockHttpServletRequest.setPathInfo(path);
+		_mockHttpServletRequest.setRequestURI(_portal.getPathMain() + path);
+
+		long plid = _getThemeDisplayPlid(true, false);
+
+		try (AutoCloseable autoCloseable =
+				_setLayoutsToHiddenAndDefaultLayoutToNotGuestViewable(plid)) {
+
+			Object defaultLayoutComposite = ReflectionTestUtil.invoke(
+				_servicePreAction, "_getDefaultVirtualHostLayoutComposite",
+				new Class<?>[] {HttpServletRequest.class},
+				_mockHttpServletRequest);
+
+			Object viewableLayoutComposite = ReflectionTestUtil.invoke(
+				_servicePreAction, "_getViewableLayoutComposite",
+				new Class<?>[] {
+					HttpServletRequest.class, User.class,
+					PermissionChecker.class, Layout.class, List.class,
+					boolean.class
+				},
+				_mockHttpServletRequest, _user,
+				_permissionCheckerFactory.create(_user),
+				_getLayout(defaultLayoutComposite),
+				_getLayouts(defaultLayoutComposite), false);
+
+			Layout layout = _getLayout(viewableLayoutComposite);
+
+			List<Layout> layouts = _getLayouts(viewableLayoutComposite);
+
+			Assert.assertEquals(layout.getPlid(), plid);
+
+			Assert.assertNull(layouts);
+
+			Assert.assertTrue(
+				SessionErrors.contains(
+					_mockHttpServletRequest,
+					LayoutPermissionException.class.getName()));
+		}
+	}
+
+	@Test
+	public void testHiddenLayoutsVirtualHostLayoutCompositeWithPublicPath()
+		throws Exception {
+
+		String path = "/portal/saml/metadata";
+
+		_mockHttpServletRequest.setPathInfo(path);
+		_mockHttpServletRequest.setRequestURI(_portal.getPathMain() + path);
+
+		long plid = _getThemeDisplayPlid(true, false);
+
+		try (AutoCloseable autoCloseable =
+				_setLayoutsToHiddenAndDefaultLayoutToNotGuestViewable(plid)) {
+
+			Object defaultLayoutComposite = ReflectionTestUtil.invoke(
+				_servicePreAction, "_getDefaultVirtualHostLayoutComposite",
+				new Class<?>[] {HttpServletRequest.class},
+				_mockHttpServletRequest);
+
+			Object viewableLayoutComposite = ReflectionTestUtil.invoke(
+				_servicePreAction, "_getViewableLayoutComposite",
+				new Class<?>[] {
+					HttpServletRequest.class, User.class,
+					PermissionChecker.class, Layout.class, List.class,
+					boolean.class
+				},
+				_mockHttpServletRequest, _user,
+				_permissionCheckerFactory.create(_user),
+				_getLayout(defaultLayoutComposite),
+				_getLayouts(defaultLayoutComposite), false);
+
+			Layout layout = _getLayout(viewableLayoutComposite);
+
+			List<Layout> layouts = _getLayouts(viewableLayoutComposite);
+
+			Assert.assertEquals(layout.getPlid(), plid);
+
+			Assert.assertNull(layouts);
+
+			Assert.assertTrue(SessionErrors.isEmpty(_mockHttpServletRequest));
+		}
 	}
 
 	@Test
@@ -384,6 +477,43 @@ public class ServicePreActionTest {
 				WebKeys.THEME_DISPLAY);
 
 		return themeDisplay.getPlid();
+	}
+
+	private AutoCloseable _setLayoutsToHiddenAndDefaultLayoutToNotGuestViewable(
+			long defaultLayoutPlid)
+		throws PortalException {
+
+		_resourcePermissionLocalService.removeResourcePermission(
+			_group.getCompanyId(), Layout.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(defaultLayoutPlid), _guestRoleId, ActionKeys.VIEW);
+
+		List<Layout> updatedLayouts = new ArrayList<>();
+
+		List<Layout> layouts = _layoutLocalService.getLayouts(
+			_group.getCompanyId());
+
+		for (Layout layout : layouts) {
+			if (!layout.isHidden()) {
+				layout.setHidden(true);
+
+				updatedLayouts.add(_layoutLocalService.updateLayout(layout));
+			}
+		}
+
+		return () -> {
+			_resourcePermissionLocalService.setResourcePermissions(
+				_group.getCompanyId(), Layout.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(defaultLayoutPlid), _guestRoleId,
+				new String[] {ActionKeys.VIEW});
+
+			for (Layout layout : updatedLayouts) {
+				layout.setHidden(false);
+
+				_layoutLocalService.updateLayout(layout);
+			}
+		};
 	}
 
 	private void _testCustomErrorPage(String expectedMessage, String location)

--- a/modules/apps/portal/portal-events-test/src/testIntegration/java/com/liferay/portal/events/test/ServicePreActionTest.java
+++ b/modules/apps/portal/portal-events-test/src/testIntegration/java/com/liferay/portal/events/test/ServicePreActionTest.java
@@ -85,6 +85,11 @@ public class ServicePreActionTest {
 
 		_safeCloseable = CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 			_company.getCompanyId());
+
+		Role role = _roleLocalService.getRole(
+			_company.getCompanyId(), RoleConstants.GUEST);
+
+		_guestRoleId = role.getRoleId();
 	}
 
 	@AfterClass
@@ -341,12 +346,9 @@ public class ServicePreActionTest {
 		throws Exception {
 
 		if (!hasGuestViewPermission) {
-			Role role = _roleLocalService.getRole(
-				_group.getCompanyId(), RoleConstants.GUEST);
-
 			_resourcePermissionLocalService.removeResourcePermissions(
 				_group.getCompanyId(), Layout.class.getName(),
-				ResourceConstants.SCOPE_INDIVIDUAL, role.getRoleId(),
+				ResourceConstants.SCOPE_INDIVIDUAL, _guestRoleId,
 				ActionKeys.VIEW);
 		}
 
@@ -365,17 +367,14 @@ public class ServicePreActionTest {
 		}
 		finally {
 			if (!hasGuestViewPermission) {
-				Role role = _roleLocalService.getRole(
-					_group.getCompanyId(), RoleConstants.GUEST);
-
 				for (Layout layout :
 						_layoutLocalService.getLayouts(_group.getCompanyId())) {
 
 					_resourcePermissionLocalService.setResourcePermissions(
 						layout.getCompanyId(), Layout.class.getName(),
 						ResourceConstants.SCOPE_INDIVIDUAL,
-						String.valueOf(layout.getPrimaryKey()),
-						role.getRoleId(), new String[] {ActionKeys.VIEW});
+						String.valueOf(layout.getPrimaryKey()), _guestRoleId,
+						new String[] {ActionKeys.VIEW});
 				}
 			}
 		}
@@ -464,6 +463,11 @@ public class ServicePreActionTest {
 	}
 
 	private static Company _company;
+	private static long _guestRoleId;
+
+	@Inject
+	private static RoleLocalService _roleLocalService;
+
 	private static SafeCloseable _safeCloseable;
 
 	@DeleteAfterTestRun
@@ -491,9 +495,6 @@ public class ServicePreActionTest {
 
 	@Inject
 	private ResourcePermissionLocalService _resourcePermissionLocalService;
-
-	@Inject
-	private RoleLocalService _roleLocalService;
 
 	private final ServicePreAction _servicePreAction = new ServicePreAction();
 	private User _user;

--- a/modules/apps/portal/portal-events-test/src/testIntegration/java/com/liferay/portal/events/test/ServicePreActionTest.java
+++ b/modules/apps/portal/portal-events-test/src/testIntegration/java/com/liferay/portal/events/test/ServicePreActionTest.java
@@ -191,9 +191,9 @@ public class ServicePreActionTest {
 
 		Layout layout = _getLayout(viewableLayoutComposite);
 
-		List<Layout> layouts = _getLayouts(viewableLayoutComposite);
-
 		Assert.assertEquals(layout.getPlid(), plid);
+
+		List<Layout> layouts = _getLayouts(viewableLayoutComposite);
 
 		Assert.assertEquals(layouts.toString(), 1, layouts.size());
 	}
@@ -212,11 +212,9 @@ public class ServicePreActionTest {
 
 			Layout layout = _getLayout(viewableLayoutComposite);
 
-			List<Layout> layouts = _getLayouts(viewableLayoutComposite);
-
 			Assert.assertEquals(layout.getPlid(), plid);
 
-			Assert.assertNull(layouts);
+			Assert.assertNull(_getLayouts(viewableLayoutComposite));
 
 			Assert.assertTrue(
 				SessionErrors.contains(
@@ -239,11 +237,9 @@ public class ServicePreActionTest {
 
 			Layout layout = _getLayout(viewableLayoutComposite);
 
-			List<Layout> layouts = _getLayouts(viewableLayoutComposite);
-
 			Assert.assertEquals(layout.getPlid(), plid);
 
-			Assert.assertNull(layouts);
+			Assert.assertNull(_getLayouts(viewableLayoutComposite));
 
 			Assert.assertTrue(SessionErrors.isEmpty(_mockHttpServletRequest));
 		}

--- a/modules/apps/portal/portal-events-test/src/testIntegration/java/com/liferay/portal/events/test/ServicePreActionTest.java
+++ b/modules/apps/portal/portal-events-test/src/testIntegration/java/com/liferay/portal/events/test/ServicePreActionTest.java
@@ -184,24 +184,10 @@ public class ServicePreActionTest {
 	public void testHiddenLayoutsVirtualHostLayoutCompositeWithNonexistentLayout()
 		throws Exception {
 
-		_mockHttpServletRequest.setRequestURI("/nonexistent_page");
-
 		long plid = _getThemeDisplayPlid(true, false);
 
-		Object defaultLayoutComposite = ReflectionTestUtil.invoke(
-			_servicePreAction, "_getDefaultVirtualHostLayoutComposite",
-			new Class<?>[] {HttpServletRequest.class}, _mockHttpServletRequest);
-
-		Object viewableLayoutComposite = ReflectionTestUtil.invoke(
-			_servicePreAction, "_getViewableLayoutComposite",
-			new Class<?>[] {
-				HttpServletRequest.class, User.class, PermissionChecker.class,
-				Layout.class, List.class, boolean.class
-			},
-			_mockHttpServletRequest, _user,
-			_permissionCheckerFactory.create(_user),
-			_getLayout(defaultLayoutComposite),
-			_getLayouts(defaultLayoutComposite), false);
+		Object viewableLayoutComposite = _getViewableLayoutComposite(
+			"/nonexistent_page", false);
 
 		Layout layout = _getLayout(viewableLayoutComposite);
 
@@ -216,32 +202,13 @@ public class ServicePreActionTest {
 	public void testHiddenLayoutsVirtualHostLayoutCompositeWithoutPublicPath()
 		throws Exception {
 
-		String path = "/non/public/path";
-
-		_mockHttpServletRequest.setPathInfo(path);
-		_mockHttpServletRequest.setRequestURI(_portal.getPathMain() + path);
-
 		long plid = _getThemeDisplayPlid(true, false);
 
 		try (AutoCloseable autoCloseable =
 				_setLayoutsToHiddenAndDefaultLayoutToNotGuestViewable(plid)) {
 
-			Object defaultLayoutComposite = ReflectionTestUtil.invoke(
-				_servicePreAction, "_getDefaultVirtualHostLayoutComposite",
-				new Class<?>[] {HttpServletRequest.class},
-				_mockHttpServletRequest);
-
-			Object viewableLayoutComposite = ReflectionTestUtil.invoke(
-				_servicePreAction, "_getViewableLayoutComposite",
-				new Class<?>[] {
-					HttpServletRequest.class, User.class,
-					PermissionChecker.class, Layout.class, List.class,
-					boolean.class
-				},
-				_mockHttpServletRequest, _user,
-				_permissionCheckerFactory.create(_user),
-				_getLayout(defaultLayoutComposite),
-				_getLayouts(defaultLayoutComposite), false);
+			Object viewableLayoutComposite = _getViewableLayoutComposite(
+				"/non/public/path", true);
 
 			Layout layout = _getLayout(viewableLayoutComposite);
 
@@ -262,32 +229,13 @@ public class ServicePreActionTest {
 	public void testHiddenLayoutsVirtualHostLayoutCompositeWithPublicPath()
 		throws Exception {
 
-		String path = "/portal/saml/metadata";
-
-		_mockHttpServletRequest.setPathInfo(path);
-		_mockHttpServletRequest.setRequestURI(_portal.getPathMain() + path);
-
 		long plid = _getThemeDisplayPlid(true, false);
 
 		try (AutoCloseable autoCloseable =
 				_setLayoutsToHiddenAndDefaultLayoutToNotGuestViewable(plid)) {
 
-			Object defaultLayoutComposite = ReflectionTestUtil.invoke(
-				_servicePreAction, "_getDefaultVirtualHostLayoutComposite",
-				new Class<?>[] {HttpServletRequest.class},
-				_mockHttpServletRequest);
-
-			Object viewableLayoutComposite = ReflectionTestUtil.invoke(
-				_servicePreAction, "_getViewableLayoutComposite",
-				new Class<?>[] {
-					HttpServletRequest.class, User.class,
-					PermissionChecker.class, Layout.class, List.class,
-					boolean.class
-				},
-				_mockHttpServletRequest, _user,
-				_permissionCheckerFactory.create(_user),
-				_getLayout(defaultLayoutComposite),
-				_getLayouts(defaultLayoutComposite), false);
+			Object viewableLayoutComposite = _getViewableLayoutComposite(
+				"/portal/saml/metadata", true);
 
 			Layout layout = _getLayout(viewableLayoutComposite);
 
@@ -477,6 +425,35 @@ public class ServicePreActionTest {
 				WebKeys.THEME_DISPLAY);
 
 		return themeDisplay.getPlid();
+	}
+
+	private Object _getViewableLayoutComposite(
+		String requestURI, boolean prependPathMain) {
+
+		_mockHttpServletRequest.setPathInfo(requestURI);
+
+		if (prependPathMain) {
+			_mockHttpServletRequest.setRequestURI(
+				_portal.getPathMain() + requestURI);
+		}
+		else {
+			_mockHttpServletRequest.setRequestURI(requestURI);
+		}
+
+		Object defaultLayoutComposite = ReflectionTestUtil.invoke(
+			_servicePreAction, "_getDefaultVirtualHostLayoutComposite",
+			new Class<?>[] {HttpServletRequest.class}, _mockHttpServletRequest);
+
+		return ReflectionTestUtil.invoke(
+			_servicePreAction, "_getViewableLayoutComposite",
+			new Class<?>[] {
+				HttpServletRequest.class, User.class, PermissionChecker.class,
+				Layout.class, List.class, boolean.class
+			},
+			_mockHttpServletRequest, _user,
+			_permissionCheckerFactory.create(_user),
+			_getLayout(defaultLayoutComposite),
+			_getLayouts(defaultLayoutComposite), false);
 	}
 
 	private AutoCloseable _setLayoutsToHiddenAndDefaultLayoutToNotGuestViewable(

--- a/modules/apps/portal/portal-events-test/src/testIntegration/java/com/liferay/portal/events/test/ServicePreActionTest.java
+++ b/modules/apps/portal/portal-events-test/src/testIntegration/java/com/liferay/portal/events/test/ServicePreActionTest.java
@@ -117,6 +117,7 @@ public class ServicePreActionTest {
 		_mockHttpServletRequest.setAttribute(WebKeys.COMPANY, _company);
 		_mockHttpServletRequest.setAttribute(
 			WebKeys.VIRTUAL_HOST_LAYOUT_SET, _group.getPublicLayoutSet());
+		_mockHttpServletRequest.setPathInfo("/portal/login");
 		_mockHttpServletRequest.setRequestURI(
 			_portal.getPathMain() + "/portal/login");
 	}

--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -91,6 +91,7 @@ import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.webserver.WebServerServletTokenUtil;
+import com.liferay.portal.struts.AuthPublicPathRegistry;
 import com.liferay.portal.theme.ThemeDisplayFactory;
 import com.liferay.portal.util.LayoutClone;
 import com.liferay.portal.util.LayoutCloneFactory;
@@ -712,7 +713,9 @@ public class ServicePreAction extends Action {
 			layouts = null;
 
 			if (!_isLoginRequest(httpServletRequest) &&
-				!hasViewLayoutPermission) {
+				!hasViewLayoutPermission &&
+				!AuthPublicPathRegistry.contains(
+					httpServletRequest.getPathInfo())) {
 
 				if (user.isGuestUser() &&
 					AuthLoginGroupSettingsUtil.isPromptEnabled(

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3592,6 +3592,15 @@
         /portal/open_id_response,\
         /portal/portlet_url,\
         /portal/robots,\
+        /portal/saml/acs,\
+        /portal/saml/auth_redirect,\
+        /portal/saml/login,\
+        /portal/saml/metadata,\
+        /portal/saml/slo,\
+        /portal/saml/slo_logout,\
+        /portal/saml/slo_redirect,\
+        /portal/saml/slo_soap,\
+        /portal/saml/sso,\
         /portal/session_click,\
         /portal/session_tree_js_click,\
         /portal/sitemap,\


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-49551

Hello, we believe this issue is related to your team, so we would ask for your review, thank you!

### **Issue:**
Auth Public paths can result in an error page if all the pages on the site are hidden and not guest viewable.  This is because the `ServicePreAction._getViewableLayoutComposite()` method adds a `LayoutPermissionException` to `SessionErrors`.

For our component specifically, this prevents paths like `/c/portal/saml/metadata` from being reachable, which in turn prevent proper SAML authentication.

### **Solution:**
The solution comes two-fold.

First, we add these SAML paths to the portal.properties file for the `auth.public.paths` property.  These paths are intended to be public, as suggested by [this AuthPublicPath class](https://github.com/liferay/liferay-portal/blob/master/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/auth/publicpath/AuthPublicPath.java).  **This change has been approved by our team, and no further action should be required on your end.**

Second, we must prevent `auth.public.paths` entries from adding a `LayoutPermissionException` to `SessionErrors` (and potentially a `PrincipalException` if `isPromptEnabled` is enabled).  My understanding is these `auth.public.paths` entries are public as the name implies, so we shouldn't throw exceptions related to permissioning when trying to access them.  This is the code we would like for your team to please review, as our understanding of the `ServicePreAction` class and `layoutComposites` isn't deep.

Thank you for your help, and please let me know if you have any questions.