### PR TITLE
LPD-53330 Process Low Code Configuration Apps if the payment is not required

### DIFF
--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/marketplace/MarketplaceViews.tsx
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/marketplace/MarketplaceViews.tsx
@@ -8,6 +8,7 @@ import {
 	Marketplace,
 	MarketplaceRest,
 	MarketplaceView,
+	PlacedOrder,
 	Product,
 	useMarketplaceContext,
 } from '@liferay/marketplace-js-components-web';
@@ -29,18 +30,22 @@ async function fetchFragmentBlob(
 	return response.blob();
 }
 
-function getProductAttachmentBlob(
+function getProductVirtualEntryBlob(
 	marketplaceRest: MarketplaceRest,
-	product: Product
+	placedOrder: PlacedOrder
 ): Promise<Blob> {
-	if (!product.attachments || !product.attachments.length) {
-		throw new Error('Product has no attachments.');
+	const hasPlacedOrderItems = placedOrder.placedOrderItems.some(
+		(placedOrderItem) => placedOrderItem?.virtualItems?.length
+	);
+
+	if (!hasPlacedOrderItems) {
+		throw new Error('Product has no virtual entries.');
 	}
 
-	return fetchFragmentBlob(
-		marketplaceRest,
-		new URL(product.attachments[0].src).pathname
-	);
+	const [virtualItemURL] =
+		placedOrder.placedOrderItems[0].virtualItemURLs ?? [];
+
+	return fetchFragmentBlob(marketplaceRest, virtualItemURL);
 }
 
 interface MarketplaceViewsProps {
@@ -113,9 +118,14 @@ export default function MarketplaceViews({
 
 				await marketplaceRest.checkoutCart(cart);
 
-				const blob = await getProductAttachmentBlob(
+				const placedOrder = await marketplaceRest.getPlacedOrder(
+					cart.id,
+					new URLSearchParams({nestedFields: 'placedOrderItems'})
+				);
+
+				const blob = await getProductVirtualEntryBlob(
 					marketplaceRest,
-					product
+					placedOrder
 				);
 
 				if (blob) {

--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/marketplace/MarketplaceViews.tsx
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/marketplace/MarketplaceViews.tsx
@@ -8,7 +8,6 @@ import {
 	Marketplace,
 	MarketplaceRest,
 	MarketplaceView,
-	PlacedOrder,
 	Product,
 	useMarketplaceContext,
 } from '@liferay/marketplace-js-components-web';
@@ -30,10 +29,21 @@ async function fetchFragmentBlob(
 	return response.blob();
 }
 
-function getProductVirtualEntryBlob(
+async function getProductVirtualEntryBlob(
 	marketplaceRest: MarketplaceRest,
-	placedOrder: PlacedOrder
+	product: Product
 ): Promise<Blob> {
+	const cart = await marketplaceRest.createCart(product as Product, {
+		orderTypeExternalReferenceCode: 'LOW_CODE_CONFIGURATION',
+	});
+
+	await marketplaceRest.checkoutCart(cart);
+
+	const placedOrder = await marketplaceRest.getPlacedOrder(
+		cart.id,
+		new URLSearchParams({nestedFields: 'placedOrderItems'})
+	);
+
 	const hasPlacedOrderItems = placedOrder.placedOrderItems.some(
 		(placedOrderItem) => placedOrderItem?.virtualItems?.length
 	);
@@ -108,43 +118,30 @@ export default function MarketplaceViews({
 			setProduct(product);
 
 			try {
-				const cart = await marketplaceRest.createCart(
-					product as Product,
-					{
-						orderTypeExternalReferenceCode:
-							'LOW_CODE_CONFIGURATION',
-					}
-				);
-
-				await marketplaceRest.checkoutCart(cart);
-
-				const placedOrder = await marketplaceRest.getPlacedOrder(
-					cart.id,
-					new URLSearchParams({nestedFields: 'placedOrderItems'})
-				);
-
 				const blob = await getProductVirtualEntryBlob(
 					marketplaceRest,
-					placedOrder
+					product
 				);
 
 				if (blob) {
-					const file = new File(
-						[blob],
-						`${product.name.replace(' ', '-').toLowerCase()}.zip`,
-						{type: 'application/zip'}
-					);
-
-					await handleImportFile(file);
-
-					openToast({
-						message: Liferay.Language.get(
-							'your-request-completed-successfully'
-						),
-						title: Liferay.Language.get('success'),
-						type: 'success',
-					});
+					return;
 				}
+
+				const file = new File(
+					[blob],
+					`${product.name.replace(' ', '-').toLowerCase()}.zip`,
+					{type: 'application/zip'}
+				);
+
+				await handleImportFile(file);
+
+				openToast({
+					message: Liferay.Language.get(
+						'your-request-completed-successfully'
+					),
+					title: Liferay.Language.get('success'),
+					type: 'success',
+				});
 			}
 			catch (error) {
 				console.error('Installation failed:', error);

--- a/modules/apps/layout/layout-js-components-web/test/components/marketplace/MarketplaceViews.test.js
+++ b/modules/apps/layout/layout-js-components-web/test/components/marketplace/MarketplaceViews.test.js
@@ -19,6 +19,17 @@ const mockUseMarketplaceContext = {
 		fetchMarketplace: jest.fn(() =>
 			Promise.resolve({blob: () => new Blob(['test'])})
 		),
+		getPlacedOrder: jest.fn(() =>
+			Promise.resolve({
+				id: 'test-cart-id',
+				placedOrderItems: [
+					{
+						virtualItemURLs: ['/o/marketplace/file.lpkg'],
+						virtualItems: [{url: '/o/marketplace/file.lpkg'}],
+					},
+				],
+			})
+		),
 	},
 	modal: {onOpenChange: jest.fn()},
 	product: {

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/MarketplaceRestController.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/MarketplaceRestController.java
@@ -65,8 +65,10 @@ public class MarketplaceRestController extends BaseRestController {
 		JSONObject commerceOrderJSONObject = jsonObject.getJSONObject(
 			"commerceOrder");
 
-		if (commerceOrderJSONObject.getInt("paymentStatus") !=
-				MarketplaceConstants.ORDER_PAYMENT_STATUS_COMPLETED) {
+		if ((commerceOrderJSONObject.getInt("paymentStatus") !=
+				MarketplaceConstants.ORDER_PAYMENT_STATUS_COMPLETED) &&
+			(commerceOrderJSONObject.getInt("paymentStatus") !=
+				MarketplaceConstants.ORDER_PAYMENT_STATUS_NOT_REQUIRED)) {
 
 			if (_log.isInfoEnabled()) {
 				_log.info(
@@ -100,7 +102,10 @@ public class MarketplaceRestController extends BaseRestController {
 		}
 
 		if (Objects.equals(
-				order.getOrderTypeExternalReferenceCode(), "COMPOSITE_APP")) {
+				order.getOrderTypeExternalReferenceCode(), "COMPOSITE_APP") ||
+			Objects.equals(
+				order.getOrderTypeExternalReferenceCode(),
+				"LOW_CODE_CONFIGURATION")) {
 
 			_marketplaceService.updateOrder(
 				null, order.getId(),

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/constants/MarketplaceConstants.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/constants/MarketplaceConstants.java
@@ -12,6 +12,8 @@ public class MarketplaceConstants {
 
 	public static final int ORDER_PAYMENT_STATUS_COMPLETED = 0;
 
+	public static final int ORDER_PAYMENT_STATUS_NOT_REQUIRED = 23;
+
 	public static final int ORDER_STATUS_CANCELLED = 8;
 
 	public static final String ORDER_STATUS_CANCELLED_LABEL = "Cancelled";


### PR DESCRIPTION
As part of the work done https://github.com/liferay-page-management/liferay-portal/pull/17032#discussion_r1988893062

We need to move the implementation for the **Fragment** Installation where the Attachment is used to retrieve the Fragment.zip to use the **Virtual Entry.**

Once our Marketplace environment is upgraded to 2025.Q1 we will hotfix [this ticket](https://liferay.atlassian.net/browse/LPD-51897) where the Virtual Entry will be automatic available when the order is created and the order checkout is done.

@georgel-pop-lr as we've been working together on this, do you mind having a look?