### PR TITLE
LPD-60239 NoSuchRoleException is thrown when utility error page is requested and DB Partition is enabled

### DIFF
--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributor.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributor.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.servlet.I18nServlet;
+import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
 
 import java.util.Set;
@@ -64,12 +65,9 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 		VirtualHost virtualHost = _virtualHostLocalService.fetchVirtualHost(
 			host);
 
-		long companyId = 0;
+		long companyId = PortalInstances.getCompanyId(dynamicServletRequest);
 
-		if (virtualHost != null) {
-			companyId = virtualHost.getCompanyId();
-		}
-		else {
+		if (companyId == 0) {
 			companyId = PortalInstancePool.getDefaultCompanyId();
 		}
 

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributor.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributor.java
@@ -105,7 +105,7 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 
 		for (String currentLanguageId : languageIds) {
 			if (StringUtil.startsWith(
-				currentURL, currentLanguageId + StringPool.FORWARD_SLASH)) {
+					currentURL, currentLanguageId + StringPool.FORWARD_SLASH)) {
 
 				currentURL = currentURL.substring(currentLanguageId.length());
 

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributor.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributor.java
@@ -10,7 +10,6 @@ import com.liferay.layout.utility.page.kernel.request.contributor.StatusLayoutUt
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -54,11 +53,7 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 	public void addAttributesAndParameters(
 		DynamicServletRequest dynamicServletRequest) {
 
-		long companyId = CompanyThreadLocal.getCompanyId();
-
-		if (companyId == 0) {
-			companyId = PortalInstancePool.getDefaultCompanyId();
-		}
+		long companyId = CompanyThreadLocal.getNonsystemCompanyId();
 
 		PermissionChecker permissionChecker = _getPermissionChecker(
 			companyId, dynamicServletRequest);

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributor.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributor.java
@@ -17,15 +17,12 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.model.VirtualHost;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutService;
-import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.service.VirtualHostLocalService;
 import com.liferay.portal.kernel.servlet.DynamicServletRequest;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -57,14 +54,6 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 	public void addAttributesAndParameters(
 		DynamicServletRequest dynamicServletRequest) {
 
-		String host = _portal.getHost(dynamicServletRequest);
-
-		host = StringUtil.toLowerCase(host);
-		host = StringUtil.trim(host);
-
-		VirtualHost virtualHost = _virtualHostLocalService.fetchVirtualHost(
-			host);
-
 		long companyId = PortalInstances.getCompanyId(dynamicServletRequest);
 
 		if (companyId == 0) {
@@ -82,7 +71,7 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 
 		if (Validator.isNull(currentURL)) {
 			_addVirtualHostAttributesAndParameters(
-				dynamicServletRequest, null, permissionChecker, virtualHost);
+				dynamicServletRequest, null, permissionChecker);
 
 			return;
 		}
@@ -105,7 +94,7 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 
 		if (Validator.isNull(currentURL)) {
 			_addVirtualHostAttributesAndParameters(
-				dynamicServletRequest, null, permissionChecker, virtualHost);
+				dynamicServletRequest, null, permissionChecker);
 
 			return;
 		}
@@ -116,7 +105,7 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 
 		for (String currentLanguageId : languageIds) {
 			if (StringUtil.startsWith(
-					currentURL, currentLanguageId + StringPool.FORWARD_SLASH)) {
+				currentURL, currentLanguageId + StringPool.FORWARD_SLASH)) {
 
 				currentURL = currentURL.substring(currentLanguageId.length());
 
@@ -130,8 +119,7 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 			currentURL.equals(StringPool.SLASH)) {
 
 			_addVirtualHostAttributesAndParameters(
-				dynamicServletRequest, languageId, permissionChecker,
-				virtualHost);
+				dynamicServletRequest, languageId, permissionChecker);
 
 			return;
 		}
@@ -142,8 +130,7 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 			(urlParts.length != 4)) {
 
 			_addVirtualHostAttributesAndParameters(
-				dynamicServletRequest, languageId, permissionChecker,
-				virtualHost);
+				dynamicServletRequest, languageId, permissionChecker);
 
 			return;
 		}
@@ -155,8 +142,7 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 			  _PRIVATE_USER_SERVLET_MAPPING.equals(urlPrefix))) {
 
 			_addVirtualHostAttributesAndParameters(
-				dynamicServletRequest, languageId, permissionChecker,
-				virtualHost);
+				dynamicServletRequest, languageId, permissionChecker);
 
 			return;
 		}
@@ -166,8 +152,7 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 
 		if ((group == null) || !group.isActive()) {
 			_addVirtualHostAttributesAndParameters(
-				dynamicServletRequest, languageId, permissionChecker,
-				virtualHost);
+				dynamicServletRequest, languageId, permissionChecker);
 
 			return;
 		}
@@ -176,8 +161,7 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 
 		if (layout == null) {
 			_addVirtualHostAttributesAndParameters(
-				dynamicServletRequest, languageId, permissionChecker,
-				virtualHost);
+				dynamicServletRequest, languageId, permissionChecker);
 
 			return;
 		}
@@ -203,28 +187,21 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 
 	private void _addVirtualHostAttributesAndParameters(
 		DynamicServletRequest dynamicServletRequest, String languageId,
-		PermissionChecker permissionChecker, VirtualHost virtualHost) {
+		PermissionChecker permissionChecker) {
 
-		if ((virtualHost == null) || (virtualHost.getLayoutSetId() == 0)) {
+		LayoutSet layoutSet = (LayoutSet)dynamicServletRequest.getAttribute(
+			WebKeys.VIRTUAL_HOST_LAYOUT_SET);
+
+		if (layoutSet == null) {
 			return;
 		}
 
-		try {
-			LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
-				virtualHost.getLayoutSetId());
+		Layout layout = _getFirstLayout(
+			layoutSet.getGroupId(), permissionChecker);
 
-			Layout layout = _getFirstLayout(
-				layoutSet.getGroupId(), permissionChecker);
-
-			if (layout != null) {
-				_addLayoutAttributesAndParameters(
-					dynamicServletRequest, languageId, layout);
-			}
-		}
-		catch (PortalException portalException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(portalException);
-			}
+		if (layout != null) {
+			_addLayoutAttributesAndParameters(
+				dynamicServletRequest, languageId, layout);
 		}
 	}
 
@@ -294,9 +271,6 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 	private LayoutService _layoutService;
 
 	@Reference
-	private LayoutSetLocalService _layoutSetLocalService;
-
-	@Reference
 	private PermissionCheckerFactory _permissionCheckerFactory;
 
 	@Reference
@@ -304,8 +278,5 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 
 	@Reference
 	private UserLocalService _userLocalService;
-
-	@Reference
-	private VirtualHostLocalService _virtualHostLocalService;
 
 }

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributor.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/request/contributor/CommonStatusLayoutUtilityPageEntryRequestContributor.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
@@ -29,7 +30,6 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.servlet.I18nServlet;
-import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.PropsValues;
 
 import java.util.Set;
@@ -54,7 +54,7 @@ public class CommonStatusLayoutUtilityPageEntryRequestContributor
 	public void addAttributesAndParameters(
 		DynamicServletRequest dynamicServletRequest) {
 
-		long companyId = PortalInstances.getCompanyId(dynamicServletRequest);
+		long companyId = CompanyThreadLocal.getCompanyId();
 
 		if (companyId == 0) {
 			companyId = PortalInstancePool.getDefaultCompanyId();

--- a/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SpSessionTerminationSamlPortalFilter.java
+++ b/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SpSessionTerminationSamlPortalFilter.java
@@ -7,8 +7,6 @@ package com.liferay.saml.internal.servlet.filter;
 
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.util.PortalInstances;
 import com.liferay.saml.helper.SamlHttpRequestHelper;
 import com.liferay.saml.persistence.model.SamlSpSession;
 import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
@@ -51,10 +49,6 @@ public class SpSessionTerminationSamlPortalFilter extends BaseSamlPortalFilter {
 	public boolean isFilterEnabled(
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse) {
-
-		if (httpServletRequest.getAttribute(WebKeys.COMPANY_ID) == null) {
-			PortalInstances.getCompanyId(httpServletRequest);
-		}
 
 		if (_samlProviderConfigurationHelper.isEnabled() &&
 			(httpServletRequest.getSession(false) != null)) {

--- a/portal-impl/test/unit/com/liferay/portal/kernel/servlet/filters/invoker/InvokerFilterChainTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/servlet/filters/invoker/InvokerFilterChainTest.java
@@ -1,0 +1,70 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.servlet.filters.invoker;
+
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.util.PortalImpl;
+
+import jakarta.servlet.Filter;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Jorge Avalos
+ */
+public class InvokerFilterChainTest {
+
+	@ClassRule
+	public static LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_setUpPortalUtil();
+	}
+
+	@Test
+	public void testInvokerFilterChainSetCompanyId() throws Exception {
+		InvokerFilterChain invokerFilterChain = new InvokerFilterChain(
+			new MockFilterChain());
+
+		long companyId = RandomTestUtil.randomLong();
+
+		invokerFilterChain.addFilter(Mockito.mock(Filter.class));
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(WebKeys.COMPANY_ID, companyId);
+
+		invokerFilterChain.doFilter(
+			mockHttpServletRequest, new MockHttpServletResponse());
+
+		Assert.assertEquals(
+			CompanyThreadLocal.getCompanyId(), companyId,
+			CompanyThreadLocal.getCompanyId());
+	}
+
+	private void _setUpPortalUtil() {
+		PortalUtil portalUtil = new PortalUtil();
+
+		portalUtil.setPortal(new PortalImpl());
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/filters/invoker/InvokerFilter.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/filters/invoker/InvokerFilter.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.servlet.SanitizedServletResponse;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.ServerDetector;
@@ -101,6 +102,11 @@ public class InvokerFilter implements Filter {
 		String uri = getURI(originalURI);
 
 		httpServletRequest.setAttribute(WebKeys.INVOKER_FILTER_URI, uri);
+
+		// Company ID needs to be called here so that it is set
+		// across all filters
+
+		PortalUtil.getCompanyId(httpServletRequest);
 
 		try {
 			InvokerFilterChain invokerFilterChain = getInvokerFilterChain(

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/filters/invoker/InvokerFilterChain.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/filters/invoker/InvokerFilterChain.java
@@ -15,7 +15,6 @@ import com.liferay.portal.kernel.servlet.TryFilter;
 import com.liferay.portal.kernel.servlet.TryFinallyFilter;
 import com.liferay.portal.kernel.servlet.WrapHttpServletRequestFilter;
 import com.liferay.portal.kernel.servlet.WrapHttpServletResponseFilter;
-import com.liferay.portal.kernel.util.PortalUtil;
 
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
@@ -68,11 +67,6 @@ public class InvokerFilterChain implements FilterChain {
 				(HttpServletRequest)servletRequest;
 			HttpServletResponse httpServletResponse =
 				(HttpServletResponse)servletResponse;
-
-			// Company ID needs to be called here so that it is set
-			// across all filters
-
-			PortalUtil.getCompanyId(httpServletRequest);
 
 			while (_index < _filters.size()) {
 				Filter filter = _filters.get(_index++);

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/filters/invoker/InvokerFilterChain.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/filters/invoker/InvokerFilterChain.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.servlet.TryFilter;
 import com.liferay.portal.kernel.servlet.TryFinallyFilter;
 import com.liferay.portal.kernel.servlet.WrapHttpServletRequestFilter;
 import com.liferay.portal.kernel.servlet.WrapHttpServletResponseFilter;
+import com.liferay.portal.kernel.util.PortalUtil;
 
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
@@ -67,6 +68,11 @@ public class InvokerFilterChain implements FilterChain {
 				(HttpServletRequest)servletRequest;
 			HttpServletResponse httpServletResponse =
 				(HttpServletResponse)servletResponse;
+
+			// Company ID needs to be called here so that it is set
+			// across all filters
+
+			PortalUtil.getCompanyId(httpServletRequest);
 
 			while (_index < _filters.size()) {
 				Filter filter = _filters.get(_index++);


### PR DESCRIPTION
@javalosjr96 @achaparro 

Previous PR https://github.com/liferay-page-management/liferay-portal/pull/17455

The implemented solution doesn't work because `PortalUtil.getCompanyId(httpServletRequest)` is not executed when in **InvokerFilterChain** _filters is null. For more information, see https://liferay.atlassian.net/browse/LPP-59785?focusedCommentId=2981848

I have moved the new code to **InvokerFilter**, see 12359d4add11213f10367f7ca8179031bc8a0836

I have also added a small simplification here: f9d044d1f12bde4f72828e925b7cd685cc36a328

I didn't change the tests clase, @javalosjr96 can you move your new code from InvokerFilterChainTest to InvokerFilterTest?

I also noticed that this Assert has three parameters: https://github.com/liferay-page-management/liferay-portal/pull/17455/commits/d9fe6dce69f7e41e05258ef3667dc5629c2e24fc#diff-2bf3361aa479edfb17b19084cfbadc27bf3241f7cbdddd80a4918176845ce1d6R59-R61 its should be: `Assert.assertEquals(companyId, CompanyThreadLocal.getCompanyId())`