### PR TITLE
LPD-60239

### DIFF
--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributor.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributor.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.servlet.I18nServlet;
+import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
 
 import java.util.Set;
@@ -64,12 +65,9 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 		VirtualHost virtualHost = _virtualHostLocalService.fetchVirtualHost(
 			host);
 
-		long companyId = 0;
+		long companyId = PortalInstances.getCompanyId(dynamicServletRequest);
 
-		if (virtualHost != null) {
-			companyId = virtualHost.getCompanyId();
-		}
-		else {
+		if (companyId == 0) {
 			companyId = PortalInstancePool.getDefaultCompanyId();
 		}
 

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributor.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributor.java
@@ -105,7 +105,7 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 
 		for (String currentLanguageId : languageIds) {
 			if (StringUtil.startsWith(
-				currentURL, currentLanguageId + StringPool.FORWARD_SLASH)) {
+					currentURL, currentLanguageId + StringPool.FORWARD_SLASH)) {
 
 				currentURL = currentURL.substring(currentLanguageId.length());
 

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributor.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributor.java
@@ -17,15 +17,12 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.model.VirtualHost;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutService;
-import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.service.VirtualHostLocalService;
 import com.liferay.portal.kernel.servlet.DynamicServletRequest;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -57,14 +54,6 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 	public void addAttributesAndParameters(
 		DynamicServletRequest dynamicServletRequest) {
 
-		String host = _portal.getHost(dynamicServletRequest);
-
-		host = StringUtil.toLowerCase(host);
-		host = StringUtil.trim(host);
-
-		VirtualHost virtualHost = _virtualHostLocalService.fetchVirtualHost(
-			host);
-
 		long companyId = PortalInstances.getCompanyId(dynamicServletRequest);
 
 		if (companyId == 0) {
@@ -82,7 +71,7 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 
 		if (Validator.isNull(currentURL)) {
 			_addVirtualHostAttributesAndParameters(
-				dynamicServletRequest, null, permissionChecker, virtualHost);
+				dynamicServletRequest, null, permissionChecker);
 
 			return;
 		}
@@ -105,7 +94,7 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 
 		if (Validator.isNull(currentURL)) {
 			_addVirtualHostAttributesAndParameters(
-				dynamicServletRequest, null, permissionChecker, virtualHost);
+				dynamicServletRequest, null, permissionChecker);
 
 			return;
 		}
@@ -116,7 +105,7 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 
 		for (String currentLanguageId : languageIds) {
 			if (StringUtil.startsWith(
-					currentURL, currentLanguageId + StringPool.FORWARD_SLASH)) {
+				currentURL, currentLanguageId + StringPool.FORWARD_SLASH)) {
 
 				currentURL = currentURL.substring(currentLanguageId.length());
 
@@ -130,8 +119,7 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 			currentURL.equals(StringPool.SLASH)) {
 
 			_addVirtualHostAttributesAndParameters(
-				dynamicServletRequest, languageId, permissionChecker,
-				virtualHost);
+				dynamicServletRequest, languageId, permissionChecker);
 
 			return;
 		}
@@ -142,8 +130,7 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 			(urlParts.length != 4)) {
 
 			_addVirtualHostAttributesAndParameters(
-				dynamicServletRequest, languageId, permissionChecker,
-				virtualHost);
+				dynamicServletRequest, languageId, permissionChecker);
 
 			return;
 		}
@@ -155,8 +142,7 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 			  _PRIVATE_USER_SERVLET_MAPPING.equals(urlPrefix))) {
 
 			_addVirtualHostAttributesAndParameters(
-				dynamicServletRequest, languageId, permissionChecker,
-				virtualHost);
+				dynamicServletRequest, languageId, permissionChecker);
 
 			return;
 		}
@@ -166,8 +152,7 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 
 		if ((group == null) || !group.isActive()) {
 			_addVirtualHostAttributesAndParameters(
-				dynamicServletRequest, languageId, permissionChecker,
-				virtualHost);
+				dynamicServletRequest, languageId, permissionChecker);
 
 			return;
 		}
@@ -176,8 +161,7 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 
 		if (layout == null) {
 			_addVirtualHostAttributesAndParameters(
-				dynamicServletRequest, languageId, permissionChecker,
-				virtualHost);
+				dynamicServletRequest, languageId, permissionChecker);
 
 			return;
 		}
@@ -203,28 +187,21 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 
 	private void _addVirtualHostAttributesAndParameters(
 		DynamicServletRequest dynamicServletRequest, String languageId,
-		PermissionChecker permissionChecker, VirtualHost virtualHost) {
+		PermissionChecker permissionChecker) {
 
-		if ((virtualHost == null) || (virtualHost.getLayoutSetId() == 0)) {
+		LayoutSet layoutSet = (LayoutSet)dynamicServletRequest.getAttribute(
+			WebKeys.VIRTUAL_HOST_LAYOUT_SET);
+
+		if (layoutSet == null) {
 			return;
 		}
 
-		try {
-			LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
-				virtualHost.getLayoutSetId());
+		Layout layout = _getFirstLayout(
+			layoutSet.getGroupId(), permissionChecker);
 
-			Layout layout = _getFirstLayout(
-				layoutSet.getGroupId(), permissionChecker);
-
-			if (layout != null) {
-				_addLayoutAttributesAndParameters(
-					dynamicServletRequest, languageId, layout);
-			}
-		}
-		catch (PortalException portalException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(portalException);
-			}
+		if (layout != null) {
+			_addLayoutAttributesAndParameters(
+				dynamicServletRequest, languageId, layout);
 		}
 	}
 
@@ -294,9 +271,6 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 	private LayoutService _layoutService;
 
 	@Reference
-	private LayoutSetLocalService _layoutSetLocalService;
-
-	@Reference
 	private PermissionCheckerFactory _permissionCheckerFactory;
 
 	@Reference
@@ -304,8 +278,5 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 
 	@Reference
 	private UserLocalService _userLocalService;
-
-	@Reference
-	private VirtualHostLocalService _virtualHostLocalService;
 
 }

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalInstancesTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalInstancesTest.java
@@ -41,7 +41,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -96,7 +95,6 @@ public class PortalInstancesTest {
 			_virtualHostsDefaultSiteName);
 	}
 
-	@Ignore
 	@Test
 	public void testGetCompanyId() {
 		_updateLayoutSetVirtualHostname(

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalInstancesTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalInstancesTest.java
@@ -7,10 +7,12 @@ package com.liferay.portal.util.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
@@ -123,6 +125,43 @@ public class PortalInstancesTest {
 		_testGetCompanyId(
 			_nondefaultGroupPublicLayoutHostname,
 			_nondefaultGroupPublicLayout.getLayoutSet());
+	}
+
+	@Test
+	public void testGetCompanyIdFromHttpServletRequestAttribute() {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.COMPANY_ID, _company.getCompanyId());
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					CompanyConstants.SYSTEM)) {
+
+			Assert.assertEquals(
+				_company.getCompanyId(),
+				PortalInstances.getCompanyId(mockHttpServletRequest));
+
+			Assert.assertEquals(
+				_company.getCompanyId(),
+				CompanyThreadLocal.getCompanyId(
+				).longValue());
+		}
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					RandomTestUtil.randomLong())) {
+
+			Assert.assertEquals(
+				_company.getCompanyId(),
+				PortalInstances.getCompanyId(mockHttpServletRequest));
+
+			Assert.assertNotEquals(
+				_company.getCompanyId(),
+				CompanyThreadLocal.getCompanyId(
+				).longValue());
+		}
 	}
 
 	@Test

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalInstancesTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalInstancesTest.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -175,6 +176,15 @@ public class PortalInstancesTest {
 		Assert.assertEquals(
 			_company.getCompanyId(),
 			PortalInstances.getCompanyId(mockHttpServletRequest));
+
+		Assert.assertEquals(
+			_company.getCompanyId(),
+			CompanyThreadLocal.getCompanyId(
+			).longValue());
+
+		Assert.assertEquals(
+			_company.getCompanyId(),
+			mockHttpServletRequest.getAttribute(WebKeys.COMPANY_ID));
 
 		Assert.assertEquals(
 			expectedLayoutSet,

--- a/portal-impl/src/com/liferay/portal/util/PortalInstances.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalInstances.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.User;
@@ -98,7 +99,9 @@ public class PortalInstances {
 		if (companyIdObj != null) {
 			long companyId = companyIdObj.longValue();
 
-			CompanyThreadLocal.setCompanyId(companyId);
+			if (CompanyThreadLocal.getCompanyId() == CompanyConstants.SYSTEM) {
+				CompanyThreadLocal.setCompanyId(companyId);
+			}
 
 			return companyId;
 		}

--- a/portal-impl/src/com/liferay/portal/util/PortalInstances.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalInstances.java
@@ -96,7 +96,11 @@ public class PortalInstances {
 		}
 
 		if (companyIdObj != null) {
-			return companyIdObj.longValue();
+			long companyId = companyIdObj.longValue();
+
+			CompanyThreadLocal.setCompanyId(companyId);
+
+			return companyId;
 		}
 
 		long companyId = _getCompanyIdByVirtualHosts(


### PR DESCRIPTION
Hi @achaparro @javalosjr96 

About [LPD-60239](https://liferay.atlassian.net/browse/LPD-60239) I think after my changes in [LPD-61175](https://liferay.atlassian.net/browse/LPD-61175), if you call `PortalInstances.getCompanyId(dynamicServletRequest);` in CommonStatusLayoutUtilityPageEntryRequestContributor it will solve your problem, see 12294e23c8a900b6e1025c2a896cfdcfcb38769b

You can also simplify the code of CommonStatusLayoutUtilityPageEntryRequestContributor getting the LayoutSet from from the VIRTUAL_HOST_LAYOUT_SET attribute, see 7eda150c5b53f08e2c75ce3e1ba1443fb9867751

My PR is being reviewed here: https://github.com/liferay-database-infra/liferay-portal/pull/2939 so once mine is merged you can send this change.

The root cause of this problem is the CompanyThreadLocal is reset by the ThreadLocalFilter when a redirect sendError is executed, so it is necessary to initialize it. (I discovered debugging it but I didn't save any evidence)

[LPD-60239]: https://liferay.atlassian.net/browse/LPD-60239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-61175]: https://liferay.atlassian.net/browse/LPD-61175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ