### PR TITLE
LPD-62059 use getId when using portletDisplay

### DIFF
--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/add_configuration_template.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/add_configuration_template.jsp
@@ -35,7 +35,7 @@ String redirect = ParamUtil.getString(request, "redirect");
 							boolean useCustomTitle = GetterUtil.getBoolean(portletPreferences.getValue("portletSetupUseCustomTitle", null));
 
 							if (useCustomTitle) {
-								name = PortletConfigurationUtil.getPortletTitle(portletDisplay.getPortletName(), portletPreferences, LocaleUtil.toLanguageId(themeDisplay.getSiteDefaultLocale()));
+								name = PortletConfigurationUtil.getPortletTitle(portletDisplay.getId(), portletPreferences, LocaleUtil.toLanguageId(themeDisplay.getSiteDefaultLocale()));
 							}
 							%>
 

--- a/portal-impl/src/com/liferay/portlet/internal/RenderResponseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/RenderResponseImpl.java
@@ -73,8 +73,7 @@ public class RenderResponseImpl
 		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
 
 		String localizedCustomTitle = PortletConfigurationUtil.getPortletTitle(
-			portletDisplay.getPortletName(),
-			portletDisplay.getPortletPreferences(),
+			portletDisplay.getId(), portletDisplay.getPortletPreferences(),
 			themeDisplay.getLanguageId());
 
 		if (Validator.isNull(localizedCustomTitle)) {
@@ -82,8 +81,8 @@ public class RenderResponseImpl
 				themeDisplay.getSiteDefaultLocale());
 
 			localizedCustomTitle = PortletConfigurationUtil.getPortletTitle(
-				portletDisplay.getPortletName(),
-				portletDisplay.getPortletPreferences(), siteDefaultLanguageId);
+				portletDisplay.getId(), portletDisplay.getPortletPreferences(),
+				siteDefaultLanguageId);
 		}
 
 		if (portletDisplay.isActive() &&

--- a/portal-impl/test/unit/com/liferay/portlet/internal/RenderResponseImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portlet/internal/RenderResponseImplTest.java
@@ -1,0 +1,200 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portlet.internal;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.portlet.PortletConfigFactory;
+import com.liferay.portal.kernel.portlet.PortletConfigFactoryUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ConcurrentHashMapBuilder;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.util.PortalImpl;
+import com.liferay.portlet.PortletPreferencesImpl;
+
+import jakarta.portlet.PortletConfig;
+import jakarta.portlet.PortletPreferences;
+
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.ResourceBundle;
+import java.util.Vector;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Jorge Avalos
+ */
+public class RenderResponseImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		PortalUtil portalUtil = new PortalUtil();
+
+		portalUtil.setPortal(new PortalImpl());
+
+		_setUpLanguageUtil();
+
+		_portletId = RandomTestUtil.randomString();
+
+		_portletTitle = RandomTestUtil.randomString();
+	}
+
+	@Test
+	public void testSetTitle() throws Exception {
+		RenderResponseImpl renderResponseImpl = new RenderResponseImpl();
+
+		PortletRequestImpl portletRequestImpl = Mockito.mock(
+			PortletRequestImpl.class);
+
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		PortletDisplay portletDisplay = Mockito.mock(PortletDisplay.class);
+
+		PortletConfigFactory portletConfigFactory = Mockito.mock(
+			PortletConfigFactory.class);
+
+		PortletConfig portletConfig = Mockito.mock(PortletConfig.class);
+
+		Mockito.when(
+			portletConfigFactory.get(_portletId)
+		).thenReturn(
+			portletConfig
+		);
+
+		ResourceBundle testResourceBundle = new TestResourceBundle();
+
+		Mockito.when(
+			portletConfig.getResourceBundle(Mockito.any(Locale.class))
+		).thenReturn(
+			testResourceBundle
+		);
+
+		Mockito.when(
+			portletDisplay.getId()
+		).thenReturn(
+			_portletId
+		);
+
+		PortletPreferences portletPreferences = new PortletPreferencesImpl();
+
+		portletPreferences.setValue("portletSetupUseCustomTitle", "true");
+
+		Mockito.when(
+			portletDisplay.getPortletPreferences()
+		).thenReturn(
+			portletPreferences
+		);
+
+		Mockito.when(
+			themeDisplay.getLanguageId()
+		).thenReturn(
+			"en_US"
+		);
+
+		Mockito.when(
+			portletRequestImpl.getAttribute(WebKeys.THEME_DISPLAY)
+		).thenReturn(
+			themeDisplay
+		);
+
+		Mockito.when(
+			themeDisplay.getPortletDisplay()
+		).thenReturn(
+			portletDisplay
+		);
+
+		Map<String, PortletConfig> portletConfigs =
+			HashMapBuilder.<String, PortletConfig>put(
+				_portletId, portletConfig
+			).build();
+
+		Map<String, Map<String, PortletConfig>> pool =
+			ConcurrentHashMapBuilder.<String, Map<String, PortletConfig>>put(
+				StringBundler.concat(
+					JavaConstants.JAKARTA_PORTLET_TITLE, StringPool.PERIOD,
+					_portletId),
+				portletConfigs
+			).build();
+
+		ReflectionTestUtil.setFieldValue(
+			new PortletConfigFactoryUtil(), "_portletConfigFactory",
+			portletConfigFactory);
+
+		ReflectionTestUtil.setFieldValue(
+			new PortletConfigFactoryImpl(), "_pool", pool);
+
+		ReflectionTestUtil.setFieldValue(
+			renderResponseImpl, "portletRequestImpl", portletRequestImpl);
+
+		renderResponseImpl.setTitle("");
+
+		Assert.assertEquals(_portletTitle, renderResponseImpl.getTitle());
+	}
+
+	public class TestResourceBundle extends ResourceBundle {
+
+		public TestResourceBundle() {
+			_data.put(JavaConstants.JAKARTA_PORTLET_TITLE, _portletTitle);
+		}
+
+		@Override
+		public Enumeration<String> getKeys() {
+			return new Vector<>(
+				_data.keySet()
+			).elements();
+		}
+
+		@Override
+		protected Object handleGetObject(String key) {
+			return _data.get(key);
+		}
+
+		private Map<String, Object> _data = new HashMap<>();
+
+	}
+
+	private void _setUpLanguageUtil() {
+		LanguageUtil languageUtil = new LanguageUtil();
+
+		Language language = Mockito.mock(Language.class);
+
+		languageUtil.setLanguage(language);
+
+		Mockito.when(
+			language.isAvailableLocale(LocaleUtil.US)
+		).thenReturn(
+			true
+		);
+	}
+
+	private String _portletId;
+	private String _portletTitle;
+
+}

--- a/portal-impl/test/unit/com/liferay/portlet/internal/RenderResponseImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portlet/internal/RenderResponseImplTest.java
@@ -60,10 +60,6 @@ public class RenderResponseImplTest {
 		portalUtil.setPortal(new PortalImpl());
 
 		_setUpLanguageUtil();
-
-		_portletId = RandomTestUtil.randomString();
-
-		_portletTitle = RandomTestUtil.randomString();
 	}
 
 	@Test
@@ -82,11 +78,15 @@ public class RenderResponseImplTest {
 
 		PortletConfig portletConfig = Mockito.mock(PortletConfig.class);
 
+		_portletId = RandomTestUtil.randomString();
+
 		Mockito.when(
 			portletConfigFactory.get(_portletId)
 		).thenReturn(
 			portletConfig
 		);
+
+		_portletTitle = RandomTestUtil.randomString();
 
 		ResourceBundle testResourceBundle = new TestResourceBundle();
 

--- a/portal-web/docroot/html/common/themes/portlet.jsp
+++ b/portal-web/docroot/html/common/themes/portlet.jsp
@@ -18,7 +18,7 @@ LiferayRenderResponse liferayRenderResponse = (LiferayRenderResponse)LiferayPort
 
 // Portlet title
 
-String portletTitle = PortletConfigurationUtil.getPortletTitle(portletDisplay.getPortletName(), portletDisplay.getPortletPreferences(), themeDisplay.getLanguageId());
+String portletTitle = PortletConfigurationUtil.getPortletTitle(portletDisplay.getId(), portletDisplay.getPortletPreferences(), themeDisplay.getLanguageId());
 
 if (portletDisplay.isActive() && Validator.isNull(portletTitle)) {
 	portletTitle = liferayRenderResponse.getTitle();


### PR DESCRIPTION
Issue:
When portletDisplay is used the portletName is being used instead of the portletsId which causes it to pull the incorrect portlet name.

To Do:
Still needs unit test, the customer wants a fix.
