### PR TITLE
LPD-62059 use getId when using portletDisplay

### DIFF
--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/add_configuration_template.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/add_configuration_template.jsp
@@ -35,7 +35,7 @@ String redirect = ParamUtil.getString(request, "redirect");
 							boolean useCustomTitle = GetterUtil.getBoolean(portletPreferences.getValue("portletSetupUseCustomTitle", null));
 
 							if (useCustomTitle) {
-								name = PortletConfigurationUtil.getPortletTitle(portletDisplay.getPortletName(), portletPreferences, LocaleUtil.toLanguageId(themeDisplay.getSiteDefaultLocale()));
+								name = PortletConfigurationUtil.getPortletTitle(portletDisplay.getId(), portletPreferences, LocaleUtil.toLanguageId(themeDisplay.getSiteDefaultLocale()));
 							}
 							%>
 

--- a/portal-impl/src/com/liferay/portlet/internal/RenderResponseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/RenderResponseImpl.java
@@ -73,8 +73,7 @@ public class RenderResponseImpl
 		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
 
 		String localizedCustomTitle = PortletConfigurationUtil.getPortletTitle(
-			portletDisplay.getPortletName(),
-			portletDisplay.getPortletPreferences(),
+			portletDisplay.getId(), portletDisplay.getPortletPreferences(),
 			themeDisplay.getLanguageId());
 
 		if (Validator.isNull(localizedCustomTitle)) {
@@ -82,7 +81,7 @@ public class RenderResponseImpl
 				themeDisplay.getSiteDefaultLocale());
 
 			localizedCustomTitle = PortletConfigurationUtil.getPortletTitle(
-				portletDisplay.getPortletName(),
+				portletDisplay.getId(),
 				portletDisplay.getPortletPreferences(), siteDefaultLanguageId);
 		}
 

--- a/portal-web/docroot/html/common/themes/portlet.jsp
+++ b/portal-web/docroot/html/common/themes/portlet.jsp
@@ -18,7 +18,7 @@ LiferayRenderResponse liferayRenderResponse = (LiferayRenderResponse)LiferayPort
 
 // Portlet title
 
-String portletTitle = PortletConfigurationUtil.getPortletTitle(portletDisplay.getPortletName(), portletDisplay.getPortletPreferences(), themeDisplay.getLanguageId());
+String portletTitle = PortletConfigurationUtil.getPortletTitle(portletDisplay.getPortletId(), portletDisplay.getPortletPreferences(), themeDisplay.getLanguageId());
 
 if (portletDisplay.isActive() && Validator.isNull(portletTitle)) {
 	portletTitle = liferayRenderResponse.getTitle();


### PR DESCRIPTION
Issue:
When portletDisplay is used the portletName is being used instead of the portletsId which causes it to pull the incorrect portlet name.


To Do:
Still needs unit test, the customer wants a fix.