### PR TITLE
LPD-47416 Add new column to the DDBB for fragment collections from marketplace

### DIFF
--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/model/FragmentCollectionModel.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/model/FragmentCollectionModel.java
@@ -295,6 +295,27 @@ public interface FragmentCollectionModel
 	public void setDescription(String description);
 
 	/**
+	 * Returns the marketplace of this fragment collection.
+	 *
+	 * @return the marketplace of this fragment collection
+	 */
+	public boolean getMarketplace();
+
+	/**
+	 * Returns <code>true</code> if this fragment collection is marketplace.
+	 *
+	 * @return <code>true</code> if this fragment collection is marketplace; <code>false</code> otherwise
+	 */
+	public boolean isMarketplace();
+
+	/**
+	 * Sets whether this fragment collection is marketplace.
+	 *
+	 * @param marketplace the marketplace of this fragment collection
+	 */
+	public void setMarketplace(boolean marketplace);
+
+	/**
 	 * Returns the last publish date of this fragment collection.
 	 *
 	 * @return the last publish date of this fragment collection

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/model/FragmentCollectionTable.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/model/FragmentCollectionTable.java
@@ -65,6 +65,9 @@ public class FragmentCollectionTable
 	public final Column<FragmentCollectionTable, String> description =
 		createColumn(
 			"description", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
+	public final Column<FragmentCollectionTable, Boolean> marketplace =
+		createColumn(
+			"marketplace", Boolean.class, Types.BOOLEAN, Column.FLAG_DEFAULT);
 	public final Column<FragmentCollectionTable, Date> lastPublishDate =
 		createColumn(
 			"lastPublishDate", Date.class, Types.TIMESTAMP,

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/model/FragmentCollectionWrapper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/model/FragmentCollectionWrapper.java
@@ -50,6 +50,7 @@ public class FragmentCollectionWrapper
 		attributes.put("fragmentCollectionKey", getFragmentCollectionKey());
 		attributes.put("name", getName());
 		attributes.put("description", getDescription());
+		attributes.put("marketplace", isMarketplace());
 		attributes.put("lastPublishDate", getLastPublishDate());
 
 		return attributes;
@@ -142,6 +143,12 @@ public class FragmentCollectionWrapper
 
 		if (description != null) {
 			setDescription(description);
+		}
+
+		Boolean marketplace = (Boolean)attributes.get("marketplace");
+
+		if (marketplace != null) {
+			setMarketplace(marketplace);
 		}
 
 		Date lastPublishDate = (Date)attributes.get("lastPublishDate");
@@ -244,6 +251,16 @@ public class FragmentCollectionWrapper
 	@Override
 	public Date getLastPublishDate() {
 		return model.getLastPublishDate();
+	}
+
+	/**
+	 * Returns the marketplace of this fragment collection.
+	 *
+	 * @return the marketplace of this fragment collection
+	 */
+	@Override
+	public boolean getMarketplace() {
+		return model.getMarketplace();
 	}
 
 	/**
@@ -370,6 +387,16 @@ public class FragmentCollectionWrapper
 		return model.hasResources();
 	}
 
+	/**
+	 * Returns <code>true</code> if this fragment collection is marketplace.
+	 *
+	 * @return <code>true</code> if this fragment collection is marketplace; <code>false</code> otherwise
+	 */
+	@Override
+	public boolean isMarketplace() {
+		return model.isMarketplace();
+	}
+
 	@Override
 	public void persist() {
 		model.persist();
@@ -479,6 +506,16 @@ public class FragmentCollectionWrapper
 	@Override
 	public void setLastPublishDate(Date lastPublishDate) {
 		model.setLastPublishDate(lastPublishDate);
+	}
+
+	/**
+	 * Sets whether this fragment collection is marketplace.
+	 *
+	 * @param marketplace the marketplace of this fragment collection
+	 */
+	@Override
+	public void setMarketplace(boolean marketplace) {
+		model.setMarketplace(marketplace);
 	}
 
 	/**

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/model/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/model/packageinfo
@@ -1,1 +1,1 @@
-version 3.9.0
+version 3.10.0

--- a/modules/apps/fragment/fragment-service/bnd.bnd
+++ b/modules/apps/fragment/fragment-service/bnd.bnd
@@ -5,6 +5,6 @@ Import-Package:\
 	com.liferay.fragment.util.comparator,\
 	\
 	*
-Liferay-Require-SchemaVersion: 2.14.0
+Liferay-Require-SchemaVersion: 2.15.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/fragment/fragment-service/service.xml
+++ b/modules/apps/fragment/fragment-service/service.xml
@@ -26,6 +26,7 @@
 		<column name="fragmentCollectionKey" type="String" />
 		<column name="name" type="String" />
 		<column name="description" type="String" />
+		<column name="marketplace" type="boolean" />
 		<column name="lastPublishDate" type="Date" />
 
 		<!-- Order -->

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/registry/FragmentServiceUpgradeStepRegistrator.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/registry/FragmentServiceUpgradeStepRegistrator.java
@@ -259,6 +259,11 @@ public class FragmentServiceUpgradeStepRegistrator
 				"FragmentEntry", "marketplace BOOLEAN"),
 			UpgradeProcessFactory.addColumns(
 				"FragmentEntryVersion", "marketplace BOOLEAN"));
+
+		registry.register(
+			"2.14.0", "2.15.0",
+			UpgradeProcessFactory.addColumns(
+				"FragmentCollection", "marketplace BOOLEAN"));
 	}
 
 	@Reference

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionCacheModel.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionCacheModel.java
@@ -69,7 +69,7 @@ public class FragmentCollectionCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(31);
+		StringBundler sb = new StringBundler(33);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -99,6 +99,8 @@ public class FragmentCollectionCacheModel
 		sb.append(name);
 		sb.append(", description=");
 		sb.append(description);
+		sb.append(", marketplace=");
+		sb.append(marketplace);
 		sb.append(", lastPublishDate=");
 		sb.append(lastPublishDate);
 		sb.append("}");
@@ -177,6 +179,8 @@ public class FragmentCollectionCacheModel
 			fragmentCollectionImpl.setDescription(description);
 		}
 
+		fragmentCollectionImpl.setMarketplace(marketplace);
+
 		if (lastPublishDate == Long.MIN_VALUE) {
 			fragmentCollectionImpl.setLastPublishDate(null);
 		}
@@ -211,6 +215,8 @@ public class FragmentCollectionCacheModel
 		fragmentCollectionKey = objectInput.readUTF();
 		name = objectInput.readUTF();
 		description = objectInput.readUTF();
+
+		marketplace = objectInput.readBoolean();
 		lastPublishDate = objectInput.readLong();
 	}
 
@@ -273,6 +279,7 @@ public class FragmentCollectionCacheModel
 			objectOutput.writeUTF(description);
 		}
 
+		objectOutput.writeBoolean(marketplace);
 		objectOutput.writeLong(lastPublishDate);
 	}
 
@@ -290,6 +297,7 @@ public class FragmentCollectionCacheModel
 	public String fragmentCollectionKey;
 	public String name;
 	public String description;
+	public boolean marketplace;
 	public long lastPublishDate;
 
 }

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionModelImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionModelImpl.java
@@ -72,7 +72,8 @@ public class FragmentCollectionModelImpl
 		{"userName", Types.VARCHAR}, {"createDate", Types.TIMESTAMP},
 		{"modifiedDate", Types.TIMESTAMP},
 		{"fragmentCollectionKey", Types.VARCHAR}, {"name", Types.VARCHAR},
-		{"description", Types.VARCHAR}, {"lastPublishDate", Types.TIMESTAMP}
+		{"description", Types.VARCHAR}, {"marketplace", Types.BOOLEAN},
+		{"lastPublishDate", Types.TIMESTAMP}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -93,11 +94,12 @@ public class FragmentCollectionModelImpl
 		TABLE_COLUMNS_MAP.put("fragmentCollectionKey", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("marketplace", Types.BOOLEAN);
 		TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table FragmentCollection (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,fragmentCollectionId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,fragmentCollectionKey VARCHAR(75) null,name VARCHAR(75) null,description STRING null,lastPublishDate DATE null,primary key (fragmentCollectionId, ctCollectionId))";
+		"create table FragmentCollection (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,fragmentCollectionId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,fragmentCollectionKey VARCHAR(75) null,name VARCHAR(75) null,description STRING null,marketplace BOOLEAN,lastPublishDate DATE null,primary key (fragmentCollectionId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP = "drop table FragmentCollection";
 
@@ -289,6 +291,8 @@ public class FragmentCollectionModelImpl
 			attributeGetterFunctions.put(
 				"description", FragmentCollection::getDescription);
 			attributeGetterFunctions.put(
+				"marketplace", FragmentCollection::getMarketplace);
+			attributeGetterFunctions.put(
 				"lastPublishDate", FragmentCollection::getLastPublishDate);
 
 			_attributeGetterFunctions = Collections.unmodifiableMap(
@@ -364,6 +368,10 @@ public class FragmentCollectionModelImpl
 				"description",
 				(BiConsumer<FragmentCollection, String>)
 					FragmentCollection::setDescription);
+			attributeSetterBiConsumers.put(
+				"marketplace",
+				(BiConsumer<FragmentCollection, Boolean>)
+					FragmentCollection::setMarketplace);
 			attributeSetterBiConsumers.put(
 				"lastPublishDate",
 				(BiConsumer<FragmentCollection, Date>)
@@ -694,6 +702,27 @@ public class FragmentCollectionModelImpl
 
 	@JSON
 	@Override
+	public boolean getMarketplace() {
+		return _marketplace;
+	}
+
+	@JSON
+	@Override
+	public boolean isMarketplace() {
+		return _marketplace;
+	}
+
+	@Override
+	public void setMarketplace(boolean marketplace) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_marketplace = marketplace;
+	}
+
+	@JSON
+	@Override
 	public Date getLastPublishDate() {
 		return _lastPublishDate;
 	}
@@ -788,6 +817,7 @@ public class FragmentCollectionModelImpl
 			getFragmentCollectionKey());
 		fragmentCollectionImpl.setName(getName());
 		fragmentCollectionImpl.setDescription(getDescription());
+		fragmentCollectionImpl.setMarketplace(isMarketplace());
 		fragmentCollectionImpl.setLastPublishDate(getLastPublishDate());
 
 		fragmentCollectionImpl.resetOriginalValues();
@@ -828,6 +858,8 @@ public class FragmentCollectionModelImpl
 			this.<String>getColumnOriginalValue("name"));
 		fragmentCollectionImpl.setDescription(
 			this.<String>getColumnOriginalValue("description"));
+		fragmentCollectionImpl.setMarketplace(
+			this.<Boolean>getColumnOriginalValue("marketplace"));
 		fragmentCollectionImpl.setLastPublishDate(
 			this.<Date>getColumnOriginalValue("lastPublishDate"));
 
@@ -993,6 +1025,8 @@ public class FragmentCollectionModelImpl
 			fragmentCollectionCacheModel.description = null;
 		}
 
+		fragmentCollectionCacheModel.marketplace = isMarketplace();
+
 		Date lastPublishDate = getLastPublishDate();
 
 		if (lastPublishDate != null) {
@@ -1080,6 +1114,7 @@ public class FragmentCollectionModelImpl
 	private String _fragmentCollectionKey;
 	private String _name;
 	private String _description;
+	private boolean _marketplace;
 	private Date _lastPublishDate;
 
 	public <T> T getColumnValue(String columnName) {
@@ -1129,6 +1164,7 @@ public class FragmentCollectionModelImpl
 			"fragmentCollectionKey", _fragmentCollectionKey);
 		_columnOriginalValues.put("name", _name);
 		_columnOriginalValues.put("description", _description);
+		_columnOriginalValues.put("marketplace", _marketplace);
 		_columnOriginalValues.put("lastPublishDate", _lastPublishDate);
 	}
 
@@ -1181,7 +1217,9 @@ public class FragmentCollectionModelImpl
 
 		columnBitmasks.put("description", 8192L);
 
-		columnBitmasks.put("lastPublishDate", 16384L);
+		columnBitmasks.put("marketplace", 16384L);
+
+		columnBitmasks.put("lastPublishDate", 32768L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/persistence/impl/FragmentCollectionPersistenceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/persistence/impl/FragmentCollectionPersistenceImpl.java
@@ -4495,6 +4495,7 @@ public class FragmentCollectionPersistenceImpl
 		ctMergeColumnNames.add("fragmentCollectionKey");
 		ctMergeColumnNames.add("name");
 		ctMergeColumnNames.add("description");
+		ctMergeColumnNames.add("marketplace");
 		ctMergeColumnNames.add("lastPublishDate");
 
 		_ctColumnNamesMap.put(

--- a/modules/apps/fragment/fragment-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/fragment/fragment-service/src/main/resources/META-INF/module-hbm.xml
@@ -24,6 +24,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="fragmentCollectionKey" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="name" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="description" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="marketplace" type="com.liferay.portal.dao.orm.hibernate.BooleanType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="lastPublishDate" type="org.hibernate.type.TimestampType" />
 	</class>
 	<class dynamic-update="true" name="com.liferay.fragment.model.impl.FragmentCompositionImpl" table="FragmentComposition">

--- a/modules/apps/fragment/fragment-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/fragment/fragment-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -20,6 +20,7 @@
 		<field name="description" type="String">
 			<hint-collection name="TEXTAREA" />
 		</field>
+		<field name="marketplace" type="boolean" />
 		<field name="lastPublishDate" type="Date" />
 	</model>
 	<model name="com.liferay.fragment.model.FragmentComposition">

--- a/modules/apps/fragment/fragment-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/fragment/fragment-service/src/main/resources/META-INF/sql/tables.sql
@@ -13,6 +13,7 @@ create table FragmentCollection (
 	fragmentCollectionKey VARCHAR(75) null,
 	name VARCHAR(75) null,
 	description STRING null,
+	marketplace BOOLEAN,
 	lastPublishDate DATE null,
 	primary key (fragmentCollectionId, ctCollectionId)
 );

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentCollectionPersistenceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentCollectionPersistenceTest.java
@@ -145,6 +145,8 @@ public class FragmentCollectionPersistenceTest {
 
 		newFragmentCollection.setDescription(RandomTestUtil.randomString());
 
+		newFragmentCollection.setMarketplace(RandomTestUtil.randomBoolean());
+
 		newFragmentCollection.setLastPublishDate(RandomTestUtil.nextDate());
 
 		_fragmentCollections.add(_persistence.update(newFragmentCollection));
@@ -196,6 +198,9 @@ public class FragmentCollectionPersistenceTest {
 		Assert.assertEquals(
 			existingFragmentCollection.getDescription(),
 			newFragmentCollection.getDescription());
+		Assert.assertEquals(
+			existingFragmentCollection.isMarketplace(),
+			newFragmentCollection.isMarketplace());
 		Assert.assertEquals(
 			Time.getShortTimestamp(
 				existingFragmentCollection.getLastPublishDate()),
@@ -328,7 +333,7 @@ public class FragmentCollectionPersistenceTest {
 			true, "groupId", true, "companyId", true, "userId", true,
 			"userName", true, "createDate", true, "modifiedDate", true,
 			"fragmentCollectionKey", true, "name", true, "description", true,
-			"lastPublishDate", true);
+			"marketplace", true, "lastPublishDate", true);
 	}
 
 	@Test
@@ -673,6 +678,8 @@ public class FragmentCollectionPersistenceTest {
 		fragmentCollection.setName(RandomTestUtil.randomString());
 
 		fragmentCollection.setDescription(RandomTestUtil.randomString());
+
+		fragmentCollection.setMarketplace(RandomTestUtil.randomBoolean());
 
 		fragmentCollection.setLastPublishDate(RandomTestUtil.nextDate());
 


### PR DESCRIPTION
Added to help with [LPD-43455](https://liferay.atlassian.net/browse/LPD-43455)

We need to add this to recognize the fragment sets that came from marketplace. This has been also implemented to fragment entries and compositions.

[LPD-43455]: https://liferay.atlassian.net/browse/LPD-43455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ