### PR TITLE
LPD-51437 Split layout-taglib in UI vs non-UI parts

### DIFF
--- a/modules/apps/layout/layout-taglib/node-scripts.config.js
+++ b/modules/apps/layout/layout-taglib/node-scripts.config.js
@@ -5,4 +5,7 @@
 
 module.exports = {
 	main: './src/main/resources/META-INF/resources/js/index.js',
+	submodules: {
+		render: './src/main/resources/META-INF/resources/js/render.js',
+	},
 };

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/renderer/LayoutStructureRenderer.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/renderer/LayoutStructureRenderer.java
@@ -135,7 +135,7 @@ public class LayoutStructureRenderer {
 				"infoItemActionComponent",
 				_renderLayoutStructureDisplayContext.
 					getInfoItemActionComponentContext(),
-				"{InfoItemActionHandler} from layout-taglib");
+				"{InfoItemActionHandler} from layout-taglib/render");
 		}
 
 		LayoutStructureRulesHelper.LayoutStructureRulesResult
@@ -150,7 +150,7 @@ public class LayoutStructureRenderer {
 				"RulesHandlerComponent",
 				_renderLayoutStructureDisplayContext.
 					getRulesHandlerComponentContext(),
-				"{RulesHandler} from layout-taglib");
+				"{RulesHandler} from layout-taglib/render");
 		}
 	}
 
@@ -512,7 +512,7 @@ public class LayoutStructureRenderer {
 			paginationBarTag.setCssClass("pb-2 pt-3");
 			paginationBarTag.setPropsTransformer(
 				"{NumericCollectionPaginationPropsTransformer} from " +
-					"layout-taglib");
+					"layout-taglib/render");
 			paginationBarTag.setShowDeltasDropDown(false);
 			paginationBarTag.setTotalItems(
 				renderCollectionLayoutStructureItemDisplayContext.
@@ -583,7 +583,7 @@ public class LayoutStructureRenderer {
 					"collectionId",
 					collectionStyledLayoutStructureItem.getItemId()
 				).build(),
-				"{SimpleCollectionPagination} from layout-taglib");
+				"{SimpleCollectionPagination} from layout-taglib/render");
 		}
 
 		jspWriter.write("</div>");
@@ -958,7 +958,7 @@ public class LayoutStructureRenderer {
 				"formId",
 				formStepContainerStyledLayoutStructureItem.getParentItemId()
 			).build(),
-			"{FormStepHandler} from layout-taglib");
+			"{FormStepHandler} from layout-taglib/render");
 	}
 
 	private void _renderFormStyledLayoutStructureItem(

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/js/index.js
@@ -4,10 +4,5 @@
  */
 
 export {default as ViewUsages} from './layout_classed_model_usages_view/ViewUsages';
-export {default as FormStepHandler} from './render_layout_structure/FormStepHandler';
-export {default as InfoItemActionHandler} from './render_layout_structure/InfoItemActionHandler';
-export {default as NumericCollectionPaginationPropsTransformer} from './render_layout_structure/NumericCollectionPaginationPropsTransformer';
-export {default as RulesHandler} from './render_layout_structure/RulesHandler';
-export {default as SimpleCollectionPagination} from './render_layout_structure/SimpleCollectionPagination';
 export {default as SelectLayout} from './select_layout/SelectLayout';
 export {default as SelectLayoutTree} from './select_layout/SelectLayoutTree';

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/js/render.js
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/js/render.js
@@ -1,0 +1,10 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export {default as FormStepHandler} from './render_layout_structure/FormStepHandler';
+export {default as InfoItemActionHandler} from './render_layout_structure/InfoItemActionHandler';
+export {default as NumericCollectionPaginationPropsTransformer} from './render_layout_structure/NumericCollectionPaginationPropsTransformer';
+export {default as RulesHandler} from './render_layout_structure/RulesHandler';
+export {default as SimpleCollectionPagination} from './render_layout_structure/SimpleCollectionPagination';

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/js/render_layout_structure/InfoItemActionHandler.js
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/js/render_layout_structure/InfoItemActionHandler.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openToast} from 'frontend-js-components-web';
 import {escapeHTML, navigate, objectToFormData} from 'frontend-js-web';
 
 const INTERACTION_NOTIFICATION = 'notification';
@@ -174,9 +173,14 @@ function handleResult(interaction, reload, text, toastData, url) {
 }
 
 function openResultToast({message, title, type}, text) {
-	openToast({
-		message: escapeHTML(text || message),
-		title: escapeHTML(title),
-		type,
-	});
+	import(
+		Liferay.ThemeDisplay.getPathContext() +
+			'/o/frontend-js-components-web/__liferay__/index.js'
+	).then(({openToast}) =>
+		openToast({
+			message: escapeHTML(text || message),
+			title: escapeHTML(title),
+			type,
+		})
+	);
 }

--- a/modules/node-scripts.config.js
+++ b/modules/node-scripts.config.js
@@ -10,7 +10,7 @@
  */
 
 module.exports = {
-	hash: '9a5335532af04c2fe0bad2d5345c973dc211470092d9e7263175749aaac3208c',
+	hash: 'b3841cf4213a6ccaa90b6a2931622f59cfb77efa8c2b8db58b20ccc85247d682',
 	imports: {
 		'@liferay/accessibility-settings-state-web': [],
 		'@liferay/address-web': [],
@@ -155,6 +155,7 @@ module.exports = {
 		],
 		'item-selector-taglib': [],
 		'item-selector-web': [],
+		'layout-taglib': ['./render'],
 		'portal-search-web': ['./search-bar'],
 		'social-bookmarks-taglib': [],
 	},


### PR DESCRIPTION
This prevents preloading UI stuff (React and Clay, even if the page is completely empty) just because we render a layout in a page.