### PR TITLE
LPD-55643 Use fileTitle instead of fileName to pick up the correct resources

### DIFF
--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalService.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalService.java
@@ -73,7 +73,7 @@ public interface BlogsEntryLocalService
 	 */
 	public FileEntry addAttachmentFileEntry(
 			String externalReferenceCode, long userId, long groupId,
-			String fileName, String mimeType, InputStream inputStream)
+			String title, String mimeType, InputStream inputStream)
 		throws PortalException;
 
 	public Folder addAttachmentsFolder(long userId, long groupId)

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalServiceUtil.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalServiceUtil.java
@@ -41,11 +41,11 @@ public class BlogsEntryLocalServiceUtil {
 	public static com.liferay.portal.kernel.repository.model.FileEntry
 			addAttachmentFileEntry(
 				String externalReferenceCode, long userId, long groupId,
-				String fileName, String mimeType, InputStream inputStream)
+				String title, String mimeType, InputStream inputStream)
 		throws PortalException {
 
 		return getService().addAttachmentFileEntry(
-			externalReferenceCode, userId, groupId, fileName, mimeType,
+			externalReferenceCode, userId, groupId, title, mimeType,
 			inputStream);
 	}
 

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalServiceWrapper.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryLocalServiceWrapper.java
@@ -35,12 +35,12 @@ public class BlogsEntryLocalServiceWrapper
 	public com.liferay.portal.kernel.repository.model.FileEntry
 			addAttachmentFileEntry(
 				String externalReferenceCode, long userId, long groupId,
-				String fileName, String mimeType,
+				String title, String mimeType,
 				java.io.InputStream inputStream)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _blogsEntryLocalService.addAttachmentFileEntry(
-			externalReferenceCode, userId, groupId, fileName, mimeType,
+			externalReferenceCode, userId, groupId, title, mimeType,
 			inputStream);
 	}
 

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryService.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryService.java
@@ -54,7 +54,7 @@ public interface BlogsEntryService extends BaseService {
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.blogs.service.impl.BlogsEntryServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the blogs entry remote service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link BlogsEntryServiceUtil} if injection and service tracking are not available.
 	 */
 	public FileEntry addAttachmentFileEntry(
-			String externalReferenceCode, long groupId, String fileName,
+			String externalReferenceCode, long groupId, String title,
 			String mimeType, InputStream inputStream)
 		throws PortalException;
 

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceUtil.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceUtil.java
@@ -35,12 +35,12 @@ public class BlogsEntryServiceUtil {
 	 */
 	public static com.liferay.portal.kernel.repository.model.FileEntry
 			addAttachmentFileEntry(
-				String externalReferenceCode, long groupId, String fileName,
+				String externalReferenceCode, long groupId, String title,
 				String mimeType, InputStream inputStream)
 		throws PortalException {
 
 		return getService().addAttachmentFileEntry(
-			externalReferenceCode, groupId, fileName, mimeType, inputStream);
+			externalReferenceCode, groupId, title, mimeType, inputStream);
 	}
 
 	public static com.liferay.portal.kernel.repository.model.Folder

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceWrapper.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceWrapper.java
@@ -29,12 +29,12 @@ public class BlogsEntryServiceWrapper
 	@Override
 	public com.liferay.portal.kernel.repository.model.FileEntry
 			addAttachmentFileEntry(
-				String externalReferenceCode, long groupId, String fileName,
+				String externalReferenceCode, long groupId, String title,
 				String mimeType, java.io.InputStream inputStream)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _blogsEntryService.addAttachmentFileEntry(
-			externalReferenceCode, groupId, fileName, mimeType, inputStream);
+			externalReferenceCode, groupId, title, mimeType, inputStream);
 	}
 
 	@Override

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/v1_1_2/BlogsImagesUpgradeProcess.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/upgrade/v1_1_2/BlogsImagesUpgradeProcess.java
@@ -79,7 +79,7 @@ public class BlogsImagesUpgradeProcess extends UpgradeProcess {
 
 				byte[] bytes = smallImage.getTextObj();
 
-				String fileName = StringBundler.concat(
+				String title = StringBundler.concat(
 					smallImage.getImageId(), StringPool.PERIOD,
 					smallImage.getType());
 
@@ -92,15 +92,15 @@ public class BlogsImagesUpgradeProcess extends UpgradeProcess {
 					_portletFileRepository.addPortletFileEntry(
 						groupId, userId, BlogsEntry.class.getName(), entryId,
 						BlogsConstants.SERVICE_NAME,
-						smallImagefolder.getFolderId(), bytes, fileName,
-						mimeType, true);
+						smallImagefolder.getFolderId(), bytes, title, mimeType,
+						true);
 
 				Folder blogsImagefolder = _addFolder(
 					userId, groupId, BlogsConstants.SERVICE_NAME);
 
 				_portletFileRepository.addPortletFileEntry(
 					groupId, userId, null, 0, BlogsConstants.SERVICE_NAME,
-					blogsImagefolder.getFolderId(), bytes, fileName, mimeType,
+					blogsImagefolder.getFolderId(), bytes, title, mimeType,
 					true);
 
 				preparedStatement2.setLong(

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceHttp.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceHttp.java
@@ -44,7 +44,7 @@ public class BlogsEntryServiceHttp {
 	public static com.liferay.portal.kernel.repository.model.FileEntry
 			addAttachmentFileEntry(
 				HttpPrincipal httpPrincipal, String externalReferenceCode,
-				long groupId, String fileName, String mimeType,
+				long groupId, String title, String mimeType,
 				java.io.InputStream inputStream)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -54,7 +54,7 @@ public class BlogsEntryServiceHttp {
 				_addAttachmentFileEntryParameterTypes0);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, groupId, fileName, mimeType,
+				methodKey, externalReferenceCode, groupId, title, mimeType,
 				inputStream);
 
 			Object returnObj = null;

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryLocalServiceImpl.java
@@ -159,7 +159,7 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 	@Override
 	public FileEntry addAttachmentFileEntry(
 			String externalReferenceCode, long userId, long groupId,
-			String fileName, String mimeType, InputStream inputStream)
+			String title, String mimeType, InputStream inputStream)
 		throws PortalException {
 
 		Folder folder = addAttachmentsFolder(userId, groupId);
@@ -167,8 +167,8 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 		return _portletFileRepository.addPortletFileEntry(
 			externalReferenceCode, groupId, userId, null, 0,
 			BlogsConstants.SERVICE_NAME, folder.getFolderId(), inputStream,
-			_getUniqueFileName(groupId, fileName, folder.getFolderId()),
-			mimeType, true);
+			_getUniqueTitle(groupId, title, folder.getFolderId()), mimeType,
+			true);
 	}
 
 	@Override
@@ -511,7 +511,7 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 			_portletFileRepository.addPortletFileEntry(
 				groupId, userId, null, 0, BlogsConstants.SERVICE_NAME,
 				folder.getFolderId(), imageBytes,
-				_getUniqueFileName(
+				_getUniqueTitle(
 					groupId, imageSelector.getImageTitle(),
 					folder.getFolderId()),
 				imageSelector.getImageMimeType(), true);
@@ -1692,7 +1692,7 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 			_portletFileRepository.addPortletFileEntry(
 				groupId, userId, BlogsEntry.class.getName(), entryId,
 				BlogsConstants.SERVICE_NAME, folderId, bytes,
-				_getUniqueFileName(groupId, title, folderId), mimeType, true);
+				_getUniqueTitle(groupId, title, folderId), mimeType, true);
 
 		return processedImageFileEntry.getFileEntryId();
 	}
@@ -1837,13 +1837,11 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 			themeDisplay);
 	}
 
-	private String _getUniqueFileName(
-			long groupId, String fileName, long folderId)
+	private String _getUniqueTitle(long groupId, String title, long folderId)
 		throws PortalException {
 
 		return _uniqueFileNameProvider.provide(
-			fileName,
-			curFileName -> _hasFileEntry(groupId, folderId, curFileName));
+			title, curTitle -> _hasFileEntry(groupId, folderId, curTitle));
 	}
 
 	private String _getUniqueUrlTitle(BlogsEntry entry) {
@@ -1892,11 +1890,9 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 		return StringPool.BLANK;
 	}
 
-	private boolean _hasFileEntry(
-		long groupId, long folderId, String fileName) {
-
+	private boolean _hasFileEntry(long groupId, long folderId, String title) {
 		FileEntry fileEntry = _portletFileRepository.fetchPortletFileEntry(
-			groupId, folderId, fileName);
+			groupId, folderId, title);
 
 		if (fileEntry == null) {
 			return false;

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
@@ -74,7 +74,7 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 
 	@Override
 	public FileEntry addAttachmentFileEntry(
-			String externalReferenceCode, long groupId, String fileName,
+			String externalReferenceCode, long groupId, String title,
 			String mimeType, InputStream inputStream)
 		throws PortalException {
 
@@ -82,7 +82,7 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 			getPermissionChecker(), groupId, ActionKeys.ADD_ENTRY);
 
 		return blogsEntryLocalService.addAttachmentFileEntry(
-			externalReferenceCode, getUserId(), groupId, fileName, mimeType,
+			externalReferenceCode, getUserId(), groupId, title, mimeType,
 			inputStream);
 	}
 

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/attachments/test/BlogsEntryAttachmentFileEntryHelperTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/attachments/test/BlogsEntryAttachmentFileEntryHelperTest.java
@@ -243,14 +243,14 @@ public class BlogsEntryAttachmentFileEntryHelperTest {
 
 	private FileEntry _addBlogsEntryAttachmentFileEntry(
 			long groupId, long userId, long blogsEntryId, long folderId,
-			String fileName, String mimeType, InputStream inputStream)
+			String title, String mimeType, InputStream inputStream)
 		throws Exception {
 
-		String uniqueFileName = _getUniqueFileName(groupId, fileName, folderId);
+		String uniqueTitle = _getUniqueTitle(groupId, title, folderId);
 
 		return PortletFileRepositoryUtil.addPortletFileEntry(
 			null, groupId, userId, BlogsEntry.class.getName(), blogsEntryId,
-			BlogsConstants.SERVICE_NAME, folderId, inputStream, uniqueFileName,
+			BlogsConstants.SERVICE_NAME, folderId, inputStream, uniqueTitle,
 			mimeType, true);
 	}
 
@@ -277,20 +277,16 @@ public class BlogsEntryAttachmentFileEntryHelperTest {
 		return tempBlogsEntryAttachmentFileEntries;
 	}
 
-	private String _getUniqueFileName(
-			long groupId, String fileName, long folderId)
+	private String _getUniqueTitle(long groupId, String title, long folderId)
 		throws Exception {
 
 		return _uniqueFileNameProvider.provide(
-			fileName,
-			curFileName -> _hasFileEntry(groupId, folderId, curFileName));
+			title, curTitle -> _hasFileEntry(groupId, folderId, curTitle));
 	}
 
-	private boolean _hasFileEntry(
-		long groupId, long folderId, String fileName) {
-
+	private boolean _hasFileEntry(long groupId, long folderId, String title) {
 		FileEntry fileEntry = _portletFileRepository.fetchPortletFileEntry(
-			groupId, folderId, fileName);
+			groupId, folderId, title);
 
 		if (fileEntry == null) {
 			return false;

--- a/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
+++ b/modules/apps/blogs/blogs-test/src/testIntegration/java/com/liferay/blogs/service/test/BlogsEntryLocalServiceTest.java
@@ -285,11 +285,11 @@ public class BlogsEntryLocalServiceTest {
 
 	@Test
 	public void testAddDuplicateAttachmentFileEntry() throws Exception {
-		String fileName = StringUtil.randomString();
+		String title = StringUtil.randomString();
 
-		FileEntry fileEntry1 = _addAttachmentFileEntry(null, fileName);
+		FileEntry fileEntry1 = _addAttachmentFileEntry(null, title);
 
-		FileEntry fileEntry2 = _addAttachmentFileEntry(null, fileName);
+		FileEntry fileEntry2 = _addAttachmentFileEntry(null, title);
 
 		Assert.assertNotEquals(
 			fileEntry1.getFileName(), fileEntry2.getFileName());
@@ -1766,12 +1766,12 @@ public class BlogsEntryLocalServiceTest {
 	}
 
 	private FileEntry _addAttachmentFileEntry(
-			String externalReferenceCode, String fileName)
+			String externalReferenceCode, String title)
 		throws Exception {
 
 		return _blogsEntryLocalService.addAttachmentFileEntry(
 			externalReferenceCode, _user.getUserId(), _group.getGroupId(),
-			fileName, ContentTypes.APPLICATION_OCTET_STREAM,
+			title, ContentTypes.APPLICATION_OCTET_STREAM,
 			new UnsyncByteArrayInputStream(new byte[0]));
 	}
 

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalService.java
@@ -70,7 +70,7 @@ public interface CommerceOrderLocalService
 	 */
 	public FileEntry addAttachmentFileEntry(
 			String externalReferenceCode, long userId, long commerceOrderId,
-			String fileName, InputStream inputStream)
+			String title, InputStream inputStream)
 		throws PortalException;
 
 	/**

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceUtil.java
@@ -41,11 +41,11 @@ public class CommerceOrderLocalServiceUtil {
 	public static com.liferay.portal.kernel.repository.model.FileEntry
 			addAttachmentFileEntry(
 				String externalReferenceCode, long userId, long commerceOrderId,
-				String fileName, InputStream inputStream)
+				String title, InputStream inputStream)
 		throws PortalException {
 
 		return getService().addAttachmentFileEntry(
-			externalReferenceCode, userId, commerceOrderId, fileName,
+			externalReferenceCode, userId, commerceOrderId, title,
 			inputStream);
 	}
 

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderLocalServiceWrapper.java
@@ -33,11 +33,11 @@ public class CommerceOrderLocalServiceWrapper
 	public com.liferay.portal.kernel.repository.model.FileEntry
 			addAttachmentFileEntry(
 				String externalReferenceCode, long userId, long commerceOrderId,
-				String fileName, java.io.InputStream inputStream)
+				String title, java.io.InputStream inputStream)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceOrderLocalService.addAttachmentFileEntry(
-			externalReferenceCode, userId, commerceOrderId, fileName,
+			externalReferenceCode, userId, commerceOrderId, title,
 			inputStream);
 	}
 

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderService.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderService.java
@@ -54,7 +54,7 @@ public interface CommerceOrderService extends BaseService {
 	 */
 	public FileEntry addAttachmentFileEntry(
 			String externalReferenceCode, long userId, long commerceOrderId,
-			String fileName, InputStream inputStream)
+			String title, InputStream inputStream)
 		throws PortalException;
 
 	public CommerceOrder addCommerceOrder(

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderServiceUtil.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderServiceUtil.java
@@ -36,11 +36,11 @@ public class CommerceOrderServiceUtil {
 	public static com.liferay.portal.kernel.repository.model.FileEntry
 			addAttachmentFileEntry(
 				String externalReferenceCode, long userId, long commerceOrderId,
-				String fileName, InputStream inputStream)
+				String title, InputStream inputStream)
 		throws PortalException {
 
 		return getService().addAttachmentFileEntry(
-			externalReferenceCode, userId, commerceOrderId, fileName,
+			externalReferenceCode, userId, commerceOrderId, title,
 			inputStream);
 	}
 

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderServiceWrapper.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/service/CommerceOrderServiceWrapper.java
@@ -31,11 +31,11 @@ public class CommerceOrderServiceWrapper
 	public com.liferay.portal.kernel.repository.model.FileEntry
 			addAttachmentFileEntry(
 				String externalReferenceCode, long userId, long commerceOrderId,
-				String fileName, java.io.InputStream inputStream)
+				String title, java.io.InputStream inputStream)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _commerceOrderService.addAttachmentFileEntry(
-			externalReferenceCode, userId, commerceOrderId, fileName,
+			externalReferenceCode, userId, commerceOrderId, title,
 			inputStream);
 	}
 

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/http/CommerceOrderServiceHttp.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/http/CommerceOrderServiceHttp.java
@@ -44,7 +44,7 @@ public class CommerceOrderServiceHttp {
 	public static com.liferay.portal.kernel.repository.model.FileEntry
 			addAttachmentFileEntry(
 				HttpPrincipal httpPrincipal, String externalReferenceCode,
-				long userId, long commerceOrderId, String fileName,
+				long userId, long commerceOrderId, String title,
 				java.io.InputStream inputStream)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -55,7 +55,7 @@ public class CommerceOrderServiceHttp {
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, userId, commerceOrderId,
-				fileName, inputStream);
+				title, inputStream);
 
 			Object returnObj = null;
 

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderLocalServiceImpl.java
@@ -177,10 +177,10 @@ public class CommerceOrderLocalServiceImpl
 	@Override
 	public FileEntry addAttachmentFileEntry(
 			String externalReferenceCode, long userId, long commerceOrderId,
-			String fileName, InputStream inputStream)
+			String title, InputStream inputStream)
 		throws PortalException {
 
-		if (Validator.isNull(fileName)) {
+		if (Validator.isNull(title)) {
 			return null;
 		}
 
@@ -224,10 +224,10 @@ public class CommerceOrderLocalServiceImpl
 			serviceContext.setIndexingEnabled(false);
 
 			return localRepository.addFileEntry(
-				externalReferenceCode, userId, folder.getFolderId(), fileName,
-				MimeTypesUtil.getContentType(file, fileName), fileName,
-				fileName, StringPool.BLANK, StringPool.BLANK, file, null, null,
-				null, serviceContext);
+				externalReferenceCode, userId, folder.getFolderId(), title,
+				MimeTypesUtil.getContentType(file, title), title, title,
+				StringPool.BLANK, StringPool.BLANK, file, null, null, null,
+				serviceContext);
 		}
 		catch (IOException ioException) {
 			throw new SystemException(

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderServiceImpl.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/service/impl/CommerceOrderServiceImpl.java
@@ -55,15 +55,14 @@ public class CommerceOrderServiceImpl extends CommerceOrderServiceBaseImpl {
 	@Override
 	public FileEntry addAttachmentFileEntry(
 			String externalReferenceCode, long userId, long commerceOrderId,
-			String fileName, InputStream inputStream)
+			String title, InputStream inputStream)
 		throws PortalException {
 
 		_commerceOrderModelResourcePermission.check(
 			getPermissionChecker(), commerceOrderId, ActionKeys.UPDATE);
 
 		return commerceOrderLocalService.addAttachmentFileEntry(
-			externalReferenceCode, userId, commerceOrderId, fileName,
-			inputStream);
+			externalReferenceCode, userId, commerceOrderId, title, inputStream);
 	}
 
 	@Override

--- a/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
+++ b/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
@@ -401,13 +401,13 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 
 	@Override
 	public FileEntry fetchPortletFileEntry(
-		long groupId, long folderId, String fileName) {
+		long groupId, long folderId, String title) {
 
 		try {
 			LocalRepository localRepository =
 				_repositoryProvider.getLocalRepository(groupId);
 
-			return localRepository.fetchFileEntry(folderId, fileName);
+			return localRepository.fetchFileEntry(folderId, title);
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
+++ b/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
@@ -81,18 +81,18 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 				inputStreamObjectValuePairs) {
 
 			InputStream inputStream = inputStreamObjectValuePair.getValue();
-			String fileName = inputStreamObjectValuePair.getKey();
+			String title = inputStreamObjectValuePair.getKey();
 
 			addPortletFileEntry(
 				null, groupId, userId, className, classPK, portletId, folderId,
-				inputStream, fileName, StringPool.BLANK, true);
+				inputStream, title, StringPool.BLANK, true);
 		}
 	}
 
 	@Override
 	public FileEntry addPortletFileEntry(
 			long groupId, long userId, String className, long classPK,
-			String portletId, long folderId, byte[] bytes, String fileName,
+			String portletId, long folderId, byte[] bytes, String title,
 			String mimeType, boolean indexingEnabled)
 		throws PortalException {
 
@@ -107,7 +107,7 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 
 			return addPortletFileEntry(
 				null, groupId, userId, className, classPK, portletId, folderId,
-				file, fileName, mimeType, indexingEnabled);
+				file, title, mimeType, indexingEnabled);
 		}
 		catch (IOException ioException) {
 			throw new SystemException(
@@ -122,11 +122,10 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 	public FileEntry addPortletFileEntry(
 			String externalReferenceCode, long groupId, long userId,
 			String className, long classPK, String portletId, long folderId,
-			File file, String fileName, String mimeType,
-			boolean indexingEnabled)
+			File file, String title, String mimeType, boolean indexingEnabled)
 		throws PortalException {
 
-		if (Validator.isNull(fileName)) {
+		if (Validator.isNull(title)) {
 			return null;
 		}
 
@@ -148,7 +147,7 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 		if (Validator.isNull(mimeType) ||
 			mimeType.equals(ContentTypes.APPLICATION_OCTET_STREAM)) {
 
-			mimeType = MimeTypesUtil.getContentType(file, fileName);
+			mimeType = MimeTypesUtil.getContentType(file, title);
 		}
 
 		boolean dlAppHelperEnabled = DLAppHelperThreadLocal.isEnabled();
@@ -161,9 +160,9 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 					repository.getRepositoryId());
 
 			return localRepository.addFileEntry(
-				externalReferenceCode, userId, folderId, fileName, mimeType,
-				fileName, fileName, StringPool.BLANK, StringPool.BLANK, file,
-				null, null, null, serviceContext);
+				externalReferenceCode, userId, folderId, title, mimeType, title,
+				title, StringPool.BLANK, StringPool.BLANK, file, null, null,
+				null, serviceContext);
 		}
 		finally {
 			DLAppHelperThreadLocal.setEnabled(dlAppHelperEnabled);
@@ -174,7 +173,7 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 	public FileEntry addPortletFileEntry(
 			String externalReferenceCode, long groupId, long userId,
 			String className, long classPK, String portletId, long folderId,
-			InputStream inputStream, String fileName, String mimeType,
+			InputStream inputStream, String title, String mimeType,
 			boolean indexingEnabled)
 		throws PortalException {
 
@@ -189,7 +188,7 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 
 			return addPortletFileEntry(
 				externalReferenceCode, groupId, userId, className, classPK,
-				portletId, folderId, file, fileName, mimeType, indexingEnabled);
+				portletId, folderId, file, title, mimeType, indexingEnabled);
 		}
 		catch (IOException ioException) {
 			throw new SystemException(
@@ -354,13 +353,13 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 
 	@Override
 	public void deletePortletFileEntry(
-			long groupId, long folderId, String fileName)
+			long groupId, long folderId, String title)
 		throws PortalException {
 
 		LocalRepository localRepository =
 			_repositoryProvider.getLocalRepository(groupId);
 
-		FileEntry fileEntry = localRepository.getFileEntry(folderId, fileName);
+		FileEntry fileEntry = localRepository.getFileEntry(folderId, title);
 
 		deletePortletFileEntry(fileEntry.getFileEntryId());
 	}
@@ -566,13 +565,13 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 
 	@Override
 	public FileEntry getPortletFileEntry(
-			long groupId, long folderId, String fileName)
+			long groupId, long folderId, String title)
 		throws PortalException {
 
 		LocalRepository localRepository =
 			_repositoryProvider.getLocalRepository(groupId);
 
-		return localRepository.getFileEntry(folderId, fileName);
+		return localRepository.getFileEntry(folderId, title);
 	}
 
 	@Override
@@ -623,13 +622,13 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 		sb.append(fileEntry.getGroupId());
 		sb.append(StringPool.SLASH);
 
-		String fileName = fileEntry.getFileName();
+		String title = fileEntry.getTitle();
 
 		if (fileEntry.isInTrash()) {
-			fileName = _trashHelper.getOriginalTitle(fileEntry.getTitle());
+			title = _trashHelper.getOriginalTitle(fileEntry.getTitle());
 		}
 
-		sb.append(URLCodec.encodeURL(HtmlUtil.unescape(fileName)));
+		sb.append(URLCodec.encodeURL(HtmlUtil.unescape(title)));
 
 		sb.append(StringPool.SLASH);
 		sb.append(URLCodec.encodeURL(fileEntry.getUuid()));
@@ -682,10 +681,8 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 	}
 
 	@Override
-	public String getUniqueFileName(
-		long groupId, long folderId, String fileName) {
-
-		String uniqueFileName = fileName;
+	public String getUniqueFileName(long groupId, long folderId, String title) {
+		String uniqueFileName = title;
 
 		for (int i = 1;; i++) {
 			FileEntry fileEntry = fetchPortletFileEntry(
@@ -696,7 +693,7 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 			}
 
 			uniqueFileName = FileUtil.appendParentheticalSuffix(
-				fileName, String.valueOf(i));
+				title, String.valueOf(i));
 		}
 
 		return uniqueFileName;
@@ -719,13 +716,13 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 
 	@Override
 	public FileEntry movePortletFileEntryToTrash(
-			long groupId, long userId, long folderId, String fileName)
+			long groupId, long userId, long folderId, String title)
 		throws PortalException {
 
 		LocalRepository localRepository =
 			_repositoryProvider.getLocalRepository(groupId);
 
-		FileEntry fileEntry = localRepository.getFileEntry(folderId, fileName);
+		FileEntry fileEntry = localRepository.getFileEntry(folderId, title);
 
 		return movePortletFileEntryToTrash(userId, fileEntry.getFileEntryId());
 	}
@@ -765,13 +762,13 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 
 	@Override
 	public void restorePortletFileEntryFromTrash(
-			long groupId, long userId, long folderId, String fileName)
+			long groupId, long userId, long folderId, String title)
 		throws PortalException {
 
 		LocalRepository localRepository =
 			_repositoryProvider.getLocalRepository(groupId);
 
-		FileEntry fileEntry = localRepository.getFileEntry(folderId, fileName);
+		FileEntry fileEntry = localRepository.getFileEntry(folderId, title);
 
 		restorePortletFileEntryFromTrash(userId, fileEntry.getFileEntryId());
 	}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionImpl.java
@@ -322,7 +322,7 @@ public class FragmentCollectionImpl extends FragmentCollectionBaseImpl {
 			else if (object instanceof FileEntry) {
 				FileEntry fileEntry = (FileEntry)object;
 
-				String fileEntryPath = fileEntry.getFileName();
+				String fileEntryPath = fileEntry.getTitle();
 
 				if (!Validator.isBlank(parentPath)) {
 					fileEntryPath =

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionImpl.java
@@ -51,7 +51,7 @@ public class FragmentCollectionImpl extends FragmentCollectionBaseImpl {
 				_getResourcesFolderId(
 					getResourcesFolderId(true), path,
 					repository.getRepositoryId()),
-				_getFileName(path));
+				_getFileTitle(path));
 		}
 		catch (PortalException portalException) {
 			if (_log.isDebugEnabled()) {
@@ -203,7 +203,7 @@ public class FragmentCollectionImpl extends FragmentCollectionBaseImpl {
 		}
 	}
 
-	private String _getFileName(String path) {
+	private String _getFileTitle(String path) {
 		if (Validator.isNull(path) || path.endsWith(StringPool.SLASH)) {
 			return StringPool.BLANK;
 		}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
@@ -742,14 +742,14 @@ public class FragmentEntryLocalServiceImpl
 		).build();
 
 		for (Map.Entry<String, FileEntry> entry : fileEntries.entrySet()) {
-			String fileName = entry.getKey();
+			String title = entry.getKey();
 			String folderPath = StringPool.BLANK;
 
-			int index = fileName.lastIndexOf(StringPool.SLASH);
+			int index = title.lastIndexOf(StringPool.SLASH);
 
 			if (index != -1) {
-				folderPath = fileName.substring(0, index);
-				fileName = fileName.substring(index + 1);
+				folderPath = title.substring(0, index);
+				title = title.substring(index + 1);
 			}
 
 			long folderId = _getOrCreateFolderId(
@@ -758,7 +758,7 @@ public class FragmentEntryLocalServiceImpl
 
 			FileEntry existingFileEntry =
 				PortletFileRepositoryUtil.fetchPortletFileEntry(
-					fragmentEntry.getGroupId(), folderId, fileName);
+					fragmentEntry.getGroupId(), folderId, title);
 
 			if (existingFileEntry == null) {
 				FileEntry fileEntry = entry.getValue();
@@ -769,7 +769,7 @@ public class FragmentEntryLocalServiceImpl
 					FragmentCollection.class.getName(),
 					targetFragmentCollection.getFragmentCollectionId(),
 					FragmentPortletKeys.FRAGMENT, folderId,
-					fileEntry.getContentStream(), fileName,
+					fileEntry.getContentStream(), title,
 					fileEntry.getMimeType(), false);
 			}
 		}

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/model/impl/test/FragmentCollectionImplTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/model/impl/test/FragmentCollectionImplTest.java
@@ -6,6 +6,8 @@
 package com.liferay.fragment.model.impl.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
+import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.fragment.constants.FragmentExportImportConstants;
 import com.liferay.fragment.constants.FragmentPortletKeys;
 import com.liferay.fragment.model.FragmentCollection;
@@ -16,9 +18,11 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
@@ -74,12 +78,18 @@ public class FragmentCollectionImplTest {
 
 	@Test
 	public void testGetResourcesMap() throws Exception {
-		Map<String, FileEntry> resourcesMap =
-			_fragmentCollection.getResourcesMap();
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
 
-		Assert.assertEquals(resourcesMap.toString(), 1, resourcesMap.size());
+		FileEntry fileEntry = _assertResourcesMap("liferay.png");
 
-		Assert.assertNotNull(resourcesMap.get("liferay.png"));
+		_dlAppService.updateFileEntry(
+			fileEntry.getFileEntryId(), null, null, "liferay", null, null, null,
+			DLVersionNumberIncrease.NONE, (byte[])null, null, null, null,
+			serviceContext);
+
+		_assertResourcesMap("liferay");
 	}
 
 	@Test
@@ -116,6 +126,22 @@ public class FragmentCollectionImplTest {
 
 		FileUtil.delete(zipWriter.getFile());
 	}
+
+	private FileEntry _assertResourcesMap(String fileTitle) throws Exception {
+		Map<String, FileEntry> resourcesMap =
+			_fragmentCollection.getResourcesMap();
+
+		Assert.assertEquals(resourcesMap.toString(), 1, resourcesMap.size());
+
+		FileEntry fileEntry = resourcesMap.get(fileTitle);
+
+		Assert.assertNotNull(fileEntry);
+
+		return fileEntry;
+	}
+
+	@Inject
+	private static DLAppService _dlAppService;
 
 	private FragmentCollection _fragmentCollection;
 

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/UpdateFragmentEntryPreviewMVCActionCommand.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/UpdateFragmentEntryPreviewMVCActionCommand.java
@@ -71,13 +71,12 @@ public class UpdateFragmentEntryPreviewMVCActionCommand
 				serviceContext);
 		}
 
-		String fileName =
-			fragmentEntryId + "_preview." + fileEntry.getExtension();
+		String title = fragmentEntryId + "_preview." + fileEntry.getExtension();
 
 		FileEntry oldFileEntry =
 			PortletFileRepositoryUtil.fetchPortletFileEntry(
 				themeDisplay.getScopeGroupId(), repository.getDlFolderId(),
-				fileName);
+				title);
 
 		if (oldFileEntry != null) {
 			PortletFileRepositoryUtil.deletePortletFileEntry(
@@ -88,7 +87,7 @@ public class UpdateFragmentEntryPreviewMVCActionCommand
 			null, themeDisplay.getScopeGroupId(), themeDisplay.getUserId(),
 			FragmentEntry.class.getName(), fragmentEntryId,
 			FragmentPortletKeys.FRAGMENT, repository.getDlFolderId(),
-			fileEntry.getContentStream(), fileName, fileEntry.getMimeType(),
+			fileEntry.getContentStream(), title, fileEntry.getMimeType(),
 			false);
 
 		_fragmentEntryService.updateFragmentEntry(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/ImageTypeContentUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/ImageTypeContentUpgradeProcess.java
@@ -88,11 +88,11 @@ public class ImageTypeContentUpgradeProcess extends UpgradeProcess {
 					long groupId = (Long)values[1];
 					long folderId = (Long)values[4];
 
-					String fileName = String.valueOf(articleImageId);
+					String title = String.valueOf(articleImageId);
 
 					FileEntry fileEntry =
 						_portletFileRepository.fetchPortletFileEntry(
-							groupId, folderId, fileName);
+							groupId, folderId, title);
 
 					if (fileEntry != null) {
 						return;
@@ -110,20 +110,20 @@ public class ImageTypeContentUpgradeProcess extends UpgradeProcess {
 						}
 
 						String mimeType = MimeTypesUtil.getContentType(
-							fileName + StringPool.PERIOD + image.getType());
+							title + StringPool.PERIOD + image.getType());
 
 						_portletFileRepository.addPortletFileEntry(
 							groupId, userId, JournalArticle.class.getName(),
 							resourcePrimKey, JournalConstants.SERVICE_NAME,
-							folderId, image.getTextObj(), fileName, mimeType,
+							folderId, image.getTextObj(), title, mimeType,
 							false);
 
 						_imageLocalService.deleteImage(image.getImageId());
 					}
 					catch (Exception exception) {
 						_log.error(
-							"Unable to add the journal article image " +
-								fileName + " into the file repository",
+							"Unable to add the journal article image " + title +
+								" into the file repository",
 							exception);
 
 						throw exception;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6103,7 +6103,7 @@ public class JournalArticleLocalServiceImpl
 							_portletFileRepository.fetchPortletFileEntry(
 								finalTempFileEntry.getGroupId(),
 								finalTempFileEntry.getFolderId(),
-								finalTempFileEntry.getFileName());
+								finalTempFileEntry.getTitle());
 
 						if (persistedFileEntry != null) {
 							TempFileEntryUtil.deleteTempFileEntry(

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
@@ -877,10 +877,10 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 				ServiceContextThreadLocal.getServiceContext());
 		}
 
-		String imageFileName = classPK + "_preview" + thumbnail.getExtension();
+		String imageTitle = classPK + "_preview" + thumbnail.getExtension();
 
 		FileEntry fileEntry = _portletFileRepository.fetchPortletFileEntry(
-			groupId, repository.getDlFolderId(), imageFileName);
+			groupId, repository.getDlFolderId(), imageTitle);
 
 		if (fileEntry != null) {
 			_portletFileRepository.deletePortletFileEntry(
@@ -890,8 +890,8 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 		fileEntry = _portletFileRepository.addPortletFileEntry(
 			groupId, userId, className, classPK,
 			LayoutAdminPortletKeys.GROUP_PAGES, repository.getDlFolderId(),
-			thumbnail.getBytes(), imageFileName,
-			MimeTypesUtil.getContentType(imageFileName), false);
+			thumbnail.getBytes(), imageTitle,
+			MimeTypesUtil.getContentType(imageTitle), false);
 
 		return fileEntry.getFileEntryId();
 	}

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/UpdateLayoutPageTemplateEntryPreviewMVCActionCommand.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/UpdateLayoutPageTemplateEntryPreviewMVCActionCommand.java
@@ -71,12 +71,11 @@ public class UpdateLayoutPageTemplateEntryPreviewMVCActionCommand
 				LayoutAdminPortletKeys.GROUP_PAGES, serviceContext);
 		}
 
-		String fileName =
+		String title =
 			layoutPageTemplateEntryId + "_preview." + fileEntry.getExtension();
 
 		FileEntry oldFileEntry = _portletFileRepository.fetchPortletFileEntry(
-			themeDisplay.getScopeGroupId(), repository.getDlFolderId(),
-			fileName);
+			themeDisplay.getScopeGroupId(), repository.getDlFolderId(), title);
 
 		if (oldFileEntry != null) {
 			_portletFileRepository.deletePortletFileEntry(
@@ -87,7 +86,7 @@ public class UpdateLayoutPageTemplateEntryPreviewMVCActionCommand
 			null, themeDisplay.getScopeGroupId(), themeDisplay.getUserId(),
 			LayoutPageTemplateEntry.class.getName(), layoutPageTemplateEntryId,
 			LayoutAdminPortletKeys.GROUP_PAGES, repository.getDlFolderId(),
-			fileEntry.getContentStream(), fileName, fileEntry.getMimeType(),
+			fileEntry.getContentStream(), title, fileEntry.getMimeType(),
 			false);
 
 		_layoutPageTemplateEntryService.updateLayoutPageTemplateEntry(

--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/portlet/action/EditMessageMVCActionCommand.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/portlet/action/EditMessageMVCActionCommand.java
@@ -393,11 +393,9 @@ public class EditMessageMVCActionCommand extends BaseMVCActionCommand {
 		).buildString();
 	}
 
-	private boolean _hasFileEntry(
-		long groupId, long folderId, String fileName) {
-
+	private boolean _hasFileEntry(long groupId, long folderId, String title) {
 		FileEntry fileEntry = _portletFileRepository.fetchPortletFileEntry(
-			groupId, folderId, fileName);
+			groupId, folderId, title);
 
 		if (fileEntry == null) {
 			return false;

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/UpdateStyleBookEntryPreviewMVCActionCommand.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/UpdateStyleBookEntryPreviewMVCActionCommand.java
@@ -96,13 +96,13 @@ public class UpdateStyleBookEntryPreviewMVCActionCommand
 			long styleBookEntryId = ParamUtil.getLong(
 				actionRequest, "styleBookEntryId");
 
-			String fileName = StringBundler.concat(
+			String title = StringBundler.concat(
 				styleBookEntryId, "_preview.", extension);
 
 			FileEntry oldFileEntry =
 				PortletFileRepositoryUtil.fetchPortletFileEntry(
 					themeDisplay.getScopeGroupId(), repository.getDlFolderId(),
-					fileName);
+					title);
 
 			if (oldFileEntry != null) {
 				PortletFileRepositoryUtil.deletePortletFileEntry(
@@ -113,7 +113,7 @@ public class UpdateStyleBookEntryPreviewMVCActionCommand
 				null, themeDisplay.getScopeGroupId(), themeDisplay.getUserId(),
 				StyleBookEntry.class.getName(), styleBookEntryId,
 				StyleBookPortletKeys.STYLE_BOOK, repository.getDlFolderId(),
-				fileEntry.getContentStream(), fileName, fileEntry.getMimeType(),
+				fileEntry.getContentStream(), title, fileEntry.getMimeType(),
 				false);
 
 			_styleBookEntryService.updatePreviewFileEntryId(

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/importer/MediaWikiImporter.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/importer/MediaWikiImporter.java
@@ -726,12 +726,12 @@ public class MediaWikiImporter {
 			Matcher matcher = _mediaLinkPattern.matcher(content);
 
 			while (matcher.find()) {
-				String fileName = matcher.group(2);
+				String title = matcher.group(2);
 
 				FileEntry fileEntry =
 					_portletFileRepository.fetchPortletFileEntry(
 						node.getGroupId(),
-						sharedImagesPage.getAttachmentsFolderId(), fileName);
+						sharedImagesPage.getAttachmentsFolderId(), title);
 
 				if (fileEntry == null) {
 					matcher.appendReplacement(sb, matcher.group());
@@ -746,7 +746,7 @@ public class MediaWikiImporter {
 				String linkLabel = matcher.group(3);
 
 				if (linkLabel == null) {
-					linkLabel = StringPool.PIPE + fileName;
+					linkLabel = StringPool.PIPE + title;
 				}
 
 				matcher.appendReplacement(

--- a/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/PortletFileRepository.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/PortletFileRepository.java
@@ -89,7 +89,7 @@ public interface PortletFileRepository {
 		throws PortalException;
 
 	public FileEntry fetchPortletFileEntry(
-		long groupId, long folderId, String fileName);
+		long groupId, long folderId, String title);
 
 	public FileEntry fetchPortletFileEntryByExternalReferenceCode(
 		String externalReferenceCode, long groupId);

--- a/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/PortletFileRepository.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/PortletFileRepository.java
@@ -38,21 +38,20 @@ public interface PortletFileRepository {
 
 	public FileEntry addPortletFileEntry(
 			long groupId, long userId, String className, long classPK,
-			String portletId, long folderId, byte[] bytes, String fileName,
+			String portletId, long folderId, byte[] bytes, String title,
 			String mimeType, boolean indexingEnabled)
 		throws PortalException;
 
 	public FileEntry addPortletFileEntry(
 			String externalReferenceCode, long groupId, long userId,
 			String className, long classPK, String portletId, long folderId,
-			File file, String fileName, String mimeType,
-			boolean indexingEnabled)
+			File file, String title, String mimeType, boolean indexingEnabled)
 		throws PortalException;
 
 	public FileEntry addPortletFileEntry(
 			String externalReferenceCode, long groupId, long userId,
 			String className, long classPK, String portletId, long folderId,
-			InputStream inputStream, String fileName, String mimeType,
+			InputStream inputStream, String title, String mimeType,
 			boolean indexingEnabled)
 		throws PortalException;
 
@@ -80,7 +79,7 @@ public interface PortletFileRepository {
 	public void deletePortletFileEntry(long fileEntryId) throws PortalException;
 
 	public void deletePortletFileEntry(
-			long groupId, long folderId, String fileName)
+			long groupId, long folderId, String title)
 		throws PortalException;
 
 	public void deletePortletFolder(long folderId) throws PortalException;
@@ -140,7 +139,7 @@ public interface PortletFileRepository {
 		throws PortalException;
 
 	public FileEntry getPortletFileEntry(
-			long groupId, long folderId, String fileName)
+			long groupId, long folderId, String title)
 		throws PortalException;
 
 	public FileEntry getPortletFileEntry(String uuid, long groupId)
@@ -166,14 +165,13 @@ public interface PortletFileRepository {
 	public Repository getPortletRepository(long groupId, String portletId)
 		throws PortalException;
 
-	public String getUniqueFileName(
-		long groupId, long folderId, String fileName);
+	public String getUniqueFileName(long groupId, long folderId, String title);
 
 	public FileEntry movePortletFileEntryToTrash(long userId, long fileEntryId)
 		throws PortalException;
 
 	public FileEntry movePortletFileEntryToTrash(
-			long groupId, long userId, long folderId, String fileName)
+			long groupId, long userId, long folderId, String title)
 		throws PortalException;
 
 	public Folder movePortletFolder(
@@ -185,7 +183,7 @@ public interface PortletFileRepository {
 		throws PortalException;
 
 	public void restorePortletFileEntryFromTrash(
-			long groupId, long userId, long folderId, String fileName)
+			long groupId, long userId, long folderId, String title)
 		throws PortalException;
 
 	public Hits searchPortletFileEntries(

--- a/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/PortletFileRepositoryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/PortletFileRepositoryUtil.java
@@ -182,13 +182,13 @@ public class PortletFileRepositoryUtil {
 	}
 
 	public static FileEntry fetchPortletFileEntry(
-		long groupId, long folderId, String fileName) {
+		long groupId, long folderId, String title) {
 
 		PortletFileRepository portletFileRepository =
 			_portletFileRepositorySnapshot.get();
 
 		return portletFileRepository.fetchPortletFileEntry(
-			groupId, folderId, fileName);
+			groupId, folderId, title);
 	}
 
 	public static FileEntry fetchPortletFileEntryByExternalReferenceCode(

--- a/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/PortletFileRepositoryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/PortletFileRepositoryUtil.java
@@ -44,7 +44,7 @@ public class PortletFileRepositoryUtil {
 
 	public static FileEntry addPortletFileEntry(
 			long groupId, long userId, String className, long classPK,
-			String portletId, long folderId, byte[] bytes, String fileName,
+			String portletId, long folderId, byte[] bytes, String title,
 			String mimeType, boolean indexingEnabled)
 		throws PortalException {
 
@@ -53,13 +53,27 @@ public class PortletFileRepositoryUtil {
 
 		return portletFileRepository.addPortletFileEntry(
 			groupId, userId, className, classPK, portletId, folderId, bytes,
-			fileName, mimeType, indexingEnabled);
+			title, mimeType, indexingEnabled);
 	}
 
 	public static FileEntry addPortletFileEntry(
 			String externalReferenceCode, long groupId, long userId,
 			String className, long classPK, String portletId, long folderId,
-			File file, String fileName, String mimeType,
+			File file, String title, String mimeType, boolean indexingEnabled)
+		throws PortalException {
+
+		PortletFileRepository portletFileRepository =
+			_portletFileRepositorySnapshot.get();
+
+		return portletFileRepository.addPortletFileEntry(
+			externalReferenceCode, groupId, userId, className, classPK,
+			portletId, folderId, file, title, mimeType, indexingEnabled);
+	}
+
+	public static FileEntry addPortletFileEntry(
+			String externalReferenceCode, long groupId, long userId,
+			String className, long classPK, String portletId, long folderId,
+			InputStream inputStream, String title, String mimeType,
 			boolean indexingEnabled)
 		throws PortalException {
 
@@ -68,23 +82,7 @@ public class PortletFileRepositoryUtil {
 
 		return portletFileRepository.addPortletFileEntry(
 			externalReferenceCode, groupId, userId, className, classPK,
-			portletId, folderId, file, fileName, mimeType, indexingEnabled);
-	}
-
-	public static FileEntry addPortletFileEntry(
-			String externalReferenceCode, long groupId, long userId,
-			String className, long classPK, String portletId, long folderId,
-			InputStream inputStream, String fileName, String mimeType,
-			boolean indexingEnabled)
-		throws PortalException {
-
-		PortletFileRepository portletFileRepository =
-			_portletFileRepositorySnapshot.get();
-
-		return portletFileRepository.addPortletFileEntry(
-			externalReferenceCode, groupId, userId, className, classPK,
-			portletId, folderId, inputStream, fileName, mimeType,
-			indexingEnabled);
+			portletId, folderId, inputStream, title, mimeType, indexingEnabled);
 	}
 
 	public static Folder addPortletFolder(
@@ -153,14 +151,13 @@ public class PortletFileRepositoryUtil {
 	}
 
 	public static void deletePortletFileEntry(
-			long groupId, long folderId, String fileName)
+			long groupId, long folderId, String title)
 		throws PortalException {
 
 		PortletFileRepository portletFileRepository =
 			_portletFileRepositorySnapshot.get();
 
-		portletFileRepository.deletePortletFileEntry(
-			groupId, folderId, fileName);
+		portletFileRepository.deletePortletFileEntry(groupId, folderId, title);
 	}
 
 	public static void deletePortletFolder(long folderId)
@@ -332,14 +329,14 @@ public class PortletFileRepositoryUtil {
 	}
 
 	public static FileEntry getPortletFileEntry(
-			long groupId, long folderId, String fileName)
+			long groupId, long folderId, String title)
 		throws PortalException {
 
 		PortletFileRepository portletFileRepository =
 			_portletFileRepositorySnapshot.get();
 
 		return portletFileRepository.getPortletFileEntry(
-			groupId, folderId, fileName);
+			groupId, folderId, title);
 	}
 
 	public static FileEntry getPortletFileEntry(String uuid, long groupId)
@@ -418,13 +415,13 @@ public class PortletFileRepositoryUtil {
 	}
 
 	public static String getUniqueFileName(
-		long groupId, long folderId, String fileName) {
+		long groupId, long folderId, String title) {
 
 		PortletFileRepository portletFileRepository =
 			_portletFileRepositorySnapshot.get();
 
 		return portletFileRepository.getUniqueFileName(
-			groupId, folderId, fileName);
+			groupId, folderId, title);
 	}
 
 	public static FileEntry movePortletFileEntryToTrash(
@@ -439,14 +436,14 @@ public class PortletFileRepositoryUtil {
 	}
 
 	public static FileEntry movePortletFileEntryToTrash(
-			long groupId, long userId, long folderId, String fileName)
+			long groupId, long userId, long folderId, String title)
 		throws PortalException {
 
 		PortletFileRepository portletFileRepository =
 			_portletFileRepositorySnapshot.get();
 
 		return portletFileRepository.movePortletFileEntryToTrash(
-			groupId, userId, folderId, fileName);
+			groupId, userId, folderId, title);
 	}
 
 	public static Folder movePortletFolder(
@@ -473,14 +470,14 @@ public class PortletFileRepositoryUtil {
 	}
 
 	public static void restorePortletFileEntryFromTrash(
-			long groupId, long userId, long folderId, String fileName)
+			long groupId, long userId, long folderId, String title)
 		throws PortalException {
 
 		PortletFileRepository portletFileRepository =
 			_portletFileRepositorySnapshot.get();
 
 		portletFileRepository.restorePortletFileEntryFromTrash(
-			groupId, userId, folderId, fileName);
+			groupId, userId, folderId, title);
 	}
 
 	public static Hits searchPortletFileEntries(


### PR DESCRIPTION
/cc @liferay-content-management could you please have a look at this pull

I think there is the same issue with addFileEntry https://github.com/liferay/liferay-portal/blob/17fb99f43cf5e3e8c27413752ce61d9f9f0ca58f/portal-kernel/src/com/liferay/portal/kernel/repository/DocumentRepository.java#L30 

Title is needed, but we provide fileName instead, please review.