### PR TITLE
LPD-51300 Defer axe-core import

### DIFF
--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/tests/checkAccessibility.ts
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/tests/checkAccessibility.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import axe, {AxeResults, ContextObject} from 'axe-core';
+import type {AxeResults, ContextObject} from 'axe-core';
 
 const config = {
 
@@ -22,6 +22,11 @@ export default async function checkAccessibility({
 	bestPractices: boolean;
 	context: ContextObject;
 }) {
+	const axe = await import(
+		Liferay.ThemeDisplay.getPathContext() +
+			'/o/frontend-js-dependencies-web/__liferay__/exports/axe-core.js'
+	);
+
 	if (bestPractices) {
 		config.runOnly = [...config.runOnly, 'best-practice'];
 	}

--- a/modules/apps/layout/layout-js-components-web/test/components/import/ImportOptionsModal.test.js
+++ b/modules/apps/layout/layout-js-components-web/test/components/import/ImportOptionsModal.test.js
@@ -13,6 +13,14 @@ import {
 } from '../../../src/main/resources/META-INF/resources/js';
 import {ModalContent} from '../../../src/main/resources/META-INF/resources/js/components/import/ImportOptionsModal';
 
+Liferay.ThemeDisplay.getPathContext = () => '';
+
+jest.mock(
+	'/o/frontend-js-dependencies-web/__liferay__/exports/axe-core.js',
+	() => jest.requireActual('axe-core'),
+	{virtual: true}
+);
+
 const renderComponent = async ({
 	onCloseModal = () => null,
 	onImport = () => null,

--- a/modules/apps/layout/layout-js-components-web/test/components/import/ImportResults.test.js
+++ b/modules/apps/layout/layout-js-components-web/test/components/import/ImportResults.test.js
@@ -12,6 +12,14 @@ import {
 	checkAccessibility,
 } from '../../../src/main/resources/META-INF/resources/js/index';
 
+Liferay.ThemeDisplay.getPathContext = () => '';
+
+jest.mock(
+	'/o/frontend-js-dependencies-web/__liferay__/exports/axe-core.js',
+	() => jest.requireActual('axe-core'),
+	{virtual: true}
+);
+
 const SUCCESS_RESULT = {
 	success: [
 		{


### PR DESCRIPTION
Hey team, as the description of the first commit says:

>This is because 'axe-core' is ~0.5MB in size and it's not really used that much.
>
>With this change we only pull it from the server when needed, which is when users run accessibility tests through the content they have generated.

The intention is to make the downloaded content smaller for empty blank pages in DXP so that users don't need to pre-download a huge amount of JavaScript before it is really used.

Can you please check that everything is OK? 

I've fixed Jest tests already but haven't run any test suite because I don't know which ones to run...

Thank you :heart: 