### PR TITLE
LPD-51721 Orphaned data in Repository table when deleting a site

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionImpl.java
@@ -44,7 +44,7 @@ public class FragmentCollectionImpl extends FragmentCollectionBaseImpl {
 	@Override
 	public FileEntry getResource(String path) {
 		try {
-			Repository repository = _getRepository();
+			Repository repository = _getRepository(true);
 
 			return PortletFileRepositoryUtil.fetchPortletFileEntry(
 				getGroupId(),
@@ -84,7 +84,11 @@ public class FragmentCollectionImpl extends FragmentCollectionBaseImpl {
 			return _resourcesFolderId;
 		}
 
-		Repository repository = _getRepository();
+		Repository repository = _getRepository(createIfAbsent);
+
+		if (repository == null) {
+			return 0;
+		}
 
 		Folder folder = null;
 
@@ -128,7 +132,7 @@ public class FragmentCollectionImpl extends FragmentCollectionBaseImpl {
 
 	@Override
 	public boolean hasResources() throws PortalException {
-		Repository repository = _getRepository();
+		Repository repository = _getRepository(true);
 
 		int fileEntriesCount =
 			DLAppServiceUtil.getFoldersAndFileEntriesAndFileShortcutsCount(
@@ -217,7 +221,9 @@ public class FragmentCollectionImpl extends FragmentCollectionBaseImpl {
 		return path.substring(index + 1);
 	}
 
-	private Repository _getRepository() throws PortalException {
+	private Repository _getRepository(boolean createIfAbsent)
+		throws PortalException {
+
 		if (_repository != null) {
 			return _repository;
 		}
@@ -234,7 +240,7 @@ public class FragmentCollectionImpl extends FragmentCollectionBaseImpl {
 			PortletFileRepositoryUtil.fetchPortletRepository(
 				groupId, FragmentPortletKeys.FRAGMENT);
 
-		if (repository == null) {
+		if ((repository == null) && createIfAbsent) {
 			ServiceContext serviceContext = new ServiceContext();
 
 			serviceContext.setAddGroupPermissions(true);
@@ -291,7 +297,7 @@ public class FragmentCollectionImpl extends FragmentCollectionBaseImpl {
 
 		Map<String, FileEntry> resourcesMap = new HashMap<>();
 
-		Repository repository = _getRepository();
+		Repository repository = _getRepository(true);
 
 		List<Object> foldersAndFileEntriesAndFileShortcuts =
 			DLAppServiceUtil.getFoldersAndFileEntriesAndFileShortcuts(

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentCollectionLocalServiceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentCollectionLocalServiceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.fragment.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.fragment.constants.FragmentPortletKeys;
 import com.liferay.fragment.exception.DuplicateFragmentCollectionExternalReferenceCodeException;
 import com.liferay.fragment.exception.FragmentCollectionNameException;
 import com.liferay.fragment.model.FragmentCollection;
@@ -18,6 +19,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -154,6 +156,10 @@ public class FragmentCollectionLocalServiceTest {
 		Assert.assertNull(
 			_fragmentCollectionLocalService.fetchFragmentCollection(
 				fragmentCollection.getFragmentCollectionId()));
+
+		Assert.assertNull(
+			PortletFileRepositoryUtil.fetchPortletRepository(
+				_group.getGroupId(), FragmentPortletKeys.FRAGMENT));
 	}
 
 	@Test


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-51721

# How am I fixing it?

When a Fragment Collection is deleted it attempts to also remove its images - https://github.com/liferay/liferay-portal/blob/master/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCollectionLocalServiceImpl.java#L136-L137

In this call it passes `false` for `createIfAbsent` to avoid creating a folder is one doesn't already exist. However, this boolean is not passed along to `_getRepository`, which always created a Repository entity.

For the change I pass along this boolean to optionally create the Repository and avoid creating one when we're deleting the Fragment Collection. If there's a reason to keep this repository or abetter way to resolve this please let me know.

# How can you verify that it works?

In `fragment-test` run `gw testIntegration --tests *.FragmentCollectionLocalServiceTest`

Alternatively there are steps to reproduce on LPD-51721.