### PR TITLE
LPD-50146 The configuration of D&M and Media Gallery widget cannot be changed after publication

### DIFF
--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/configuration/icon/ModalConfigurationEditModePortletConfigurationIcon.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/configuration/icon/ModalConfigurationEditModePortletConfigurationIcon.java
@@ -98,7 +98,7 @@ public class ModalConfigurationEditModePortletConfigurationIcon
 							httpServletRequest, "settingsScope", settingsScope);
 
 						if (Validator.isNotNull(settingsScope)) {
-							return "settingsScope";
+							return settingsScope;
 						}
 					}
 


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-50146

Saving the configuration of DL widgets is failing (after first publication).

# How am I fixing it?

I think it is a very clear bug to solve: returning variable instead of string