### PR TITLE
LPD-51722 Orphaned data in LayoutSEOSite table when deleting a site

### DIFF
--- a/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/internal/model/listener/GroupModelListener.java
+++ b/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/internal/model/listener/GroupModelListener.java
@@ -1,0 +1,45 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.seo.internal.model.listener;
+
+import com.liferay.layout.seo.model.LayoutSEOSite;
+import com.liferay.layout.seo.service.LayoutSEOSiteLocalService;
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ModelListener;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jonathan McCann
+ */
+@Component(service = ModelListener.class)
+public class GroupModelListener extends BaseModelListener<Group> {
+
+	@Override
+	public void onAfterRemove(Group group) throws ModelListenerException {
+		try {
+			LayoutSEOSite layoutSEOSite =
+				_layoutSEOSiteLocalService.fetchLayoutSEOSiteByGroupId(
+					group.getGroupId());
+
+			if (layoutSEOSite != null) {
+				_layoutSEOSiteLocalService.deleteLayoutSEOSite(
+					layoutSEOSite.getLayoutSEOSiteId());
+			}
+		}
+		catch (PortalException portalException) {
+			throw new ModelListenerException(portalException);
+		}
+	}
+
+	@Reference
+	private LayoutSEOSiteLocalService _layoutSEOSiteLocalService;
+
+}

--- a/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/internal/model/listener/test/GroupModelListenerTest.java
+++ b/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/internal/model/listener/test/GroupModelListenerTest.java
@@ -1,0 +1,65 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.seo.internal.model.listener.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.seo.service.LayoutSEOSiteLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jonathan McCann
+ */
+@RunWith(Arquillian.class)
+public class GroupModelListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testDeleteGroup() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		_layoutSEOSiteLocalService.updateLayoutSEOSite(
+			TestPropsValues.getUserId(), group.getGroupId(), false,
+			Collections.emptyMap(), RandomTestUtil.randomLong(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertNotNull(
+			_layoutSEOSiteLocalService.fetchLayoutSEOSiteByGroupId(
+				group.getGroupId()));
+
+		_groupLocalService.deleteGroup(group);
+
+		Assert.assertNull(
+			_layoutSEOSiteLocalService.fetchLayoutSEOSiteByGroupId(
+				group.getGroupId()));
+	}
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private LayoutSEOSiteLocalService _layoutSEOSiteLocalService;
+
+}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-51722

# How am I fixing it?

I created a model listener to clean up the Layout SEO Site entry once a group is deleted. If there is a reason to keep this entry or if there is a better way to resolve this please let me know.

# How can you verify that it works?

In `layout-seo-test` run `gw testIntegration --tests *.GroupModelListenerTest`

Alternatively there are steps to reproduce on LPD-51722.