### PR TITLE
LPD-51051

### DIFF
--- a/modules/apps/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/internal/upgrade/v1_0_2/UpgradePortletPreferences.java
+++ b/modules/apps/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/internal/upgrade/v1_0_2/UpgradePortletPreferences.java
@@ -91,7 +91,7 @@ public class UpgradePortletPreferences extends BaseUpgradePortletPreferences {
 				groupAssetVocabularyExternalReferenceCodesMap.entrySet()) {
 
 			String scopeExternalReferenceCode = getScopeExternalReferenceCode(
-				companyId, plid, entries.getKey());
+				companyId, ownerId, ownerType, plid, entries.getKey());
 
 			if (Validator.isNull(scopeExternalReferenceCode)) {
 				portletPreferences.setValues(

--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/web/internal/upgrade/v1_0_6/test/UpgradePortletPreferencesTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/web/internal/upgrade/v1_0_6/test/UpgradePortletPreferencesTest.java
@@ -11,10 +11,12 @@ import com.liferay.asset.list.service.AssetListEntryLocalService;
 import com.liferay.asset.publisher.constants.AssetPublisherPortletKeys;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
@@ -53,6 +55,40 @@ public class UpgradePortletPreferencesTest
 					"assetListEntryId",
 					String.valueOf(assetListEntry.getAssetListEntryId())
 				).build());
+		}
+		finally {
+			_assetListEntryLocalService.deleteAssetListEntry(assetListEntry);
+		}
+	}
+
+	@Test
+	@TestInfo("LPD-51051")
+	public void testUpgradeWithDifferentGroupAssetListEntryAndPreferencesPlidShared()
+		throws Exception {
+
+		Group guestGroup = groupLocalService.getGroup(
+			TestPropsValues.getCompanyId(), GroupConstants.GUEST);
+
+		AssetListEntry assetListEntry = _addAssetListEntry(guestGroup);
+
+		try {
+			testUpgrade(
+				HashMapBuilder.put(
+					"assetListEntryExternalReferenceCode",
+					assetListEntry.getExternalReferenceCode()
+				).put(
+					"assetListEntryGroupExternalReferenceCode",
+					guestGroup.getExternalReferenceCode()
+				).put(
+					"assetListEntryId",
+					String.valueOf(assetListEntry.getAssetListEntryId())
+				).build(),
+				HashMapBuilder.put(
+					"assetListEntryId",
+					String.valueOf(assetListEntry.getAssetListEntryId())
+				).build(),
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
+				PortletKeys.PREFS_PLID_SHARED);
 		}
 		finally {
 			_assetListEntryLocalService.deleteAssetListEntry(assetListEntry);

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/upgrade/v1_0_6/UpgradePortletPreferences.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/upgrade/v1_0_6/UpgradePortletPreferences.java
@@ -87,7 +87,7 @@ public class UpgradePortletPreferences extends BaseUpgradePortletPreferences {
 			assetListEntry.getExternalReferenceCode());
 
 		String scopeExternalReferenceCode = getScopeExternalReferenceCode(
-			companyId, plid, assetListEntry.getGroupId());
+			companyId, ownerId, ownerType, plid, assetListEntry.getGroupId());
 
 		if (Validator.isNotNull(scopeExternalReferenceCode)) {
 			portletPreferences.setValue(

--- a/modules/apps/portlet-display-template/portlet-display-template-api/src/main/java/com/liferay/portlet/display/template/upgrade/BaseUpgradePortletPreferences.java
+++ b/modules/apps/portlet-display-template/portlet-display-template-api/src/main/java/com/liferay/portlet/display/template/upgrade/BaseUpgradePortletPreferences.java
@@ -12,6 +12,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.upgrade.BasePortletPreferencesUpgradeProcess;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.sql.PreparedStatement;
@@ -79,10 +80,12 @@ public abstract class BaseUpgradePortletPreferences
 	protected abstract String[] getPortletIds();
 
 	protected String getScopeExternalReferenceCode(
-			long companyId, long plid, long scopeGroupId)
+			long companyId, long ownerId, int ownerType, long plid,
+			long scopeGroupId)
 		throws Exception {
 
-		long layoutGroupId = _getLayoutGroupId(companyId, plid);
+		long layoutGroupId = _getLayoutGroupId(
+			companyId, ownerId, ownerType, plid);
 
 		if ((layoutGroupId == 0L) || (layoutGroupId == scopeGroupId)) {
 			return StringPool.BLANK;
@@ -92,10 +95,12 @@ public abstract class BaseUpgradePortletPreferences
 	}
 
 	protected String getScopeExternalReferenceCode(
-			long companyId, long plid, String scopeGroupKey)
+			long companyId, long ownerId, int ownerType, long plid,
+			String scopeGroupKey)
 		throws Exception {
 
-		long layoutGroupId = _getLayoutGroupId(companyId, plid);
+		long layoutGroupId = _getLayoutGroupId(
+			companyId, ownerId, ownerType, plid);
 		long scopeGroupId = getGroupId(companyId, scopeGroupKey);
 
 		if ((layoutGroupId == 0L) || (layoutGroupId == scopeGroupId)) {
@@ -127,7 +132,7 @@ public abstract class BaseUpgradePortletPreferences
 
 		if (Validator.isNotNull(displayStyleGroupKey)) {
 			groupExternalReferenceCode = getScopeExternalReferenceCode(
-				companyId, plid, displayStyleGroupKey);
+				companyId, ownerId, ownerType, plid, displayStyleGroupKey);
 		}
 		else {
 			long displayStyleGroupId = GetterUtil.getLong(
@@ -135,7 +140,7 @@ public abstract class BaseUpgradePortletPreferences
 
 			if (displayStyleGroupId > 0) {
 				groupExternalReferenceCode = getScopeExternalReferenceCode(
-					companyId, plid, displayStyleGroupId);
+					companyId, ownerId, ownerType, plid, displayStyleGroupId);
 			}
 		}
 
@@ -205,7 +210,16 @@ public abstract class BaseUpgradePortletPreferences
 		return StringPool.BLANK;
 	}
 
-	private long _getLayoutGroupId(long companyId, long plid) {
+	private long _getLayoutGroupId(
+		long companyId, long ownerId, int ownerType, long plid) {
+
+		if (((ownerType == PortletKeys.PREFS_OWNER_TYPE_LAYOUT) ||
+			 (ownerType == PortletKeys.PREFS_OWNER_TYPE_GROUP)) &&
+			(ownerId > 0) && (plid == PortletKeys.PREFS_PLID_SHARED)) {
+
+			return ownerId;
+		}
+
 		Map<Long, Long> companyIdPlidMap = _plidMap.computeIfAbsent(
 			companyId, curCompanyId -> new ConcurrentHashMap<>());
 

--- a/modules/apps/portlet-display-template/portlet-display-template-test-util/src/main/java/com/liferay/portlet/display/template/test/util/BaseUpgradePortletPreferencesTestCase.java
+++ b/modules/apps/portlet-display-template/portlet-display-template-test-util/src/main/java/com/liferay/portlet/display/template/test/util/BaseUpgradePortletPreferencesTestCase.java
@@ -11,7 +11,10 @@ import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.PortletConstants;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -182,20 +185,20 @@ public abstract class BaseUpgradePortletPreferencesTestCase {
 	protected void assertPortletPreferences(Map<String, String> expectedMap)
 		throws Exception {
 
+		_assertPortletPreferences(
+			expectedMap,
+			LayoutTestUtil.getPortletPreferences(layout, portletId));
+	}
+
+	protected void assertPortletPreferences(
+		Map<String, String> expectedMap, long ownerId, int ownerType,
+		long plid) {
+
 		PortletPreferences portletPreferences =
-			LayoutTestUtil.getPortletPreferences(layout, portletId);
+			_portletPreferencesLocalService.getPreferences(
+				group.getCompanyId(), ownerId, ownerType, plid, portletId);
 
-		Map<String, String[]> map = portletPreferences.getMap();
-
-		Assert.assertEquals(
-			MapUtil.toString(map), expectedMap.size(), map.size());
-
-		for (Map.Entry<String, String> entry : expectedMap.entrySet()) {
-			Assert.assertTrue(entry.getKey(), map.containsKey(entry.getKey()));
-
-			Assert.assertArrayEquals(
-				new String[] {entry.getValue()}, map.get(entry.getKey()));
-		}
+		_assertPortletPreferences(expectedMap, portletPreferences);
 	}
 
 	protected abstract String getPortletId();
@@ -235,6 +238,30 @@ public abstract class BaseUpgradePortletPreferencesTestCase {
 		assertPortletPreferences(expectedMap);
 	}
 
+	protected void testUpgrade(
+			Map<String, String> expectedMap, Map<String, String> map,
+			int ownerType, long plid)
+		throws Exception {
+
+		PortletPreferences portletPreferences =
+			PortletPreferencesFactoryUtil.getLayoutPortletSetup(
+				group.getCompanyId(), group.getGroupId(), ownerType, plid,
+				portletId, PortletConstants.DEFAULT_PREFERENCES);
+
+		for (Map.Entry<String, String> entry : map.entrySet()) {
+			portletPreferences.setValue(entry.getKey(), entry.getValue());
+		}
+
+		portletPreferences.store();
+
+		assertPortletPreferences(map, group.getGroupId(), ownerType, plid);
+
+		runUpgrade();
+
+		assertPortletPreferences(
+			expectedMap, group.getGroupId(), ownerType, plid);
+	}
+
 	protected void updateLayoutPortletPreference(
 			Map<String, String> portletPreferencesMap)
 		throws Exception {
@@ -260,5 +287,25 @@ public abstract class BaseUpgradePortletPreferencesTestCase {
 	protected MultiVMPool multiVMPool;
 
 	protected String portletId;
+
+	private void _assertPortletPreferences(
+		Map<String, String> expectedMap,
+		PortletPreferences portletPreferences) {
+
+		Map<String, String[]> map = portletPreferences.getMap();
+
+		Assert.assertEquals(
+			MapUtil.toString(map), expectedMap.size(), map.size());
+
+		for (Map.Entry<String, String> entry : expectedMap.entrySet()) {
+			Assert.assertTrue(entry.getKey(), map.containsKey(entry.getKey()));
+
+			Assert.assertArrayEquals(
+				new String[] {entry.getValue()}, map.get(entry.getKey()));
+		}
+	}
+
+	@Inject
+	private PortletPreferencesLocalService _portletPreferencesLocalService;
 
 }

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/upgrade/v1_0_2/UpgradePortletPreferences.java
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/upgrade/v1_0_2/UpgradePortletPreferences.java
@@ -63,7 +63,8 @@ public class UpgradePortletPreferences extends BaseUpgradePortletPreferences {
 			siteNavigationMenu.getExternalReferenceCode());
 
 		String scopeExternalReferenceCode = getScopeExternalReferenceCode(
-			companyId, plid, siteNavigationMenu.getGroupId());
+			companyId, ownerId, ownerType, plid,
+			siteNavigationMenu.getGroupId());
 
 		if (Validator.isNotNull(scopeExternalReferenceCode)) {
 			portletPreferences.setValue(

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/upgrade/v1_0_2/test/UpgradePortletPreferencesTest.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/upgrade/v1_0_2/test/UpgradePortletPreferencesTest.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.test.rule.Inject;
@@ -134,6 +135,39 @@ public class UpgradePortletPreferencesTest
 				"siteNavigationMenuId",
 				String.valueOf(siteNavigationMenu.getSiteNavigationMenuId())
 			).build());
+	}
+
+	@Test
+	@TestInfo("LPD-51051")
+	public void testUpgradePreferenceWithSiteNavigationMenuFromDifferentGroupAndPreferencesPlidShared()
+		throws Exception {
+
+		Group curGroup = GroupTestUtil.addGroup();
+
+		SiteNavigationMenu siteNavigationMenu =
+			_siteNavigationMenuLocalService.addSiteNavigationMenu(
+				null, TestPropsValues.getUserId(), curGroup.getGroupId(),
+				RandomTestUtil.randomString(),
+				SiteNavigationConstants.TYPE_DEFAULT, true,
+				ServiceContextTestUtil.getServiceContext(
+					curGroup.getGroupId(), TestPropsValues.getUserId()));
+
+		testUpgrade(
+			HashMapBuilder.put(
+				"siteNavigationMenuExternalReferenceCode",
+				siteNavigationMenu.getExternalReferenceCode()
+			).put(
+				"siteNavigationMenuGroupExternalReferenceCode",
+				curGroup.getExternalReferenceCode()
+			).put(
+				"siteNavigationMenuId",
+				String.valueOf(siteNavigationMenu.getSiteNavigationMenuId())
+			).build(),
+			HashMapBuilder.put(
+				"siteNavigationMenuId",
+				String.valueOf(siteNavigationMenu.getSiteNavigationMenuId())
+			).build(),
+			PortletKeys.PREFS_OWNER_TYPE_LAYOUT, PortletKeys.PREFS_PLID_SHARED);
 	}
 
 	@Test


### PR DESCRIPTION
Dear reviewer,
This pull fixes a problem upgrading portletPreferences that have plid== and reference other entities that belong to a parent site. As the plid is zero, we can't use it to obtain the layout and get the groupId of it. The only way to guess the groupId that the portletPreference belong to is using the ownerId: https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/portal-kernel/src/com/liferay/portal/kernel/settings/PortletInstanceSettingsLocator.java#L40-L46