### PR TITLE
LPD-62059 use getId when using portletDisplay

### DIFF
--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/add_configuration_template.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/add_configuration_template.jsp
@@ -35,7 +35,7 @@ String redirect = ParamUtil.getString(request, "redirect");
 							boolean useCustomTitle = GetterUtil.getBoolean(portletPreferences.getValue("portletSetupUseCustomTitle", null));
 
 							if (useCustomTitle) {
-								name = PortletConfigurationUtil.getPortletTitle(portletDisplay.getPortletName(), portletPreferences, LocaleUtil.toLanguageId(themeDisplay.getSiteDefaultLocale()));
+								name = PortletConfigurationUtil.getPortletTitle(portletDisplay.getId(), portletPreferences, LocaleUtil.toLanguageId(themeDisplay.getSiteDefaultLocale()));
 							}
 							%>
 

--- a/portal-impl/src/com/liferay/portlet/internal/RenderResponseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/RenderResponseImpl.java
@@ -73,8 +73,7 @@ public class RenderResponseImpl
 		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
 
 		String localizedCustomTitle = PortletConfigurationUtil.getPortletTitle(
-			portletDisplay.getPortletName(),
-			portletDisplay.getPortletPreferences(),
+			portletDisplay.getId(), portletDisplay.getPortletPreferences(),
 			themeDisplay.getLanguageId());
 
 		if (Validator.isNull(localizedCustomTitle)) {
@@ -82,8 +81,8 @@ public class RenderResponseImpl
 				themeDisplay.getSiteDefaultLocale());
 
 			localizedCustomTitle = PortletConfigurationUtil.getPortletTitle(
-				portletDisplay.getPortletName(),
-				portletDisplay.getPortletPreferences(), siteDefaultLanguageId);
+				portletDisplay.getId(), portletDisplay.getPortletPreferences(),
+				siteDefaultLanguageId);
 		}
 
 		if (portletDisplay.isActive() &&

--- a/portal-impl/test/unit/com/liferay/portlet/internal/RenderResponseImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portlet/internal/RenderResponseImplTest.java
@@ -66,13 +66,8 @@ public class RenderResponseImplTest {
 
 	@Test
 	public void testSetTitle() throws Exception {
-		PortletDisplay portletDisplay = Mockito.mock(PortletDisplay.class);
-
-		Mockito.when(
-			portletDisplay.getId()
-		).thenReturn(
-			_PORTLET_ID
-		);
+		PortletRequestImpl portletRequestImpl = Mockito.mock(
+			PortletRequestImpl.class);
 
 		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
 
@@ -82,14 +77,13 @@ public class RenderResponseImplTest {
 			"en_US"
 		);
 
-		PortletRequestImpl portletRequestImpl = Mockito.mock(
-			PortletRequestImpl.class);
-
 		Mockito.when(
 			portletRequestImpl.getAttribute(WebKeys.THEME_DISPLAY)
 		).thenReturn(
 			themeDisplay
 		);
+
+		PortletDisplay portletDisplay = Mockito.mock(PortletDisplay.class);
 
 		Mockito.when(
 			themeDisplay.getPortletDisplay()
@@ -97,27 +91,38 @@ public class RenderResponseImplTest {
 			portletDisplay
 		);
 
+		String portletId = RandomTestUtil.randomString();
+
+		Mockito.when(
+			portletDisplay.getId()
+		).thenReturn(
+			portletId
+		);
+
 		RenderResponseImpl renderResponseImpl = new RenderResponseImpl();
 
 		ReflectionTestUtil.setFieldValue(
 			renderResponseImpl, "portletRequestImpl", portletRequestImpl);
+
+		String portletTitle = RandomTestUtil.randomString();
 
 		_portletConfigurationUtilMockedStatic.when(
 			() -> PortletConfigurationUtil.getPortletTitle(
 				portletDisplay.getId(), portletDisplay.getPortletPreferences(),
 				themeDisplay.getLanguageId())
 		).thenReturn(
-			_PORTLET_TITLE
+			portletTitle
 		);
 
 		renderResponseImpl.setTitle("");
 
-		Assert.assertEquals(_PORTLET_TITLE, renderResponseImpl.getTitle());
+		Assert.assertEquals(portletTitle, renderResponseImpl.getTitle());
+
+		_portletConfigurationUtilMockedStatic.verify(
+			() -> PortletConfigurationUtil.getPortletTitle(
+				portletDisplay.getId(), portletDisplay.getPortletPreferences(),
+				themeDisplay.getLanguageId()));
 	}
-
-	private static final String _PORTLET_ID = RandomTestUtil.randomString();
-
-	private static final String _PORTLET_TITLE = RandomTestUtil.randomString();
 
 	private static final MockedStatic<PortletConfigurationUtil>
 		_portletConfigurationUtilMockedStatic = Mockito.mockStatic(

--- a/portal-impl/test/unit/com/liferay/portlet/internal/RenderResponseImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portlet/internal/RenderResponseImplTest.java
@@ -121,7 +121,8 @@ public class RenderResponseImplTest {
 		_portletConfigurationUtilMockedStatic.verify(
 			() -> PortletConfigurationUtil.getPortletTitle(
 				portletDisplay.getId(), portletDisplay.getPortletPreferences(),
-				themeDisplay.getLanguageId()));
+				themeDisplay.getLanguageId()),
+			Mockito.times(1));
 	}
 
 	private static final MockedStatic<PortletConfigurationUtil>

--- a/portal-impl/test/unit/com/liferay/portlet/internal/RenderResponseImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portlet/internal/RenderResponseImplTest.java
@@ -1,0 +1,126 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portlet.internal;
+
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.util.PortalImpl;
+import com.liferay.portlet.configuration.kernel.util.PortletConfigurationUtil;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Jorge Avalos
+ */
+public class RenderResponseImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@AfterClass
+	public static void tearDownClass() {
+		_portletConfigurationUtilMockedStatic.close();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		PortalUtil portalUtil = new PortalUtil();
+
+		portalUtil.setPortal(new PortalImpl());
+
+		LanguageUtil languageUtil = new LanguageUtil();
+
+		Language language = Mockito.mock(Language.class);
+
+		languageUtil.setLanguage(language);
+
+		Mockito.when(
+			language.isAvailableLocale(LocaleUtil.US)
+		).thenReturn(
+			true
+		);
+
+		_portletConfigurationUtilMockedStatic.reset();
+	}
+
+	@Test
+	public void testSetTitle() throws Exception {
+		PortletDisplay portletDisplay = Mockito.mock(PortletDisplay.class);
+
+		Mockito.when(
+			portletDisplay.getId()
+		).thenReturn(
+			_PORTLET_ID
+		);
+
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			themeDisplay.getLanguageId()
+		).thenReturn(
+			"en_US"
+		);
+
+		PortletRequestImpl portletRequestImpl = Mockito.mock(
+			PortletRequestImpl.class);
+
+		Mockito.when(
+			portletRequestImpl.getAttribute(WebKeys.THEME_DISPLAY)
+		).thenReturn(
+			themeDisplay
+		);
+
+		Mockito.when(
+			themeDisplay.getPortletDisplay()
+		).thenReturn(
+			portletDisplay
+		);
+
+		RenderResponseImpl renderResponseImpl = new RenderResponseImpl();
+
+		ReflectionTestUtil.setFieldValue(
+			renderResponseImpl, "portletRequestImpl", portletRequestImpl);
+
+		_portletConfigurationUtilMockedStatic.when(
+			() -> PortletConfigurationUtil.getPortletTitle(
+				portletDisplay.getId(), portletDisplay.getPortletPreferences(),
+				themeDisplay.getLanguageId())
+		).thenReturn(
+			_PORTLET_TITLE
+		);
+
+		renderResponseImpl.setTitle("");
+
+		Assert.assertEquals(_PORTLET_TITLE, renderResponseImpl.getTitle());
+	}
+
+	private static final String _PORTLET_ID = RandomTestUtil.randomString();
+
+	private static final String _PORTLET_TITLE = RandomTestUtil.randomString();
+
+	private static final MockedStatic<PortletConfigurationUtil>
+		_portletConfigurationUtilMockedStatic = Mockito.mockStatic(
+			PortletConfigurationUtil.class);
+
+}

--- a/portal-web/docroot/html/common/themes/portlet.jsp
+++ b/portal-web/docroot/html/common/themes/portlet.jsp
@@ -18,7 +18,7 @@ LiferayRenderResponse liferayRenderResponse = (LiferayRenderResponse)LiferayPort
 
 // Portlet title
 
-String portletTitle = PortletConfigurationUtil.getPortletTitle(portletDisplay.getPortletName(), portletDisplay.getPortletPreferences(), themeDisplay.getLanguageId());
+String portletTitle = PortletConfigurationUtil.getPortletTitle(portletDisplay.getId(), portletDisplay.getPortletPreferences(), themeDisplay.getLanguageId());
 
 if (portletDisplay.isActive() && Validator.isNull(portletTitle)) {
 	portletTitle = liferayRenderResponse.getTitle();


### PR DESCRIPTION
Previous PR:
https://github.com/liferay-page-management/liferay-portal/pull/17481

Issue:
When portletDisplay is used the portletName is being used instead of the portletsId which causes it to pull the incorrect portlet name.

To Do:
Still needs unit test, the customer wants a fix.

The code changes are good,  the test needed to be written. 

