### PR TITLE
LPD-52717 Fix add button 

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -52,6 +52,10 @@
 		},
 
 		_checkImageWidth(editor, editorContent, imageSrc) {
+			if (!editorContent) {
+				return;
+			}
+
 			const url = imageSrc.url ? imageSrc.url : imageSrc;
 
 			const editorContentDocument =

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/test/ContentPageEditorDefaultEditorConfigurationTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/test/ContentPageEditorDefaultEditorConfigurationTest.java
@@ -33,7 +33,6 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.util.Collections;
-import java.util.Objects;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -142,9 +141,13 @@ public class ContentPageEditorDefaultEditorConfigurationTest {
 	private void _assertToolbarsJSONObject(JSONObject jsonObject) {
 		JSONObject addJSONObject = jsonObject.getJSONObject("add");
 
-		Objects.equals(
-			JSONUtil.putAll("image", "hline"),
-			addJSONObject.getJSONArray("buttons"));
+		JSONArray buttonsJSONArray = addJSONObject.getJSONArray("buttons");
+
+		Assert.assertEquals(
+			JSONUtil.putAll(
+				"image", "hline"
+			).toString(),
+			buttonsJSONArray.toString());
 
 		JSONObject stylesJSONObject = jsonObject.getJSONObject("styles");
 
@@ -155,7 +158,10 @@ public class ContentPageEditorDefaultEditorConfigurationTest {
 			selectionsStylesJSONArray.toString(), 4,
 			selectionsStylesJSONArray.length());
 
-		Objects.equals(
+		JSONObject selectionsStylesJSONObject =
+			selectionsStylesJSONArray.getJSONObject(0);
+
+		Assert.assertEquals(
 			JSONUtil.put(
 				"buttons",
 				JSONUtil.putAll("imageLeft", "imageCenter", "imageRight")
@@ -163,23 +169,27 @@ public class ContentPageEditorDefaultEditorConfigurationTest {
 				"name", "image"
 			).put(
 				"test", "AlloyEditor.SelectionTest.image"
-			),
-			selectionsStylesJSONArray.getJSONObject(0));
+			).toString(),
+			selectionsStylesJSONObject.toString());
 
-		Objects.equals(
+		selectionsStylesJSONObject = selectionsStylesJSONArray.getJSONObject(1);
+
+		Assert.assertEquals(
 			JSONUtil.put(
 				"buttons", JSONUtil.put("linkEditBrowse")
 			).put(
 				"name", "link"
 			).put(
 				"test", "AlloyEditor.SelectionTest.link"
-			),
-			selectionsStylesJSONArray.getJSONObject(1));
+			).toString(),
+			selectionsStylesJSONObject.toString());
 
 		_assertToolbarStylesSelectionsTextJSONObject(
 			selectionsStylesJSONArray.getJSONObject(2));
 
-		Objects.equals(
+		selectionsStylesJSONObject = selectionsStylesJSONArray.getJSONObject(3);
+
+		Assert.assertEquals(
 			JSONUtil.put(
 				"buttons",
 				JSONUtil.putAll(
@@ -194,8 +204,8 @@ public class ContentPageEditorDefaultEditorConfigurationTest {
 				"setPosition", "AlloyEditor.SelectionSetPosition.table"
 			).put(
 				"test", "AlloyEditor.SelectionTest.table"
-			),
-			selectionsStylesJSONArray.getJSONObject(3));
+			).toString(),
+			selectionsStylesJSONObject.toString());
 	}
 
 	private void _assertToolbarStylesSelectionsTextJSONObject(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkRichTextEditorConfigContributor.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkRichTextEditorConfigContributor.java
@@ -214,7 +214,7 @@ public class FragmentEntryLinkRichTextEditorConfigContributor
 		return JSONUtil.put(
 			"add",
 			JSONUtil.put(
-				"buttons", JSONUtil.put("image", "hline")
+				"buttons", JSONUtil.putAll("image", "hline")
 			).put(
 				"tabIndex", 1
 			)

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_DisabledArea.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_DisabledArea.scss
@@ -22,6 +22,10 @@ html#{$cadmin-selector} {
 	}
 }
 
-.ae-toolbar-styles {
-	z-index: $alloyEditorZIndex;
+.ae-ui .ae-toolbars {
+	.ae-toolbar,
+	.ae-toolbar-add,
+	.ae-toolbar-styles {
+		z-index: $alloyEditorZIndex;
+	}
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_DisabledArea.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_DisabledArea.scss
@@ -29,3 +29,7 @@ html#{$cadmin-selector} {
 		z-index: $alloyEditorZIndex;
 	}
 }
+
+.cke_dialog_contents_body {
+	min-width: 20rem;
+}


### PR DESCRIPTION
/cc @sandrodw3 Do you agree on adding this to master https://github.com/liferay-page-management/liferay-portal/commit/c59d64b13f55e8a759a6e2ef39f42a5aab14987e I think I was able to reproduce it a few times without it, is harder but from 10 times I reproduce it once, is not that easy but not impossible.
https://github.com/user-attachments/assets/fa8c8f45-65e5-4690-a95a-71d36dd375d1

/cc @antonio-ortega please review https://github.com/liferay-page-management/liferay-portal/commit/679408196e580928f15e4725933e27a788deb067 it is breaking to add an image from our page because of https://github.com/liferay/liferay-portal/commit/aa8d0ad2ca7f769f4a135a395984eb608dad31b1
Steps:
1 Add a content page with a paragraph
2. Try to add an image with add button
3. The popup doesn't close when selecting an image because of editorContent is null

/cc @lfbesada could you please review the backend part as it comes from a change you did https://github.com/liferay/liferay-portal/commit/632009484d5f9d5bb10e0100b9ad4f63094658b8, and I think you have all the needed context