### PR TITLE
LPD-57772 Adapt tests to the block toolbar

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/node-scripts.config.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/node-scripts.config.js
@@ -15,6 +15,7 @@ module.exports = {
 			'Alignment',
 			'BalloonEditor',
 			'BlockQuote',
+			'BlockToolbar',
 			'Bold',
 			'ButtonView',
 			'ClassicEditor',

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/BaseEditor.tsx
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/BaseEditor.tsx
@@ -50,13 +50,14 @@ const BaseEditor = ({
 			return;
 		}
 
-		const {licenseKey, plugins} = editorConfig;
+		const {extraPlugins, licenseKey, plugins} = editorConfig;
 
 		loadEditorClientExtensions({
 			config: editorConfig,
 			onLoad: ({transformedConfig}: any) => {
 				setEditorConfig(() => ({
 					...transformedConfig,
+					extraPlugins,
 					licenseKey,
 					plugins,
 				}));

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getDefaultEditorConfig.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getDefaultEditorConfig.ts
@@ -6,6 +6,7 @@
 import {
 	Alignment,
 	BlockQuote,
+	BlockToolbar,
 	Bold,
 	EditorConfig,
 	Essentials,
@@ -49,6 +50,7 @@ const getDefaultEditorConfig = ({
 	preset: EEditorConfigPreset;
 }): EditorConfig => {
 	const basicPlugins = [
+		BlockToolbar,
 		Bold,
 		Essentials,
 		GeneralHtmlSupport,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/RichTextFragmentEntryLinkEditorConfigContributor.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/RichTextFragmentEntryLinkEditorConfigContributor.java
@@ -73,6 +73,14 @@ public class RichTextFragmentEntryLinkEditorConfigContributor
 
 		if (FeatureFlagManagerUtil.isEnabled("LPD-11235")) {
 			jsonObject.put(
+				"blockToolbar",
+				JSONUtil.put(
+					"icon", "plus"
+				).put(
+					"items",
+					new String[] {"imageSelector", "|", "horizontalLine"}
+				)
+			).put(
 				"preset", "advanced"
 			).put(
 				"toolbar",
@@ -84,8 +92,7 @@ public class RichTextFragmentEntryLinkEditorConfigContributor
 						"fontColor", "fontBackgroundColor", "|", "removeFormat",
 						"|", "numberedList", "bulletedList", "|", "indent",
 						"outdent", "|", "blockQuote", "|", "link",
-						"insertTable", "imageSelector", "|", "horizontalLine",
-						"|", "alignment"
+						"insertTable", "|", "alignment"
 					}
 				).put(
 					"shouldNotGroupWhenFull", true

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/ShortcutManager.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/ShortcutManager.js
@@ -421,7 +421,8 @@ function isInteractiveElement(element) {
 		!!element.closest('.cke_editable') ||
 		!!element.closest('.dropdown-menu') ||
 		!!element.closest('.page-editor__page-structure__item-configuration') ||
-		!!element.closest('.page-editor__allowed-fragment__tree')
+		!!element.closest('.page-editor__allowed-fragment__tree') ||
+		!!element.classList.contains('ck-editor__editable')
 	);
 }
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_Layout.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_Layout.scss
@@ -421,3 +421,19 @@ html#{$cadmin-selector} {
 		padding: 0;
 	}
 }
+
+.ck-body-wrapper .ck.ck-block-toolbar-button {
+	background-color: $white;
+	border: 1px solid var(--ck-color-base-border);
+	border-radius: 0.25rem;
+	transform: translateX(-0.25rem);
+	z-index: 990;
+
+	&:not(:hover) .ck-icon_inherit-color {
+		color: $gray-600;
+	}
+
+	&:hover {
+		background-color: $gray-100;
+	}
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorConfig.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorConfig.ts
@@ -32,9 +32,16 @@ export default function getCKEditorConfig({
 	itemSelectorEventName: string;
 }) {
 	let config = initialConfig;
-	const toolbarItems = Array.isArray(config.toolbar)
-		? config.toolbar
-		: config.toolbar?.items;
+
+	const blockToolbarItems = Array.isArray(config.blockToolbar)
+		? config.blockToolbar
+		: config.blockToolbar?.items;
+
+	const extraPlugins = [];
+
+	if (blockToolbarItems?.includes('imageSelector')) {
+		extraPlugins.push(EmptyAltImagePlugin);
+	}
 
 	if (config.preset === 'advanced') {
 		config = {
@@ -61,16 +68,13 @@ export default function getCKEditorConfig({
 					'_EDITOR_NAME_',
 					editorName
 				),
-
 			itemSelectorEventName,
 		};
 	}
 
 	return {
 		...config,
-		...(toolbarItems?.includes('imageSelector') && {
-			extraPlugins: [EmptyAltImagePlugin],
-		}),
+		extraPlugins,
 		initialData,
 		name: editorName,
 	};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorConfig.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorConfig.ts
@@ -3,9 +3,14 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {LiferayEditorConfig, TEditor} from 'frontend-editor-ckeditor-web';
+import {
+	EEditorConfigPreset,
+	LiferayEditorConfig,
+	TEditor,
+} from 'frontend-editor-ckeditor-web';
 import {openSelectionModal} from 'frontend-js-components-web';
 
+import BlockButtonCustomization from './plugins/BlockButtonCustomization';
 import EmptyAltImagePlugin from './plugins/EmptyAltImagePlugin';
 
 export type EditorConfig = LiferayEditorConfig & {
@@ -39,11 +44,15 @@ export default function getCKEditorConfig({
 
 	const extraPlugins = [];
 
+	if (blockToolbarItems) {
+		extraPlugins.push(BlockButtonCustomization);
+	}
+
 	if (blockToolbarItems?.includes('imageSelector')) {
 		extraPlugins.push(EmptyAltImagePlugin);
 	}
 
-	if (config.preset === 'advanced') {
+	if (config.preset === EEditorConfigPreset.ADVANCED) {
 		config = {
 			...config,
 			documentBrowseLinkCallback: (editor, url, changeLinkCallback) => {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorConfig.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorConfig.ts
@@ -14,15 +14,13 @@ import BlockButtonCustomization from './plugins/BlockButtonCustomization';
 import EmptyAltImagePlugin from './plugins/EmptyAltImagePlugin';
 
 export type EditorConfig = LiferayEditorConfig & {
-	documentBrowseLinkCallback: (
+	documentBrowseLinkCallback?: (
 		editor: TEditor,
 		url: string,
 		changeLinkCallback: () => void
 	) => void;
-	documentBrowseLinkUrl: string;
-	editorTransformerURLs: string;
-	filebrowserImageBrowseLinkUrl: string;
-	filebrowserImageBrowseUrl: string;
+	documentBrowseLinkUrl?: string;
+	filebrowserImageBrowseLinkUrl?: string;
 };
 
 export default function getCKEditorConfig({
@@ -32,9 +30,9 @@ export default function getCKEditorConfig({
 	itemSelectorEventName,
 }: {
 	editorConfig: EditorConfig;
-	editorName: string;
+	editorName?: string;
 	initialData: string;
-	itemSelectorEventName: string;
+	itemSelectorEventName?: string;
 }) {
 	let config = initialConfig;
 
@@ -52,7 +50,7 @@ export default function getCKEditorConfig({
 		extraPlugins.push(EmptyAltImagePlugin);
 	}
 
-	if (config.preset === EEditorConfigPreset.ADVANCED) {
+	if (editorName && config.preset === EEditorConfigPreset.ADVANCED) {
 		config = {
 			...config,
 			documentBrowseLinkCallback: (editor, url, changeLinkCallback) => {
@@ -63,17 +61,17 @@ export default function getCKEditorConfig({
 					url,
 				});
 			},
-			documentBrowseLinkUrl: config.documentBrowseLinkUrl.replaceAll(
+			documentBrowseLinkUrl: config.documentBrowseLinkUrl?.replaceAll(
 				'_EDITOR_NAME_',
 				editorName
 			),
 			filebrowserImageBrowseLinkUrl:
-				config.filebrowserImageBrowseLinkUrl.replaceAll(
+				config.filebrowserImageBrowseLinkUrl?.replaceAll(
 					'_EDITOR_NAME_',
 					editorName
 				),
 			filebrowserImageBrowseUrl:
-				config.filebrowserImageBrowseUrl.replaceAll(
+				config.filebrowserImageBrowseUrl?.replaceAll(
 					'_EDITOR_NAME_',
 					editorName
 				),
@@ -83,8 +81,8 @@ export default function getCKEditorConfig({
 
 	return {
 		...config,
+		...(editorName && {name: editorName}),
 		extraPlugins,
 		initialData,
-		name: editorName,
-	};
+	} as LiferayEditorConfig;
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorProcessor.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getCKEditorProcessor.ts
@@ -127,15 +127,15 @@ export default function getCKEditorProcessor(
 			if (data.keyCode === KEYCODES.ESCAPE) {
 				onBlurEditor(state.editor);
 			}
-			else if (
-				data.keyCode === KEYCODES.ENTER ||
-				KEYCODES.ARROWS.includes(data.keyCode)
-			) {
+			else if (data.keyCode === KEYCODES.ENTER) {
 				data.stopPropagation();
 
 				if (editorType === 'text') {
 					data.preventDefault();
 				}
+			}
+			else if (KEYCODES.ARROWS.includes(data.keyCode)) {
+				data.stopPropagation();
 			}
 		};
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/plugins/BlockButtonCustomization.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/plugins/BlockButtonCustomization.ts
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {TEditor} from 'frontend-editor-ckeditor-web';
+
+export default function BlockButtonCustomization(editor: TEditor) {
+	let button: HTMLElement | null = null;
+
+	const setTitle = () => {
+		button!.dataset.ckeTooltipText = Liferay.Language.get('add');
+	};
+
+	editor.on('ready', () => {
+		button = document.querySelector('.ck-block-toolbar-button');
+
+		if (button) {
+			setTitle();
+
+			button.setAttribute('draggable', 'false');
+
+			const label = button.querySelector('.ck-button__label');
+
+			if (label) {
+				label.innerHTML = Liferay.Language.get('add');
+			}
+
+			// Set this event because opening and closing the toolbar with
+			// the button causes a re-render, which resets the title.
+
+			button.addEventListener('click', setTitle);
+		}
+	});
+
+	// Set this event because changes in the editor cause the button to
+	// re-render and lose its title.
+
+	editor.model.document.on('change:data', () => {
+		if (button) {
+			setTitle();
+		}
+	});
+
+	editor.on('destroy', () => {
+		button?.removeEventListener('click', setTitle);
+
+		editor.model.document.off('change:data', setTitle);
+	});
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/comments/components/CKEditor.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/comments/components/CKEditor.tsx
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {CKEditor5BalloonEditor} from 'frontend-editor-ckeditor-web';
+import React from 'react';
+
+import {config} from '../../../app/config/index';
+import getCKEditorConfig, {
+	EditorConfig,
+} from '../../../app/processors/getCKEditorConfig';
+
+export default function CKEditor({
+	initialData,
+	onChange,
+}: {
+	initialData: string;
+	onChange: (value: string) => void;
+}) {
+	const {editorConfig: initialConfig} =
+		config.defaultEditorConfigurations['comment'];
+
+	const editorConfig = {
+		...initialConfig,
+		label: Liferay.Language.get('add-comment'),
+		placeholder: Liferay.Language.get('type-your-comment-here'),
+	} as EditorConfig;
+
+	return (
+		<CKEditor5BalloonEditor
+			className="c-mb-3 form-control form-control-sm"
+			config={getCKEditorConfig({
+				editorConfig,
+				initialData,
+			})}
+			onChange={(event, editor) => onChange(editor.getData())}
+		/>
+	);
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/comments/components/CommentForm.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/comments/components/CommentForm.js
@@ -10,6 +10,7 @@ import React from 'react';
 import Button from '../../../common/components/Button';
 import Editor from '../../../common/components/Editor';
 import InvisibleFieldset from '../../../common/components/InvisibleFieldset';
+import CKEditor from './CKEditor';
 
 export default function CommentForm({
 	autoFocus = false,
@@ -26,19 +27,26 @@ export default function CommentForm({
 	return (
 		<form onFocus={onFormFocus}>
 			<InvisibleFieldset disabled={loading}>
-				<div className="form-group form-group-sm">
-					<Editor
-						autoFocus={autoFocus}
-						configurationName="comment"
-						id={id}
-						initialValue={textareaContent}
-						label={Liferay.Language.get('add-comment')}
+				{Liferay.FeatureFlags['LPD-11235'] ? (
+					<CKEditor
+						initialData={textareaContent}
 						onChange={onTextareaChange}
-						placeholder={Liferay.Language.get(
-							'type-your-comment-here'
-						)}
 					/>
-				</div>
+				) : (
+					<div className="form-group form-group-sm">
+						<Editor
+							autoFocus={autoFocus}
+							configurationName="comment"
+							id={id}
+							initialValue={textareaContent}
+							label={Liferay.Language.get('add-comment')}
+							onChange={onTextareaChange}
+							placeholder={Liferay.Language.get(
+								'type-your-comment-here'
+							)}
+						/>
+					</div>
+				)}
 
 				{showButtons && (
 					<ClayButton.Group className="mb-3" spaced>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/comments/components/_FragmentComment.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/comments/components/_FragmentComment.scss
@@ -25,6 +25,12 @@
 	}
 }
 
+@mixin ckeditor-paragraph-margin {
+	.lfr-ck p {
+		margin-bottom: 0;
+	}
+}
+
 html#{$cadmin-selector} {
 	.cadmin {
 		.page-editor__fragment-comment {
@@ -102,6 +108,16 @@ html#{$cadmin-selector} {
 
 			&__form {
 				border-bottom: 1px solid $cadmin-gray-300;
+
+				.form-control {
+					&:has(> .ck-focused) {
+						background-color: $input-focus-bg;
+						border-color: $input-focus-border-color;
+						box-shadow: $input-focus-box-shadow;
+					}
+				}
+
+				@include ckeditor-paragraph-margin();
 			}
 
 			.content {
@@ -112,6 +128,8 @@ html#{$cadmin-selector} {
 					margin-bottom: 0;
 				}
 			}
+
+			@include ckeditor-paragraph-margin();
 		}
 	}
 }

--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/drag_preview/DragPreview.tsx
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/drag_preview/DragPreview.tsx
@@ -11,6 +11,8 @@ import './DragPreview.scss';
 
 import {debounce} from 'frontend-js-web';
 
+import isNullOrUndefined from '../../utils/isNullOrUndefined';
+
 type Alignment = {
 	element: HTMLElement;
 	position: 'bottom' | 'middle' | 'top';
@@ -164,9 +166,14 @@ export default function DragPreview<T extends DragItem>({
 		};
 	});
 
-	// Return if no movement is enabled
+	// CKEditor allows you to drag text within the editor, so the drag preview
+	// should not appear in this case.
 
-	if ((!isDragging && !alignment) || (!icon && !label)) {
+	const isCKEditorText = !isNullOrUndefined(item) && 'text' in item;
+
+	// Return if no movement is enabled or the selected element is text
+
+	if ((!isDragging && !alignment) || (!icon && !label) || isCKEditorText) {
 		return null;
 	}
 

--- a/modules/node-scripts.config.js
+++ b/modules/node-scripts.config.js
@@ -431,6 +431,7 @@ module.exports = {
 			'Alignment',
 			'BalloonEditor',
 			'BlockQuote',
+			'BlockToolbar',
 			'Bold',
 			'ButtonView',
 			'ClassicEditor',

--- a/modules/node-scripts.config.js
+++ b/modules/node-scripts.config.js
@@ -10,7 +10,7 @@
  */
 
 module.exports = {
-	hash: '133910df067de36aee16a4739f83f0a06b83511d939ecb371862ab083467f0a5',
+	hash: 'cac6b8ea804d21118a3e2177c78eb5f99eebaa49455dc1992c173ebfdf65f2b3',
 	imports: {
 		'@liferay/accessibility-menu-web': [],
 		'@liferay/accessibility-settings-state-web': [],

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/editables.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/editables.spec.ts
@@ -514,3 +514,91 @@ test(
 		);
 	}
 );
+
+test(
+	'Check the keyboard interactions inside the editor and the blur behavior',
+	{
+		tag: '@LPD-56399',
+	},
+	async ({apiHelpers, page, pageEditorPage, site}) => {
+
+		// Create a page with a Paragraph and Heading fragments
+
+		const headingId = getRandomString();
+		const headingDefinition = getFragmentDefinition({
+			id: headingId,
+			key: 'BASIC_COMPONENT-heading',
+		});
+
+		const paragraphId = getRandomString();
+		const paragraphDefinition = getFragmentDefinition({
+			id: paragraphId,
+			key: 'BASIC_COMPONENT-paragraph',
+		});
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				headingDefinition,
+				paragraphDefinition,
+			]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		// Pressing the key introduces line breaks and the escape key destroys
+		// the editor for a rich text editable
+
+		await pageEditorPage.selectEditable(paragraphId, 'element-text');
+
+		const richTexteditable = pageEditorPage.getEditable({
+			editableId: 'element-text',
+			fragmentId: paragraphId,
+		});
+
+		await expect(richTexteditable.locator('p')).toHaveCount(0);
+
+		await richTexteditable.click();
+
+		let editor = richTexteditable.locator('[contenteditable="true"]');
+
+		await editor.click();
+
+		await page.keyboard.press('Enter');
+		await page.keyboard.press('Enter');
+		await page.keyboard.press('Escape');
+
+		await expect(editor).not.toBeAttached();
+
+		await expect(page.locator('.component-paragraph p')).toHaveCount(3);
+
+		// Pressing the key does not introduce line breaks and clicking outside
+		// the editor destroys the editor for a text editable
+
+		await pageEditorPage.selectEditable(headingId, 'element-text');
+
+		const texteditable = pageEditorPage.getEditable({
+			editableId: 'element-text',
+			fragmentId: headingId,
+		});
+
+		await expect(texteditable.locator('p')).toHaveCount(0);
+
+		await texteditable.click();
+
+		editor = texteditable.locator('[contenteditable="true"]');
+
+		await editor.click();
+
+		await page.keyboard.press('Enter');
+		await page.keyboard.press('Enter');
+		await page
+			.locator('header.page-editor__disabled-area')
+			.click({force: true});
+
+		await expect(editor).not.toBeAttached();
+
+		await expect(page.locator('.component-heading p')).toHaveCount(0);
+	}
+);

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/editables.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/editables.spec.ts
@@ -10,10 +10,12 @@ import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
+import {pageManagementSiteTest} from '../../../fixtures/pageManagementSiteTest';
 import {clickAndExpectToBeHidden} from '../../../utils/clickAndExpectToBeHidden';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../../utils/getRandomString';
 import getBasicWebContentStructureId from '../../../utils/structured-content/getBasicWebContentStructureId';
+import chooseFileFromDocumentLibrary from './utils/chooseFileFromDocumentLibrary';
 import getFragmentDefinition from './utils/getFragmentDefinition';
 import getPageDefinition from './utils/getPageDefinition';
 
@@ -25,7 +27,8 @@ const test = mergeTests(
 	}),
 	isolatedSiteTest,
 	loginTest(),
-	pageEditorPagesTest
+	pageEditorPagesTest,
+	pageManagementSiteTest
 );
 
 const testWithCKEditor4 = mergeTests(
@@ -359,5 +362,70 @@ test(
 		});
 
 		await expect(page.getByText('2 Items Selected')).toBeVisible();
+	}
+);
+
+test(
+	'Add an image to an editable and check that by default the image has the alt attribute empty',
+	{
+		tag: '@LPD-56399',
+	},
+	async ({apiHelpers, page, pageEditorPage, pageManagementSite}) => {
+
+		// Create a page with a Paragraph fragment
+
+		const paragraphId = getRandomString();
+		const paragraphDefinition = getFragmentDefinition({
+			id: paragraphId,
+			key: 'BASIC_COMPONENT-paragraph',
+		});
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([paragraphDefinition]),
+			siteId: pageManagementSite.id,
+			title: getRandomString(),
+		});
+
+		// Go to edit mode and add an image inside the paragraph
+
+		await pageEditorPage.goto(layout, pageManagementSite.friendlyUrlPath);
+
+		await pageEditorPage.selectEditable(paragraphId, 'element-text');
+
+		const editable = pageEditorPage.getEditable({
+			editableId: 'element-text',
+			fragmentId: paragraphId,
+		});
+
+		await editable.click();
+
+		await editable.locator('[contenteditable="true"]').click();
+
+		const blockToolbarButton = page.locator('.ck-block-toolbar-button', {
+			hasText: 'Add',
+		});
+
+		await blockToolbarButton.waitFor();
+
+		await expect(blockToolbarButton).toHaveAttribute('draggable', 'false');
+
+		await blockToolbarButton.click();
+
+		const blockToolbar = page.locator('.ck-toolbar');
+
+		await blockToolbar.waitFor();
+
+		await chooseFileFromDocumentLibrary({
+			fileName: 'balinese.jpg',
+			page,
+			trigger: blockToolbar.getByLabel('Image', {exact: true}),
+			type: 'image',
+		});
+
+		// Check that the image has an empty alt
+
+		const image = page.locator('.component-paragraph img');
+
+		await expect(image).toHaveAttribute('alt', '');
 	}
 );

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/editables.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/editables.spec.ts
@@ -13,6 +13,7 @@ import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
 import {pageManagementSiteTest} from '../../../fixtures/pageManagementSiteTest';
 import {clickAndExpectToBeHidden} from '../../../utils/clickAndExpectToBeHidden';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
+import dragAndDropElement from '../../../utils/dragAndDropElement';
 import getRandomString from '../../../utils/getRandomString';
 import getBasicWebContentStructureId from '../../../utils/structured-content/getBasicWebContentStructureId';
 import chooseFileFromDocumentLibrary from './utils/chooseFileFromDocumentLibrary';
@@ -600,5 +601,87 @@ test(
 		await expect(editor).not.toBeAttached();
 
 		await expect(page.locator('.component-heading p')).toHaveCount(0);
+	}
+);
+
+test(
+	'Prevent the drag preview from appearing when dragging text inside the editor',
+	{
+		tag: '@LPD-56399',
+	},
+	async ({apiHelpers, page, pageEditorPage, site}) => {
+
+		// Create a page with a Paragraph fragment and select it
+
+		const html =
+			'<p><strong>List:</strong></p><ul><li><a href="option1Link">option1</a></li><li>option2</li><li>option3</li></ul>';
+
+		const paragraphId = getRandomString();
+		const paragraphDefinition = getFragmentDefinition({
+			fragmentFields: [
+				{
+					id: 'element-text',
+					value: {
+						fragmentLink: {},
+						text: {
+							value_i18n: {
+								en_US: html,
+							},
+						},
+					},
+				},
+			],
+			id: paragraphId,
+			key: 'BASIC_COMPONENT-paragraph',
+		});
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([paragraphDefinition]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.selectEditable(paragraphId, 'element-text');
+
+		const editable = pageEditorPage.getEditable({
+			editableId: 'element-text',
+			fragmentId: paragraphId,
+		});
+
+		// Edit the editable
+
+		await editable.click();
+
+		const editor = editable.locator('[contenteditable="true"]');
+
+		await editor.waitFor();
+
+		await editor.click();
+
+		const paragraphFragment = page.locator('.component-paragraph');
+
+		await expect(paragraphFragment).toHaveText(
+			'List:option1option2option3'
+		);
+
+		// Drag the selected text
+
+		await page.getByText('option1').selectText();
+
+		await dragAndDropElement({
+			dragTarget: page.getByText('option1'),
+			dropTarget: page.getByText('option3'),
+			onDragging: () =>
+				expect(page.locator('.drag-preview')).not.toBeAttached(),
+			page,
+		});
+
+		// Check that the text has been dragged
+
+		await expect(paragraphFragment).toHaveText(
+			'List:option2option1⁠⁠⁠⁠⁠⁠⁠option3'
+		);
 	}
 );

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/editables.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/editables.spec.ts
@@ -176,7 +176,9 @@ test(
 
 		// Check toolbar appears
 
-		const toolbar = page.locator('.ck-toolbar');
+		const toolbar = page.locator('.ck-toolbar', {
+			hasText: 'Text alignment',
+		});
 
 		await toolbar.waitFor();
 

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/editables.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/editables.spec.ts
@@ -429,3 +429,88 @@ test(
 		await expect(image).toHaveAttribute('alt', '');
 	}
 );
+
+test(
+	'A rich text editable accepts rich text, while a text editable does not',
+	{
+		tag: '@LPD-56399',
+	},
+	async ({apiHelpers, page, pageEditorPage, site}) => {
+
+		// Create a page with a Paragraph and Heading fragments with html
+
+		const html =
+			'<p><strong>List:</strong></p><ul><li><a href="option1Link">option1</a></li><li>option2</li><li>option3</li></ul>';
+
+		const headingId = getRandomString();
+		const headingDefinition = getFragmentDefinition({
+			fragmentFields: [
+				{
+					id: 'element-text',
+					value: {
+						fragmentLink: {},
+						text: {
+							value_i18n: {
+								en_US: html,
+							},
+						},
+					},
+				},
+			],
+			id: headingId,
+			key: 'BASIC_COMPONENT-heading',
+		});
+
+		const paragraphId = getRandomString();
+		const paragraphDefinition = getFragmentDefinition({
+			fragmentFields: [
+				{
+					id: 'element-text',
+					value: {
+						fragmentLink: {},
+						text: {
+							value_i18n: {
+								en_US: html,
+							},
+						},
+					},
+				},
+			],
+			id: paragraphId,
+			key: 'BASIC_COMPONENT-paragraph',
+		});
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				headingDefinition,
+				paragraphDefinition,
+			]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		// Go to edit mode and check the html in each fragment
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		const paragraphFragment = page.locator('.component-paragraph');
+
+		await paragraphFragment.waitFor();
+
+		await expect(paragraphFragment.locator('a')).toBeAttached();
+		await expect(paragraphFragment.locator('ul')).toBeAttached();
+		await expect(paragraphFragment.locator('li')).toHaveCount(3);
+		await expect(paragraphFragment).toContainText(
+			'List:option1option2option3'
+		);
+
+		const headingFragment = page.locator('.component-heading');
+
+		await expect(headingFragment.locator('a')).not.toBeAttached();
+		await expect(headingFragment.locator('ul')).not.toBeAttached();
+		await expect(headingFragment.locator('li')).toHaveCount(0);
+		await expect(headingFragment).toContainText(
+			'List:option1option2option3'
+		);
+	}
+);

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/formContainer.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/formContainer.spec.ts
@@ -7548,7 +7548,9 @@ test.describe('Rich Text Fragment', () => {
 
 			await page.getByText('student description').selectText();
 
-			const toolbar = page.locator('.ck-toolbar');
+			const toolbar = page.locator('.ck-toolbar', {
+				hasText: 'Text alignment',
+			});
 
 			await toolbar.waitFor();
 

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/formContainer.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/formContainer.spec.ts
@@ -32,6 +32,7 @@ import getRandomString from '../../../utils/getRandomString';
 import {waitForAlert} from '../../../utils/waitForAlert';
 import {getObjectERC} from '../../setup/page-management-site/main/utils/getObjectERC';
 import {goToObjectEntity} from '../../setup/page-management-site/main/utils/goToObjectEntity';
+import chooseFileFromDocumentLibrary from './utils/chooseFileFromDocumentLibrary';
 import getContainerDefinition from './utils/getContainerDefinition';
 import getFormContainerDefinition from './utils/getFormContainerDefinition';
 import getFragmentDefinition from './utils/getFragmentDefinition';
@@ -10698,30 +10699,6 @@ test(
 		).not.toBeVisible();
 	}
 );
-
-async function chooseFileFromDocumentLibrary({
-	fileName,
-	page,
-	trigger,
-}: {
-	fileName: string;
-	page: Page;
-	trigger: Locator;
-}) {
-	const iframe = page.frameLocator('iframe');
-
-	await clickAndExpectToBeVisible({
-		target: iframe.getByText('Drag & Drop Your Files or Browse to Upload'),
-		timeout: 2000,
-		trigger,
-	});
-
-	await clickAndExpectToBeHidden({
-		target: iframe.getByText(fileName),
-		timeout: 2000,
-		trigger: iframe.locator('.card', {hasText: fileName}).locator('img'),
-	});
-}
 
 test.describe('URL Video Previewer Fragment', () => {
 	test(

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/fragments.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/fragments.spec.ts
@@ -1837,7 +1837,9 @@ test.describe('Paragraph Fragment', () => {
 
 			await page.keyboard.press('ControlOrMeta+KeyA');
 
-			const toolbar = page.locator('.ck-toolbar');
+			const toolbar = page.locator('.ck-toolbar', {
+				hasText: 'Text alignment',
+			});
 
 			await toolbar.waitFor();
 

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/sidebar.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/sidebar.spec.ts
@@ -2593,6 +2593,51 @@ test.describe('Rules Panel', () => {
 	});
 });
 
+test.describe('Comments Panel', () => {
+	test('Prevent fragment deletion by pressing the Backspace key while editing a comment', async ({
+		apiHelpers,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+
+		// Create content page with a Heading fragment and go to edit mode
+
+		const headingId = getRandomString();
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				getFragmentDefinition({
+					id: headingId,
+					key: 'BASIC_COMPONENT-heading',
+				}),
+			]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		// Add a comment to the heading fragment
+
+		await pageEditorPage.selectFragment(headingId);
+
+		await pageEditorPage.goToSidebarTab('Comments');
+
+		const editor = page.getByLabel('Add Comment');
+
+		await editor.click();
+
+		await page.keyboard.type('This is my commentt');
+
+		// Pres the Backspace key to remove
+
+		await page.keyboard.press('Backspace');
+
+		await expect(editor).toHaveText('This is my comment');
+	});
+});
+
 test(
 	'Check the resize sidebar limits',
 	{tag: ['@LPS-153383']},

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/utils/chooseFileFromDocumentLibrary.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/utils/chooseFileFromDocumentLibrary.ts
@@ -1,0 +1,37 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {clickAndExpectToBeHidden} from '../../../../utils/clickAndExpectToBeHidden';
+import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
+
+export default async function chooseFileFromDocumentLibrary({
+	fileName,
+	page,
+	trigger,
+	type = 'file',
+}: {
+	fileName: string;
+	page: Page;
+	trigger: Locator;
+	type?: 'file' | 'image';
+}) {
+	const iframe = page.frameLocator('iframe');
+
+	await clickAndExpectToBeVisible({
+		target: iframe.getByText(
+			`Drag & Drop Your ${type === 'file' ? 'Files' : 'Images'} or Browse to Upload`
+		),
+		timeout: 2000,
+		trigger,
+	});
+
+	await clickAndExpectToBeHidden({
+		target: iframe.getByText(fileName),
+		timeout: 2000,
+		trigger: iframe.locator('.card', {hasText: fileName}).locator('img'),
+	});
+}

--- a/modules/test/playwright/utils/dragAndDropElement.ts
+++ b/modules/test/playwright/utils/dragAndDropElement.ts
@@ -9,11 +9,13 @@ export default async function dragAndDropElement({
 	dragTarget,
 	dropTarget,
 	force = false,
+	onDragging,
 	page,
 }: {
 	dragTarget: Locator;
 	dropTarget: Locator;
 	force?: boolean;
+	onDragging?: () => Promise<void>;
 	page: Page;
 }) {
 	await dragTarget.hover({force});
@@ -33,6 +35,8 @@ export default async function dragAndDropElement({
 			y: boundingClientRect.height / 2,
 		},
 	});
+
+	await onDragging?.();
 
 	await page.mouse.up();
 }


### PR DESCRIPTION
Review only the commits with the [LPD-57772](https://github.com/veroglez/liferay-portal/tree/LPD-57772)

[LPD-57772]: https://liferay.atlassian.net/browse/LPD-57772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ





To review for @liferay-frontend:
- https://github.com/liferay-page-management/liferay-portal/pull/17339/commits/f1e5e99bea64ea472a0bd1f1eeb9d7b76446f5d6: Take extra plugins into account when loading the client extension, just like we take plugins into account.
- https://github.com/liferay-page-management/liferay-portal/pull/17339/commits/3c004c08a3f58a01ec449caaef66e2150f579c03: A new plugin has been added to the [block toolbar](https://ckeditor.com/docs/ckeditor5/latest/getting-started/setup/toolbar.html#block-toolbar), since we use it in the page editor. <img width="300" alt="Screenshot 2025-06-16 at 16 24 59" src="https://github.com/user-attachments/assets/7f517b1b-1df7-4761-9c8d-37fff8338396" />

