### PR TITLE
LPD-63068 Adding Collection Filter fails with SQL Exception

### DIFF
--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -5344,18 +5344,6 @@
 				</licenses>
 			</library>
 			<library>
-				<file-name>com.liferay.shared.dependencies.netty.jar!nimbus-jose-jwt.jar</file-name>
-				<version>10.4</version>
-				<project-name>Nimbus JOSE+JWT</project-name>
-				<project-url>https://connect2id.com</project-url>
-				<licenses>
-					<license>
-						<license-name>The Apache Software License, Version 2.0</license-name>
-						<license-url>https://www.apache.org/licenses/LICENSE-2.0.txt</license-url>
-					</license>
-				</licenses>
-			</library>
-			<library>
 				<file-name>com.liferay.shared.dependencies.netty.jar!oauth2-oidc-sdk.jar</file-name>
 				<version>11.13</version>
 				<project-name>OAuth 2.0 SDK with OpenID Connect extensions</project-name>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -2781,12 +2781,6 @@
                 </tr>
                 			
                 <tr>
-                    <td nowrap="nowrap">com.liferay.shared.dependencies.netty.jar!nimbus-jose-jwt.jar</td><td nowrap="nowrap">10.4</td><td nowrap="nowrap"><a href="https://connect2id.com">Nimbus JOSE+JWT</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
-                        <br>
-                    </td><td></td>
-                </tr>
-                			
-                <tr>
                     <td nowrap="nowrap">com.liferay.shared.dependencies.netty.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">11.13</td><td nowrap="nowrap"><a href="https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.html">Apache License, version 2.0</a>
                         <br>
                     </td><td></td>

--- a/modules/apps/fragment/fragment-service/bnd.bnd
+++ b/modules/apps/fragment/fragment-service/bnd.bnd
@@ -5,6 +5,6 @@ Import-Package:\
 	com.liferay.fragment.util.comparator,\
 	\
 	*
-Liferay-Require-SchemaVersion: 2.15.0
+Liferay-Require-SchemaVersion: 2.15.1
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/registry/FragmentServiceUpgradeStepRegistrator.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/registry/FragmentServiceUpgradeStepRegistrator.java
@@ -264,6 +264,11 @@ public class FragmentServiceUpgradeStepRegistrator
 			"2.14.0", "2.15.0",
 			UpgradeProcessFactory.addColumns(
 				"FragmentCollection", "marketplace BOOLEAN"));
+
+		registry.register(
+			"2.15.0", "2.15.1",
+			UpgradeProcessFactory.alterColumnType(
+				"FragmentEntry", "fragmentEntryKey", "VARCHAR(100) null"));
 	}
 
 	@Reference

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentEntryModelImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentEntryModelImpl.java
@@ -124,7 +124,7 @@ public class FragmentEntryModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table FragmentEntry (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,headId LONG,head BOOLEAN,fragmentEntryId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,fragmentCollectionId LONG,fragmentEntryKey VARCHAR(75) null,name VARCHAR(75) null,css TEXT null,html TEXT null,js TEXT null,cacheable BOOLEAN,configuration TEXT null,icon VARCHAR(75) null,previewFileEntryId LONG,marketplace BOOLEAN,readOnly BOOLEAN,type_ INTEGER,typeOptions TEXT null,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null,primary key (fragmentEntryId, ctCollectionId))";
+		"create table FragmentEntry (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,headId LONG,head BOOLEAN,fragmentEntryId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,fragmentCollectionId LONG,fragmentEntryKey VARCHAR(100) null,name VARCHAR(75) null,css TEXT null,html TEXT null,js TEXT null,cacheable BOOLEAN,configuration TEXT null,icon VARCHAR(75) null,previewFileEntryId LONG,marketplace BOOLEAN,readOnly BOOLEAN,type_ INTEGER,typeOptions TEXT null,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null,primary key (fragmentEntryId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP = "drop table FragmentEntry";
 

--- a/modules/apps/fragment/fragment-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/fragment/fragment-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -66,7 +66,9 @@
 		<field name="createDate" type="Date" />
 		<field name="modifiedDate" type="Date" />
 		<field name="fragmentCollectionId" type="long" />
-		<field name="fragmentEntryKey" type="String" />
+		<field name="fragmentEntryKey" type="String">
+			<hint name="max-length">100</hint>
+		</field>
 		<field name="name" type="String">
 			<validator name="required" />
 		</field>

--- a/modules/apps/fragment/fragment-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/fragment/fragment-service/src/main/resources/META-INF/sql/indexes.sql
@@ -22,9 +22,9 @@ create index IX_14AA0B48 on FragmentEntry (groupId, fragmentCollectionId, head, 
 create index IX_18F9DFE on FragmentEntry (groupId, fragmentCollectionId, name[$COLUMN_LENGTH:75$]);
 create index IX_BE29E964 on FragmentEntry (groupId, fragmentCollectionId, status, name[$COLUMN_LENGTH:75$]);
 create index IX_BD1F4C5C on FragmentEntry (groupId, fragmentCollectionId, type_, status);
-create index IX_7F3F0EB3 on FragmentEntry (groupId, fragmentEntryKey[$COLUMN_LENGTH:75$]);
+create index IX_7F3F0EB3 on FragmentEntry (groupId, fragmentEntryKey[$COLUMN_LENGTH:100$]);
 create unique index IX_8DDC1989 on FragmentEntry (groupId, head, ctCollectionId, externalReferenceCode[$COLUMN_LENGTH:75$]);
-create unique index IX_C3F2A8E5 on FragmentEntry (groupId, head, ctCollectionId, fragmentEntryKey[$COLUMN_LENGTH:75$]);
+create unique index IX_C3F2A8E5 on FragmentEntry (groupId, head, ctCollectionId, fragmentEntryKey[$COLUMN_LENGTH:100$]);
 create unique index IX_A420787C on FragmentEntry (groupId, head, uuid_[$COLUMN_LENGTH:75$], ctCollectionId);
 create index IX_515CC759 on FragmentEntry (head, type_);
 create index IX_40CE21AD on FragmentEntry (type_);

--- a/modules/apps/fragment/fragment-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/fragment/fragment-service/src/main/resources/META-INF/sql/tables.sql
@@ -60,7 +60,7 @@ create table FragmentEntry (
 	createDate DATE null,
 	modifiedDate DATE null,
 	fragmentCollectionId LONG,
-	fragmentEntryKey VARCHAR(75) null,
+	fragmentEntryKey VARCHAR(100) null,
 	name VARCHAR(75) null,
 	css TEXT null,
 	html TEXT null,

--- a/modules/apps/fragment/fragment-service/src/main/resources/service.properties
+++ b/modules/apps/fragment/fragment-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.fragment.service
-    build.number=1
-    build.date=1505731263383
+    build.number=2
+    build.date=1755627399736


### PR DESCRIPTION
Issue:
The column fragmentEntryKey in the FragmentEntry table is not longer enough to support the search done when adding the Collection filter.  While this is not an issue for databases like MySQL/Maria,  it is for DB2(and perhaps others). 

The problematic fragmentEntryKey is:
com.liferay.fragment.renderer.collection.filter.internal.collectionfilterfragmentrenderer

In MySQL/MariaDB,  the database will truncate the text to match the 75 (varchar), which avoids the issue, but if inserted,  it can caused the data to be saved as such. 

In DB2,  it just fails. 

Solution:
Increase the column length of fragmentEntryKey to (100).  

The largest value(81) that I have been able to find is the one found in this ticket:
`com.liferay.fragment.renderer.collection.filter.internal.collectionfilterfragmentrenderer`
