### PR TITLE
LPD-52640 Fix SF failure in MarketplaceModal.tsx

### DIFF
--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/marketplace/MarketplaceModal.tsx
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/marketplace/MarketplaceModal.tsx
@@ -5,6 +5,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import {
+	AppsPermissions,
 	Marketplace,
 	MarketplaceContext,
 	MarketplaceContextProvider,
@@ -28,12 +29,18 @@ import MarketplaceViews from './MarketplaceViews';
 interface MarketplaceModalProps {
 	children?: ReactNode;
 	openOnRender?: boolean;
+	permissions?: AppsPermissions;
 	trigger?: ReactElement | null;
 }
 
 export default function MarketplaceModal({
 	children,
 	openOnRender,
+	permissions = {
+		installFreeApps: true,
+		purchaseAndInstallPaidApps: false,
+		viewApps: true,
+	},
 	trigger,
 	...marketplaceViewProps
 }: MarketplaceModalProps & ComponentProps<typeof MarketplaceViews>) {
@@ -42,6 +49,7 @@ export default function MarketplaceModal({
 	return (
 		<MarketplaceContextProvider
 			baseResourceURL={MarketplaceRest.getBaseResourceURL()}
+			permissions={permissions}
 			settings={{productFilter: 'fragments'}}
 		>
 			{children}


### PR DESCRIPTION
Due to: [LPD-52627](https://liferay.atlassian.net/browse/LPD-52627)

Fix SF failure:
`../../layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/marketplace/MarketplaceModal.tsx(43,4): error TS2741: Property 'permissions' is missing in type '{ children: (Element | ReactNode)[]; baseResourceURL: string; settings: { productFilter: "fragments"; }; }' but required in type 'MarketplaceContextProviderProps'.
`

Seen  [here](https://github.com/liferay-page-management/liferay-portal/pull/17168#issuecomment-2778796337)

[LPD-52627]: https://liferay.atlassian.net/browse/LPD-52627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ