### PR TITLE
LPD-60053 NoSuchUserException in LayoutPageTemplateStructureUpgradeProcess

### DIFF
--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/registry/LayoutPageTemplateServiceUpgradeStepRegistrator.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/registry/LayoutPageTemplateServiceUpgradeStepRegistrator.java
@@ -200,7 +200,8 @@ public class LayoutPageTemplateServiceUpgradeStepRegistrator
 		registry.register(
 			"5.1.0", "5.1.1",
 			new com.liferay.layout.page.template.internal.upgrade.v5_1_1.
-				LayoutPageTemplateStructureUpgradeProcess(_layoutLocalService));
+				LayoutPageTemplateStructureUpgradeProcess(
+					_layoutLocalService, _userLocalService));
 
 		registry.register(
 			"5.1.1", "5.2.0",

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/LayoutPageTemplateStructureUpgradeProcess.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/LayoutPageTemplateStructureUpgradeProcess.java
@@ -9,8 +9,10 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
@@ -26,9 +28,11 @@ import java.util.List;
 public class LayoutPageTemplateStructureUpgradeProcess extends UpgradeProcess {
 
 	public LayoutPageTemplateStructureUpgradeProcess(
-		LayoutLocalService layoutLocalService) {
+		LayoutLocalService layoutLocalService,
+		UserLocalService userLocalService) {
 
 		_layoutLocalService = layoutLocalService;
+		_userLocalService = userLocalService;
 	}
 
 	@Override
@@ -132,12 +136,19 @@ public class LayoutPageTemplateStructureUpgradeProcess extends UpgradeProcess {
 				continue;
 			}
 
+			User user = _userLocalService.fetchUser(layout.getUserId());
+
+			if (user == null) {
+				user = _userLocalService.getGuestUser(layout.getCompanyId());
+			}
+
 			_layoutLocalService.updateStatus(
-				layout.getUserId(), plid, WorkflowConstants.STATUS_APPROVED,
+				user.getUserId(), plid, WorkflowConstants.STATUS_APPROVED,
 				serviceContext);
 		}
 	}
 
 	private final LayoutLocalService _layoutLocalService;
+	private final UserLocalService _userLocalService;
 
 }

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/test/LayoutPageTemplateStructureUpgradeProcessTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/test/LayoutPageTemplateStructureUpgradeProcessTest.java
@@ -79,11 +79,10 @@ public class LayoutPageTemplateStructureUpgradeProcessTest {
 			DisplayPageTemplateTestUtil.addDisplayPageTemplate(
 				TestPropsValues.getGroupId());
 
-		String updateLayoutPageTemplateStructureSql = StringBundler.concat(
-			"update LayoutPageTemplateStructure set classPK = plid where plid ",
-			"= ", layoutPageTemplateEntry.getPlid());
-
-		_db.runSQL(updateLayoutPageTemplateStructureSql);
+		_db.runSQL(
+			StringBundler.concat(
+				"update LayoutPageTemplateStructure set classPK = plid where ",
+				"plid = ", layoutPageTemplateEntry.getPlid()));
 
 		Layout layout = _layoutLocalService.fetchLayout(
 			layoutPageTemplateEntry.getPlid());

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/test/LayoutPageTemplateStructureUpgradeProcessTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/test/LayoutPageTemplateStructureUpgradeProcessTest.java
@@ -76,7 +76,7 @@ public class LayoutPageTemplateStructureUpgradeProcessTest {
 
 	@Test
 	@TestInfo("LPD-60053")
-	public void testUpgradePortletTypeLayoutWithNullUser() throws Exception {
+	public void testUpgrade() throws Exception {
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
 			DisplayPageTemplateTestUtil.addDisplayPageTemplate(
 				TestPropsValues.getGroupId());

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/test/LayoutPageTemplateStructureUpgradeProcessTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/test/LayoutPageTemplateStructureUpgradeProcessTest.java
@@ -75,8 +75,8 @@ public class LayoutPageTemplateStructureUpgradeProcessTest {
 	public void testUpgradePortletLayoutWithoutUser() throws Exception {
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
 			_layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
-				null, TestPropsValues.getUserId(), TestPropsValues.getGroupId(), 0, null,
-				0, 0, RandomTestUtil.randomString(),
+				null, TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
+				0, null, 0, 0, RandomTestUtil.randomString(),
 				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE, 0, true, 0,
 				0, 0, WorkflowConstants.STATUS_APPROVED, new ServiceContext());
 
@@ -111,13 +111,13 @@ public class LayoutPageTemplateStructureUpgradeProcessTest {
 			DBInspector dbInspector = new DBInspector(connection);
 
 			if (!dbInspector.hasColumn(
-				"LayoutPageTemplateStructure", "classNameId") &&
+					"LayoutPageTemplateStructure", "classNameId") &&
 				!dbInspector.hasColumn(
 					"LayoutPageTemplateStructure", "classPK")) {
 
 				_db.runSQLTemplate(
 					"alter table LayoutPageTemplateStructure add classNameId " +
-					"LONG;",
+						"LONG;",
 					true);
 				_db.runSQLTemplate(
 					"alter table LayoutPageTemplateStructure add classPK LONG;",
@@ -143,17 +143,17 @@ public class LayoutPageTemplateStructureUpgradeProcessTest {
 			DBInspector dbInspector = new DBInspector(connection);
 
 			if (dbInspector.hasColumn(
-				"LayoutPageTemplateStructure", "classNameId") &&
+					"LayoutPageTemplateStructure", "classNameId") &&
 				dbInspector.hasColumn(
 					"LayoutPageTemplateStructure", "classPK")) {
 
 				_db.runSQLTemplate(
 					"alter table LayoutPageTemplateStructure drop column " +
-					"classNameId;",
+						"classNameId;",
 					true);
 				_db.runSQLTemplate(
 					"alter table LayoutPageTemplateStructure drop column " +
-					"classPK;",
+						"classPK;",
 					true);
 			}
 
@@ -165,7 +165,7 @@ public class LayoutPageTemplateStructureUpgradeProcessTest {
 
 	private void _runUpgrade() throws Exception {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-			_CLASS_NAME, LoggerTestUtil.OFF)) {
+				_CLASS_NAME, LoggerTestUtil.OFF)) {
 
 			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
 				_upgradeStepRegistrator, _CLASS_NAME);
@@ -176,7 +176,7 @@ public class LayoutPageTemplateStructureUpgradeProcessTest {
 
 	private static final String _CLASS_NAME =
 		"com.liferay.layout.page.template.internal.upgrade.v5_1_1." +
-		"LayoutPageTemplateStructureUpgradeProcess";
+			"LayoutPageTemplateStructureUpgradeProcess";
 
 	private static boolean _classPKColumnsAdded;
 	private static DB _db;

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/test/LayoutPageTemplateStructureUpgradeProcessTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/test/LayoutPageTemplateStructureUpgradeProcessTest.java
@@ -1,0 +1,200 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.internal.upgrade.v5_1_1.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.IndexMetadata;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.sql.Connection;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jorge Avalos
+ */
+@RunWith(Arquillian.class)
+public class LayoutPageTemplateStructureUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_db = DBManagerUtil.getDB();
+
+		_addClassPKColumn();
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		_dropClassPKColumn();
+	}
+
+	@Test
+	public void testUpgradePortletLayoutWithoutUser() throws Exception {
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
+				null, TestPropsValues.getUserId(), TestPropsValues.getGroupId(), 0, null,
+				0, 0, RandomTestUtil.randomString(),
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE, 0, true, 0,
+				0, 0, WorkflowConstants.STATUS_APPROVED, new ServiceContext());
+
+		_db.runSQLTemplate(
+			"update LayoutPageTemplateStructure set classPK = plid;", true);
+
+		Layout layout = _layoutLocalService.fetchLayout(
+			layoutPageTemplateEntry.getPlid());
+
+		layout.setStatus(WorkflowConstants.STATUS_DRAFT);
+
+		layout.setType(LayoutConstants.TYPE_PORTLET);
+
+		layout.setUserId(0);
+
+		layout = _layoutLocalService.updateLayout(layout);
+
+		_runUpgrade();
+
+		layout = _layoutLocalService.fetchLayout(layout.getPlid());
+
+		Assert.assertEquals(
+			layout.getStatusByUserId(),
+			_userLocalService.getGuestUserId(layout.getCompanyId()));
+	}
+
+	private static void _addClassPKColumn() throws Exception {
+		_classPKColumnsAdded = false;
+		_indexMetadataList = Collections.emptyList();
+
+		try (Connection connection = DataAccess.getConnection()) {
+			DBInspector dbInspector = new DBInspector(connection);
+
+			if (!dbInspector.hasColumn(
+				"LayoutPageTemplateStructure", "classNameId") &&
+				!dbInspector.hasColumn(
+					"LayoutPageTemplateStructure", "classPK")) {
+
+				_db.runSQLTemplate(
+					"alter table LayoutPageTemplateStructure add classNameId " +
+					"LONG;",
+					true);
+				_db.runSQLTemplate(
+					"alter table LayoutPageTemplateStructure add classPK LONG;",
+					true);
+				_db.runSQLTemplate(
+					"update LayoutPageTemplateStructure set classPK = plid;",
+					true);
+
+				_classPKColumnsAdded = true;
+
+				_indexMetadataList = _db.dropIndexes(
+					connection, "LayoutPageTemplateStructure", "plid");
+			}
+		}
+	}
+
+	private static void _dropClassPKColumn() throws Exception {
+		if (!_classPKColumnsAdded) {
+			return;
+		}
+
+		try (Connection connection = DataAccess.getConnection()) {
+			DBInspector dbInspector = new DBInspector(connection);
+
+			if (dbInspector.hasColumn(
+				"LayoutPageTemplateStructure", "classNameId") &&
+				dbInspector.hasColumn(
+					"LayoutPageTemplateStructure", "classPK")) {
+
+				_db.runSQLTemplate(
+					"alter table LayoutPageTemplateStructure drop column " +
+					"classNameId;",
+					true);
+				_db.runSQLTemplate(
+					"alter table LayoutPageTemplateStructure drop column " +
+					"classPK;",
+					true);
+			}
+
+			if (ListUtil.isNotEmpty(_indexMetadataList)) {
+				_db.addIndexes(connection, _indexMetadataList);
+			}
+		}
+	}
+
+	private void _runUpgrade() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+			_CLASS_NAME, LoggerTestUtil.OFF)) {
+
+			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+				_upgradeStepRegistrator, _CLASS_NAME);
+
+			upgradeProcess.upgrade();
+		}
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.layout.page.template.internal.upgrade.v5_1_1." +
+		"LayoutPageTemplateStructureUpgradeProcess";
+
+	private static boolean _classPKColumnsAdded;
+	private static DB _db;
+	private static List<IndexMetadata> _indexMetadataList;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.layout.page.template.internal.upgrade.registry.LayoutPageTemplateServiceUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
+
+	@Inject
+	private LayoutPageTemplateEntryLocalService
+		_layoutPageTemplateEntryLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/test/LayoutPageTemplateStructureUpgradeProcessTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/test/LayoutPageTemplateStructureUpgradeProcessTest.java
@@ -62,7 +62,9 @@ public class LayoutPageTemplateStructureUpgradeProcessTest {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
+		_connection = DataAccess.getConnection();
 		_db = DBManagerUtil.getDB();
+		_dbInspector = new DBInspector(DataAccess.getConnection());
 
 		_addLegacyColumns();
 	}
@@ -108,27 +110,21 @@ public class LayoutPageTemplateStructureUpgradeProcessTest {
 		_legacyColumnsAdded = false;
 		_indexMetadataList = Collections.emptyList();
 
-		try (Connection connection = DataAccess.getConnection()) {
-			DBInspector dbInspector = new DBInspector(connection);
+		if (!_dbInspector.hasColumn(
+				"LayoutPageTemplateStructure", "classNameId") &&
+			!_dbInspector.hasColumn("LayoutPageTemplateStructure", "classPK")) {
 
-			if (!dbInspector.hasColumn(
-					"LayoutPageTemplateStructure", "classNameId") &&
-				!dbInspector.hasColumn(
-					"LayoutPageTemplateStructure", "classPK")) {
+			_db.alterTableAddColumn(
+				_connection, "LayoutPageTemplateStructure", "classNameId",
+				"LONG");
 
-				_db.alterTableAddColumn(
-					connection, "LayoutPageTemplateStructure", "classNameId",
-					"LONG");
+			_db.alterTableAddColumn(
+				_connection, "LayoutPageTemplateStructure", "classPK", "LONG");
 
-				_db.alterTableAddColumn(
-					connection, "LayoutPageTemplateStructure", "classPK",
-					"LONG");
+			_legacyColumnsAdded = true;
 
-				_legacyColumnsAdded = true;
-
-				_indexMetadataList = _db.dropIndexes(
-					connection, "LayoutPageTemplateStructure", "plid");
-			}
+			_indexMetadataList = _db.dropIndexes(
+				_connection, "LayoutPageTemplateStructure", "plid");
 		}
 	}
 
@@ -137,24 +133,19 @@ public class LayoutPageTemplateStructureUpgradeProcessTest {
 			return;
 		}
 
-		try (Connection connection = DataAccess.getConnection()) {
-			DBInspector dbInspector = new DBInspector(connection);
+		if (_dbInspector.hasColumn(
+				"LayoutPageTemplateStructure", "classNameId") &&
+			_dbInspector.hasColumn("LayoutPageTemplateStructure", "classPK")) {
 
-			if (dbInspector.hasColumn(
-					"LayoutPageTemplateStructure", "classNameId") &&
-				dbInspector.hasColumn(
-					"LayoutPageTemplateStructure", "classPK")) {
+			_db.alterTableDropColumn(
+				_connection, "LayoutPageTemplateStructure", "classNameId");
 
-				_db.alterTableDropColumn(
-					connection, "LayoutPageTemplateStructure", "classNameId");
+			_db.alterTableDropColumn(
+				_connection, "LayoutPageTemplateStructure", "classPK");
+		}
 
-				_db.alterTableDropColumn(
-					connection, "LayoutPageTemplateStructure", "classPK");
-			}
-
-			if (ListUtil.isNotEmpty(_indexMetadataList)) {
-				_db.addIndexes(connection, _indexMetadataList);
-			}
+		if (ListUtil.isNotEmpty(_indexMetadataList)) {
+			_db.addIndexes(_connection, _indexMetadataList);
 		}
 	}
 
@@ -173,7 +164,9 @@ public class LayoutPageTemplateStructureUpgradeProcessTest {
 		"com.liferay.layout.page.template.internal.upgrade.v5_1_1." +
 			"LayoutPageTemplateStructureUpgradeProcess";
 
+	private static Connection _connection;
 	private static DB _db;
+	private static DBInspector _dbInspector;
 	private static List<IndexMetadata> _indexMetadataList;
 	private static boolean _legacyColumnsAdded;
 

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/test/LayoutPageTemplateStructureUpgradeProcessTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/test/LayoutPageTemplateStructureUpgradeProcessTest.java
@@ -6,9 +6,10 @@
 package com.liferay.layout.page.template.internal.upgrade.v5_1_1.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
+import com.liferay.layout.page.template.test.util.DisplayPageTemplateTestUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
@@ -17,8 +18,8 @@ import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.service.LayoutLocalService;
-import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -63,25 +64,26 @@ public class LayoutPageTemplateStructureUpgradeProcessTest {
 	public static void setUpClass() throws Exception {
 		_db = DBManagerUtil.getDB();
 
-		_addClassPKColumn();
+		_addLegacyColumns();
 	}
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
-		_dropClassPKColumn();
+		_dropLegacyColumns();
 	}
 
 	@Test
+	@TestInfo("LPD-60053")
 	public void testUpgradePortletTypeLayoutWithNullUser() throws Exception {
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
-			_layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
-				null, TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
-				0, null, 0, 0, RandomTestUtil.randomString(),
-				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE, 0, true, 0,
-				0, 0, WorkflowConstants.STATUS_APPROVED, new ServiceContext());
+			DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+				TestPropsValues.getGroupId());
 
-		_db.runSQLTemplate(
-			"update LayoutPageTemplateStructure set classPK = plid;", true);
+		String updateLayoutPageTemplateStructureSql = StringBundler.concat(
+			"update LayoutPageTemplateStructure set classPK = plid where plid ",
+			"= ", layoutPageTemplateEntry.getPlid());
+
+		_db.runSQL(updateLayoutPageTemplateStructureSql);
 
 		Layout layout = _layoutLocalService.fetchLayout(
 			layoutPageTemplateEntry.getPlid());
@@ -90,21 +92,21 @@ public class LayoutPageTemplateStructureUpgradeProcessTest {
 
 		layout.setType(LayoutConstants.TYPE_PORTLET);
 
-		layout.setUserId(0);
+		layout.setUserId(RandomTestUtil.randomLong());
 
 		layout = _layoutLocalService.updateLayout(layout);
 
 		_runUpgrade();
 
-		layout = _layoutLocalService.fetchLayout(layout.getPlid());
+		layout = _layoutLocalService.getLayout(layout.getPlid());
 
 		Assert.assertEquals(
 			layout.getStatusByUserId(),
 			_userLocalService.getGuestUserId(layout.getCompanyId()));
 	}
 
-	private static void _addClassPKColumn() throws Exception {
-		_classPKColumnsAdded = false;
+	private static void _addLegacyColumns() throws Exception {
+		_legacyColumnsAdded = false;
 		_indexMetadataList = Collections.emptyList();
 
 		try (Connection connection = DataAccess.getConnection()) {
@@ -115,18 +117,15 @@ public class LayoutPageTemplateStructureUpgradeProcessTest {
 				!dbInspector.hasColumn(
 					"LayoutPageTemplateStructure", "classPK")) {
 
-				_db.runSQLTemplate(
-					"alter table LayoutPageTemplateStructure add classNameId " +
-						"LONG;",
-					true);
-				_db.runSQLTemplate(
-					"alter table LayoutPageTemplateStructure add classPK LONG;",
-					true);
-				_db.runSQLTemplate(
-					"update LayoutPageTemplateStructure set classPK = plid;",
-					true);
+				_db.alterTableAddColumn(
+					connection, "LayoutPageTemplateStructure", "classNameId",
+					"LONG");
 
-				_classPKColumnsAdded = true;
+				_db.alterTableAddColumn(
+					connection, "LayoutPageTemplateStructure", "classPK",
+					"LONG");
+
+				_legacyColumnsAdded = true;
 
 				_indexMetadataList = _db.dropIndexes(
 					connection, "LayoutPageTemplateStructure", "plid");
@@ -134,8 +133,8 @@ public class LayoutPageTemplateStructureUpgradeProcessTest {
 		}
 	}
 
-	private static void _dropClassPKColumn() throws Exception {
-		if (!_classPKColumnsAdded) {
+	private static void _dropLegacyColumns() throws Exception {
+		if (!_legacyColumnsAdded) {
 			return;
 		}
 
@@ -147,14 +146,11 @@ public class LayoutPageTemplateStructureUpgradeProcessTest {
 				dbInspector.hasColumn(
 					"LayoutPageTemplateStructure", "classPK")) {
 
-				_db.runSQLTemplate(
-					"alter table LayoutPageTemplateStructure drop column " +
-						"classNameId;",
-					true);
-				_db.runSQLTemplate(
-					"alter table LayoutPageTemplateStructure drop column " +
-						"classPK;",
-					true);
+				_db.alterTableDropColumn(
+					connection, "LayoutPageTemplateStructure", "classNameId");
+
+				_db.alterTableDropColumn(
+					connection, "LayoutPageTemplateStructure", "classPK");
 			}
 
 			if (ListUtil.isNotEmpty(_indexMetadataList)) {
@@ -178,9 +174,9 @@ public class LayoutPageTemplateStructureUpgradeProcessTest {
 		"com.liferay.layout.page.template.internal.upgrade.v5_1_1." +
 			"LayoutPageTemplateStructureUpgradeProcess";
 
-	private static boolean _classPKColumnsAdded;
 	private static DB _db;
 	private static List<IndexMetadata> _indexMetadataList;
+	private static boolean _legacyColumnsAdded;
 
 	@Inject(
 		filter = "(&(component.name=com.liferay.layout.page.template.internal.upgrade.registry.LayoutPageTemplateServiceUpgradeStepRegistrator))"

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/test/LayoutPageTemplateStructureUpgradeProcessTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/test/LayoutPageTemplateStructureUpgradeProcessTest.java
@@ -72,7 +72,7 @@ public class LayoutPageTemplateStructureUpgradeProcessTest {
 	}
 
 	@Test
-	public void testUpgradePortletLayoutWithoutUser() throws Exception {
+	public void testUpgradePortletTypeLayoutWithNullUser() throws Exception {
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
 			_layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
 				null, TestPropsValues.getUserId(), TestPropsValues.getGroupId(),


### PR DESCRIPTION
https://liferay.atlassian.net/issues/LPD-60053

**Original PR:** https://github.com/liferay-page-management/liferay-portal/pull/17423
**Original commit message:**
Issue:
If a user creates a widget page and saves it as a draft and the user is deleted, the upgrade process will fail with a no such user exception.

Solution:
Use company guest user to update the status of the layout.

Ticket:
https://liferay.atlassian.net/issues/LPD-60053

@javalosjr96