### PR TITLE
LPD-XXX Add Fragment and Layout Portlet Names to Marketplace MVC Commands

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/MarketplaceSearchResults.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/MarketplaceSearchResults.tsx
@@ -29,7 +29,9 @@ export default function MarketplaceSearchResults({
 }: {
 	searchValue: string;
 }) {
-	const baseResourceURL = MarketplaceRest.getBaseResourceURL();
+	const baseResourceURL = MarketplaceRest.getBaseResourceURL(
+		config.portletNamespace || config.fragmentPortletNamespace
+	);
 
 	const marketplaceConfiguration =
 		useMarketplaceConfiguration(baseResourceURL);
@@ -65,7 +67,9 @@ export default function MarketplaceSearchResults({
 }
 
 function SearchResultsPanel({searchValue}: {searchValue: string}) {
-	const baseResourceURL = MarketplaceRest.getBaseResourceURL();
+	const baseResourceURL = MarketplaceRest.getBaseResourceURL(
+		config.portletNamespace || config.fragmentPortletNamespace
+	);
 
 	const marketplaceConfiguration =
 		useMarketplaceConfiguration(baseResourceURL);

--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/marketplace/MarketplaceButton.tsx
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/marketplace/MarketplaceButton.tsx
@@ -22,6 +22,7 @@ interface MarketplaceButtonProps {
 	heading: string;
 	isMarketplaceButtonVisited: boolean;
 	permissions: AppsPermissions;
+	portletId?: string;
 	portletNamespace: string;
 }
 
@@ -57,6 +58,7 @@ function MarketplaceButton({
 		return (
 			<MarketplaceModal
 				permissions={permissions}
+				portletNamespace={portletNamespace}
 				{...marketplaceViewProps}
 			/>
 		);

--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/marketplace/MarketplaceModal.tsx
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/marketplace/MarketplaceModal.tsx
@@ -30,6 +30,8 @@ interface MarketplaceModalProps {
 	children?: ReactNode;
 	openOnRender?: boolean;
 	permissions: AppsPermissions;
+	portletId?: string;
+	portletNamespace?: string;
 	trigger?: ReactElement | null;
 }
 
@@ -37,6 +39,8 @@ export default function MarketplaceModal({
 	children,
 	openOnRender,
 	permissions,
+	portletId,
+	portletNamespace,
 	trigger,
 	...marketplaceViewProps
 }: MarketplaceModalProps & ComponentProps<typeof MarketplaceViews>) {
@@ -47,7 +51,9 @@ export default function MarketplaceModal({
 		// @ts-ignore
 
 		<MarketplaceContextProvider
-			baseResourceURL={MarketplaceRest.getBaseResourceURL()}
+			baseResourceURL={MarketplaceRest.getBaseResourceURL(
+				portletId || portletNamespace
+			)}
 			permissions={permissions}
 			settings={{productFilter: 'fragments'}}
 		>

--- a/modules/apps/marketplace/marketplace-js-components-web/src/main/resources/META-INF/resources/js/core/MarketplaceRest.ts
+++ b/modules/apps/marketplace/marketplace-js-components-web/src/main/resources/META-INF/resources/js/core/MarketplaceRest.ts
@@ -58,6 +58,7 @@ async function getBaseFetch<T = any>(url: string, options?: FetchOptions) {
 	return response.json() as unknown as T;
 }
 
+const removeEdgesUnderscoresRegEx = /^_+|_+$/g;
 const sessionKey = '@marketplace/token';
 
 export class MarketplaceRest {
@@ -128,8 +129,21 @@ export class MarketplaceRest {
 		);
 	}
 
-	static getBaseResourceURL() {
-		return `/group/guest/~/control_panel/manage?p_p_id=${Liferay.PortletKeys.INSTANCE_SETTINGS}`;
+	static getBaseResourceURL(portletId?: string) {
+		if (!portletId) {
+			return `/group/guest/~/control_panel/manage?p_p_id=${Liferay.PortletKeys.INSTANCE_SETTINGS}`;
+		}
+
+		const url = new URL(window.location.href);
+
+		if (!url.searchParams.get('p_p_id')) {
+			url.searchParams.set(
+				'p_p_id',
+				portletId.replace(removeEdgesUnderscoresRegEx, '')
+			);
+		}
+
+		return url.href;
 	}
 
 	private static async getMarketplaceConfiguration() {

--- a/modules/apps/marketplace/marketplace-settings-web/src/main/java/com/liferay/marketplace/settings/web/internal/portlet/action/GetAuthorizationMVCResourceCommand.java
+++ b/modules/apps/marketplace/marketplace-settings-web/src/main/java/com/liferay/marketplace/settings/web/internal/portlet/action/GetAuthorizationMVCResourceCommand.java
@@ -31,6 +31,8 @@ import org.osgi.service.component.annotations.Component;
 	property = {
 		"javax.portlet.name=" + ConfigurationAdminPortletKeys.INSTANCE_SETTINGS,
 		"javax.portlet.name=com_liferay_commerce_channel_web_internal_portlet_CommerceChannelsPortlet",
+		"javax.portlet.name=com_liferay_fragment_web_portlet_FragmentPortlet",
+		"javax.portlet.name=com_liferay_layout_content_page_editor_web_internal_portlet_ContentPageEditorPortlet",
 		"mvc.command.name=/marketplace_settings/get_authorization"
 	},
 	service = MVCResourceCommand.class

--- a/modules/apps/marketplace/marketplace-settings-web/src/main/java/com/liferay/marketplace/settings/web/internal/portlet/action/GetConfigurationMVCResourceCommand.java
+++ b/modules/apps/marketplace/marketplace-settings-web/src/main/java/com/liferay/marketplace/settings/web/internal/portlet/action/GetConfigurationMVCResourceCommand.java
@@ -33,6 +33,8 @@ import org.osgi.service.component.annotations.Reference;
 	property = {
 		"javax.portlet.name=" + ConfigurationAdminPortletKeys.INSTANCE_SETTINGS,
 		"javax.portlet.name=com_liferay_commerce_channel_web_internal_portlet_CommerceChannelsPortlet",
+		"javax.portlet.name=com_liferay_fragment_web_portlet_FragmentPortlet",
+		"javax.portlet.name=com_liferay_layout_content_page_editor_web_internal_portlet_ContentPageEditorPortlet",
 		"mvc.command.name=/marketplace_settings/get_configuration"
 	},
 	service = MVCResourceCommand.class


### PR DESCRIPTION
Hey @georgel-pop-lr  👋🏻 

As we discussed before the current state of the permissions to Fragment / Layout were missing the correct baseResourceURL + PortletKey

I tested this locally and I was able to access Marketplace Integration for both components with a non administrator user, as long as the User has the correct privileges for Marketplace and the Fragment's page.

If you need anything I'm glad to help.

As I don't have any ticket to assign feel free to create a ticket / bug and use my commits as part of it.

Also I kindly ask you to test, review this code and make changes if necessary, thank you!