### PR TITLE
LPD-59351 Use layout plid when checking for permissions

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/struts/UpdateLayoutStrutsAction.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/struts/UpdateLayoutStrutsAction.java
@@ -103,7 +103,7 @@ public class UpdateLayoutStrutsAction implements StrutsAction {
 				throw new IllegalArgumentException("Portlet ID is null");
 			}
 
-			_checkPortletPermission(portletId, themeDisplay);
+			_checkPortletPermission(portletId, themeDisplay, layout.getPlid());
 
 			String columnId = ParamUtil.getString(
 				httpServletRequest, "p_p_col_id", null);
@@ -397,11 +397,11 @@ public class UpdateLayoutStrutsAction implements StrutsAction {
 	}
 
 	private void _checkPortletPermission(
-			String portletId, ThemeDisplay themeDisplay)
+			String portletId, ThemeDisplay themeDisplay, long plid)
 		throws Exception {
 
 		PortletPermissionUtil.check(
-			themeDisplay.getPermissionChecker(), portletId,
+			themeDisplay.getPermissionChecker(), plid, portletId,
 			ActionKeys.ADD_TO_PAGE);
 
 		LayoutTypePortlet layoutTypePortlet =

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/struts/test/UpdateLayoutStrutsActionTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/struts/test/UpdateLayoutStrutsActionTest.java
@@ -15,19 +15,28 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.struts.StrutsAction;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -79,7 +88,7 @@ public class UpdateLayoutStrutsActionTest {
 	@TestInfo("LPD-49304")
 	public void testExecute() throws Exception {
 		MockHttpServletRequest mockHttpServletRequest =
-			_getMockHttpServletRequest();
+			_getMockHttpServletRequest(TestPropsValues.getUser());
 		MockHttpServletResponse mockHttpServletResponse =
 			new MockHttpServletResponse();
 
@@ -152,7 +161,7 @@ public class UpdateLayoutStrutsActionTest {
 
 		try {
 			MockHttpServletRequest mockHttpServletRequest =
-				_getMockHttpServletRequest();
+				_getMockHttpServletRequest(TestPropsValues.getUser());
 			MockHttpServletResponse mockHttpServletResponse =
 				new MockHttpServletResponse();
 
@@ -178,7 +187,48 @@ public class UpdateLayoutStrutsActionTest {
 		}
 	}
 
-	private MockHttpServletRequest _getMockHttpServletRequest()
+	@Test
+	@TestInfo("LPD-59351")
+	public void testExecuteWithScopedSitePermissions() throws Exception {
+		User user = UserTestUtil.addUser();
+
+		Role testRole = RoleTestUtil.addRole(
+			"testRole", RoleConstants.TYPE_SITE);
+
+		RoleTestUtil.addResourcePermission(
+			testRole.getName(), _ALLOWED_PORTLET_IDS[0],
+			ResourceConstants.SCOPE_GROUP, String.valueOf(_group.getGroupId()),
+			ActionKeys.ADD_TO_PAGE);
+
+		_roleLocalService.addUserRole(user.getUserId(), testRole);
+
+		Role userRole = _roleLocalService.getRole(
+			_group.getCompanyId(), RoleConstants.USER);
+
+		_revokeAssetPublisherResourcePermissions(userRole);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			_getMockHttpServletRequest(user);
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		try {
+			mockHttpServletRequest.setParameter(
+				"p_p_id", _ALLOWED_PORTLET_IDS[0]);
+
+			_updateLayoutStrutsAction.execute(
+				mockHttpServletRequest, mockHttpServletResponse);
+		}
+		catch (Exception exception) {
+			throw new Exception(exception);
+		}
+		finally {
+			_restoreAssetPublisherResourcePermissions(userRole);
+		}
+	}
+
+	private MockHttpServletRequest _getMockHttpServletRequest(User user)
 		throws Exception {
 
 		MockHttpServletRequest mockHttpServletRequest =
@@ -190,8 +240,10 @@ public class UpdateLayoutStrutsActionTest {
 			_companyLocalService.getCompany(_group.getCompanyId()), _group,
 			_layout);
 
+		themeDisplay.setUser(user);
+
 		themeDisplay.setPermissionChecker(
-			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
+			PermissionCheckerFactoryUtil.create(user));
 
 		mockHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);
@@ -199,6 +251,35 @@ public class UpdateLayoutStrutsActionTest {
 		mockHttpServletRequest.setParameter(Constants.CMD, Constants.ADD);
 
 		return mockHttpServletRequest;
+	}
+
+	private void _restoreAssetPublisherResourcePermissions(Role role)
+		throws Exception {
+
+		_resourcePermissionService.addResourcePermission(
+			TestPropsValues.getGroupId(), TestPropsValues.getCompanyId(),
+			_ALLOWED_PORTLET_IDS[0], ResourceConstants.SCOPE_COMPANY,
+			String.valueOf(role.getCompanyId()), role.getRoleId(),
+			ActionKeys.ADD_TO_PAGE);
+	}
+
+	private void _revokeAssetPublisherResourcePermissions(Role role)
+		throws Exception {
+
+		_resourcePermissionService.removeResourcePermissions(
+			TestPropsValues.getGroupId(), TestPropsValues.getCompanyId(),
+			_ALLOWED_PORTLET_IDS[0], ResourceConstants.SCOPE_COMPANY,
+			role.getRoleId(), ActionKeys.ADD_TO_PAGE);
+
+		_resourcePermissionService.removeResourcePermissions(
+			TestPropsValues.getGroupId(), TestPropsValues.getCompanyId(),
+			_ALLOWED_PORTLET_IDS[0], ResourceConstants.SCOPE_GROUP_TEMPLATE,
+			role.getRoleId(), ActionKeys.ADD_TO_PAGE);
+
+		_resourcePermissionService.removeResourcePermissions(
+			TestPropsValues.getGroupId(), TestPropsValues.getCompanyId(),
+			_ALLOWED_PORTLET_IDS[0], ResourceConstants.SCOPE_GROUP,
+			role.getRoleId(), ActionKeys.ADD_TO_PAGE);
 	}
 
 	private static final String[] _ALLOWED_PORTLET_IDS = {
@@ -239,6 +320,12 @@ public class UpdateLayoutStrutsActionTest {
 
 	@Inject
 	private PortletPreferencesLocalService _portletPreferencesLocalService;
+
+	@Inject
+	private ResourcePermissionService _resourcePermissionService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
 
 	@Inject(filter = "path=/portal/update_layout")
 	private StrutsAction _updateLayoutStrutsAction;


### PR DESCRIPTION
Issue:
When the User Role has Asset Publisher:Add to Page permission revoked and a Site Role with the appropriate permissions to allow the user to add to the page, the permission check fails.

Proposed Solution:
Use the layout in the permission check so that the site role is used in the check.