### PR TITLE
LPD-53607 Remove true param, as it should be an object or undefined

### DIFF
--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/LayoutFinder.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/LayoutFinder.js
@@ -79,7 +79,7 @@ function LayoutFinder({
 	);
 
 	const handleOnClick = useCallback(() => {
-		Liferay.Portlet.destroy(`#p_p_id${namespace}`, true);
+		Liferay.Portlet.destroy(`#p_p_id${namespace}`);
 
 		setSessionValue(
 			'com.liferay.product.navigation.product.menu.web_pagesTreeState',

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PageTypeSelector.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PageTypeSelector.js
@@ -27,7 +27,7 @@ function PageTypeSelector({
 	const handleSelect = (type) => {
 		setSessionValue(`${namespace}PAGE_TYPE_SELECTED_OPTION`, type).then(
 			() => {
-				Liferay.Portlet.destroy(`#p_p_id${namespace}`, true);
+				Liferay.Portlet.destroy(`#p_p_id${namespace}`);
 
 				fetch(pagesTreeURL)
 					.then((response) => {

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PagesAdministrationLink.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PagesAdministrationLink.js
@@ -23,6 +23,6 @@ export default function PagesAdministrationLink({
 }
 
 PagesAdministrationLink.propTypes = {
-	administrationPortletURL: PropTypes.array.isRequired,
+	administrationPortletURL: PropTypes.string.isRequired,
 	hasAdministrationPortletPermission: PropTypes.bool.isRequired,
 };

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PagesTree.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PagesTree.js
@@ -299,6 +299,9 @@ function TreeItem({
 									renderMenuOnClick
 									trigger={
 										<ClayButtonWithIcon
+											aria-label={Liferay.Language.get(
+												'actions'
+											)}
 											className="component-action quick-action-item"
 											displayType={null}
 											size="sm"

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
@@ -110,7 +110,7 @@ SiteAdministrationPanelCategoryDisplayContext siteAdministrationPanelCategoryDis
 		);
 
 		pagesTreeToggle.addEventListener('click', (event) => {
-			Liferay.Portlet.destroy('#p_p_id<portlet:namespace />', true);
+			Liferay.Portlet.destroy('#p_p_id<portlet:namespace />');
 
 			Liferay.Util.Session.set(
 				'com.liferay.product.navigation.product.menu.web_pagesTreeState',


### PR DESCRIPTION
Opened cause pageTree tests were failing: https://liferay.slack.com/archives/C08BKV4MV2R/p1744728998027369

Not sure if this is the proper solution and a discussion with front-end team was opened on https://liferay.slack.com/archives/CNBG06JS3/p1744808394658749

We need to remove the true param from the destroy function `Liferay.Portlet.destroy(...` because in [portlet.js#L174](https://github.com/liferay/liferay-portal/blob/9190a80a139b2b4fbb4c8e2c7e34a0d9c325fbfe/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js#L174) options is undefined and if is true is not an object and would fail to get property doAsUserId on this line `options.doAsUserId || themeDisplay.getDoAsUserIdEncoded();`