### PR TITLE
LPD-57528 Replace CKEditor 5 in editables

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -288,7 +288,7 @@
 					}
 					else {
 						const editorContentHeight =
-							editorContent.getBoundingClientRect().height;
+							editorContent?.getBoundingClientRect().height;
 
 						const imgElement = new Image();
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/BalloonEditor.tsx
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/BalloonEditor.tsx
@@ -6,12 +6,13 @@
 import {BalloonEditor as BaseBalloonEditor, EventInfo} from 'ckeditor5';
 import React from 'react';
 
-import BaseEditor, {TEditor} from './BaseEditor';
+import BaseEditor from './BaseEditor';
 import getDefaultEditorConfig from './utils/getDefaultEditorConfig';
 import {
 	EEditorConfigPreset,
 	EEditorVariant,
 	LiferayEditorConfig,
+	TEditor,
 } from './utils/types';
 
 const BalloonEditor = ({

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/BaseEditor.tsx
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/BaseEditor.tsx
@@ -3,11 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {
-	BalloonEditor as BaseBalloonEditor,
-	ClassicEditor as BaseClassicEditor,
-	EventInfo,
-} from 'ckeditor5';
+import {EventInfo} from 'ckeditor5';
 import {loadEditorClientExtensions} from 'frontend-js-web';
 import React, {useEffect, useRef, useState} from 'react';
 
@@ -16,9 +12,7 @@ import '../../css/ckeditor5/editor.scss';
 import {CKEditor} from '@ckeditor/ckeditor5-react';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 
-import {LiferayEditorConfig} from './utils/types';
-
-export type TEditor = BaseBalloonEditor | BaseClassicEditor;
+import {LiferayEditorConfig, TEditor} from './utils/types';
 
 const BaseEditor = ({
 	className,

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/ClassicEditor.tsx
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/ClassicEditor.tsx
@@ -6,12 +6,13 @@
 import {ClassicEditor as BaseClassicEditor, EventInfo} from 'ckeditor5';
 import React from 'react';
 
-import BaseEditor, {TEditor} from './BaseEditor';
+import BaseEditor from './BaseEditor';
 import getDefaultEditorConfig from './utils/getDefaultEditorConfig';
 import {
 	EEditorConfigPreset,
 	EEditorVariant,
 	LiferayEditorConfig,
+	TEditor,
 } from './utils/types';
 
 const ClassicEditor = ({

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/types.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/types.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {EditorConfig} from 'ckeditor5';
+import {BalloonEditor, ClassicEditor, EditorConfig} from 'ckeditor5';
 
 export enum EEditorConfigPreset {
 	BASIC = 'basic',
@@ -31,3 +31,5 @@ export interface LiferayEditorConfig extends EditorConfig {
 	itemSelectorEventName?: string;
 	preset?: EEditorConfigPreset;
 }
+
+export type TEditor = BalloonEditor | ClassicEditor;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/index.ts
@@ -27,4 +27,5 @@ export {default as CKEditor5ClassicEditor} from './ckeditor5/ClassicEditor';
 export {
 	EEditorConfigPreset,
 	LiferayEditorConfig,
+	TEditor,
 } from './ckeditor5/utils/types';

--- a/modules/apps/layout/layout-content-page-editor-web/package.json
+++ b/modules/apps/layout/layout-content-page-editor-web/package.json
@@ -35,6 +35,7 @@
 		"@liferay/marketplace-js-components-web": "*",
 		"axe-core": "^4.9.1",
 		"classnames": "2.3.1",
+		"frontend-editor-ckeditor-web": "*",
 		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"item-selector-taglib": "*",

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/BaseFragmentEntryLinkEditorConfigContributor.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/BaseFragmentEntryLinkEditorConfigContributor.java
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.page.editor.web.internal.editor.configuration;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.editor.configuration.BaseEditorConfigContributor;
+import com.liferay.portal.kernel.editor.configuration.EditorConfiguration;
+import com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * @author Víctor Galán
+ */
+public class BaseFragmentEntryLinkEditorConfigContributor
+	extends BaseEditorConfigContributor {
+
+	@Override
+	public void populateConfigJSONObject(
+		JSONObject jsonObject, Map<String, Object> inputEditorTaglibAttributes,
+		ThemeDisplay themeDisplay,
+		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
+
+		EditorConfiguration editorConfiguration =
+			EditorConfigurationFactoryUtil.getEditorConfiguration(
+				StringPool.BLANK, StringPool.BLANK, "ckeditor5_balloon",
+				Collections.emptyMap(), themeDisplay,
+				requestBackedPortletURLFactory);
+
+		JSONObject configJSONObject = editorConfiguration.getConfigJSONObject();
+
+		jsonObject.put("licenseKey", configJSONObject.getString("licenseKey"));
+	}
+
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/BaseFragmentEntryLinkEditorConfigContributor.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/BaseFragmentEntryLinkEditorConfigContributor.java
@@ -9,6 +9,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.editor.configuration.BaseEditorConfigContributor;
 import com.liferay.portal.kernel.editor.configuration.EditorConfiguration;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -28,15 +29,22 @@ public class BaseFragmentEntryLinkEditorConfigContributor
 		ThemeDisplay themeDisplay,
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
 
-		EditorConfiguration editorConfiguration =
-			EditorConfigurationFactoryUtil.getEditorConfiguration(
-				StringPool.BLANK, StringPool.BLANK, "ckeditor5_balloon",
-				Collections.emptyMap(), themeDisplay,
-				requestBackedPortletURLFactory);
+		if (FeatureFlagManagerUtil.isEnabled("LPD-11235")) {
+			EditorConfiguration editorConfiguration =
+				EditorConfigurationFactoryUtil.getEditorConfiguration(
+					StringPool.BLANK, StringPool.BLANK, "ckeditor5_balloon",
+					Collections.emptyMap(), themeDisplay,
+					requestBackedPortletURLFactory);
 
-		JSONObject configJSONObject = editorConfiguration.getConfigJSONObject();
+			JSONObject configJSONObject =
+				editorConfiguration.getConfigJSONObject();
 
-		jsonObject.put("licenseKey", configJSONObject.getString("licenseKey"));
+			jsonObject.put(
+				"editorType", configJSONObject.getString("editorType")
+			).put(
+				"licenseKey", configJSONObject.getString("licenseKey")
+			);
+		}
 	}
 
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkEditorConfigContributor.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkEditorConfigContributor.java
@@ -15,6 +15,7 @@ import com.liferay.item.selector.criteria.url.criterion.URLItemSelectorCriterion
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.layout.item.selector.criterion.LayoutItemSelectorCriterion;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
@@ -50,34 +51,50 @@ public class FragmentEntryLinkEditorConfigContributor
 			jsonObject, inputEditorTaglibAttributes, themeDisplay,
 			requestBackedPortletURLFactory);
 
-		PortletURL itemSelectorURL = itemSelector.getItemSelectorURL(
-			requestBackedPortletURLFactory, "_EDITOR_NAME_selectItem",
-			getFileItemSelectorCriterion(), getLayoutItemSelectorURL());
-		PortletURL imageSelectorURL = itemSelector.getItemSelectorURL(
-			requestBackedPortletURLFactory, "_EDITOR_NAME_selectImage",
-			getImageItemSelectorCriterion(), getURLItemSelectorCriterion());
+		if (FeatureFlagManagerUtil.isEnabled("LPD-11235")) {
+			jsonObject.put(
+				"preset", "basic"
+			).put(
+				"removePlugins",
+				new String[] {
+					"Bold", "GeneralHtmlSupport", "Italic", "Image", "Link",
+					"List", "Underline"
+				}
+			).put(
+				"toolbar", new String[0]
+			);
+		}
+		else {
+			PortletURL imageSelectorURL = itemSelector.getItemSelectorURL(
+				requestBackedPortletURLFactory, "_EDITOR_NAME_selectImage",
+				getImageItemSelectorCriterion(), getURLItemSelectorCriterion());
 
-		jsonObject.put(
-			"allowedContent", ""
-		).put(
-			"disallowedContent", "br"
-		).put(
-			"documentBrowseLinkUrl", itemSelectorURL.toString()
-		).put(
-			"enterMode", 2
-		).put(
-			"extraPlugins", getExtraPluginsLists()
-		).put(
-			"filebrowserImageBrowseLinkUrl", imageSelectorURL.toString()
-		).put(
-			"filebrowserImageBrowseUrl", imageSelectorURL.toString()
-		).put(
-			"removePlugins", getRemovePluginsLists()
-		).put(
-			"skin", "moono-lisa"
-		).put(
-			"toolbars", jsonFactory.createJSONObject()
-		);
+			jsonObject.put(
+				"allowedContent", ""
+			).put(
+				"disallowedContent", "br"
+			).put(
+				"documentBrowseLinkUrl",
+				itemSelector.getItemSelectorURL(
+					requestBackedPortletURLFactory, "_EDITOR_NAME_selectItem",
+					getFileItemSelectorCriterion(), getLayoutItemSelectorURL()
+				).toString()
+			).put(
+				"enterMode", 2
+			).put(
+				"extraPlugins", getExtraPluginsLists()
+			).put(
+				"filebrowserImageBrowseLinkUrl", imageSelectorURL.toString()
+			).put(
+				"filebrowserImageBrowseUrl", imageSelectorURL.toString()
+			).put(
+				"removePlugins", getRemovePluginsLists()
+			).put(
+				"skin", "moono-lisa"
+			).put(
+				"toolbars", jsonFactory.createJSONObject()
+			);
+		}
 	}
 
 	protected String getExtraPluginsLists() {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkEditorConfigContributor.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkEditorConfigContributor.java
@@ -14,7 +14,6 @@ import com.liferay.item.selector.criteria.image.criterion.ImageItemSelectorCrite
 import com.liferay.item.selector.criteria.url.criterion.URLItemSelectorCriterion;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.layout.item.selector.criterion.LayoutItemSelectorCriterion;
-import com.liferay.portal.kernel.editor.configuration.BaseEditorConfigContributor;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -39,13 +38,17 @@ import org.osgi.service.component.annotations.Reference;
 	service = EditorConfigContributor.class
 )
 public class FragmentEntryLinkEditorConfigContributor
-	extends BaseEditorConfigContributor {
+	extends BaseFragmentEntryLinkEditorConfigContributor {
 
 	@Override
 	public void populateConfigJSONObject(
 		JSONObject jsonObject, Map<String, Object> inputEditorTaglibAttributes,
 		ThemeDisplay themeDisplay,
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
+
+		super.populateConfigJSONObject(
+			jsonObject, inputEditorTaglibAttributes, themeDisplay,
+			requestBackedPortletURLFactory);
 
 		PortletURL itemSelectorURL = itemSelector.getItemSelectorURL(
 			requestBackedPortletURLFactory, "_EDITOR_NAME_selectItem",

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkRichTextEditorConfigContributor.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkRichTextEditorConfigContributor.java
@@ -15,7 +15,6 @@ import com.liferay.item.selector.criteria.url.criterion.URLItemSelectorCriterion
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.layout.item.selector.criterion.LayoutItemSelectorCriterion;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.editor.configuration.BaseEditorConfigContributor;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -44,13 +43,17 @@ import org.osgi.service.component.annotations.Reference;
 	service = EditorConfigContributor.class
 )
 public class FragmentEntryLinkRichTextEditorConfigContributor
-	extends BaseEditorConfigContributor {
+	extends BaseFragmentEntryLinkEditorConfigContributor {
 
 	@Override
 	public void populateConfigJSONObject(
 		JSONObject jsonObject, Map<String, Object> inputEditorTaglibAttributes,
 		ThemeDisplay themeDisplay,
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
+
+		super.populateConfigJSONObject(
+			jsonObject, inputEditorTaglibAttributes, themeDisplay,
+			requestBackedPortletURLFactory);
 
 		PortletURL itemSelectorURL = _itemSelector.getItemSelectorURL(
 			requestBackedPortletURLFactory, "_EDITOR_NAME_selectItem",

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkRichTextEditorConfigContributor.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkRichTextEditorConfigContributor.java
@@ -73,8 +73,6 @@ public class FragmentEntryLinkRichTextEditorConfigContributor
 
 		if (FeatureFlagManagerUtil.isEnabled("LPD-11235")) {
 			jsonObject.put(
-				"editorType", "ckeditor5"
-			).put(
 				"preset", "advanced"
 			).put(
 				"toolbar",

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkRichTextEditorConfigContributor.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkRichTextEditorConfigContributor.java
@@ -16,6 +16,7 @@ import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortlet
 import com.liferay.layout.item.selector.criterion.LayoutItemSelectorCriterion;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -63,31 +64,58 @@ public class FragmentEntryLinkRichTextEditorConfigContributor
 			getImageItemSelectorCriterion(), getURLItemSelectorCriterion());
 
 		jsonObject.put(
-			"allowedContent",
-			StringBundler.concat(
-				_getAllowedContentText(),
-				" a[*](*); div[*](*){text-align}; img[*](*){*}; p[*](*); ",
-				_getAllowedContentLists(), _getAllowedContentTable(),
-				" span[*](*){*}; ")
-		).put(
-			"autoParagraph", false
-		).put(
 			"documentBrowseLinkUrl", itemSelectorURL.toString()
-		).put(
-			"extraPlugins", getExtraPluginsLists()
 		).put(
 			"filebrowserImageBrowseLinkUrl", imageSelectorURL.toString()
 		).put(
 			"filebrowserImageBrowseUrl", imageSelectorURL.toString()
-		).put(
-			"removePlugins", getRemovePluginsLists()
-		).put(
-			"skin", "moono-lisa"
-		).put(
-			"spritemap", themeDisplay.getPathThemeSpritemap()
-		).put(
-			"toolbars", _getToolbarsJSONObject(themeDisplay.getLocale())
 		);
+
+		if (FeatureFlagManagerUtil.isEnabled("LPD-11235")) {
+			jsonObject.put(
+				"editorType", "ckeditor5"
+			).put(
+				"preset", "advanced"
+			).put(
+				"toolbar",
+				JSONUtil.put(
+					"items",
+					new String[] {
+						"undo", "redo", "|", "style", "|", "heading", "|",
+						"bold", "italic", "underline", "strikethrough", "|",
+						"fontColor", "fontBackgroundColor", "|", "removeFormat",
+						"|", "numberedList", "bulletedList", "|", "indent",
+						"outdent", "|", "blockQuote", "|", "link",
+						"insertTable", "imageSelector", "|", "horizontalLine",
+						"|", "alignment"
+					}
+				).put(
+					"shouldNotGroupWhenFull", true
+				)
+			);
+		}
+		else {
+			jsonObject.put(
+				"allowedContent",
+				StringBundler.concat(
+					_getAllowedContentText(),
+					" a[*](*); div[*](*){text-align}; img[*](*){*}; p[*](*); ",
+					_getAllowedContentLists(), _getAllowedContentTable(),
+					" span[*](*){*}; ")
+			).put(
+				"autoParagraph", false
+			).put(
+				"extraPlugins", getExtraPluginsLists()
+			).put(
+				"removePlugins", getRemovePluginsLists()
+			).put(
+				"skin", "moono-lisa"
+			).put(
+				"spritemap", themeDisplay.getPathThemeSpritemap()
+			).put(
+				"toolbars", _getToolbarsJSONObject(themeDisplay.getLocale())
+			);
+		}
 	}
 
 	protected String getExtraPluginsLists() {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_Layout.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_Layout.scss
@@ -351,6 +351,25 @@ html#{$cadmin-selector} {
 		border: none;
 	}
 
+	.page-editor__editable {
+		.lfr-ck {
+			outline: $cadmin-primary-d2 auto 1px;
+
+			.ck.ck-editor__editable_inline {
+				border: 0;
+				padding: 0;
+
+				& > *:last-child {
+					margin-bottom: 0;
+				}
+
+				& *:first-child {
+					margin-top: 0;
+				}
+			}
+		}
+	}
+
 	img.page-editor__editable {
 		box-sizing: border-box;
 		outline-offset: -$editablesBorderWidth;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment_content/FragmentContent.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment_content/FragmentContent.js
@@ -9,6 +9,7 @@ import {useId} from 'frontend-js-components-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 
+import {EDITABLE_TYPES} from '../../config/constants/editableTypes';
 import {TEXT_EDITABLE_TYPES} from '../../config/constants/textEditableTypes';
 import {
 	useGetContent,
@@ -187,6 +188,10 @@ const FragmentContent = ({
 						);
 
 						editable.element.classList.add('page-editor__editable');
+
+						if (editable.type === EDITABLE_TYPES['rich-text']) {
+							editable.element.classList.add('ck-content');
+						}
 
 						if (TEXT_EDITABLE_TYPES.has(editable.type)) {
 							editable.element.setAttribute(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/js-index.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/js-index.ts
@@ -17,4 +17,8 @@ export {useActiveItemIds} from './contexts/ControlsContext';
 
 // @ts-ignore
 
+export {default as getAlloyEditorProcessor} from './processors/getAlloyEditorProcessor';
+
+// @ts-ignore
+
 export {default as addFragment} from './thunks/addFragment';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/ActionProcessor.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/ActionProcessor.ts
@@ -4,5 +4,10 @@
  */
 
 import {getAlloyEditorProcessor} from '../js-index';
+import getCKEditorProcessor from './getCKEditorProcessor';
 
-export default getAlloyEditorProcessor('text');
+const processor = Liferay.FeatureFlags['LPD-11235']
+	? getCKEditorProcessor
+	: getAlloyEditorProcessor;
+
+export default processor('text');

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/ActionProcessor.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/ActionProcessor.ts
@@ -3,5 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import getAlloyEditorProcessor from './getAlloyEditorProcessor';
+import {getAlloyEditorProcessor} from '../js-index';
+
 export default getAlloyEditorProcessor('text');

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/LinkProcessor.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/LinkProcessor.ts
@@ -5,14 +5,20 @@
 
 import {isNullOrUndefined} from '@liferay/layout-js-components-web';
 
+import {EditableConfig} from '../../types/editables/EditableValue';
+import {getAlloyEditorProcessor} from '../js-index';
 import {getEditableLinkValue} from '../utils/getEditableLinkValue';
-import getAlloyEditorProcessor from './getAlloyEditorProcessor';
 import {getLinkableEditableEditorWrapper} from './getLinkableEditableEditorWrapper';
 
 export default getAlloyEditorProcessor(
 	'text',
 	getLinkableEditableEditorWrapper,
-	(element, value, editableConfig, languageId) => {
+	(
+		element: HTMLElement,
+		value: string,
+		editableConfig: EditableConfig,
+		languageId: Liferay.Language.Locale
+	) => {
 		const anchor =
 			element instanceof HTMLAnchorElement
 				? element

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/LinkProcessor.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/LinkProcessor.ts
@@ -8,9 +8,14 @@ import {isNullOrUndefined} from '@liferay/layout-js-components-web';
 import {EditableConfig} from '../../types/editables/EditableValue';
 import {getAlloyEditorProcessor} from '../js-index';
 import {getEditableLinkValue} from '../utils/getEditableLinkValue';
+import getCKEditorProcessor from './getCKEditorProcessor';
 import {getLinkableEditableEditorWrapper} from './getLinkableEditableEditorWrapper';
 
-export default getAlloyEditorProcessor(
+const processor = Liferay.FeatureFlags['LPD-11235']
+	? getCKEditorProcessor
+	: getAlloyEditorProcessor;
+
+export default processor(
 	'text',
 	getLinkableEditableEditorWrapper,
 	(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/RichTextProcessor.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/RichTextProcessor.js
@@ -1,7 +1,0 @@
-/**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
- * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
- */
-
-import getAlloyEditorProcessor from './getAlloyEditorProcessor';
-export default getAlloyEditorProcessor('rich-text');

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/RichTextProcessor.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/RichTextProcessor.ts
@@ -1,0 +1,13 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {getAlloyEditorProcessor} from '../js-index';
+import getCKEditorProcessor from './getCKEditorProcessor';
+
+const processor = Liferay.FeatureFlags['LPD-11235']
+	? getCKEditorProcessor
+	: getAlloyEditorProcessor;
+
+export default processor('rich-text');

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/TextProcessor.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/TextProcessor.ts
@@ -8,9 +8,14 @@ import {isNullOrUndefined} from '@liferay/layout-js-components-web';
 import {EditableConfig} from '../../types/editables/EditableValue';
 import {getAlloyEditorProcessor} from '../js-index';
 import {getEditableLinkValue} from '../utils/getEditableLinkValue';
+import getCKEditorProcessor from './getCKEditorProcessor';
 import {getLinkableEditableEditorWrapper} from './getLinkableEditableEditorWrapper';
 
-export default getAlloyEditorProcessor(
+const processor = Liferay.FeatureFlags['LPD-11235']
+	? getCKEditorProcessor
+	: getAlloyEditorProcessor;
+
+export default processor(
 	'text',
 	getLinkableEditableEditorWrapper,
 	(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/TextProcessor.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/TextProcessor.ts
@@ -5,14 +5,20 @@
 
 import {isNullOrUndefined} from '@liferay/layout-js-components-web';
 
+import {EditableConfig} from '../../types/editables/EditableValue';
+import {getAlloyEditorProcessor} from '../js-index';
 import {getEditableLinkValue} from '../utils/getEditableLinkValue';
-import getAlloyEditorProcessor from './getAlloyEditorProcessor';
 import {getLinkableEditableEditorWrapper} from './getLinkableEditableEditorWrapper';
 
 export default getAlloyEditorProcessor(
 	'text',
 	getLinkableEditableEditorWrapper,
-	(element, value, editableConfig = {}, languageId) => {
+	(
+		element: HTMLElement,
+		value: string,
+		editableConfig: EditableConfig = {},
+		languageId: Liferay.Language.Locale
+	) => {
 		const link = getEditableLinkValue(editableConfig, languageId);
 
 		if (link.href) {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorConfig.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorConfig.ts
@@ -9,6 +9,11 @@ import {openSelectionModal} from 'frontend-js-components-web';
 import EmptyAltImagePlugin from './plugins/EmptyAltImagePlugin';
 
 export type EditorConfig = LiferayEditorConfig & {
+	documentBrowseLinkCallback: (
+		editor: TEditor,
+		url: string,
+		changeLinkCallback: () => void
+	) => void;
 	documentBrowseLinkUrl: string;
 	editorTransformerURLs: string;
 	filebrowserImageBrowseLinkUrl: string;
@@ -16,7 +21,7 @@ export type EditorConfig = LiferayEditorConfig & {
 };
 
 export default function getCKEditorConfig({
-	editorConfig,
+	editorConfig: initialConfig,
 	editorName,
 	initialData,
 	itemSelectorEventName,
@@ -26,43 +31,47 @@ export default function getCKEditorConfig({
 	initialData: string;
 	itemSelectorEventName: string;
 }) {
-	const toolbarItems = Array.isArray(editorConfig.toolbar)
-		? editorConfig.toolbar
-		: editorConfig.toolbar?.items;
+	let config = initialConfig;
+	const toolbarItems = Array.isArray(config.toolbar)
+		? config.toolbar
+		: config.toolbar?.items;
+
+	if (config.preset === 'advanced') {
+		config = {
+			...config,
+			documentBrowseLinkCallback: (editor, url, changeLinkCallback) => {
+				openSelectionModal({
+					onSelect: changeLinkCallback,
+					selectEventName: itemSelectorEventName,
+					title: Liferay.Language.get('select-item'),
+					url,
+				});
+			},
+			documentBrowseLinkUrl: config.documentBrowseLinkUrl.replaceAll(
+				'_EDITOR_NAME_',
+				editorName
+			),
+			filebrowserImageBrowseLinkUrl:
+				config.filebrowserImageBrowseLinkUrl.replaceAll(
+					'_EDITOR_NAME_',
+					editorName
+				),
+			filebrowserImageBrowseUrl:
+				config.filebrowserImageBrowseUrl.replaceAll(
+					'_EDITOR_NAME_',
+					editorName
+				),
+
+			itemSelectorEventName,
+		};
+	}
 
 	return {
-		...editorConfig,
+		...config,
 		...(toolbarItems?.includes('imageSelector') && {
 			extraPlugins: [EmptyAltImagePlugin],
 		}),
-		documentBrowseLinkCallback: (
-			editor: TEditor,
-			url: string,
-			changeLinkCallback: () => void
-		) => {
-			openSelectionModal({
-				onSelect: changeLinkCallback,
-				selectEventName: itemSelectorEventName,
-				title: Liferay.Language.get('select-item'),
-				url,
-			});
-		},
-		documentBrowseLinkUrl: editorConfig.documentBrowseLinkUrl.replaceAll(
-			'_EDITOR_NAME_',
-			editorName
-		),
-		filebrowserImageBrowseLinkUrl:
-			editorConfig.filebrowserImageBrowseLinkUrl.replaceAll(
-				'_EDITOR_NAME_',
-				editorName
-			),
-		filebrowserImageBrowseUrl:
-			editorConfig.filebrowserImageBrowseUrl.replaceAll(
-				'_EDITOR_NAME_',
-				editorName
-			),
 		initialData,
-		itemSelectorEventName,
 		name: editorName,
 	};
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorConfig.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorConfig.ts
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {LiferayEditorConfig, TEditor} from 'frontend-editor-ckeditor-web';
+import {openSelectionModal} from 'frontend-js-components-web';
+
+export type EditorConfig = LiferayEditorConfig & {
+	documentBrowseLinkUrl: string;
+	editorTransformerURLs: string;
+	filebrowserImageBrowseLinkUrl: string;
+	filebrowserImageBrowseUrl: string;
+};
+
+export default function getCKEditorConfig({
+	editorConfig,
+	editorName,
+	initialData,
+	itemSelectorEventName,
+}: {
+	editorConfig: EditorConfig;
+	editorName: string;
+	initialData: string;
+	itemSelectorEventName: string;
+}) {
+	return {
+		...editorConfig,
+		documentBrowseLinkCallback: (
+			editor: TEditor,
+			url: string,
+			changeLinkCallback: () => void
+		) => {
+			openSelectionModal({
+				onSelect: changeLinkCallback,
+				selectEventName: itemSelectorEventName,
+				title: Liferay.Language.get('select-item'),
+				url,
+			});
+		},
+		documentBrowseLinkUrl: editorConfig.documentBrowseLinkUrl.replaceAll(
+			'_EDITOR_NAME_',
+			editorName
+		),
+		filebrowserImageBrowseLinkUrl:
+			editorConfig.filebrowserImageBrowseLinkUrl.replaceAll(
+				'_EDITOR_NAME_',
+				editorName
+			),
+		filebrowserImageBrowseUrl:
+			editorConfig.filebrowserImageBrowseUrl.replaceAll(
+				'_EDITOR_NAME_',
+				editorName
+			),
+		initialData,
+		itemSelectorEventName,
+		name: editorName,
+	};
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorConfig.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorConfig.ts
@@ -6,6 +6,8 @@
 import {LiferayEditorConfig, TEditor} from 'frontend-editor-ckeditor-web';
 import {openSelectionModal} from 'frontend-js-components-web';
 
+import EmptyAltImagePlugin from './plugins/EmptyAltImagePlugin';
+
 export type EditorConfig = LiferayEditorConfig & {
 	documentBrowseLinkUrl: string;
 	editorTransformerURLs: string;
@@ -24,8 +26,15 @@ export default function getCKEditorConfig({
 	initialData: string;
 	itemSelectorEventName: string;
 }) {
+	const toolbarItems = Array.isArray(editorConfig.toolbar)
+		? editorConfig.toolbar
+		: editorConfig.toolbar?.items;
+
 	return {
 		...editorConfig,
+		...(toolbarItems?.includes('imageSelector') && {
+			extraPlugins: [EmptyAltImagePlugin],
+		}),
 		documentBrowseLinkCallback: (
 			editor: TEditor,
 			url: string,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorProcessor.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorProcessor.ts
@@ -6,6 +6,7 @@
 import {render as renderElement} from '@liferay/frontend-js-react-web';
 import {isNullOrUndefined} from '@liferay/layout-js-components-web';
 import {CKEditor5BalloonEditor, TEditor} from 'frontend-editor-ckeditor-web';
+import {loadEditorClientExtensions} from 'frontend-js-web';
 
 import {EditableConfig} from '../../types/editables/EditableValue';
 import {config} from '../config/index';
@@ -89,7 +90,18 @@ export default function getCKEditorProcessor(
 				);
 			};
 
-			initEditor(editorConfig);
+			const editorTransformerURLs = editorConfig.editorTransformerURLs;
+
+			if (editorTransformerURLs) {
+				initEditorWithClientExtensions({
+					editorConfig,
+					element,
+					initEditor,
+				});
+			}
+			else {
+				initEditor(editorConfig);
+			}
 		},
 
 		render: (
@@ -119,4 +131,32 @@ function defaultRender(element: HTMLElement, value: string) {
 	if (!isNullOrUndefined(value)) {
 		element.innerHTML = value;
 	}
+}
+
+function initEditorWithClientExtensions({
+	editorConfig,
+	element,
+	initEditor,
+}: {
+	editorConfig: EditorConfig;
+	element: HTMLElement;
+	initEditor: (config: EditorConfig) => void;
+}) {
+	const loadingIndicator = document.createElement('span');
+
+	loadingIndicator.classList.add('loading-animation');
+	loadingIndicator.setAttribute('aria-hidden', 'true');
+
+	element?.appendChild(loadingIndicator);
+
+	loadEditorClientExtensions({
+		config: editorConfig,
+		onLoad: ({transformedConfig}: {transformedConfig: EditorConfig}) => {
+			if (loadingIndicator) {
+				loadingIndicator.remove();
+			}
+
+			initEditor(transformedConfig);
+		},
+	});
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorProcessor.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorProcessor.ts
@@ -132,6 +132,10 @@ export default function getCKEditorProcessor(
 				KEYCODES.ARROWS.includes(data.keyCode)
 			) {
 				data.stopPropagation();
+
+				if (editorType === 'text') {
+					data.preventDefault();
+				}
 			}
 		};
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorProcessor.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorProcessor.ts
@@ -44,7 +44,7 @@ export default function getCKEditorProcessor(
 	getEditorWrapper = defaultGetEditorWrapper,
 	render: RenderFunction = defaultRender
 ) {
-	const state: State = INITIAL_STATE;
+	let state: State = INITIAL_STATE;
 
 	return {
 		createEditor: (
@@ -102,6 +102,27 @@ export default function getCKEditorProcessor(
 			else {
 				initEditor(editorConfig);
 			}
+		},
+
+		destroyEditor: (
+			element: HTMLElement,
+			editableConfig: EditableConfig
+		) => {
+			if (!state.editor) {
+				return;
+			}
+
+			const lastValue = state.editor.getData();
+
+			state.callbacks.changeCallback?.(lastValue);
+
+			state.editor.destroy();
+
+			if (state.element) {
+				render(state.element, lastValue, editableConfig);
+			}
+
+			state = INITIAL_STATE;
 		},
 
 		render: (

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorProcessor.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorProcessor.ts
@@ -45,6 +45,12 @@ const INITIAL_STATE = {
 	eventHandlers: [],
 };
 
+const KEYCODES = {
+	ARROWS: [37, 38, 39, 40],
+	ENTER: 13,
+	ESCAPE: 27,
+};
+
 export default function getCKEditorProcessor(
 	editorType: EditorType,
 	getEditorWrapper = defaultGetEditorWrapper,
@@ -109,6 +115,25 @@ export default function getCKEditorProcessor(
 			onBlurEditor(state.editor);
 		};
 
+		const onKeydownEditor = (
+			event: Event,
+			data: KeyboardEvent & {keyCode: number}
+		) => {
+			if (!state.editor) {
+				return;
+			}
+
+			if (data.keyCode === KEYCODES.ESCAPE) {
+				onBlurEditor(state.editor);
+			}
+			else if (
+				data.keyCode === KEYCODES.ENTER ||
+				KEYCODES.ARROWS.includes(data.keyCode)
+			) {
+				data.stopPropagation();
+			}
+		};
+
 		return [
 			{
 				callback: onClickOutside,
@@ -122,6 +147,11 @@ export default function getCKEditorProcessor(
 				callback: onFocusEditor,
 				emitter: state.editor.ui.focusTracker,
 				event: 'change:isFocused',
+			},
+			{
+				callback: onKeydownEditor,
+				emitter: state.editor.editing.view.document,
+				event: 'keydown',
 			},
 		];
 	};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorProcessor.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorProcessor.ts
@@ -11,6 +11,7 @@ import {loadEditorClientExtensions} from 'frontend-js-web';
 import {EditableConfig} from '../../types/editables/EditableValue';
 import {config} from '../config/index';
 import getCKEditorConfig, {EditorConfig} from './getCKEditorConfig';
+import setCursorPosition, {Position} from './setCursorPosition';
 
 type ChangeCallback = (data: string) => Promise<void>;
 
@@ -160,7 +161,8 @@ export default function getCKEditorProcessor(
 		createEditor: (
 			element: HTMLElement,
 			changeCallback: ChangeCallback,
-			destroyCallback: DestroyCallback
+			destroyCallback: DestroyCallback,
+			clickPosition: Position
 		) => {
 			state.callbacks = {changeCallback, destroyCallback};
 			state.element = element;
@@ -194,6 +196,8 @@ export default function getCKEditorProcessor(
 
 							state.editor = editor;
 							editor.focus();
+
+							setCursorPosition(editor, clickPosition);
 
 							state.eventHandlers = createEventHandlers(
 								editorName,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorProcessor.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorProcessor.ts
@@ -1,0 +1,122 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {render as renderElement} from '@liferay/frontend-js-react-web';
+import {isNullOrUndefined} from '@liferay/layout-js-components-web';
+import {CKEditor5BalloonEditor, TEditor} from 'frontend-editor-ckeditor-web';
+
+import {EditableConfig} from '../../types/editables/EditableValue';
+import {config} from '../config/index';
+import getCKEditorConfig, {EditorConfig} from './getCKEditorConfig';
+
+type ChangeCallback = (data: string) => Promise<void>;
+
+type DestroyCallback = () => void;
+
+type EditorType = 'text' | 'rich-text';
+
+type RenderFunction = (
+	element: HTMLElement,
+	value: string,
+	editableConfig?: EditableConfig
+) => void;
+
+type State = {
+	callbacks: {
+		changeCallback?: ChangeCallback;
+		destroyCallback?: DestroyCallback;
+	};
+	editor: TEditor | null;
+	element: HTMLElement | null;
+};
+
+const INITIAL_STATE = {
+	callbacks: {},
+	editor: null,
+	element: null,
+};
+
+export default function getCKEditorProcessor(
+	editorType: EditorType,
+	getEditorWrapper = defaultGetEditorWrapper,
+	render: RenderFunction = defaultRender
+) {
+	const state: State = INITIAL_STATE;
+
+	return {
+		createEditor: (
+			element: HTMLElement,
+			changeCallback: ChangeCallback,
+			destroyCallback: DestroyCallback
+		) => {
+			state.callbacks = {changeCallback, destroyCallback};
+			state.element = element;
+
+			const {editorConfig} = config.defaultEditorConfigurations[
+				editorType
+			] as {editorConfig: EditorConfig};
+
+			const editorName = `${config.portletNamespace}FragmentEntryLinkEditable_${state.element?.id}`;
+			const itemSelectorEventName = `${editorName}selectItem`;
+
+			const editorWrapper = getEditorWrapper(state.element!);
+
+			editorWrapper.setAttribute('id', editorName);
+			editorWrapper.setAttribute('name', editorName);
+
+			const initEditor = (editorConfig: EditorConfig) => {
+				renderElement(
+					CKEditor5BalloonEditor as any,
+					{
+						config: getCKEditorConfig({
+							editorConfig,
+							editorName,
+							initialData: editorWrapper.innerHTML,
+							itemSelectorEventName,
+						}),
+						onReady: (editor: TEditor) => {
+							if (!editor) {
+								return;
+							}
+
+							state.editor = editor;
+							editor.focus();
+						},
+					},
+					editorWrapper
+				);
+			};
+
+			initEditor(editorConfig);
+		},
+
+		render: (
+			element: HTMLElement,
+			value: string,
+			editableConfig: EditableConfig
+		) => {
+			if (element !== state.element) {
+				render(element, value, editableConfig);
+			}
+		},
+	};
+}
+
+function defaultGetEditorWrapper(element: HTMLElement) {
+	const wrapper = document.createElement('div');
+
+	wrapper.innerHTML = element.innerHTML;
+
+	element.innerHTML = '';
+	element.appendChild(wrapper);
+
+	return wrapper;
+}
+
+function defaultRender(element: HTMLElement, value: string) {
+	if (!isNullOrUndefined(value)) {
+		element.innerHTML = value;
+	}
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorProcessor.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorProcessor.ts
@@ -63,10 +63,30 @@ export default function getCKEditorProcessor(
 		}
 	};
 
-	const createEventHandlers = () => {
+	const createEventHandlers = (
+		editorName: string,
+		itemSelectorEventName: string
+	) => {
 		if (!state.editor) {
 			return [];
 		}
+
+		// For the cases where we open the item selector we need to make sure that
+		// the editor is destroyed. Since the focus listener does not work for these cases
+		// we have to setup an additional listener.
+
+		const onClickOutside = (event: Event) => {
+			const target = event.target as Element;
+
+			if (
+				state.editor &&
+				!target.closest(`[name="${editorName}"]`) &&
+				(target.closest('.page-editor__toolbar') ||
+					target.closest('.page-editor__wrapper'))
+			) {
+				onBlurEditor(state.editor);
+			}
+		};
 
 		const onFocusEditor = (
 			event: Event,
@@ -77,10 +97,27 @@ export default function getCKEditorProcessor(
 				return;
 			}
 
+			// Ignoring the blur event, because we don't want to destroy the editor
+			// when opening the item selector.
+
+			if (document.getElementById(itemSelectorEventName)) {
+				document.addEventListener('click', onClickOutside);
+
+				return;
+			}
+
 			onBlurEditor(state.editor);
 		};
 
 		return [
+			{
+				callback: onClickOutside,
+				emitter: {
+					off: (event: string, callback: () => void) =>
+						document.removeEventListener(event, callback),
+				},
+				event: 'click',
+			},
 			{
 				callback: onFocusEditor,
 				emitter: state.editor.ui.focusTracker,
@@ -128,7 +165,10 @@ export default function getCKEditorProcessor(
 							state.editor = editor;
 							editor.focus();
 
-							state.eventHandlers = createEventHandlers()!;
+							state.eventHandlers = createEventHandlers(
+								editorName,
+								itemSelectorEventName
+							)!;
 
 							state.eventHandlers.forEach(
 								({callback, emitter, event}) => {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorProcessor.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorProcessor.ts
@@ -31,12 +31,18 @@ type State = {
 	};
 	editor: TEditor | null;
 	element: HTMLElement | null;
+	eventHandlers: {
+		callback: (...args: any[]) => void;
+		emitter: any;
+		event: string;
+	}[];
 };
 
 const INITIAL_STATE = {
 	callbacks: {},
 	editor: null,
 	element: null,
+	eventHandlers: [],
 };
 
 export default function getCKEditorProcessor(
@@ -45,6 +51,43 @@ export default function getCKEditorProcessor(
 	render: RenderFunction = defaultRender
 ) {
 	let state: State = INITIAL_STATE;
+
+	const onBlurEditor = (editor: TEditor) => {
+		const {changeCallback, destroyCallback} = state.callbacks;
+
+		if (changeCallback) {
+			changeCallback(editor.getData()).finally(() => destroyCallback?.());
+		}
+		else if (destroyCallback) {
+			requestAnimationFrame(() => destroyCallback());
+		}
+	};
+
+	const createEventHandlers = () => {
+		if (!state.editor) {
+			return [];
+		}
+
+		const onFocusEditor = (
+			event: Event,
+			name: string,
+			isFocused: boolean
+		) => {
+			if (!state.editor || isFocused) {
+				return;
+			}
+
+			onBlurEditor(state.editor);
+		};
+
+		return [
+			{
+				callback: onFocusEditor,
+				emitter: state.editor.ui.focusTracker,
+				event: 'change:isFocused',
+			},
+		];
+	};
 
 	return {
 		createEditor: (
@@ -84,6 +127,14 @@ export default function getCKEditorProcessor(
 
 							state.editor = editor;
 							editor.focus();
+
+							state.eventHandlers = createEventHandlers()!;
+
+							state.eventHandlers.forEach(
+								({callback, emitter, event}) => {
+									emitter.on?.(event, callback);
+								}
+							);
 						},
 					},
 					editorWrapper
@@ -117,6 +168,10 @@ export default function getCKEditorProcessor(
 			state.callbacks.changeCallback?.(lastValue);
 
 			state.editor.destroy();
+
+			state.eventHandlers.forEach(({callback, emitter, event}) => {
+				emitter.off(event, callback);
+			});
 
 			if (state.element) {
 				render(state.element, lastValue, editableConfig);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorProcessor.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorProcessor.ts
@@ -55,7 +55,7 @@ const KEYCODES = {
 export default function getCKEditorProcessor(
 	editorType: EditorType,
 	getEditorWrapper = defaultGetEditorWrapper,
-	render: RenderFunction = defaultRender
+	initialRender: RenderFunction = defaultRender
 ) {
 	let state: State = INITIAL_STATE;
 
@@ -159,6 +159,18 @@ export default function getCKEditorProcessor(
 				event: 'keydown',
 			},
 		];
+	};
+
+	const render = (
+		element: HTMLElement,
+		value: string,
+		editableConfig: EditableConfig
+	) => {
+		initialRender(
+			element,
+			editorType === 'text' ? getEscapedTextFromHTML(value) : value,
+			editableConfig
+		);
 	};
 
 	return {
@@ -285,6 +297,17 @@ function defaultRender(element: HTMLElement, value: string) {
 	if (!isNullOrUndefined(value)) {
 		element.innerHTML = value;
 	}
+}
+
+function getEscapedTextFromHTML(value: string) {
+	const div = document.createElement('div');
+
+	div.innerHTML = value;
+
+	return (div.textContent || '')
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;');
 }
 
 function initEditorWithClientExtensions({

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getLinkableEditableEditorWrapper.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getLinkableEditableEditorWrapper.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-export function getLinkableEditableEditorWrapper(element) {
+export function getLinkableEditableEditorWrapper(element: HTMLElement) {
 	const anchor =
 		element instanceof HTMLAnchorElement
 			? element

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/plugins/EmptyAltImagePlugin.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/plugins/EmptyAltImagePlugin.ts
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {TEditor} from 'frontend-editor-ckeditor-web';
+
+type Change = {
+	name: string;
+	position: {nodeAfter: any};
+	type: 'insert' | 'remove';
+};
+
+export default function EmptyAltImagePlugin(editor: TEditor) {
+	const model = editor.model;
+
+	model.document.on('change:data', () => {
+		const changes = model.document.differ.getChanges();
+
+		(changes as Change[]).forEach(({name, position, type}) => {
+
+			// When an image is inserted, the alt attribute is set to empty
+			// by default to indicate that the image is decorative.
+
+			if (type === 'insert' && name === 'imageInline') {
+				model.change((writer: any) => {
+					writer.setAttribute('alt', '', position.nodeAfter);
+				});
+			}
+		});
+	});
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/setCursorPosition.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/setCursorPosition.ts
@@ -1,0 +1,74 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {TEditor} from 'frontend-editor-ckeditor-web';
+
+export type Position = {clientX: number; clientY: number};
+
+export default function setCursorPosition(
+	editor: TEditor,
+	clickPosition: Position
+) {
+	let caretPosition = null;
+
+	if (!clickPosition) {
+		editor.execute('selectAll');
+
+		return;
+	}
+
+	// @ts-ignore
+
+	if (document.caretPositionFromPoint) {
+
+		// @ts-ignore
+
+		caretPosition = document.caretPositionFromPoint(
+			clickPosition.clientX,
+			clickPosition.clientY
+		);
+	}
+	else if (document.caretRangeFromPoint) {
+		const range = document.caretRangeFromPoint(
+			clickPosition.clientX,
+			clickPosition.clientY
+		);
+
+		if (!range) {
+			return;
+		}
+
+		caretPosition = {
+			offset: range.startOffset,
+			offsetNode: range.startContainer,
+		};
+	}
+
+	if (!caretPosition) {
+		return;
+	}
+
+	// Convert DOM position to editor view position
+
+	const viewPosition = editor.editing.view.domConverter.domPositionToView(
+		caretPosition.offsetNode,
+		caretPosition.offset
+	);
+
+	if (!viewPosition) {
+		return;
+	}
+
+	// Convert editor view position to editor model position
+
+	editor.model.change((writer) => {
+		const modelPosition =
+			editor.editing.mapper.toModelPosition(viewPosition);
+
+		writer.setSelection(modelPosition);
+
+		editor.editing.view.focus();
+	});
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getEditableLinkValue.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getEditableLinkValue.ts
@@ -3,9 +3,13 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {LinkEditableValue} from '../../types/editables/EditableValue';
 import {getEditableLocalizedValue} from './getEditableLocalizedValue';
 
-export function getEditableLinkValue(editableValue, languageId) {
+export function getEditableLinkValue(
+	editableValue: LinkEditableValue,
+	languageId: Liferay.Language.Locale
+) {
 	return {
 		...(typeof editableValue === 'object' && editableValue
 			? editableValue

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getEditableLocalizedValue.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getEditableLocalizedValue.ts
@@ -9,20 +9,20 @@ import {EditableValue} from '../../types/editables/EditableValue';
 import {config} from '../config/index';
 
 export function getEditableLocalizedValue(
-	editableValue: EditableValue,
+	editableValue: EditableValue | undefined,
 	languageId: Liferay.Language.Locale | null = null,
-	defaultValue = ''
+	defaultValue: string = ''
 ) {
 	let content;
 
 	if (languageId && !isNullOrUndefined(editableValue?.[languageId])) {
-		content = editableValue[languageId];
+		content = editableValue?.[languageId];
 	}
 	else if (!isNullOrUndefined(editableValue?.[config.defaultLanguageId])) {
-		content = editableValue[config.defaultLanguageId];
+		content = editableValue?.[config.defaultLanguageId];
 	}
 	else if (!isNullOrUndefined(editableValue?.defaultValue)) {
-		content = editableValue.defaultValue;
+		content = editableValue?.defaultValue;
 	}
 	else if (typeof editableValue === typeof defaultValue) {
 		content = editableValue;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/types/editables/EditableValue.d.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/types/editables/EditableValue.d.ts
@@ -13,3 +13,9 @@ export type EditableValue = {
 	config?: EditableConfig;
 	defaultValue?: string;
 } & LocalizedValue;
+
+export type LinkEditableValue = {
+	href?: LocalizedValue;
+	rel?: string;
+	target?: string;
+};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/types/editables/EditableValue.d.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/types/editables/EditableValue.d.ts
@@ -7,7 +7,9 @@ export type LocalizedValue = {
 	[key in Liferay.Language.Locale]?: string;
 };
 
+export type EditableConfig = Record<string, unknown>;
+
 export type EditableValue = {
-	config?: Record<string, unknown>;
+	config?: EditableConfig;
 	defaultValue?: string;
 } & LocalizedValue;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "36581dd8acc0832c796f63fb3c88fd675cdaef1d",
+	"@generated": "438a1f1e7e322b0b291fc60c47ef45100c12f042",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -34,6 +34,9 @@
 			],
 			"@liferay/marketplace-js-components-web": [
 				"../../../../../../../marketplace/marketplace-js-components-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
+			"frontend-editor-ckeditor-web": [
+				"../../../../../../../frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/index.ts"
 			],
 			"frontend-js-components-web": [
 				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
@@ -84,6 +87,9 @@
 		},
 		{
 			"path": "../../../../../../../marketplace/marketplace-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/apps/layout/layout-content-page-editor-web/test/tsconfig.json
+++ b/modules/apps/layout/layout-content-page-editor-web/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "f368000d91a234b451f0092e18bc8112bd51b1b4",
+	"@generated": "e18889706b22010762b6ea9e03298d611fdfc736",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -34,6 +34,9 @@
 			],
 			"@liferay/marketplace-js-components-web": [
 				"../../../marketplace/marketplace-js-components-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
+			"frontend-editor-ckeditor-web": [
+				"../../../frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/index.ts"
 			],
 			"frontend-js-components-web": [
 				"../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
@@ -86,6 +89,9 @@
 		},
 		{
 			"path": "../../../marketplace/marketplace-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -790,9 +790,10 @@ export class PageEditorPage {
 
 		// Click CKEditor
 
-		await editable.locator('.cke_editable_inline').waitFor();
+		const editor = editable.locator('[contenteditable="true"]');
 
-		await editable.locator('.cke_editable_inline').click();
+		await editor.waitFor();
+		await editor.click();
 
 		// Clear current content and fill with new one
 
@@ -804,14 +805,11 @@ export class PageEditorPage {
 		// Make sure the editable gets the new value
 
 		await expect(async () => {
-			await this.page
-				.getByLabel('Configuration Panel')
-				.getByRole('heading', {name: editableId})
-				.click();
+			await this.page.keyboard.press('Escape');
 
 			await this.waitForChangesSaved();
 
-			await expect(this.page.locator('.cke_editable')).not.toBeVisible({
+			await expect(editor).not.toBeVisible({
 				timeout: 1000,
 			});
 

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/editables.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/editables.spec.ts
@@ -20,6 +20,7 @@ import getPageDefinition from './utils/getPageDefinition';
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
+		'LPD-11235': {enabled: true},
 		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
@@ -27,8 +28,20 @@ const test = mergeTests(
 	pageEditorPagesTest
 );
 
-test(
-	'Saves edited contend when leaving page while editing',
+const testWithCKEditor4 = mergeTests(
+	apiHelpersTest,
+	featureFlagsTest({
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+// Remove when the feature flag LPD-11235 is removed
+
+testWithCKEditor4(
+	'Saves edited content when leaving page while editing with CKEditor 4',
 	{
 		tag: ['@LPD-40982', '@LPD-48256'],
 	},
@@ -78,11 +91,11 @@ test(
 
 		// Clear current content and fill with new one
 
-		await page.keyboard.press('Control+KeyA');
+		await page.keyboard.press('ControlOrMeta+KeyA');
 
 		// Check toolbar appears
 
-		await expect(page.locator('.ae-toolbar-styles')).toBeVisible();
+		await page.locator('.ae-toolbar-styles').waitFor();
 
 		await page.keyboard.press('Backspace');
 
@@ -94,10 +107,94 @@ test(
 
 		// Go back to edit mode and check value was saved
 
+		const editButton = page
+			.getByLabel('Control Menu')
+			.getByText('Edit', {exact: true});
+
+		await editButton.waitFor();
+		await editButton.click();
+
+		await expect(page.getByText('Papa')).toBeVisible();
+	}
+);
+
+test(
+	'Saves edited content when leaving page while editing',
+	{
+		tag: ['@LPD-40982', '@LPD-48256'],
+	},
+	async ({apiHelpers, page, pageEditorPage, site}) => {
+
+		// Create a page with a Paragraph fragment and go to view mode
+
+		const paragraphId = getRandomString();
+		const paragraphDefinition = getFragmentDefinition({
+			id: paragraphId,
+			key: 'BASIC_COMPONENT-paragraph',
+		});
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([paragraphDefinition]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`);
+
+		// Go to edit mode
+
 		await page
 			.getByLabel('Control Menu')
 			.getByText('Edit', {exact: true})
 			.click();
+
+		await page.locator('.page-editor').waitFor();
+
+		// Write text in editable
+
+		await pageEditorPage.selectFragment(paragraphId);
+
+		await pageEditorPage.selectEditable(paragraphId, 'element-text');
+
+		const editable = pageEditorPage.getEditable({
+			editableId: 'element-text',
+			fragmentId: paragraphId,
+		});
+
+		await editable.click();
+
+		const editor = editable.locator('[contenteditable="true"]');
+
+		await editor.waitFor();
+
+		await editor.click();
+
+		// Clear current content and fill with new one
+
+		await page.keyboard.press('ControlOrMeta+KeyA');
+
+		// Check toolbar appears
+
+		const toolbar = page.locator('.ck-toolbar');
+
+		await toolbar.waitFor();
+
+		await page.keyboard.press('Backspace');
+
+		await page.keyboard.type('Papa');
+
+		// Leave page while editing
+
+		await page.getByLabel('Control Menu').locator('.lfr-back-link').click();
+
+		// Go back to edit mode and check value was saved
+
+		const editButton = page
+			.getByLabel('Control Menu')
+			.getByText('Edit', {exact: true});
+
+		await editButton.waitFor();
+		await editButton.click();
 
 		await expect(page.getByText('Papa')).toBeVisible();
 	}

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/editables.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/editables.spec.ts
@@ -29,13 +29,10 @@ const test = mergeTests(
 );
 
 const testWithCKEditor4 = mergeTests(
-	apiHelpersTest,
+	test,
 	featureFlagsTest({
 		'LPS-178052': {enabled: true},
-	}),
-	isolatedSiteTest,
-	loginTest(),
-	pageEditorPagesTest
+	})
 );
 
 // Remove when the feature flag LPD-11235 is removed

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/fragments.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/fragments.spec.ts
@@ -47,6 +47,7 @@ const test = mergeTests(
 	displayPageTemplatesPagesTest,
 	documentLibraryPagesTest,
 	featureFlagsTest({
+		'LPD-11235': {enabled: true},
 		'LPD-17564': {enabled: true},
 		'LPD-39304': {enabled: true},
 		'LPS-178052': {enabled: true},
@@ -59,6 +60,15 @@ const test = mergeTests(
 	objectPagesTest,
 	pageEditorPagesTest,
 	pageManagementSiteTest
+);
+
+const testWithCKEditor4 = mergeTests(
+	test,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPD-39304': {enabled: true},
+		'LPS-178052': {enabled: true},
+	})
 );
 
 const testWithPrivatePages = mergeTests(
@@ -1619,6 +1629,140 @@ test.describe('Multiselect Fragment', () => {
 	);
 });
 
+// Remove when the feature flag LPD-11235 is removed
+
+testWithCKEditor4.describe('Paragraph Fragment with CKEditor 4', () => {
+	testWithCKEditor4(
+		'Can edit text editable with CKEditor 4',
+		{tag: ['@LPS-127732']},
+		async ({apiHelpers, page, pageEditorPage, site}) => {
+
+			// Create page with a paragraph fragment and go to edit mode
+
+			const fragmentId = getRandomString();
+
+			const fragment = getFragmentDefinition({
+				id: fragmentId,
+				key: 'BASIC_COMPONENT-paragraph',
+			});
+
+			const layout = await apiHelpers.headlessDelivery.createSitePage({
+				pageDefinition: getPageDefinition([fragment]),
+				siteId: site.id,
+				title: getRandomString(),
+			});
+
+			await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+			// Check paragraph editable can be edited
+
+			await pageEditorPage.editTextEditable(
+				fragmentId,
+				'element-text',
+				'New editable fragment text'
+			);
+
+			await expect(
+				page.getByText('New editable fragment text')
+			).toBeAttached();
+		}
+	);
+
+	testWithCKEditor4(
+		'Can use CKEditor options when editing a rich text editable with CKEditor 4',
+		{tag: ['@LPS-127732']},
+		async ({apiHelpers, page, pageEditorPage, site}) => {
+
+			// Create page with a paragraph fragment and go to edit mode
+
+			const fragmentId = getRandomString();
+
+			const fragment = getFragmentDefinition({
+				id: fragmentId,
+				key: 'BASIC_COMPONENT-paragraph',
+			});
+
+			const layout = await apiHelpers.headlessDelivery.createSitePage({
+				pageDefinition: getPageDefinition([fragment]),
+				siteId: site.id,
+				title: getRandomString(),
+			});
+
+			await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+			// Open editor options
+
+			await pageEditorPage.selectEditable(fragmentId, 'element-text');
+
+			const editable = pageEditorPage.getEditable({
+				editableId: 'element-text',
+				fragmentId,
+			});
+
+			await editable.click();
+
+			await editable.locator('.cke_editable_inline').click();
+
+			await page.keyboard.press('ControlOrMeta+KeyA');
+
+			// Check that the button is visible and works
+
+			await expect(page.getByTitle('Right')).toBeVisible();
+
+			await page.getByTitle('Right').click();
+
+			expect(
+				await page
+					.locator('.ae-editable p')
+					.evaluate((element) => element.style.textAlign)
+			).toBe('right');
+		}
+	);
+
+	testWithCKEditor4(
+		'Editor config contributor client extension is applied with CKEditor 4',
+		{tag: ['@LPD-54262']},
+		async ({apiHelpers, page, pageEditorPage, site}) => {
+
+			// Create page with a paragraph fragment and go to edit mode
+
+			const fragmentId = getRandomString();
+
+			const fragment = getFragmentDefinition({
+				id: fragmentId,
+				key: 'BASIC_COMPONENT-paragraph',
+			});
+
+			const layout = await apiHelpers.headlessDelivery.createSitePage({
+				pageDefinition: getPageDefinition([fragment]),
+				siteId: site.id,
+				title: getRandomString(),
+			});
+
+			await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+			// Open editor options
+
+			await pageEditorPage.selectEditable(fragmentId, 'element-text');
+
+			const editable = pageEditorPage.getEditable({
+				editableId: 'element-text',
+				fragmentId,
+			});
+
+			await editable.dblclick();
+
+			await editable.locator('.cke_editable_inline').dblclick();
+
+			// Assert "Insert Video" button is visible as provided by the CX
+
+			await page.getByText('A paragraph').selectText();
+
+			await expect(page.getByTitle('Insert Video')).toBeInViewport();
+		}
+	);
+});
+
 test.describe('Paragraph Fragment', () => {
 	test(
 		'Can edit text editable',
@@ -1689,19 +1833,22 @@ test.describe('Paragraph Fragment', () => {
 
 			await editable.click();
 
-			await editable.locator('.cke_editable_inline').click();
+			await editable.locator('[contenteditable="true"]').click();
 
 			await page.keyboard.press('ControlOrMeta+KeyA');
 
+			const toolbar = page.locator('.ck-toolbar');
+
+			await toolbar.waitFor();
+
 			// Check that the button is visible and works
 
-			await expect(page.getByTitle('Right')).toBeVisible();
-
-			await page.getByTitle('Right').click();
+			await toolbar.getByLabel('Text alignment', {exact: true}).click();
+			await toolbar.getByLabel('Align right', {exact: true}).click();
 
 			expect(
 				await page
-					.locator('.ae-editable p')
+					.locator('.ck-editor__editable p')
 					.evaluate((element) => element.style.textAlign)
 			).toBe('right');
 		}
@@ -1740,13 +1887,15 @@ test.describe('Paragraph Fragment', () => {
 
 			await editable.dblclick();
 
-			await editable.locator('.cke_editable_inline').dblclick();
+			await editable.locator('[contenteditable="true"]').dblclick();
 
-			// Assert "Insert Video" button is visible as provided by the CX
+			// Assert "Accessibility Help" button is visible as provided by the CX
 
 			await page.getByText('A paragraph').selectText();
 
-			await expect(page.getByTitle('Insert Video')).toBeInViewport();
+			await expect(
+				page.getByLabel('Accessibility help')
+			).toBeInViewport();
 		}
 	);
 });

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/fragments.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/fragments.spec.ts
@@ -1127,7 +1127,7 @@ test.describe('HTML Fragment', () => {
 
 			// Check value is loaded in the page correctly
 
-			await expect(page.getByText('test html')).toBeAttached();
+			await expect(page.getByText('test html')).toHaveCount(1);
 
 			// Check value is loaded in the editor correctly
 
@@ -1182,7 +1182,7 @@ test.describe('HTML Fragment', () => {
 				value: '<div class="text-success"><h1>test html</h1></div>',
 			});
 
-			await expect(page.getByText('test html')).toBeAttached();
+			await expect(page.getByText('test html')).toHaveCount(1);
 		}
 	);
 });
@@ -1823,6 +1823,8 @@ test.describe('Slider Fragment', () => {
 		// Change the number of slides
 
 		const slide = page.locator('[aria-roledescription="slide"]');
+
+		await slide.first().waitFor();
 
 		expect(await slide.all()).toHaveLength(3);
 

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/sidebar.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/sidebar.spec.ts
@@ -45,6 +45,7 @@ const test = mergeTests(
 	applicationsMenuPageTest,
 	collectionsPagesTest,
 	featureFlagsTest({
+		'LPD-11235': {enabled: true},
 		'LPD-34938': {enabled: true},
 		'LPS-169837': {enabled: true},
 		'LPS-178052': {enabled: true},
@@ -56,6 +57,16 @@ const test = mergeTests(
 	pageEditorPagesTest,
 	pageManagementSiteTest,
 	pageViewModePagesTest
+);
+
+const testWithCKEditor4 = mergeTests(
+	apiHelpersTest,
+	featureFlagsTest({
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
 );
 
 const PANELS: SidebarTab[] = [
@@ -970,6 +981,75 @@ test.describe('Fragments Panel', () => {
 	);
 });
 
+// Remove when the feature flag LPD-11235 is removed
+
+testWithCKEditor4.describe('Page Contents Panel with CKEditor 4', () => {
+	testWithCKEditor4(
+		'Allows editing inline text from Page Content Panel with CKEditor 4',
+		async ({apiHelpers, page, pageEditorPage, site}) => {
+
+			// Create a page with a Heading fragment
+
+			const headingId = getRandomString();
+			const headingDefinition = getFragmentDefinition({
+				id: headingId,
+				key: 'BASIC_COMPONENT-heading',
+			});
+
+			const layout = await apiHelpers.headlessDelivery.createSitePage({
+				pageDefinition: getPageDefinition([headingDefinition]),
+				siteId: site.id,
+				title: getRandomString(),
+			});
+
+			// Go to edit mode of page
+
+			await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+			// Go to Page Contents panel
+
+			await pageEditorPage.goToSidebarTab('Page Content');
+
+			// Hover the content and check that the fragment is hovered
+
+			const content = page.getByLabel('Edit Text Heading Example');
+
+			await content.hover();
+
+			const headingFragment = page.locator('.component-heading');
+
+			await expect(headingFragment).toHaveClass(
+				/page-editor__editable--content-hovered/
+			);
+
+			// Edit inline text
+
+			await content.click();
+
+			const editable = pageEditorPage.getEditable({
+				editableId: 'element-text',
+				fragmentId: headingId,
+			});
+
+			await editable.locator('[contenteditable="true"]').waitFor();
+
+			// Clear current content text and fill with new one
+
+			await page.keyboard.press('Control+KeyA');
+			await page.keyboard.press('Backspace');
+
+			await page.keyboard.type('New Content');
+			await page.locator('body').click();
+
+			await pageEditorPage.waitForChangesSaved();
+
+			await expect(
+				page.locator('.page-editor__page-contents__page-content')
+			).toContainText('New Content');
+		}
+	);
+});
+
 test.describe('Page Contents Panel', () => {
 	const FRAGMENT_FIELDS = [
 		{
@@ -1037,7 +1117,7 @@ test.describe('Page Contents Panel', () => {
 			fragmentId: headingId,
 		});
 
-		await editable.locator('.cke_editable_inline').waitFor();
+		await editable.locator('[contenteditable="true"]').waitFor();
 
 		// Clear current content text and fill with new one
 

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor/src/index.ts
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor/src/index.ts
@@ -26,6 +26,8 @@ const editorConfigTransformer: EditorConfigTransformer<any> = (config) => {
 				label: 'A dropdown with a custom icon',
 			},
 			separator,
+			'alignment',
+			separator,
 			{
 
 				// This dropdown has the icon disabled and a text label instead.


### PR DESCRIPTION
Hey @liferay-frontend, we’ve been implementing CKEditor 5 in our editables within the Page Editor, and to do so, we’ve made the following changes in your files:
- https://github.com/liferay-page-management/liferay-portal/pull/17327/commits/2fdd0c654701e4305b9dfa3f755647988951acf6: `TEditor` type has been exported so we can use it in our modules.
- https://github.com/liferay-page-management/liferay-portal/pull/17327/commits/ad125af170b9694f68d6d2c627545362cef0f7bd: A button in the CKEditor toolbar has been added for the CX example so our Playwright tests don’t fail.
- https://github.com/liferay-page-management/liferay-portal/pull/17327/commits/7a24477e072e894b4d18c62026822362b767de30: A js error has been fixed that occurs when adding images with CKEditor 4.

Could you take a look? Thanks a lot in advance!