### PR TITLE
LPD-57728 Fragment set Imported can be exported after installing fragments from markeplace

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentCollectionStagedModelDataHandler.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentCollectionStagedModelDataHandler.java
@@ -62,6 +62,10 @@ public class FragmentCollectionStagedModelDataHandler
 			FragmentCollection fragmentCollection)
 		throws Exception {
 
+		if (fragmentCollection.isMarketplace()) {
+			return;
+		}
+
 		Element fragmentCollectionElement =
 			portletDataContext.getExportDataElement(fragmentCollection);
 

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentCollectionStagedModelDataHandler.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentCollectionStagedModelDataHandler.java
@@ -7,6 +7,7 @@ package com.liferay.fragment.internal.exportimport.data.handler;
 
 import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
@@ -62,7 +63,9 @@ public class FragmentCollectionStagedModelDataHandler
 			FragmentCollection fragmentCollection)
 		throws Exception {
 
-		if (fragmentCollection.isMarketplace()) {
+		if (fragmentCollection.isMarketplace() &&
+			!ExportImportThreadLocal.isStagingInProcess()) {
+
 			return;
 		}
 

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentEntryStagedModelDataHandler.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentEntryStagedModelDataHandler.java
@@ -8,6 +8,7 @@ package com.liferay.fragment.internal.exportimport.data.handler;
 import com.liferay.exportimport.content.processor.ExportImportContentProcessor;
 import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
@@ -69,7 +70,9 @@ public class FragmentEntryStagedModelDataHandler
 			PortletDataContext portletDataContext, FragmentEntry fragmentEntry)
 		throws Exception {
 
-		if (fragmentEntry.isMarketplace()) {
+		if (fragmentEntry.isMarketplace() &&
+			!ExportImportThreadLocal.isStagingInProcess()) {
+
 			return;
 		}
 

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentEntryStagedModelDataHandler.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentEntryStagedModelDataHandler.java
@@ -69,6 +69,10 @@ public class FragmentEntryStagedModelDataHandler
 			PortletDataContext portletDataContext, FragmentEntry fragmentEntry)
 		throws Exception {
 
+		if (fragmentEntry.isMarketplace()) {
+			return;
+		}
+
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.fetchFragmentCollection(
 				fragmentEntry.getFragmentCollectionId());

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionImpl.java
@@ -171,6 +171,10 @@ public class FragmentCollectionImpl extends FragmentCollectionBaseImpl {
 				getFragmentCollectionId());
 
 		for (FragmentComposition fragmentComposition : fragmentCompositions) {
+			if (fragmentComposition.isMarketplace()) {
+				continue;
+			}
+
 			fragmentComposition.populateZipWriter(
 				zipWriter, path + "/fragment-compositions");
 		}
@@ -181,7 +185,7 @@ public class FragmentCollectionImpl extends FragmentCollectionBaseImpl {
 				QueryUtil.ALL_POS);
 
 		for (FragmentEntry fragmentEntry : fragmentEntries) {
-			if (fragmentEntry.isTypeReact()) {
+			if (fragmentEntry.isTypeReact() || fragmentEntry.isMarketplace()) {
 				continue;
 			}
 

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentEntryImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentEntryImpl.java
@@ -174,6 +174,10 @@ public class FragmentEntryImpl extends FragmentEntryBaseImpl {
 	public void populateZipWriter(ZipWriter zipWriter, String path)
 		throws Exception {
 
+		if (isTypeReact() || isMarketplace()) {
+			return;
+		}
+
 		path = path + StringPool.SLASH + getFragmentEntryKey();
 
 		JSONObject jsonObject = JSONUtil.put(

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/exportimport/test/FragmentExportImportTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/exportimport/test/FragmentExportImportTest.java
@@ -182,6 +182,30 @@ public class FragmentExportImportTest extends BasePortletExportImportTestCase {
 	}
 
 	@Test
+	@TestInfo("LPD-57728")
+	public void testExportImportMarketplaceFragments() throws Exception {
+		FragmentCollection fragmentCollection =
+			_fragmentCollectionLocalService.addFragmentCollection(
+				null, TestPropsValues.getUserId(),
+				_serviceContext.getScopeGroupId(), null,
+				RandomTestUtil.randomString(), StringPool.BLANK, false,
+				_serviceContext);
+
+		_addFragmentEntry(fragmentCollection, false, _serviceContext);
+
+		_addFragmentEntry(fragmentCollection, true, _serviceContext);
+
+		exportImportPortlet(FragmentPortletKeys.FRAGMENT, false);
+
+		List<FragmentEntry> fragmentEntries =
+			_fragmentEntryLocalService.getFragmentEntries(
+				fragmentCollection.getFragmentCollectionId());
+
+		Assert.assertEquals(
+			fragmentEntries.toString(), 1, fragmentEntries.size());
+	}
+
+	@Test
 	public void testImportUpdateFragmentEntryWithPropagationEnabled()
 		throws Exception {
 

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/exportimport/test/FragmentExportImportTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/exportimport/test/FragmentExportImportTest.java
@@ -108,6 +108,18 @@ public class FragmentExportImportTest extends BasePortletExportImportTestCase {
 					"label", "Configuration"
 				))
 		).toString();
+
+		_group = GroupTestUtil.addGroup();
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_group, TestPropsValues.getUserId());
+
+		_fragmentCollection =
+			_fragmentCollectionLocalService.addFragmentCollection(
+				null, TestPropsValues.getUserId(),
+				_serviceContext.getScopeGroupId(), null,
+				RandomTestUtil.randomString(), StringPool.BLANK, false,
+				_serviceContext);
 	}
 
 	@Override
@@ -136,13 +148,8 @@ public class FragmentExportImportTest extends BasePortletExportImportTestCase {
 							"propagateChanges", true
 						).build())) {
 
-			Group group = GroupTestUtil.addGroup();
-
-			ServiceContext serviceContext =
-				ServiceContextTestUtil.getServiceContext(
-					group, TestPropsValues.getUserId());
-
-			FragmentEntry fragmentEntry = _addFragmentEntry(serviceContext);
+			FragmentEntry fragmentEntry = _addFragmentEntry(
+				_fragmentCollection, false, _serviceContext);
 
 			try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 					"com.liferay.exportimport.internal.lifecycle." +
@@ -150,15 +157,15 @@ public class FragmentExportImportTest extends BasePortletExportImportTestCase {
 					LoggerTestUtil.ERROR)) {
 
 				_stagingLocalService.enableLocalStaging(
-					TestPropsValues.getUserId(), group, false, false,
-					serviceContext);
+					TestPropsValues.getUserId(), _group, false, false,
+					_serviceContext);
 
 				List<LogEntry> logEntries = logCapture.getLogEntries();
 
 				Assert.assertTrue(logEntries.toString(), logEntries.isEmpty());
 			}
 
-			Group stagingGroup = group.getStagingGroup();
+			Group stagingGroup = _group.getStagingGroup();
 
 			FragmentEntry importedGroupFragmentEntry =
 				_fragmentEntryLocalService.getFragmentEntryByUuidAndGroupId(
@@ -189,9 +196,19 @@ public class FragmentExportImportTest extends BasePortletExportImportTestCase {
 							"propagateChanges", true
 						).build())) {
 
-			FragmentEntry fragmentEntry = _addFragmentEntry(
+			ServiceContext serviceContext =
 				ServiceContextTestUtil.getServiceContext(
-					group, TestPropsValues.getUserId()));
+					group, TestPropsValues.getUserId());
+
+			FragmentCollection fragmentCollection =
+				_fragmentCollectionLocalService.addFragmentCollection(
+					null, TestPropsValues.getUserId(),
+					serviceContext.getScopeGroupId(),
+					RandomTestUtil.randomString(), StringPool.BLANK,
+					serviceContext);
+
+			FragmentEntry fragmentEntry = _addFragmentEntry(
+				fragmentCollection, false, serviceContext);
 
 			exportImportPortlet(FragmentPortletKeys.FRAGMENT, false);
 
@@ -262,21 +279,17 @@ public class FragmentExportImportTest extends BasePortletExportImportTestCase {
 		}
 	}
 
-	private FragmentEntry _addFragmentEntry(ServiceContext serviceContext)
+	private FragmentEntry _addFragmentEntry(
+			FragmentCollection fragmentCollection, boolean marketplace,
+			ServiceContext serviceContext)
 		throws Exception {
-
-		FragmentCollection fragmentCollection =
-			_fragmentCollectionLocalService.addFragmentCollection(
-				null, TestPropsValues.getUserId(),
-				serviceContext.getScopeGroupId(), RandomTestUtil.randomString(),
-				StringPool.BLANK, serviceContext);
 
 		return _fragmentEntryLocalService.addFragmentEntry(
 			null, TestPropsValues.getUserId(), serviceContext.getScopeGroupId(),
 			fragmentCollection.getFragmentCollectionId(), null,
 			RandomTestUtil.randomString(), StringPool.BLANK,
 			"Original HTML Fragment" + _HTML, StringPool.BLANK, false,
-			_configuration, null, 0, false, false,
+			_configuration, null, 0, marketplace, false,
 			FragmentConstants.TYPE_COMPONENT, null,
 			WorkflowConstants.STATUS_APPROVED, serviceContext);
 	}
@@ -326,9 +339,14 @@ public class FragmentExportImportTest extends BasePortletExportImportTestCase {
 		"data-lfr-priority=\"${i+1}\"></lfr-drop-zone>\n", "</div>\n[/#list]");
 
 	private static String _configuration;
+	private static FragmentCollection _fragmentCollection;
 
 	@Inject
-	private FragmentCollectionLocalService _fragmentCollectionLocalService;
+	private static FragmentCollectionLocalService
+		_fragmentCollectionLocalService;
+
+	private static Group _group;
+	private static ServiceContext _serviceContext;
 
 	@Inject
 	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/exportimport/test/FragmentExportImportTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/exportimport/test/FragmentExportImportTest.java
@@ -200,9 +200,14 @@ public class FragmentExportImportTest extends BasePortletExportImportTestCase {
 
 		exportImportPortlet(FragmentPortletKeys.FRAGMENT, false);
 
+		FragmentCollection importedFragmentCollection =
+			_fragmentCollectionLocalService.
+				getFragmentCollectionByUuidAndGroupId(
+					fragmentCollection.getUuid(), importedGroup.getGroupId());
+
 		List<FragmentEntry> fragmentEntries =
 			_fragmentEntryLocalService.getFragmentEntries(
-				fragmentCollection.getFragmentCollectionId());
+				importedFragmentCollection.getFragmentCollectionId());
 
 		Assert.assertEquals(
 			fragmentEntries.toString(), 1, fragmentEntries.size());

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/exportimport/test/FragmentExportImportTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/exportimport/test/FragmentExportImportTest.java
@@ -184,16 +184,19 @@ public class FragmentExportImportTest extends BasePortletExportImportTestCase {
 	@Test
 	@TestInfo("LPD-57728")
 	public void testExportImportMarketplaceFragments() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				group, TestPropsValues.getUserId());
+
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
 				null, TestPropsValues.getUserId(),
-				_serviceContext.getScopeGroupId(), null,
-				RandomTestUtil.randomString(), StringPool.BLANK, false,
-				_serviceContext);
+				serviceContext.getScopeGroupId(), RandomTestUtil.randomString(),
+				StringPool.BLANK, serviceContext);
 
-		_addFragmentEntry(fragmentCollection, false, _serviceContext);
+		_addFragmentEntry(fragmentCollection, false, serviceContext);
 
-		_addFragmentEntry(fragmentCollection, true, _serviceContext);
+		_addFragmentEntry(fragmentCollection, true, serviceContext);
 
 		exportImportPortlet(FragmentPortletKeys.FRAGMENT, false);
 

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/exportimport/test/FragmentExportImportTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/exportimport/test/FragmentExportImportTest.java
@@ -49,6 +49,7 @@ import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
 
 import java.util.List;
@@ -72,6 +73,7 @@ public class FragmentExportImportTest extends BasePortletExportImportTestCase {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE,
 			SynchronousDestinationTestRule.INSTANCE);
 
 	@BeforeClass

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/exportimport/test/FragmentExportImportTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/exportimport/test/FragmentExportImportTest.java
@@ -194,9 +194,11 @@ public class FragmentExportImportTest extends BasePortletExportImportTestCase {
 				serviceContext.getScopeGroupId(), RandomTestUtil.randomString(),
 				StringPool.BLANK, serviceContext);
 
-		_addFragmentEntry(fragmentCollection, false, serviceContext);
+		FragmentEntry fragmentEntry = _addFragmentEntry(
+			fragmentCollection, false, serviceContext);
 
-		_addFragmentEntry(fragmentCollection, true, serviceContext);
+		FragmentEntry marketplaceFragmentEntry = _addFragmentEntry(
+			fragmentCollection, true, serviceContext);
 
 		exportImportPortlet(FragmentPortletKeys.FRAGMENT, false);
 
@@ -211,6 +213,17 @@ public class FragmentExportImportTest extends BasePortletExportImportTestCase {
 
 		Assert.assertEquals(
 			fragmentEntries.toString(), 1, fragmentEntries.size());
+
+		FragmentEntry actualFragmentEntry = fragmentEntries.get(0);
+
+		Assert.assertEquals(
+			fragmentEntry.getUuid(), actualFragmentEntry.getUuid());
+
+		Assert.assertNull(
+			_fragmentEntryLinkLocalService.
+				fetchFragmentEntryLinkByUuidAndGroupId(
+					marketplaceFragmentEntry.getUuid(),
+					importedGroup.getGroupId()));
 	}
 
 	@Test

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/model/impl/test/FragmentCollectionImplTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/model/impl/test/FragmentCollectionImplTest.java
@@ -11,7 +11,10 @@ import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.fragment.constants.FragmentExportImportConstants;
 import com.liferay.fragment.constants.FragmentPortletKeys;
 import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.service.FragmentCollectionLocalService;
+import com.liferay.fragment.service.FragmentEntryLocalService;
+import com.liferay.fragment.test.util.FragmentEntryTestUtil;
 import com.liferay.fragment.test.util.FragmentTestUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -22,6 +25,7 @@ import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -134,6 +138,47 @@ public class FragmentCollectionImplTest {
 		FileUtil.delete(zipWriter.getFile());
 	}
 
+	@Test
+	@TestInfo("LPD-57728")
+	public void testPopulateZipWriterForMarketplaceFragment() throws Exception {
+		ZipWriter zipWriter = _zipWriterFactory.getZipWriter();
+
+		FragmentEntryTestUtil.addFragmentEntry(
+			_fragmentCollection.getFragmentCollectionId());
+
+		FragmentEntry marketplaceFragmentEntry =
+			FragmentEntryTestUtil.addFragmentEntry(
+				_fragmentCollection.getFragmentCollectionId());
+
+		marketplaceFragmentEntry.setMarketplace(true);
+
+		marketplaceFragmentEntry =
+			_fragmentEntryLocalService.updateFragmentEntry(
+				marketplaceFragmentEntry);
+
+		marketplaceFragmentEntry.populateZipWriter(
+			zipWriter, RandomTestUtil.randomString());
+
+		ZipReader zipReader = _zipReaderFactory.getZipReader(
+			zipWriter.getFile());
+
+		Assert.assertTrue(
+			zipReader.getEntries(
+			).isEmpty());
+
+		_fragmentCollection.populateZipWriter(
+			zipWriter, RandomTestUtil.randomString());
+
+		zipReader = _zipReaderFactory.getZipReader(zipWriter.getFile());
+
+		List<String> entries = zipReader.getEntries();
+
+		for (String entry : entries) {
+			Assert.assertFalse(
+				entry.contains(marketplaceFragmentEntry.getName()));
+		}
+	}
+
 	@Inject
 	private static DLAppService _dlAppService;
 
@@ -141,6 +186,9 @@ public class FragmentCollectionImplTest {
 
 	@Inject
 	private FragmentCollectionLocalService _fragmentCollectionLocalService;
+
+	@Inject
+	private FragmentEntryLocalService _fragmentEntryLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/staging/test/FragmentCollectionStagingTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/staging/test/FragmentCollectionStagingTest.java
@@ -8,7 +8,9 @@ package com.liferay.fragment.staging.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.fragment.constants.FragmentPortletKeys;
 import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.service.FragmentCollectionLocalService;
+import com.liferay.fragment.service.FragmentEntryLocalService;
 import com.liferay.fragment.test.util.FragmentEntryTestUtil;
 import com.liferay.fragment.test.util.FragmentStagingTestUtil;
 import com.liferay.fragment.test.util.FragmentTestUtil;
@@ -18,6 +20,7 @@ import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -29,6 +32,7 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -108,6 +112,43 @@ public class FragmentCollectionStagingTest {
 	}
 
 	@Test
+	@TestInfo("LPD-57728")
+	public void testMarketplaceFragmentNotCopiedWhenLocalStagingActivated()
+		throws Exception {
+
+		FragmentCollection fragmentCollection =
+			FragmentTestUtil.addFragmentCollection(_liveGroup.getGroupId());
+
+		FragmentEntryTestUtil.addFragmentEntry(
+			fragmentCollection.getFragmentCollectionId());
+
+		FragmentEntry marketplaceFragmentEntry =
+			FragmentEntryTestUtil.addFragmentEntry(
+				fragmentCollection.getFragmentCollectionId());
+
+		marketplaceFragmentEntry.setMarketplace(true);
+
+		_fragmentEntryLocalService.updateFragmentEntry(
+			marketplaceFragmentEntry);
+
+		_stagingGroup = FragmentStagingTestUtil.enableLocalStaging(_liveGroup);
+
+		FragmentCollection stagingFragmentCollection =
+			_fragmentCollectionLocalService.
+				fetchFragmentCollectionByUuidAndGroupId(
+					fragmentCollection.getUuid(), _stagingGroup.getGroupId());
+
+		Assert.assertNotNull(stagingFragmentCollection);
+
+		List<FragmentEntry> fragmentEntries =
+			_fragmentEntryLocalService.getFragmentEntries(
+				stagingFragmentCollection.getFragmentCollectionId());
+
+		Assert.assertEquals(
+			fragmentEntries.toString(), 2, fragmentEntries.size());
+	}
+
+	@Test
 	public void testSingleFragmentResourceCopiedWhenLocalStagingActivated()
 		throws Exception {
 
@@ -161,6 +202,9 @@ public class FragmentCollectionStagingTest {
 
 	@Inject
 	private FragmentCollectionLocalService _fragmentCollectionLocalService;
+
+	@Inject
+	private FragmentEntryLocalService _fragmentEntryLocalService;
 
 	@DeleteAfterTestRun
 	private Group _liveGroup;


### PR DESCRIPTION
@BarbaraCabrera 

Original pull request comment:

### **Due to:** 
https://liferay.atlassian.net/browse/LPD-57728

## How to test it:

1. Connect to marketplace, use this Feature Flags:

> - Test Marketplace
> marketplace.url=https://marketplace-uat.liferay.com
> - Allow users to access directly marketplace while building pages
> feature.flag.LPD-34938=true
> - Purchasing and installing cloud payment method apps available on MP using the DXP
> feature.flag.LPD-35941=true
> - New payment status for free products
> feature.flag.LPD-51897=true

2. Create a Fragment Set (or install one from Marketplace. And make sure it has 1 fragment from marketplace and one normal fragment.

3. Export the fragment and import it again (using keep both).

4. Check that the fragmet from marketplace is not there because it wasn't exported (check also the exported zip).


https://github.com/user-attachments/assets/6f24c762-326f-4e25-a9d1-6bdd819a10b9

