### PR TITLE
LPD-61879 The FragmentEntryLinkNamespace is not updated in the editable values when duplicating the element

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/DuplicateItemMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/DuplicateItemMVCActionCommandTest.java
@@ -25,6 +25,7 @@ import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -36,6 +37,7 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -119,6 +121,97 @@ public class DuplicateItemMVCActionCommandTest {
 	@After
 	public void tearDown() {
 		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	@TestInfo("LPD-61879")
+	public void testDuplicatedHeadingFragmentEntryLinkUpdatesNamespace()
+		throws Exception {
+
+		long segmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				_layout.getPlid());
+
+		FragmentEntryLink headingFragmentEntryLink = _addFragmentEntryLink(
+			JSONUtil.put(
+				FragmentEntryProcessorConstants.
+					KEY_EDITABLE_FRAGMENT_ENTRY_PROCESSOR,
+				JSONUtil.put(
+					"element-text",
+					JSONUtil.put(
+						LocaleUtil.toLanguageId(
+							_portal.getSiteDefaultLocale(_group)),
+						RandomTestUtil.randomString()))
+			).toString(),
+			"<h1 data-lfr-editable-id=\"${fragmentEntryLinkNamespace}-" +
+				"element-text\" data-lfr-editable-type=\"text\">" +
+					"Heading Example</h1>",
+			null, segmentsExperienceId);
+
+		String namespace = headingFragmentEntryLink.getNamespace();
+
+		String editableValues = headingFragmentEntryLink.getEditableValues();
+
+		editableValues = StringUtil.replace(
+			editableValues, "element-text", namespace + "-element-text");
+
+		headingFragmentEntryLink =
+			_fragmentEntryLinkLocalService.updateFragmentEntryLink(
+				TestPropsValues.getUserId(),
+				headingFragmentEntryLink.getFragmentEntryLinkId(),
+				editableValues);
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_layoutPageTemplateStructureLocalService.
+				fetchLayoutPageTemplateStructure(
+					_layout.getGroupId(), _layout.getPlid());
+
+		LayoutStructure layoutStructure = LayoutStructure.of(
+			layoutPageTemplateStructure.getData(segmentsExperienceId));
+
+		FragmentStyledLayoutStructureItem
+			headingFragmentStyledLayoutStructureItem =
+				_assertFragmentStyledLayoutStructureItem(
+					layoutStructure.getLayoutStructureItemByFragmentEntryLinkId(
+						headingFragmentEntryLink.getFragmentEntryLinkId()));
+
+		JSONObject jsonObject = ReflectionTestUtil.invoke(
+			_mvcActionCommand, "doTransactionalCommand",
+			new Class<?>[] {ActionRequest.class, ActionResponse.class},
+			_getMockLiferayPortletActionRequest(
+				new String[] {
+					headingFragmentStyledLayoutStructureItem.getItemId()
+				},
+				segmentsExperienceId),
+			new MockLiferayPortletActionResponse());
+
+		JSONArray duplicatedFragmentEntryLinksJSONArray =
+			jsonObject.getJSONArray("duplicatedFragmentEntryLinks");
+
+		long duplicatedFragmentEntryLinkId = 0;
+
+		for (int i = 0; i < duplicatedFragmentEntryLinksJSONArray.length();
+			 i++) {
+
+			JSONObject duplicatedFragmentEntryLinksJSONObject =
+				duplicatedFragmentEntryLinksJSONArray.getJSONObject(i);
+
+			duplicatedFragmentEntryLinkId =
+				duplicatedFragmentEntryLinksJSONObject.getLong(
+					"fragmentEntryLinkId");
+		}
+
+		FragmentEntryLink duplicatedHeadingFragmentEntryLink =
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				duplicatedFragmentEntryLinkId);
+
+		String duplicatedEditableValues =
+			duplicatedHeadingFragmentEntryLink.getEditableValues();
+
+		Assert.assertTrue(
+			duplicatedEditableValues.contains(
+				duplicatedHeadingFragmentEntryLink.getNamespace() +
+					"-element-text"));
 	}
 
 	@Test

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/BaseDuplicateItemMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/BaseDuplicateItemMVCActionCommand.java
@@ -122,6 +122,36 @@ public abstract class BaseDuplicateItemMVCActionCommand
 				}
 			}
 
+			String fragmentEntryLinkNamespace =
+				fragmentEntryLink.getNamespace();
+
+			JSONObject duplicatedEditableValuesJSONObject =
+				jsonFactory.createJSONObject();
+
+			for (String key : editableValuesJSONObject.keySet()) {
+				Object value = editableValuesJSONObject.get(key);
+
+				if (!(value instanceof JSONObject)) {
+					duplicatedEditableValuesJSONObject.put(key, value);
+
+					continue;
+				}
+
+				JSONObject jsonObject = (JSONObject)value;
+				JSONObject duplicatedJSONObject =
+					jsonFactory.createJSONObject();
+
+				for (String curKey : jsonObject.keySet()) {
+					duplicatedJSONObject.put(
+						StringUtil.replace(
+							curKey, fragmentEntryLinkNamespace, namespace),
+						jsonObject.get(curKey));
+				}
+
+				duplicatedEditableValuesJSONObject.put(
+					key, duplicatedJSONObject);
+			}
+
 			FragmentEntryLink duplicatedFragmentEntryLink =
 				fragmentEntryLinkService.addFragmentEntryLink(
 					null, fragmentEntryLink.getGroupId(), 0,
@@ -130,7 +160,7 @@ public abstract class BaseDuplicateItemMVCActionCommand
 					fragmentEntryLink.getPlid(), fragmentEntryLink.getCss(),
 					fragmentEntryLink.getHtml(), fragmentEntryLink.getJs(),
 					fragmentEntryLink.getConfiguration(),
-					editableValuesJSONObject.toString(), namespace, 0,
+					duplicatedEditableValuesJSONObject.toString(), namespace, 0,
 					fragmentEntryLink.getRendererKey(),
 					fragmentEntryLink.getType(), serviceContext);
 


### PR DESCRIPTION
## Motivation
Due to this LPP: [LPP-59880](https://liferay.atlassian.net/browse/LPP-59880)
I just realized that the problem comes because we weren't updating the namespace in the editable values when duplicating the fragment.

## Stetps to reproduce it:

1. Open Product Menu -> Design -> Fragments
2. Go to Basic Components -> Heading and copy to a seperate folder its HTML and configuration
3. Go back to the Fragments Page and on the top with the "+" button, add a new Fragment Set.
4. On the newly added set, add a Fragment.
5. Paste the HTML and Configuration to the newly created fragment.
6. For the data-lfr-editable-id, add the fragmentEntryLinkNamespace value, like so:
    `data-lfr-editable-id="${fragmentEntryLinkNamespace}-element-text"`
7. Go to Site builder -> Pages and edit a page.
8. Add the newly created fragment to the page and duplicate it.
9. Double click on the component to edit it.

[LPP-59880]: https://liferay.atlassian.net/browse/LPP-59880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ