### PR TITLE
LPD-61553 Improve accessibility error reporting in Playwright / Jest tests

### DIFF
--- a/modules/apps/layout/layout-js-components-web/test/__lib__/checkAccessibility.ts
+++ b/modules/apps/layout/layout-js-components-web/test/__lib__/checkAccessibility.ts
@@ -33,6 +33,4 @@ export default async function checkAccessibility({
 	if (violations.length) {
 		throw new Error(formatAccessibility(violations));
 	}
-
-	expect(true).toBe(true);
 }

--- a/modules/apps/layout/layout-js-components-web/test/__lib__/checkAccessibility.ts
+++ b/modules/apps/layout/layout-js-components-web/test/__lib__/checkAccessibility.ts
@@ -5,6 +5,8 @@
 
 import axe, {AxeResults, ContextObject} from 'axe-core';
 
+import formatAccessibility from './formatAccessibility';
+
 const config = {
 
 	// Color contrast checks do not work in JSDOM so are turned off.
@@ -26,7 +28,11 @@ export default async function checkAccessibility({
 		config.runOnly = [...config.runOnly, 'best-practice'];
 	}
 
-	const results: AxeResults = await axe.run(context, config);
+	const {violations}: AxeResults = await axe.run(context, config);
 
-	expect(results.violations).toStrictEqual([]);
+	if (violations.length) {
+		throw new Error(formatAccessibility(violations));
+	}
+
+	expect(true).toBe(true);
 }

--- a/modules/apps/layout/layout-js-components-web/test/__lib__/formatAccessibility.ts
+++ b/modules/apps/layout/layout-js-components-web/test/__lib__/formatAccessibility.ts
@@ -15,6 +15,10 @@ function indentMultiline(text: string, spaces = 4): string {
 export default function formatAccessibility(
 	violations: AxeViolation[]
 ): string {
+	if (!violations.length) {
+		return 'No Accessibility issues found.';
+	}
+
 	const RED = '\x1b[31m';
 	const YELLOW = '\x1b[33m';
 	const CYAN = '\x1b[36m';
@@ -45,19 +49,22 @@ export default function formatAccessibility(
 		output.push(`  Impact : ${violation.impact}`);
 		output.push('');
 
-		for (let i = 0; i < violation.nodes.length; i++) {
-			const node = violation.nodes[i];
+		violation.nodes.forEach((node, index) => {
+			if (index > 0) {
+				output.push(`${CYAN}    ${'-'.repeat(40)}${RESET}\n`);
+			}
 
-			i > 0 && output.push(`${CYAN}    ${'-'.repeat(40)}${RESET}\n`);
 			output.push(`${CYAN}  - Affected element:${RESET}`);
 			output.push(`    ${node.html}`);
 			output.push(`${CYAN}  - Target selector(s):${RESET}`);
 			output.push(`    ${node.target.join(', ')}`);
-			output.push(`${CYAN}  - Summary:${RESET}`);
-			node.failureSummary &&
+
+			if (node.failureSummary) {
+				output.push(`${CYAN}  - Summary:${RESET}`);
 				output.push(indentMultiline(node.failureSummary.trim()));
+			}
 			output.push('');
-		}
+		});
 
 		output.push(`${CYAN}${'-'.repeat(80)}${RESET}`);
 	}

--- a/modules/apps/layout/layout-js-components-web/test/__lib__/formatAccessibility.ts
+++ b/modules/apps/layout/layout-js-components-web/test/__lib__/formatAccessibility.ts
@@ -1,0 +1,66 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import type {Result as AxeViolation} from 'axe-core';
+
+function indentMultiline(text: string, spaces = 4): string {
+	return text
+		.split('\n')
+		.map((line) => ' '.repeat(spaces) + line)
+		.join('\n');
+}
+
+export default function formatAccessibility(
+	violations: AxeViolation[]
+): string {
+	const RED = '\x1b[31m';
+	const YELLOW = '\x1b[33m';
+	const CYAN = '\x1b[36m';
+	const WHITE = '\x1b[37m';
+	const BOLD = '\x1b[1m';
+	const RESET = '\x1b[0m';
+
+	const output = [];
+
+	output.push('\n');
+	output.push(
+		`${RED}${BOLD}Accessibility issue(s) found: ${RESET}${WHITE}${
+			violations.length
+		} rule(s) affecting ${violations.reduce(
+			(acc, {nodes}) => acc + nodes.length,
+			0
+		)} node(s)${RESET}`
+	);
+	output.push(`${CYAN}${'='.repeat(80)}${RESET}`);
+
+	for (const violation of violations) {
+		output.push('');
+		output.push(
+			`${YELLOW}${BOLD}• RULE: ${RESET}${YELLOW}${violation.description}${RESET}`
+		);
+		output.push(`  Help   : ${violation.help}`);
+		output.push(`  Docs   : ${violation.helpUrl}`);
+		output.push(`  Impact : ${violation.impact}`);
+		output.push('');
+
+		for (let i = 0; i < violation.nodes.length; i++) {
+			const node = violation.nodes[i];
+
+			i > 0 && output.push(`${CYAN}    ${'-'.repeat(40)}${RESET}\n`);
+			output.push(`${CYAN}  - Affected element:${RESET}`);
+			output.push(`    ${node.html}`);
+			output.push(`${CYAN}  - Target selector(s):${RESET}`);
+			output.push(`    ${node.target.join(', ')}`);
+			output.push(`${CYAN}  - Summary:${RESET}`);
+			node.failureSummary &&
+				output.push(indentMultiline(node.failureSummary.trim()));
+			output.push('');
+		}
+
+		output.push(`${CYAN}${'-'.repeat(80)}${RESET}`);
+	}
+
+	return output.join('\n');
+}

--- a/modules/apps/layout/layout-js-components-web/test/__lib__/index.ts
+++ b/modules/apps/layout/layout-js-components-web/test/__lib__/index.ts
@@ -4,3 +4,4 @@
  */
 
 export {default as checkAccessibility} from './checkAccessibility';
+export {default as formatAccessibility} from './formatAccessibility';

--- a/modules/test/playwright/package-lock.json
+++ b/modules/test/playwright/package-lock.json
@@ -16,6 +16,7 @@
 			},
 			"devDependencies": {
 				"@axe-core/playwright": "^4.9.1",
+				"@liferay/layout-js-components-web": "../../apps/layout/layout-js-components-web/",
 				"@liferay/object-admin-rest-client-js": "../../apps/object/object-admin-rest-client-js",
 				"@liferay/portal-tools-rest-builder-test-client-js": "../../util/portal-tools-rest-builder-test-client-js",
 				"@playwright/test": "1.45.2",
@@ -26,6 +27,42 @@
 				"tslib": "^2.8.1",
 				"typescript": "4.7.4",
 				"zip-a-folder": "^3.1.6"
+			}
+		},
+		"../../apps/layout/layout-js-components-web": {
+			"version": "1.0.41",
+			"dev": true,
+			"dependencies": {
+				"@clayui/alert": "3.129.1",
+				"@clayui/button": "3.136.0",
+				"@clayui/color-picker": "3.140.0",
+				"@clayui/core": "3.140.0",
+				"@clayui/drop-down": "3.140.0",
+				"@clayui/empty-state": "3.128.0",
+				"@clayui/form": "3.140.0",
+				"@clayui/icon": "3.128.0",
+				"@clayui/label": "3.128.0",
+				"@clayui/layout": "3.128.0",
+				"@clayui/link": "3.128.0",
+				"@clayui/loading-indicator": "3.128.0",
+				"@clayui/modal": "3.140.0",
+				"@clayui/panel": "3.140.0",
+				"@clayui/toolbar": "3.140.0",
+				"@liferay/frontend-js-react-web": "*",
+				"@liferay/marketplace-js-components-web": "*",
+				"axe-core": "^4.9.1",
+				"classnames": "2.3.1",
+				"frontend-js-components-web": "*",
+				"frontend-js-web": "*",
+				"prop-types": "15.7.2",
+				"react": "18.2.0",
+				"react-dnd": "11.1.1",
+				"react-dnd-html5-backend": "11.1.1",
+				"react-dom": "18.2.0",
+				"uuid": "9.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "^1.2.7"
 			}
 		},
 		"../../apps/object/object-admin-rest-client-js": {
@@ -114,6 +151,10 @@
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
 			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
 			"dev": true
+		},
+		"node_modules/@liferay/layout-js-components-web": {
+			"resolved": "../../apps/layout/layout-js-components-web",
+			"link": true
 		},
 		"node_modules/@liferay/object-admin-rest-client-js": {
 			"resolved": "../../apps/object/object-admin-rest-client-js",
@@ -1531,6 +1572,39 @@
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
 			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
 			"dev": true
+		},
+		"@liferay/layout-js-components-web": {
+			"version": "file:../../apps/layout/layout-js-components-web",
+			"requires": {
+				"@clayui/alert": "3.129.1",
+				"@clayui/button": "3.136.0",
+				"@clayui/color-picker": "3.140.0",
+				"@clayui/core": "3.140.0",
+				"@clayui/drop-down": "3.140.0",
+				"@clayui/empty-state": "3.128.0",
+				"@clayui/form": "3.140.0",
+				"@clayui/icon": "3.128.0",
+				"@clayui/label": "3.128.0",
+				"@clayui/layout": "3.128.0",
+				"@clayui/link": "3.128.0",
+				"@clayui/loading-indicator": "3.128.0",
+				"@clayui/modal": "3.140.0",
+				"@clayui/panel": "3.140.0",
+				"@clayui/toolbar": "3.140.0",
+				"@liferay/frontend-js-react-web": "*",
+				"@liferay/marketplace-js-components-web": "*",
+				"axe-core": "^4.9.1",
+				"classnames": "2.3.1",
+				"frontend-js-components-web": "*",
+				"frontend-js-web": "*",
+				"fsevents": "^1.2.7",
+				"prop-types": "15.7.2",
+				"react": "18.2.0",
+				"react-dnd": "11.1.1",
+				"react-dnd-html5-backend": "11.1.1",
+				"react-dom": "18.2.0",
+				"uuid": "9.0.0"
+			}
 		},
 		"@liferay/object-admin-rest-client-js": {
 			"version": "file:../../apps/object/object-admin-rest-client-js",

--- a/modules/test/playwright/package.json
+++ b/modules/test/playwright/package.json
@@ -9,6 +9,7 @@
 	"description": "",
 	"devDependencies": {
 		"@axe-core/playwright": "^4.9.1",
+		"@liferay/layout-js-components-web": "../../apps/layout/layout-js-components-web/",
 		"@liferay/object-admin-rest-client-js": "../../apps/object/object-admin-rest-client-js",
 		"@liferay/portal-tools-rest-builder-test-client-js": "../../util/portal-tools-rest-builder-test-client-js",
 		"@playwright/test": "1.45.2",

--- a/modules/test/playwright/utils/checkAccessibility.ts
+++ b/modules/test/playwright/utils/checkAccessibility.ts
@@ -14,6 +14,65 @@ interface Params {
 	soft?: boolean;
 }
 
+function indentMultiline(text: string, spaces = 4): string {
+	return text
+		.split('\n')
+		.map((line) => ' '.repeat(spaces) + line)
+		.join('\n');
+}
+
+function formatAccessibility(violations: any[]): string {
+	const USE_COLORS = process.stdout.isTTY;
+
+	const RED = USE_COLORS ? '\x1b[31m' : '';
+	const YELLOW = USE_COLORS ? '\x1b[33m' : '';
+	const CYAN = USE_COLORS ? '\x1b[36m' : '';
+	const WHITE = USE_COLORS ? '\x1b[37m' : '';
+	const BOLD = USE_COLORS ? '\x1b[1m' : '';
+	const RESET = USE_COLORS ? '\x1b[0m' : '';
+
+	const output = [];
+
+	output.push('\n');
+	output.push(
+		`${RED}${BOLD}Accessibility issues found: ${RESET}${WHITE}${
+			violations.length
+		} rules affecting ${violations.reduce(
+			(acc, {nodes}) => acc + nodes.length,
+			0
+		)} node(s)${RESET}`
+	);
+	output.push(`${CYAN}${'='.repeat(80)}${RESET}`);
+
+	for (const violation of violations) {
+		output.push('');
+		output.push(
+			`${YELLOW}${BOLD}• RULE: ${RESET}${YELLOW}${violation.description}${RESET}`
+		);
+		output.push(`  Help   : ${violation.help}`);
+		output.push(`  Docs   : ${violation.helpUrl}`);
+		output.push(`  Impact : ${violation.impact}`);
+		output.push('');
+
+		for (let i = 0; i < violation.nodes.length; i++) {
+			const node = violation.nodes[i];
+
+			i > 0 && output.push(`${CYAN}    ${'-'.repeat(40)}${RESET}`);
+			output.push(`${CYAN}  - Affected element:${RESET}`);
+			output.push(`    ${node.html}`);
+			output.push(`${CYAN}  - Target selector(s):${RESET}`);
+			output.push(`    ${node.target.join(', ')}`);
+			output.push(`${CYAN}  - Summary:${RESET}`);
+			output.push(indentMultiline(node.failureSummary.trim()));
+			output.push('');
+		}
+
+		output.push(`${CYAN}${'-'.repeat(80)}${RESET}`);
+	}
+
+	return output.join('\n');
+}
+
 /**
  * Check accessibility on a page.
  *
@@ -54,10 +113,15 @@ export async function checkAccessibility({
 		}
 	}
 
-	const results = await axeBuilder.withTags(tags).analyze();
+	const {violations} = await axeBuilder.withTags(tags).analyze();
 
-	(soft ? expect.soft : expect)(
-		results.violations,
-		'Accessibility issues'
-	).toEqual([]);
+	if (!violations.length) {
+		(soft ? expect.soft : expect)(
+			false,
+			formatAccessibility(violations)
+		).toBe(true);
+	}
+	else {
+		expect(true, 'Accessibility issues').toBe(true);
+	}
 }

--- a/modules/test/playwright/utils/checkAccessibility.ts
+++ b/modules/test/playwright/utils/checkAccessibility.ts
@@ -59,13 +59,8 @@ export async function checkAccessibility({
 
 	const {violations} = await axeBuilder.withTags(tags).analyze();
 
-	if (violations.length) {
-		(soft ? expect.soft : expect)(
-			false,
-			formatAccessibility(violations)
-		).toBe(true);
-	}
-	else {
-		expect(true, 'Accessibility issues').toBe(true);
-	}
+	(soft ? expect.soft : expect)(
+		violations.length,
+		formatAccessibility(violations)
+	).toBe(0);
 }

--- a/modules/test/playwright/utils/checkAccessibility.ts
+++ b/modules/test/playwright/utils/checkAccessibility.ts
@@ -4,6 +4,8 @@
  */
 
 import AxeBuilder from '@axe-core/playwright';
+
+// eslint-disable-next-line
 import {formatAccessibility} from '@liferay/layout-js-components-web/test/__lib__/index';
 import {Page, expect} from '@playwright/test';
 

--- a/modules/test/playwright/utils/checkAccessibility.ts
+++ b/modules/test/playwright/utils/checkAccessibility.ts
@@ -4,6 +4,7 @@
  */
 
 import AxeBuilder from '@axe-core/playwright';
+import {formatAccessibility} from '@liferay/layout-js-components-web/test/__lib__/index';
 import {Page, expect} from '@playwright/test';
 
 interface Params {
@@ -12,65 +13,6 @@ interface Params {
 	selectors?: string[];
 	selectorsToExclude?: string[];
 	soft?: boolean;
-}
-
-function indentMultiline(text: string, spaces = 4): string {
-	return text
-		.split('\n')
-		.map((line) => ' '.repeat(spaces) + line)
-		.join('\n');
-}
-
-function formatAccessibility(violations: any[]): string {
-	const USE_COLORS = process.stdout.isTTY;
-
-	const RED = USE_COLORS ? '\x1b[31m' : '';
-	const YELLOW = USE_COLORS ? '\x1b[33m' : '';
-	const CYAN = USE_COLORS ? '\x1b[36m' : '';
-	const WHITE = USE_COLORS ? '\x1b[37m' : '';
-	const BOLD = USE_COLORS ? '\x1b[1m' : '';
-	const RESET = USE_COLORS ? '\x1b[0m' : '';
-
-	const output = [];
-
-	output.push('\n');
-	output.push(
-		`${RED}${BOLD}Accessibility issues found: ${RESET}${WHITE}${
-			violations.length
-		} rules affecting ${violations.reduce(
-			(acc, {nodes}) => acc + nodes.length,
-			0
-		)} node(s)${RESET}`
-	);
-	output.push(`${CYAN}${'='.repeat(80)}${RESET}`);
-
-	for (const violation of violations) {
-		output.push('');
-		output.push(
-			`${YELLOW}${BOLD}• RULE: ${RESET}${YELLOW}${violation.description}${RESET}`
-		);
-		output.push(`  Help   : ${violation.help}`);
-		output.push(`  Docs   : ${violation.helpUrl}`);
-		output.push(`  Impact : ${violation.impact}`);
-		output.push('');
-
-		for (let i = 0; i < violation.nodes.length; i++) {
-			const node = violation.nodes[i];
-
-			i > 0 && output.push(`${CYAN}    ${'-'.repeat(40)}${RESET}`);
-			output.push(`${CYAN}  - Affected element:${RESET}`);
-			output.push(`    ${node.html}`);
-			output.push(`${CYAN}  - Target selector(s):${RESET}`);
-			output.push(`    ${node.target.join(', ')}`);
-			output.push(`${CYAN}  - Summary:${RESET}`);
-			output.push(indentMultiline(node.failureSummary.trim()));
-			output.push('');
-		}
-
-		output.push(`${CYAN}${'-'.repeat(80)}${RESET}`);
-	}
-
-	return output.join('\n');
 }
 
 /**
@@ -115,7 +57,7 @@ export async function checkAccessibility({
 
 	const {violations} = await axeBuilder.withTags(tags).analyze();
 
-	if (!violations.length) {
+	if (violations.length) {
 		(soft ? expect.soft : expect)(
 			false,
 			formatAccessibility(violations)


### PR DESCRIPTION
# Issue: [LPD-61411](https://liferay.atlassian.net/browse/LPD-61411) → [LPD-61553](https://liferay.atlassian.net/browse/LPD-61553)

After watching the latest accessibility training video, `Automatic Accessibility Tests` in Liferay, thanks to @veroglez and @marcoscv-work ❤️. I felt inspired to contribute by improving the readability of accessibility reports.

This PR updates the formatting of reports in both Playwright and Jest, making them easier to read and understand.

To easily reproduce the accessibility issues, you can apply the patch below:

[`force-a11y-errors.patch`](https://github.com/user-attachments/files/21414136/force-a11y-errors.patch)


# Before and After reports:

## Playwright
### Before
<img width="2540" height="2623" alt="image" src="https://github.com/user-attachments/assets/ef7d3be1-e9e6-413b-ba40-30f80d1979f1" />

### After: single issue
<img width="2552" height="1247" alt="image" src="https://github.com/user-attachments/assets/57e3b2fe-b2fb-448f-9f76-66ef5285e898" />

### After: multiples issues 
<img width="2555" height="2122" alt="image" src="https://github.com/user-attachments/assets/3194f6c2-086b-460c-8e95-2aa659d8cdf5" />

## Jest
### Before
<img width="2555" height="2372" alt="image" src="https://github.com/user-attachments/assets/dd9e2d11-3fd7-488e-818c-29e92e32d337" />

### After
<img width="2554" height="2007" alt="image" src="https://github.com/user-attachments/assets/43e9f62f-c644-4149-8d81-e8b107e6161f" />



[LPD-61411]: https://liferay.atlassian.net/browse/LPD-61411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-61553]: https://liferay.atlassian.net/browse/LPD-61553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ