### PR TITLE
LPD-51720 Orphaned data in TemplateEntry table after deleting site

### DIFF
--- a/modules/apps/template/template-api/bnd.bnd
+++ b/modules/apps/template/template-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Template API
 Bundle-SymbolicName: com.liferay.template.api
-Bundle-Version: 6.0.1
+Bundle-Version: 6.1.0
 Export-Package:\
 	com.liferay.template.constants,\
 	com.liferay.template.exception,\

--- a/modules/apps/template/template-api/src/main/java/com/liferay/template/service/TemplateEntryLocalService.java
+++ b/modules/apps/template/template-api/src/main/java/com/liferay/template/service/TemplateEntryLocalService.java
@@ -102,6 +102,8 @@ public interface TemplateEntryLocalService
 	public PersistedModel deletePersistedModel(PersistedModel persistedModel)
 		throws PortalException;
 
+	public void deleteTemplateEntries(long groupId);
+
 	/**
 	 * Deletes the template entry with the primary key from the database. Also notifies the appropriate model listeners.
 	 *

--- a/modules/apps/template/template-api/src/main/java/com/liferay/template/service/TemplateEntryLocalServiceUtil.java
+++ b/modules/apps/template/template-api/src/main/java/com/liferay/template/service/TemplateEntryLocalServiceUtil.java
@@ -92,6 +92,10 @@ public class TemplateEntryLocalServiceUtil {
 		return getService().deletePersistedModel(persistedModel);
 	}
 
+	public static void deleteTemplateEntries(long groupId) {
+		getService().deleteTemplateEntries(groupId);
+	}
+
 	/**
 	 * Deletes the template entry with the primary key from the database. Also notifies the appropriate model listeners.
 	 *

--- a/modules/apps/template/template-api/src/main/java/com/liferay/template/service/TemplateEntryLocalServiceWrapper.java
+++ b/modules/apps/template/template-api/src/main/java/com/liferay/template/service/TemplateEntryLocalServiceWrapper.java
@@ -93,6 +93,11 @@ public class TemplateEntryLocalServiceWrapper
 		return _templateEntryLocalService.deletePersistedModel(persistedModel);
 	}
 
+	@Override
+	public void deleteTemplateEntries(long groupId) {
+		_templateEntryLocalService.deleteTemplateEntries(groupId);
+	}
+
 	/**
 	 * Deletes the template entry with the primary key from the database. Also notifies the appropriate model listeners.
 	 *

--- a/modules/apps/template/template-api/src/main/resources/com/liferay/template/service/packageinfo
+++ b/modules/apps/template/template-api/src/main/resources/com/liferay/template/service/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.1.0

--- a/modules/apps/template/template-service/src/main/java/com/liferay/template/service/impl/TemplateEntryLocalServiceImpl.java
+++ b/modules/apps/template/template-service/src/main/java/com/liferay/template/service/impl/TemplateEntryLocalServiceImpl.java
@@ -57,6 +57,11 @@ public class TemplateEntryLocalServiceImpl
 	}
 
 	@Override
+	public void deleteTemplateEntries(long groupId) {
+		templateEntryPersistence.removeByGroupId(groupId);
+	}
+
+	@Override
 	public TemplateEntry deleteTemplateEntry(long templateEntryId) {
 		TemplateEntry templateEntry =
 			templateEntryPersistence.fetchByPrimaryKey(templateEntryId);

--- a/modules/apps/template/template-test/src/testIntegration/java/com/liferay/template/service/test/TemplateEntryLocalServiceTest.java
+++ b/modules/apps/template/template-test/src/testIntegration/java/com/liferay/template/service/test/TemplateEntryLocalServiceTest.java
@@ -6,17 +6,23 @@
 package com.liferay.template.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.model.DDMTemplate;
+import com.liferay.dynamic.data.mapping.service.DDMTemplateLocalService;
+import com.liferay.dynamic.data.mapping.test.util.DDMTemplateTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.template.exception.DuplicateTemplateEntryExternalReferenceCodeException;
+import com.liferay.template.model.TemplateEntry;
 import com.liferay.template.service.TemplateEntryLocalService;
 
 import org.junit.Assert;
@@ -59,6 +65,29 @@ public class TemplateEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testDeleteGroup() throws Exception {
+		long classNameId = PortalUtil.getClassNameId(TemplateEntry.class);
+
+		DDMTemplate ddmTemplate = DDMTemplateTestUtil.addTemplate(
+			_group.getGroupId(), classNameId, 0, classNameId);
+
+		TemplateEntry templateEntry =
+			_templateEntryLocalService.addTemplateEntry(
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
+				ddmTemplate.getTemplateId(), StringPool.BLANK, StringPool.BLANK,
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		_groupLocalService.deleteGroup(_group);
+
+		Assert.assertNull(
+			_ddmTemplateLocalService.fetchDDMTemplate(
+				ddmTemplate.getTemplateId()));
+		Assert.assertNull(
+			_templateEntryLocalService.fetchTemplateEntry(
+				templateEntry.getTemplateEntryId()));
+	}
+
+	@Test
 	public void testDeleteTemplateEntryByExternalReferenceCode()
 		throws Exception {
 
@@ -95,8 +124,14 @@ public class TemplateEntryLocalServiceTest {
 					externalReferenceCode, _group.getGroupId()));
 	}
 
+	@Inject
+	private DDMTemplateLocalService _ddmTemplateLocalService;
+
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
 
 	@Inject
 	private TemplateEntryLocalService _templateEntryLocalService;

--- a/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/exportimport/data/handler/TemplatePortletDataHandler.java
+++ b/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/exportimport/data/handler/TemplatePortletDataHandler.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.template.constants.TemplatePortletKeys;
 import com.liferay.template.model.TemplateEntry;
+import com.liferay.template.service.TemplateEntryLocalService;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -122,6 +123,13 @@ public class TemplatePortletDataHandler extends BasePortletDataHandler {
 			_ddmTemplateLocalService.deleteTemplates(
 				portletDataContext.getScopeGroupId(), classNameId);
 		}
+
+		_ddmTemplateLocalService.deleteTemplates(
+			portletDataContext.getScopeGroupId(),
+			_portal.getClassNameId(TemplateEntry.class));
+
+		_templateEntryLocalService.deleteTemplateEntries(
+			portletDataContext.getScopeGroupId());
 
 		return portletPreferences;
 	}
@@ -356,6 +364,9 @@ public class TemplatePortletDataHandler extends BasePortletDataHandler {
 
 	@Reference
 	private Staging _staging;
+
+	@Reference
+	private TemplateEntryLocalService _templateEntryLocalService;
 
 	@Reference(
 		target = "(model.class.name=com.liferay.template.model.TemplateEntry)"


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-51720

# How am I fixing it?

When deleting a group the following logic is executed, which relies on the portlet's data handler to clean up its data - https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java#L4243

This method was deleting some of the `DDMTemplates` but not all of them and neither were the actual `TemplateEntries` being removed.

If you see any issues with this implementation or would like it fixed in a different way please let me know.

# How can you verify that it works?

In `template-test` run `gw testIntegration --tests *.TemplateEntryLocalServiceTest`

Alternatively there are steps on LPD-51720.