### PR TITLE
LPD-53599 Accordion fragment adjustments

### DIFF
--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/accordion/index.css
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/accordion/index.css
@@ -1,6 +1,6 @@
 .panel-collapse.collapsed {
 	max-height: 0;
-	transition: max-height 0.5s ease;
+	transition: max-height 0.3s ease;
 }
 
 .c-prefers-reduced-motion .panel-collapse.collapsed {

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/accordion/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/accordion/index.html
@@ -1,6 +1,6 @@
 <div class="component-accordion">
 	<div class="panel panel-secondary">
-		<button aria-controls="accordion-fragment-${fragmentEntryLinkNamespace}" aria-expanded="true" class="btn btn-unstyled collapse-icon collapse-icon-middle ml-n1 my-2 panel-header" type="button">
+		<button aria-controls="accordion-fragment-${fragmentEntryLinkNamespace}" aria-expanded="true" class="btn btn-unstyled collapse-icon collapse-icon-middle my-2 panel-header pl-3" type="button">
 			<span class="panel-title text-4 text-capitalize" data-lfr-editable-id="accordion-title" data-lfr-editable-type="text" id="accordion-fragment-${fragmentEntryLinkNamespace}">
 				Section title
 			</span>
@@ -9,7 +9,7 @@
 			[@clay["icon"] symbol="angle-down" className="collapse-icon-open"/]
 		</button>
 
-		<div class="overflow-hidden panel-collapse px-3[#if layoutMode == 'edit'] h-auto[/#if]">
+		<div class="overflow-hidden panel-collapse [#if layoutMode == 'edit'] h-auto[/#if]">
 			<div class="pb-3 px-3">
 				<lfr-drop-zone data-lfr-drop-zone-id="1"></lfr-drop-zone>
 			</div>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/accordion/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/accordion/index.html
@@ -1,5 +1,5 @@
 <div class="component-accordion">
-	<div class="panel panel-secondary">
+	<div class="mb-0 panel panel-secondary">
 		<button aria-controls="accordion-fragment-${fragmentEntryLinkNamespace}" aria-expanded="true" class="btn btn-unstyled collapse-icon collapse-icon-middle my-2 panel-header pl-3" type="button">
 			<span class="panel-title text-4 text-capitalize" data-lfr-editable-id="accordion-title" data-lfr-editable-type="text" id="accordion-fragment-${fragmentEntryLinkNamespace}">
 				Section title

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/heading/index.css
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/heading/index.css
@@ -1,3 +1,0 @@
-.fragment-heading-text-colored a {
-	color: inherit;
-}

--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -1442,7 +1442,9 @@ export class PageEditorPage {
 
 			if (hasMenuBar) {
 				await clickAndExpectToBeHidden({
-					target: iframe.locator('.sheet-title').getByText(entity),
+					target: iframe
+						.locator('.sheet-title')
+						.getByText(entity, {exact: true}),
 					trigger: entryLocator
 						? entryLocator
 						: iframe


### PR DESCRIPTION
> [!NOTE]  
> No tests needed.

## Motivation
Due to [LPD-53599](https://liferay.atlassian.net/browse/LPD-53599)

## Changes
- Speed up transition from 0.5 to 0.3
- Adjust drop zone area margin left and right to 16px
- Remove extra bottom padding

## Result

https://github.com/user-attachments/assets/521d9d3b-dc2f-43e5-a1e3-38805e3cad94



[LPD-53599]: https://liferay.atlassian.net/browse/LPD-53599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ