### PR TITLE
LPD-63831 Avoid usage of GuestOrUserUtil in *LocalServiceImpl classes

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-drop-zone/src/main/java/com/liferay/fragment/entry/processor/drop/zone/listener/DropZoneFragmentEntryLinkListener.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-drop-zone/src/main/java/com/liferay/fragment/entry/processor/drop/zone/listener/DropZoneFragmentEntryLinkListener.java
@@ -222,6 +222,7 @@ public class DropZoneFragmentEntryLinkListener
 
 				_layoutPageTemplateStructureLocalService.
 					updateLayoutPageTemplateStructureData(
+						fragmentEntryLink.getUserId(),
 						fragmentEntryLink.getGroupId(),
 						fragmentEntryLink.getPlid(),
 						fragmentEntryLink.getSegmentsExperienceId(),
@@ -422,6 +423,7 @@ public class DropZoneFragmentEntryLinkListener
 
 				_layoutPageTemplateStructureLocalService.
 					updateLayoutPageTemplateStructureData(
+						fragmentEntryLink.getUserId(),
 						fragmentEntryLink.getGroupId(),
 						fragmentEntryLink.getPlid(),
 						fragmentEntryLink.getSegmentsExperienceId(),

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-drop-zone/src/test/java/com/liferay/fragment/entry/processor/drop/zone/listener/DropZoneFragmentEntryLinkListenerTest.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-drop-zone/src/test/java/com/liferay/fragment/entry/processor/drop/zone/listener/DropZoneFragmentEntryLinkListenerTest.java
@@ -383,7 +383,7 @@ public class DropZoneFragmentEntryLinkListenerTest {
 				_layoutPageTemplateStructureLocalService, Mockito.never()
 			).updateLayoutPageTemplateStructureData(
 				Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong(),
-				Mockito.anyString()
+				Mockito.anyLong(), Mockito.anyString()
 			);
 
 			return;
@@ -396,7 +396,7 @@ public class DropZoneFragmentEntryLinkListenerTest {
 			_layoutPageTemplateStructureLocalService
 		).updateLayoutPageTemplateStructureData(
 			Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong(),
-			argumentCaptor.capture()
+			Mockito.anyLong(), argumentCaptor.capture()
 		);
 
 		LayoutStructure layoutStructure = LayoutStructure.of(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageElementResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageElementResourceImpl.java
@@ -95,7 +95,7 @@ public class PageElementResourceImpl extends BasePageElementResourceImpl {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				layout.getGroupId(), layout.getPlid(),
+				contextUser.getUserId(), layout.getGroupId(), layout.getPlid(),
 				layoutStructure.toString());
 	}
 
@@ -371,8 +371,8 @@ public class PageElementResourceImpl extends BasePageElementResourceImpl {
 
 			_layoutPageTemplateStructureLocalService.
 				updateLayoutPageTemplateStructureData(
-					layout.getGroupId(), layout.getPlid(),
-					layoutStructure.toString());
+					contextUser.getUserId(), layout.getGroupId(),
+					layout.getPlid(), layoutStructure.toString());
 		}
 
 		return _pageElementDTOConverter.toDTO(
@@ -394,7 +394,7 @@ public class PageElementResourceImpl extends BasePageElementResourceImpl {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				layout.getGroupId(), layout.getPlid(),
+				contextUser.getUserId(), layout.getGroupId(), layout.getPlid(),
 				layoutStructure.toString());
 
 		return _pageElementDTOConverter.toDTO(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateResourceTest.java
@@ -222,8 +222,8 @@ public class DisplayPageTemplateResourceTest
 
 		ReflectionTestUtil.invoke(
 			_mvcActionCommand, "_publishLayoutPageTemplateEntry",
-			new Class<?>[] {Layout.class, Layout.class},
-			layout.fetchDraftLayout(), layout);
+			new Class<?>[] {Layout.class, Layout.class, long.class},
+			layout.fetchDraftLayout(), layout, TestPropsValues.getUserId());
 
 		Assert.assertTrue(_isPublished(layout));
 

--- a/modules/apps/info/info-field-item-selector-web-test/src/testIntegration/java/com/liferay/info/field/item/selector/web/internal/test/InfoFieldItemSelectorViewDescriptorTest.java
+++ b/modules/apps/info/info-field-item-selector-web-test/src/testIntegration/java/com/liferay/info/field/item/selector/web/internal/test/InfoFieldItemSelectorViewDescriptorTest.java
@@ -203,8 +203,9 @@ public class InfoFieldItemSelectorViewDescriptorTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), draftLayout.getPlid(),
-				defaultSegmentsExperienceId, layoutStructure.toString());
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				draftLayout.getPlid(), defaultSegmentsExperienceId,
+				layoutStructure.toString());
 
 		mockHttpServletRequest.setParameter(
 			"formItemId", formStyledLayoutStructureItem.getItemId());

--- a/modules/apps/info/info-test/src/testIntegration/java/com/liferay/info/request/struts/test/EditInfoItemStrutsActionTest.java
+++ b/modules/apps/info/info-test/src/testIntegration/java/com/liferay/info/request/struts/test/EditInfoItemStrutsActionTest.java
@@ -804,8 +804,9 @@ public class EditInfoItemStrutsActionTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), layout.getPlid(),
-				_defaultSegmentsExperienceId, layoutStructure.toString());
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				layout.getPlid(), _defaultSegmentsExperienceId,
+				layoutStructure.toString());
 
 		return layout;
 	}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalArticleStagedModelDataHandlerTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalArticleStagedModelDataHandlerTest.java
@@ -385,6 +385,7 @@ public class JournalArticleStagedModelDataHandlerTest
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
+				TestPropsValues.getUserId(),
 				layoutPageTemplateStructure.getGroupId(),
 				layoutPageTemplateStructure.getPlid(),
 				defaultSegmentsExperienceId, layoutStructure.toString());
@@ -523,6 +524,7 @@ public class JournalArticleStagedModelDataHandlerTest
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
+				TestPropsValues.getUserId(),
 				layoutPageTemplateStructure.getGroupId(),
 				layoutPageTemplateStructure.getPlid(),
 				defaultSegmentsExperienceId, layoutStructure.toString());

--- a/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/portlet/action/test/CopyLayoutMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/portlet/action/test/CopyLayoutMVCActionCommandTest.java
@@ -48,6 +48,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.permission.ModelPermissions;
 import com.liferay.portal.kernel.service.permission.ModelPermissionsFactory;
+import com.liferay.portal.kernel.servlet.PortletServlet;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
@@ -79,6 +80,8 @@ import com.liferay.site.navigation.service.SiteNavigationMenuLocalService;
 import jakarta.portlet.ActionRequest;
 import jakarta.portlet.ActionResponse;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -90,6 +93,8 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
 
 /**
  * @author Mikel Lorza
@@ -347,6 +352,17 @@ public class CopyLayoutMVCActionCommandTest {
 			"name", RandomTestUtil.randomString());
 		mockLiferayPortletActionRequest.addParameter(
 			"plid", String.valueOf(draftLayout.getPlid()));
+
+		HttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+		mockHttpServletRequest.setAttribute(
+			WebKeys.USER_ID, TestPropsValues.getUserId());
+
+		mockLiferayPortletActionRequest.setAttribute(
+			PortletServlet.PORTLET_SERVLET_REQUEST, mockHttpServletRequest);
 
 		ReflectionTestUtil.invoke(
 			addSegmentsExperienceMVCActionCommand, "doTransactionalCommand",

--- a/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/portlet/action/test/DiscardDraftLayoutMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/portlet/action/test/DiscardDraftLayoutMVCActionCommandTest.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUti
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.servlet.PortletServlet;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.portlet.MockActionRequest;
 import com.liferay.portal.kernel.test.portlet.MockActionResponse;
@@ -48,6 +49,8 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -56,6 +59,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 /**
@@ -254,6 +258,17 @@ public class DiscardDraftLayoutMVCActionCommandTest {
 
 		mockLiferayPortletActionRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		HttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+		mockHttpServletRequest.setAttribute(
+			WebKeys.USER_ID, TestPropsValues.getUserId());
+
+		mockLiferayPortletActionRequest.setAttribute(
+			PortletServlet.PORTLET_SERVLET_REQUEST, mockHttpServletRequest);
 
 		mockLiferayPortletActionRequest.setParameter(
 			"name", RandomTestUtil.randomString());

--- a/modules/apps/layout/layout-api/bnd.bnd
+++ b/modules/apps/layout/layout-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout API
 Bundle-SymbolicName: com.liferay.layout.api
-Bundle-Version: 54.4.0
+Bundle-Version: 55.0.0
 Export-Package:\
 	com.liferay.layout.adaptive.media,\
 	com.liferay.layout.configuration,\

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/importer/LayoutsImporter.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/importer/LayoutsImporter.java
@@ -40,9 +40,9 @@ public interface LayoutsImporter {
 		throws Exception;
 
 	public List<FragmentEntryLink> importPageElement(
-			Layout layout, LayoutStructure layoutStructure, String parentItemId,
-			String pageElementJSON, int position, boolean preserveItemIds,
-			long segmentsExperienceId)
+			long userId, Layout layout, LayoutStructure layoutStructure,
+			String parentItemId, String pageElementJSON, int position,
+			boolean preserveItemIds, long segmentsExperienceId)
 		throws Exception;
 
 	public boolean validateFile(

--- a/modules/apps/layout/layout-api/src/main/resources/com/liferay/layout/importer/packageinfo
+++ b/modules/apps/layout/layout-api/src/main/resources/com/liferay/layout/importer/packageinfo
@@ -1,1 +1,1 @@
-version 5.1.0
+version 6.0.0

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/adaptive/media/test/LayoutAdaptiveMediaProcessorTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/adaptive/media/test/LayoutAdaptiveMediaProcessorTest.java
@@ -271,8 +271,9 @@ public class LayoutAdaptiveMediaProcessorTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), layout.getPlid(),
-				defaultSegmentsExperienceId, layoutStructure.toString());
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				layout.getPlid(), defaultSegmentsExperienceId,
+				layoutStructure.toString());
 
 		_themeDisplay.setLayout(layout);
 		_themeDisplay.setLayoutSet(layout.getLayoutSet());

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentCompositionMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentCompositionMVCActionCommandTest.java
@@ -342,8 +342,9 @@ public class AddFragmentCompositionMVCActionCommandTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), _layout.getPlid(),
-				defaultSegmentsExperienceId, layoutStructure.toString());
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				_layout.getPlid(), defaultSegmentsExperienceId,
+				layoutStructure.toString());
 
 		FragmentComposition fragmentComposition = _testAddFragmentComposition(
 			fragmentCollection, containerStyledLayoutStructureItem.getItemId(),

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
@@ -235,8 +235,9 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), layout.getPlid(),
-				defaultSegmentsExperienceId, layoutStructure.toString());
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				layout.getPlid(), defaultSegmentsExperienceId,
+				layoutStructure.toString());
 
 		String layoutStructureItemJSON =
 			_layoutStructureItemJSONSerializer.toJSONString(

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddItemMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddItemMVCActionCommandTest.java
@@ -131,8 +131,8 @@ public class AddItemMVCActionCommandTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), _layout.getPlid(),
-				_layoutStructure.toString());
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				_layout.getPlid(), _layoutStructure.toString());
 
 		mockLiferayPortletActionRequest.addParameter(
 			"itemType", LayoutDataItemTypeConstants.TYPE_CONTAINER);

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddSegmentsExperienceMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddSegmentsExperienceMVCActionCommandTest.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.servlet.PortletServlet;
 import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.TestInfo;
@@ -60,6 +61,8 @@ import com.liferay.segments.test.util.SegmentsTestUtil;
 import jakarta.portlet.ActionRequest;
 import jakarta.portlet.ActionResponse;
 import jakarta.portlet.PortletPreferences;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.Iterator;
 import java.util.List;
@@ -292,10 +295,25 @@ public class AddSegmentsExperienceMVCActionCommandTest {
 			"segmentsEntryId", String.valueOf(segmentsEntryId));
 		mockLiferayPortletActionRequest.setAttribute(
 			JavaConstants.JAKARTA_PORTLET_CONFIG, null);
+
+		HttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		ThemeDisplay themeDisplay = _getThemeDisplay();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.USER_ID, TestPropsValues.getUserId());
+
+		mockLiferayPortletActionRequest.setAttribute(
+			PortletServlet.PORTLET_SERVLET_REQUEST, mockHttpServletRequest);
+
 		mockLiferayPortletActionRequest.setAttribute(
 			WebKeys.LAYOUT, _draftLayout);
 		mockLiferayPortletActionRequest.setAttribute(
-			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+			WebKeys.THEME_DISPLAY, themeDisplay);
 
 		return mockLiferayPortletActionRequest;
 	}

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/CopyItemsMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/CopyItemsMVCActionCommandTest.java
@@ -448,8 +448,8 @@ public class CopyItemsMVCActionCommandTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_layout.getGroupId(), _layout.getPlid(),
-				layoutStructure.toString());
+				TestPropsValues.getUserId(), _layout.getGroupId(),
+				_layout.getPlid(), layoutStructure.toString());
 
 		JSONObject jsonObject = ReflectionTestUtil.invoke(
 			_mvcActionCommand, "doTransactionalCommand",

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/DeleteFormStepMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/DeleteFormStepMVCActionCommandTest.java
@@ -351,7 +351,8 @@ public class DeleteFormStepMVCActionCommandTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), _draftLayout.getPlid(),
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				_draftLayout.getPlid(),
 				_segmentsExperienceLocalService.
 					fetchDefaultSegmentsExperienceId(_draftLayout.getPlid()),
 				layoutStructure.toString());

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/DeleteSegmentsExperienceMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/DeleteSegmentsExperienceMVCActionCommandTest.java
@@ -18,6 +18,7 @@ import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
@@ -26,6 +27,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.servlet.PortletServlet;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.portlet.MockActionRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
@@ -42,6 +44,8 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import jakarta.portlet.PortletPreferences;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 import java.util.List;
 
 import org.junit.After;
@@ -52,6 +56,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 /**
@@ -202,10 +207,25 @@ public class DeleteSegmentsExperienceMVCActionCommandTest {
 	}
 
 	private long _addSegmentsExperience(Layout draftLayout) throws Exception {
+		Company company = _companyLocalService.getCompany(
+			TestPropsValues.getCompanyId());
+
 		MockActionRequest mockActionRequest =
 			ContentLayoutTestUtil.getMockLiferayPortletActionRequest(
-				_companyLocalService.getCompany(TestPropsValues.getCompanyId()),
-				_group, draftLayout);
+				company, _group, draftLayout);
+
+		HttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY,
+			ContentLayoutTestUtil.getThemeDisplay(
+				company, _group, draftLayout));
+		mockHttpServletRequest.setAttribute(
+			WebKeys.USER_ID, TestPropsValues.getUserId());
+
+		mockActionRequest.setAttribute(
+			PortletServlet.PORTLET_SERVLET_REQUEST, mockHttpServletRequest);
 
 		mockActionRequest.setAttribute(
 			WebKeys.PORTLET_ID,

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/DuplicateItemMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/DuplicateItemMVCActionCommandTest.java
@@ -338,8 +338,8 @@ public class DuplicateItemMVCActionCommandTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_draftLayout.getGroupId(), _draftLayout.getPlid(),
-				layoutStructure.toString());
+				TestPropsValues.getUserId(), _draftLayout.getGroupId(),
+				_draftLayout.getPlid(), layoutStructure.toString());
 
 		JSONObject jsonObject = ReflectionTestUtil.invoke(
 			_mvcActionCommand, "doTransactionalCommand",

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/GetPageContentMVCResourceCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/GetPageContentMVCResourceCommandTest.java
@@ -444,8 +444,8 @@ public class GetPageContentMVCResourceCommandTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), _layout.getPlid(),
-				layoutStructure.toString());
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				_layout.getPlid(), layoutStructure.toString());
 	}
 
 	private MockLiferayResourceRequest _getMockLiferayPortletResourceRequest(

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/MarkItemForDeletionMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/MarkItemForDeletionMVCActionCommandTest.java
@@ -123,7 +123,8 @@ public class MarkItemForDeletionMVCActionCommandTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), _layout.getPlid(),
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				_layout.getPlid(),
 				_segmentsExperienceLocalService.
 					fetchDefaultSegmentsExperienceId(_layout.getPlid()),
 				layoutStructure.toString());

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/MoveStepperFragmentEntryLinkMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/MoveStepperFragmentEntryLinkMVCActionCommandTest.java
@@ -121,8 +121,9 @@ public class MoveStepperFragmentEntryLinkMVCActionCommandTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), _draftLayout.getPlid(),
-				_segmentsExperienceId, layoutStructure.toString());
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				_draftLayout.getPlid(), _segmentsExperienceId,
+				layoutStructure.toString());
 
 		MockLiferayPortletActionResponse mockLiferayPortletActionResponse =
 			new MockLiferayPortletActionResponse();

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/PublishLayoutMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/PublishLayoutMVCActionCommandTest.java
@@ -316,8 +316,9 @@ public class PublishLayoutMVCActionCommandTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), _draftLayout.getPlid(),
-				_segmentsExperienceId, layoutStructure.toString());
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				_draftLayout.getPlid(), _segmentsExperienceId,
+				layoutStructure.toString());
 
 		ContentLayoutTestUtil.publishLayout(_draftLayout, _layout);
 
@@ -354,8 +355,9 @@ public class PublishLayoutMVCActionCommandTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), _draftLayout.getPlid(),
-				_segmentsExperienceId, layoutStructure.toString());
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				_draftLayout.getPlid(), _segmentsExperienceId,
+				layoutStructure.toString());
 
 		ContentLayoutTestUtil.publishLayout(_draftLayout, _layout);
 

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/PublishLayoutPageTemplateEntryMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/PublishLayoutPageTemplateEntryMVCActionCommandTest.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
@@ -108,14 +109,16 @@ public class PublishLayoutPageTemplateEntryMVCActionCommandTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), _draftLayout.getPlid(),
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				_draftLayout.getPlid(),
 				_segmentsExperienceLocalService.
 					fetchDefaultSegmentsExperienceId(_draftLayout.getPlid()),
 				layoutStructure.toString());
 
 		ReflectionTestUtil.invoke(
 			_mvcActionCommand, "_publishLayoutPageTemplateEntry",
-			new Class<?>[] {Layout.class, Layout.class}, _draftLayout, _layout);
+			new Class<?>[] {Layout.class, Layout.class, long.class},
+			_draftLayout, _layout, TestPropsValues.getUserId());
 
 		layoutStructure = _getLayoutStructure(_draftLayout);
 
@@ -147,7 +150,8 @@ public class PublishLayoutPageTemplateEntryMVCActionCommandTest {
 
 		ReflectionTestUtil.invoke(
 			_mvcActionCommand, "_publishLayoutPageTemplateEntry",
-			new Class<?>[] {Layout.class, Layout.class}, _draftLayout, _layout);
+			new Class<?>[] {Layout.class, Layout.class, long.class},
+			_draftLayout, _layout, TestPropsValues.getUserId());
 
 		_assertGuestViewPermission(_layout, portletId, true);
 	}
@@ -162,7 +166,8 @@ public class PublishLayoutPageTemplateEntryMVCActionCommandTest {
 
 		ReflectionTestUtil.invoke(
 			_mvcActionCommand, "_publishLayoutPageTemplateEntry",
-			new Class<?>[] {Layout.class, Layout.class}, _draftLayout, _layout);
+			new Class<?>[] {Layout.class, Layout.class, long.class},
+			_draftLayout, _layout, TestPropsValues.getUserId());
 
 		_assertGuestViewPermission(_layout, portletId, false);
 	}

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/UpdateItemConfigMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/UpdateItemConfigMVCActionCommandTest.java
@@ -113,8 +113,8 @@ public class UpdateItemConfigMVCActionCommandTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_layout.getGroupId(), _layout.getPlid(),
-				layoutStructure.toString());
+				TestPropsValues.getUserId(), _layout.getGroupId(),
+				_layout.getPlid(), layoutStructure.toString());
 
 		mockActionRequest.setParameter(
 			"itemConfig", "{\"styles\":{\"display\":\"none\"}}");
@@ -240,8 +240,8 @@ public class UpdateItemConfigMVCActionCommandTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_layout.getGroupId(), _layout.getPlid(),
-				layoutStructure.toString());
+				TestPropsValues.getUserId(), _layout.getGroupId(),
+				_layout.getPlid(), layoutStructure.toString());
 
 		JSONObject jsonObject = layoutStructureItem.getItemConfigJSONObject();
 
@@ -283,8 +283,8 @@ public class UpdateItemConfigMVCActionCommandTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_layout.getGroupId(), _layout.getPlid(),
-				layoutStructure.toString());
+				TestPropsValues.getUserId(), _layout.getGroupId(),
+				_layout.getPlid(), layoutStructure.toString());
 
 		JSONObject jsonObject = layoutStructureItem.getItemConfigJSONObject();
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/model/listener/LayoutPageTemplateEntryModelListener.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/model/listener/LayoutPageTemplateEntryModelListener.java
@@ -397,7 +397,8 @@ public class LayoutPageTemplateEntryModelListener
 
 			_layoutPageTemplateStructureLocalService.
 				updateLayoutPageTemplateStructureData(
-					layout.getGroupId(), layout.getPlid(), segmentsExperienceId,
+					layoutPageTemplateEntry.getUserId(), layout.getGroupId(),
+					layout.getPlid(), segmentsExperienceId,
 					layoutStructure.toString());
 		}
 		catch (PortalException portalException) {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentEntryLinksMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentEntryLinksMVCActionCommand.java
@@ -174,7 +174,8 @@ public class AddFragmentEntryLinksMVCActionCommand
 
 			List<FragmentEntryLink> fragmentEntryLinks =
 				_layoutsImporter.importPageElement(
-					themeDisplay.getLayout(), layoutStructure, parentItemId,
+					themeDisplay.getUserId(), themeDisplay.getLayout(),
+					layoutStructure, parentItemId,
 					fragmentComposition.getData(), position, false,
 					segmentsExperienceId);
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/PublishLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/PublishLayoutMVCActionCommand.java
@@ -152,7 +152,7 @@ public class PublishLayoutMVCActionCommand
 			layout = _layoutLocalService.getLayout(layout.getPlid());
 
 			LayoutStructureUtil.deleteMarkedForDeletionItems(
-				draftLayout.getGroupId(), draftLayout.getPlid());
+				draftLayout.getGroupId(), draftLayout.getPlid(), userId);
 
 			draftLayout = _layoutLocalService.getLayout(draftLayout.getPlid());
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/PublishLayoutPageTemplateEntryMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/PublishLayoutPageTemplateEntryMVCActionCommand.java
@@ -63,7 +63,8 @@ public class PublishLayoutPageTemplateEntryMVCActionCommand
 			themeDisplay.getPermissionChecker(), layout, ActionKeys.UPDATE);
 
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
-			_publishLayoutPageTemplateEntry(draftLayout, layout);
+			_publishLayoutPageTemplateEntry(
+				draftLayout, layout, themeDisplay.getUserId());
 
 		String portletId = _portal.getPortletId(actionRequest);
 
@@ -109,7 +110,7 @@ public class PublishLayoutPageTemplateEntryMVCActionCommand
 	}
 
 	private LayoutPageTemplateEntry _publishLayoutPageTemplateEntry(
-			Layout draftLayout, Layout layout)
+			Layout draftLayout, Layout layout, long userId)
 		throws Exception {
 
 		UnicodeProperties previousLayouTypeSettingsUnicodeProperties =
@@ -118,7 +119,7 @@ public class PublishLayoutPageTemplateEntryMVCActionCommand
 		_layoutLocalService.copyLayoutContent(draftLayout, layout);
 
 		LayoutStructureUtil.deleteMarkedForDeletionItems(
-			draftLayout.getGroupId(), draftLayout.getPlid());
+			draftLayout.getGroupId(), draftLayout.getPlid(), userId);
 
 		draftLayout = _layoutLocalService.fetchLayout(draftLayout.getPlid());
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/segments/SegmentsExperienceUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/segments/SegmentsExperienceUtil.java
@@ -198,7 +198,7 @@ public class SegmentsExperienceUtil {
 
 		LayoutPageTemplateStructureLocalServiceUtil.
 			updateLayoutPageTemplateStructureData(
-				groupId, layout.getPlid(),
+				userId, groupId, layout.getPlid(),
 				targetSegmentsExperience.getSegmentsExperienceId(),
 				dataJSONObject.toString());
 	}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/layout/structure/LayoutStructureUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/layout/structure/LayoutStructureUtil.java
@@ -24,7 +24,8 @@ import java.util.List;
  */
 public class LayoutStructureUtil {
 
-	public static void deleteMarkedForDeletionItems(long groupId, long plid)
+	public static void deleteMarkedForDeletionItems(
+			long groupId, long plid, long userId)
 		throws PortalException {
 
 		LayoutPageTemplateStructure layoutPageTemplateStructure =
@@ -59,7 +60,7 @@ public class LayoutStructureUtil {
 
 			LayoutPageTemplateStructureLocalServiceUtil.
 				updateLayoutPageTemplateStructureData(
-					groupId, plid,
+					userId, groupId, plid,
 					layoutPageTemplateStructureRel.getSegmentsExperienceId(),
 					layoutStructure.toString());
 		}

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
@@ -255,16 +255,16 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 
 	@Override
 	public List<FragmentEntryLink> importPageElement(
-			Layout layout, LayoutStructure layoutStructure, String parentItemId,
-			String pageElementJSON, int position, boolean preserveItemIds,
-			long segmentsExperienceId)
+			long userId, Layout layout, LayoutStructure layoutStructure,
+			String parentItemId, String pageElementJSON, int position,
+			boolean preserveItemIds, long segmentsExperienceId)
 		throws Exception {
 
 		Consumer<LayoutStructure> consumer = processedLayoutStructure -> {
 			try {
 				_layoutPageTemplateStructureLocalService.
 					updateLayoutPageTemplateStructureData(
-						layout.getGroupId(), layout.getPlid(),
+						userId, layout.getGroupId(), layout.getPlid(),
 						segmentsExperienceId,
 						processedLayoutStructure.toString());
 			}

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/BulkLayoutConverterImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/BulkLayoutConverterImpl.java
@@ -240,8 +240,9 @@ public class BulkLayoutConverterImpl implements BulkLayoutConverter {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				layout.getGroupId(), layout.getPlid(),
-				defaultSegmentsExperienceId, layoutDataJSONObject.toString());
+				serviceContext.getUserId(), layout.getGroupId(),
+				layout.getPlid(), defaultSegmentsExperienceId,
+				layoutDataJSONObject.toString());
 	}
 
 	private Layout _convertLayout(long plid) throws PortalException {

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
@@ -866,8 +866,8 @@ public class LayoutsImporterTest {
 
 		try {
 			_layoutsImporter.importPageElement(
-				TestPropsValues.getUserId(), draftLayout, layoutStructure, layoutStructure.getMainItemId(),
-				pageElementJSON, 0, true,
+				TestPropsValues.getUserId(), draftLayout, layoutStructure,
+				layoutStructure.getMainItemId(), pageElementJSON, 0, true,
 				_segmentsExperienceLocalService.
 					fetchDefaultSegmentsExperienceId(draftLayout.getPlid()));
 
@@ -914,8 +914,8 @@ public class LayoutsImporterTest {
 
 		try {
 			_layoutsImporter.importPageElement(
-				TestPropsValues.getUserId(), draftLayout, layoutStructure, layoutStructure.getMainItemId(),
-				pageElementJSON, 0, true,
+				TestPropsValues.getUserId(), draftLayout, layoutStructure,
+				layoutStructure.getMainItemId(), pageElementJSON, 0, true,
 				segmentsExperience.getSegmentsExperienceId());
 		}
 		finally {
@@ -954,8 +954,8 @@ public class LayoutsImporterTest {
 
 		try {
 			_layoutsImporter.importPageElement(
-				TestPropsValues.getUserId(), draftLayout, layoutStructure, layoutStructure.getMainItemId(),
-				pageElementJSON, 0, true,
+				TestPropsValues.getUserId(), draftLayout, layoutStructure,
+				layoutStructure.getMainItemId(), pageElementJSON, 0, true,
 				segmentsExperience.getSegmentsExperienceId());
 
 			Assert.fail();
@@ -1515,8 +1515,8 @@ public class LayoutsImporterTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group1.getGroupId(), layoutPageTemplateEntry.getPlid(),
-				defaultSegmentsExperienceId,
+				TestPropsValues.getUserId(), _group1.getGroupId(),
+				layoutPageTemplateEntry.getPlid(), defaultSegmentsExperienceId,
 				StringUtil.replace(
 					_read("export_import_layout_data.json"), "${", "}",
 					HashMapBuilder.put(

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
@@ -866,7 +866,7 @@ public class LayoutsImporterTest {
 
 		try {
 			_layoutsImporter.importPageElement(
-				draftLayout, layoutStructure, layoutStructure.getMainItemId(),
+				TestPropsValues.getUserId(), draftLayout, layoutStructure, layoutStructure.getMainItemId(),
 				pageElementJSON, 0, true,
 				_segmentsExperienceLocalService.
 					fetchDefaultSegmentsExperienceId(draftLayout.getPlid()));
@@ -914,7 +914,7 @@ public class LayoutsImporterTest {
 
 		try {
 			_layoutsImporter.importPageElement(
-				draftLayout, layoutStructure, layoutStructure.getMainItemId(),
+				TestPropsValues.getUserId(), draftLayout, layoutStructure, layoutStructure.getMainItemId(),
 				pageElementJSON, 0, true,
 				segmentsExperience.getSegmentsExperienceId());
 		}
@@ -954,7 +954,7 @@ public class LayoutsImporterTest {
 
 		try {
 			_layoutsImporter.importPageElement(
-				draftLayout, layoutStructure, layoutStructure.getMainItemId(),
+				TestPropsValues.getUserId(), draftLayout, layoutStructure, layoutStructure.getMainItemId(),
 				pageElementJSON, 0, true,
 				segmentsExperience.getSegmentsExperienceId());
 

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ExportDisplayPagesMVCResourceCommandTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ExportDisplayPagesMVCResourceCommandTest.java
@@ -95,7 +95,8 @@ public class ExportDisplayPagesMVCResourceCommandTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), layoutPageTemplateEntry.getPlid(),
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				layoutPageTemplateEntry.getPlid(),
 				_segmentsExperienceLocalService.
 					fetchDefaultSegmentsExperienceId(
 						layoutPageTemplateEntry.getPlid()),
@@ -171,7 +172,8 @@ public class ExportDisplayPagesMVCResourceCommandTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), layoutPageTemplateEntry1.getPlid(),
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				layoutPageTemplateEntry1.getPlid(),
 				_segmentsExperienceLocalService.
 					fetchDefaultSegmentsExperienceId(
 						layoutPageTemplateEntry1.getPlid()),
@@ -185,7 +187,8 @@ public class ExportDisplayPagesMVCResourceCommandTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), layoutPageTemplateEntry2.getPlid(),
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				layoutPageTemplateEntry2.getPlid(),
 				_segmentsExperienceLocalService.
 					fetchDefaultSegmentsExperienceId(
 						layoutPageTemplateEntry2.getPlid()),

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ExportImportDisplayPagesTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ExportImportDisplayPagesTest.java
@@ -311,7 +311,8 @@ public class ExportImportDisplayPagesTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group1.getGroupId(), layoutPageTemplateEntry1.getPlid(),
+				TestPropsValues.getUserId(), _group1.getGroupId(),
+				layoutPageTemplateEntry1.getPlid(),
 				_segmentsExperienceLocalService.
 					fetchDefaultSegmentsExperienceId(
 						layoutPageTemplateEntry1.getPlid()),

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ExportImportMasterLayoutsTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ExportImportMasterLayoutsTest.java
@@ -98,7 +98,8 @@ public class ExportImportMasterLayoutsTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group1.getGroupId(), layoutPageTemplateEntry1.getPlid(),
+				TestPropsValues.getUserId(), _group1.getGroupId(),
+				layoutPageTemplateEntry1.getPlid(),
 				_segmentsExperienceLocalService.
 					fetchDefaultSegmentsExperienceId(
 						layoutPageTemplateEntry1.getPlid()),

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ExportLayoutPageTemplateEntriesMVCResourceCommandTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ExportLayoutPageTemplateEntriesMVCResourceCommandTest.java
@@ -300,7 +300,8 @@ public class ExportLayoutPageTemplateEntriesMVCResourceCommandTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), layoutPageTemplateEntry.getPlid(),
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				layoutPageTemplateEntry.getPlid(),
 				_segmentsExperienceLocalService.
 					fetchDefaultSegmentsExperienceId(
 						layoutPageTemplateEntry.getPlid()),

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ExportMasterLayoutsMVCResourceCommandTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ExportMasterLayoutsMVCResourceCommandTest.java
@@ -85,7 +85,8 @@ public class ExportMasterLayoutsMVCResourceCommandTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), layoutPageTemplateEntry.getPlid(),
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				layoutPageTemplateEntry.getPlid(),
 				_segmentsExperienceLocalService.
 					fetchDefaultSegmentsExperienceId(
 						layoutPageTemplateEntry.getPlid()),

--- a/modules/apps/layout/layout-page-template-api/bnd.bnd
+++ b/modules/apps/layout/layout-page-template-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout Page Template API
 Bundle-SymbolicName: com.liferay.layout.page.template.api
-Bundle-Version: 31.3.1
+Bundle-Version: 32.0.0
 Export-Package:\
 	com.liferay.layout.page.template.constants,\
 	com.liferay.layout.page.template.exception,\

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureLocalService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureLocalService.java
@@ -350,11 +350,12 @@ public interface LayoutPageTemplateStructureLocalService
 		LayoutPageTemplateStructure layoutPageTemplateStructure);
 
 	public LayoutPageTemplateStructure updateLayoutPageTemplateStructureData(
-			long groupId, long plid, long segmentsExperienceId, String data)
+			long userId, long groupId, long plid, long segmentsExperienceId,
+			String data)
 		throws PortalException;
 
 	public LayoutPageTemplateStructure updateLayoutPageTemplateStructureData(
-			long groupId, long plid, String data)
+			long userId, long groupId, long plid, String data)
 		throws PortalException;
 
 	@Override

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureLocalServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureLocalServiceUtil.java
@@ -403,20 +403,21 @@ public class LayoutPageTemplateStructureLocalServiceUtil {
 
 	public static LayoutPageTemplateStructure
 			updateLayoutPageTemplateStructureData(
-				long groupId, long plid, long segmentsExperienceId, String data)
+				long userId, long groupId, long plid, long segmentsExperienceId,
+				String data)
 		throws PortalException {
 
 		return getService().updateLayoutPageTemplateStructureData(
-			groupId, plid, segmentsExperienceId, data);
+			userId, groupId, plid, segmentsExperienceId, data);
 	}
 
 	public static LayoutPageTemplateStructure
 			updateLayoutPageTemplateStructureData(
-				long groupId, long plid, String data)
+				long userId, long groupId, long plid, String data)
 		throws PortalException {
 
 		return getService().updateLayoutPageTemplateStructureData(
-			groupId, plid, data);
+			userId, groupId, plid, data);
 	}
 
 	public static LayoutPageTemplateStructureLocalService getService() {

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureLocalServiceWrapper.java
@@ -458,21 +458,22 @@ public class LayoutPageTemplateStructureLocalServiceWrapper
 
 	@Override
 	public LayoutPageTemplateStructure updateLayoutPageTemplateStructureData(
-			long groupId, long plid, long segmentsExperienceId, String data)
+			long userId, long groupId, long plid, long segmentsExperienceId,
+			String data)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				groupId, plid, segmentsExperienceId, data);
+				userId, groupId, plid, segmentsExperienceId, data);
 	}
 
 	@Override
 	public LayoutPageTemplateStructure updateLayoutPageTemplateStructureData(
-			long groupId, long plid, String data)
+			long userId, long groupId, long plid, String data)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _layoutPageTemplateStructureLocalService.
-			updateLayoutPageTemplateStructureData(groupId, plid, data);
+			updateLayoutPageTemplateStructureData(userId, groupId, plid, data);
 	}
 
 	@Override

--- a/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/packageinfo
+++ b/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/packageinfo
@@ -1,1 +1,1 @@
-version 14.2.0
+version 15.0.0

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureLocalServiceImpl.java
@@ -19,8 +19,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
-import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
@@ -149,11 +147,12 @@ public class LayoutPageTemplateStructureLocalServiceImpl
 
 	@Override
 	public LayoutPageTemplateStructure updateLayoutPageTemplateStructureData(
-			long groupId, long plid, long segmentsExperienceId, String data)
+			long userId, long groupId, long plid, long segmentsExperienceId,
+			String data)
 		throws PortalException {
 
 		if (CheckUnlockedLayoutThreadLocal.isCheckUnlockedLayout()) {
-			_checkUnlockedLayout(plid);
+			_checkUnlockedLayout(userId, plid);
 		}
 
 		// Layout page template structure
@@ -179,7 +178,7 @@ public class LayoutPageTemplateStructureLocalServiceImpl
 		if (layoutPageTemplateStructureRel == null) {
 			_layoutPageTemplateStructureRelLocalService.
 				addLayoutPageTemplateStructureRel(
-					PrincipalThreadLocal.getUserId(), groupId,
+					userId, groupId,
 					layoutPageTemplateStructure.
 						getLayoutPageTemplateStructureId(),
 					segmentsExperienceId, data,
@@ -193,17 +192,17 @@ public class LayoutPageTemplateStructureLocalServiceImpl
 					segmentsExperienceId, data);
 		}
 
-		_updateLayoutStatus(PrincipalThreadLocal.getUserId(), plid);
+		_updateLayoutStatus(userId, plid);
 
 		return layoutPageTemplateStructure;
 	}
 
 	@Override
 	public LayoutPageTemplateStructure updateLayoutPageTemplateStructureData(
-			long groupId, long plid, String data)
+			long userId, long groupId, long plid, String data)
 		throws PortalException {
 
-		_checkUnlockedLayout(plid);
+		_checkUnlockedLayout(userId, plid);
 
 		long defaultSegmentsExperienceId =
 			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
@@ -211,15 +210,15 @@ public class LayoutPageTemplateStructureLocalServiceImpl
 
 		return layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				groupId, plid, defaultSegmentsExperienceId, data);
+				userId, groupId, plid, defaultSegmentsExperienceId, data);
 	}
 
-	private void _checkUnlockedLayout(long plid) throws PortalException {
+	private void _checkUnlockedLayout(long userId, long plid)
+		throws PortalException {
+
 		Layout layout = _layoutLocalService.fetchLayout(plid);
 
-		if ((layout != null) &&
-			!layout.isUnlocked(Constants.EDIT, GuestOrUserUtil.getUserId())) {
-
+		if ((layout != null) && !layout.isUnlocked(Constants.EDIT, userId)) {
 			throw new LockedLayoutException();
 		}
 	}

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureServiceImpl.java
@@ -46,7 +46,7 @@ public class LayoutPageTemplateStructureServiceImpl
 
 			return layoutPageTemplateStructureLocalService.
 				updateLayoutPageTemplateStructureData(
-					groupId, plid, segmentsExperienceId, data);
+					getUserId(), groupId, plid, segmentsExperienceId, data);
 		}
 
 		throw new PrincipalException.MustHavePermission(

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/importer/test/DisplayPagesImporterTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/importer/test/DisplayPagesImporterTest.java
@@ -154,8 +154,8 @@ public class DisplayPagesImporterTest {
 
 			_layoutPageTemplateStructureLocalService.
 				updateLayoutPageTemplateStructureData(
-					_group.getGroupId(), draftLayout.getPlid(),
-					layoutStructure.toString());
+					TestPropsValues.getUserId(), _group.getGroupId(),
+					draftLayout.getPlid(), layoutStructure.toString());
 
 			ContentLayoutTestUtil.publishLayout(draftLayout, layout);
 

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v3_3_0/test/LayoutPageTemplateStructureRelUpgradeProcessTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v3_3_0/test/LayoutPageTemplateStructureRelUpgradeProcessTest.java
@@ -218,8 +218,8 @@ public class LayoutPageTemplateStructureRelUpgradeProcessTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), plid, segmentsExperienceId,
-				layoutStructure.toString());
+				TestPropsValues.getUserId(), _group.getGroupId(), plid,
+				segmentsExperienceId, layoutStructure.toString());
 
 		_assertFragmentStyledLayoutStructureItem(
 			fragmentEntryLinkId, plid, segmentsExperienceId);

--- a/modules/apps/layout/layout-reports-test/src/testIntegration/java/com/liferay/layout/reports/web/internal/struts/test/GetLayoutReportsLayoutItemDataStrutsActionTest.java
+++ b/modules/apps/layout/layout-reports-test/src/testIntegration/java/com/liferay/layout/reports/web/internal/struts/test/GetLayoutReportsLayoutItemDataStrutsActionTest.java
@@ -134,7 +134,8 @@ public class GetLayoutReportsLayoutItemDataStrutsActionTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_layout.getGroupId(), _layout.getPlid(),
+				TestPropsValues.getUserId(), _layout.getGroupId(),
+				_layout.getPlid(),
 				_segmentsExperienceLocalService.
 					fetchDefaultSegmentsExperienceId(_layout.getPlid()),
 				layoutStructure.toString());
@@ -204,6 +205,7 @@ public class GetLayoutReportsLayoutItemDataStrutsActionTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
+				TestPropsValues.getUserId(),
 				masterLayoutPageTemplateEntry.getGroupId(),
 				masterLayoutPageTemplateEntry.getPlid(),
 				_segmentsExperienceLocalService.
@@ -299,7 +301,8 @@ public class GetLayoutReportsLayoutItemDataStrutsActionTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_layout.getGroupId(), _layout.getPlid(),
+				TestPropsValues.getUserId(), _layout.getGroupId(),
+				_layout.getPlid(),
 				_segmentsExperienceLocalService.
 					fetchDefaultSegmentsExperienceId(_layout.getPlid()),
 				layoutStructure.toString());
@@ -412,7 +415,8 @@ public class GetLayoutReportsLayoutItemDataStrutsActionTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_layout.getGroupId(), _layout.getPlid(),
+				TestPropsValues.getUserId(), _layout.getGroupId(),
+				_layout.getPlid(),
 				_segmentsExperienceLocalService.
 					fetchDefaultSegmentsExperienceId(_layout.getPlid()),
 				layoutStructure.toString());

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
@@ -433,8 +433,9 @@ public class LayoutLocalServiceWrapper
 
 			_layoutPageTemplateStructureLocalService.
 				updateLayoutPageTemplateStructureData(
-					targetLayout.getGroupId(), targetLayout.getPlid(),
-					entry.getValue(), dataJSONObject.toString());
+					user.getUserId(), targetLayout.getGroupId(),
+					targetLayout.getPlid(), entry.getValue(),
+					dataJSONObject.toString());
 
 			SegmentsExperience targetSegmentsExperience =
 				_segmentsExperienceLocalService.fetchSegmentsExperience(
@@ -1107,8 +1108,9 @@ public class LayoutLocalServiceWrapper
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				targetLayout.getGroupId(), targetLayout.getPlid(),
-				targetSegmentsExperienceId, dataJSONObject.toString());
+				user.getUserId(), targetLayout.getGroupId(),
+				targetLayout.getPlid(), targetSegmentsExperienceId,
+				dataJSONObject.toString());
 
 		_fragmentEntryLinkLocalService.deleteFragmentEntryLinks(
 			ArrayUtil.toLongArray(targetFragmentEntryLinkIds));

--- a/modules/apps/layout/layout-test-util/src/main/java/com/liferay/layout/test/util/ContentLayoutTestUtil.java
+++ b/modules/apps/layout/layout-test-util/src/main/java/com/liferay/layout/test/util/ContentLayoutTestUtil.java
@@ -129,8 +129,8 @@ public class ContentLayoutTestUtil {
 
 		LayoutPageTemplateStructureLocalServiceUtil.
 			updateLayoutPageTemplateStructureData(
-				layout.getGroupId(), layout.getPlid(), segmentsExperienceId,
-				layoutStructure.toString());
+				layout.getUserId(), layout.getGroupId(), layout.getPlid(),
+				segmentsExperienceId, layoutStructure.toString());
 
 		return itemId;
 	}
@@ -277,8 +277,8 @@ public class ContentLayoutTestUtil {
 
 		LayoutPageTemplateStructureLocalServiceUtil.
 			updateLayoutPageTemplateStructureData(
-				layout.getGroupId(), layout.getPlid(), segmentsExperienceId,
-				layoutStructure.toString());
+				layout.getUserId(), layout.getGroupId(), layout.getPlid(),
+				segmentsExperienceId, layoutStructure.toString());
 
 		return layoutStructureItem.getItemId();
 	}

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/headless/delivery/dto/v1_0/test/PageDefinitionDTOConverterTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/headless/delivery/dto/v1_0/test/PageDefinitionDTOConverterTest.java
@@ -617,7 +617,8 @@ public class PageDefinitionDTOConverterTest {
 		LayoutPageTemplateStructure layoutPageTemplateStructure =
 			_layoutPageTemplateStructureLocalService.
 				updateLayoutPageTemplateStructureData(
-					_group.getGroupId(), _layoutPageTemplateEntry.getPlid(),
+					TestPropsValues.getUserId(), _group.getGroupId(),
+					_layoutPageTemplateEntry.getPlid(),
 					defaultSegmentsExperienceId,
 					StringUtil.replace(_read(fileName), "${", "}", valuesMap));
 

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/struts/test/EvaluateLayoutStructureRulesStrutsActionTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/struts/test/EvaluateLayoutStructureRulesStrutsActionTest.java
@@ -400,8 +400,9 @@ public class EvaluateLayoutStructureRulesStrutsActionTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), _draftLayout.getPlid(),
-				segmentsExperienceId, layoutStructure.toString());
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				_draftLayout.getPlid(), segmentsExperienceId,
+				layoutStructure.toString());
 
 		return layoutStructureRule.getId();
 	}

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/responsive/test/ResponsiveLayoutStructureUtilTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/responsive/test/ResponsiveLayoutStructureUtilTest.java
@@ -155,8 +155,9 @@ public class ResponsiveLayoutStructureUtilTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_layout.getGroupId(), _layout.getPlid(),
-				_defaultSegmentsExperienceId, layoutStructure.toString());
+				TestPropsValues.getUserId(), _layout.getGroupId(),
+				_layout.getPlid(), _defaultSegmentsExperienceId,
+				layoutStructure.toString());
 
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutPublishedSearchTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutPublishedSearchTest.java
@@ -266,7 +266,8 @@ public class LayoutPublishedSearchTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), draftLayout.getPlid(),
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				draftLayout.getPlid(),
 				_segmentsExperienceLocalService.
 					fetchDefaultSegmentsExperienceId(draftLayout.getPlid()),
 				layoutStructure.toString());
@@ -363,8 +364,8 @@ public class LayoutPublishedSearchTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), plid, segmentsExperienceId,
-				layoutStructure.toString());
+				TestPropsValues.getUserId(), _group.getGroupId(), plid,
+				segmentsExperienceId, layoutStructure.toString());
 	}
 
 	private void _addFragmentEntryLinkWithInlineContentToLayout(

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceCopyLayoutContentTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceCopyLayoutContentTest.java
@@ -235,8 +235,9 @@ public class LayoutLocalServiceCopyLayoutContentTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				sourceLayout.getGroupId(), sourceLayout.getPlid(),
-				defaultSegmentsExperienceId, layoutStructure.toString());
+				TestPropsValues.getUserId(), sourceLayout.getGroupId(),
+				sourceLayout.getPlid(), defaultSegmentsExperienceId,
+				layoutStructure.toString());
 
 		Layout targetLayout = LayoutTestUtil.addTypeContentLayout(_group);
 
@@ -415,8 +416,9 @@ public class LayoutLocalServiceCopyLayoutContentTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				sourceLayout.getGroupId(), sourceLayout.getPlid(),
-				defaultSegmentsExperienceId, layoutStructure.toString());
+				TestPropsValues.getUserId(), sourceLayout.getGroupId(),
+				sourceLayout.getPlid(), defaultSegmentsExperienceId,
+				layoutStructure.toString());
 
 		_layoutLocalService.copyLayoutContent(sourceLayout, targetLayout);
 
@@ -471,8 +473,9 @@ public class LayoutLocalServiceCopyLayoutContentTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				sourceLayout.getGroupId(), sourceLayout.getPlid(),
-				defaultSegmentsExperienceId, layoutStructure.toString());
+				TestPropsValues.getUserId(), sourceLayout.getGroupId(),
+				sourceLayout.getPlid(), defaultSegmentsExperienceId,
+				layoutStructure.toString());
 
 		_layoutLocalService.copyLayoutContent(sourceLayout, targetLayout);
 

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/servlet/test/LayoutStructureCommonStylesCSSServletTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/servlet/test/LayoutStructureCommonStylesCSSServletTest.java
@@ -80,7 +80,8 @@ public class LayoutStructureCommonStylesCSSServletTest {
 	public void testDoesNotRender() throws Exception {
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), _layout.getPlid(),
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				_layout.getPlid(),
 				_read("layout_structure_container_fixed.json"));
 
 		MockHttpServletResponse mockHttpServletResponse =
@@ -99,8 +100,8 @@ public class LayoutStructureCommonStylesCSSServletTest {
 	public void testRenderCommonStyles() throws Exception {
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), _layout.getPlid(),
-				_read("layout_structure.json"));
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				_layout.getPlid(), _read("layout_structure.json"));
 
 		MockHttpServletResponse mockHttpServletResponse =
 			new MockHttpServletResponse();
@@ -116,7 +117,8 @@ public class LayoutStructureCommonStylesCSSServletTest {
 	public void testRenderCommonStylesWithCustomCSS() throws Exception {
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), _layout.getPlid(),
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				_layout.getPlid(),
 				_read("layout_structure_with_custom_css.json"));
 
 		MockHttpServletResponse mockHttpServletResponse =
@@ -135,7 +137,8 @@ public class LayoutStructureCommonStylesCSSServletTest {
 	public void testRenderCommonStylesWithResponsive() throws Exception {
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), _layout.getPlid(),
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				_layout.getPlid(),
 				_read("layout_structure_with_responsive_styles.json"));
 
 		MockHttpServletResponse mockHttpServletResponse =
@@ -154,7 +157,8 @@ public class LayoutStructureCommonStylesCSSServletTest {
 	public void testRenderEmptyTagWhenItDoesNotHaveStyles() throws Exception {
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), _layout.getPlid(),
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				_layout.getPlid(),
 				_read("layout_structure_without_styles.json"));
 
 		MockHttpServletResponse mockHttpServletResponse =

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
@@ -351,8 +351,9 @@ public class RenderLayoutStructureTagTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				draftLayout.getGroupId(), draftLayout.getPlid(),
-				segmentsExperienceId, layoutStructure.toString());
+				TestPropsValues.getUserId(), draftLayout.getGroupId(),
+				draftLayout.getPlid(), segmentsExperienceId,
+				layoutStructure.toString());
 
 		for (FragmentEntryLink addedFragmentEntryLink :
 				addedFragmentEntryLinks) {
@@ -1935,7 +1936,8 @@ public class RenderLayoutStructureTagTest {
 
 			_layoutPageTemplateStructureLocalService.
 				updateLayoutPageTemplateStructureData(
-					_group.getGroupId(), draftLayout.getPlid(),
+					TestPropsValues.getUserId(), _group.getGroupId(),
+					draftLayout.getPlid(),
 					_segmentsExperienceLocalService.
 						fetchDefaultSegmentsExperienceId(draftLayout.getPlid()),
 					layoutStructure.toString());
@@ -2445,8 +2447,9 @@ public class RenderLayoutStructureTagTest {
 
 			_layoutPageTemplateStructureLocalService.
 				updateLayoutPageTemplateStructureData(
-					_group.getGroupId(), draftLayout.getPlid(),
-					segmentsExperienceId, layoutStructure.toString());
+					TestPropsValues.getUserId(), _group.getGroupId(),
+					draftLayout.getPlid(), segmentsExperienceId,
+					layoutStructure.toString());
 
 			ContentLayoutTestUtil.publishLayout(draftLayout, layout);
 
@@ -3149,7 +3152,8 @@ public class RenderLayoutStructureTagTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), layout.getPlid(), segmentsExperienceId,
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				layout.getPlid(), segmentsExperienceId,
 				layoutStructure.toString());
 	}
 
@@ -3713,7 +3717,8 @@ public class RenderLayoutStructureTagTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), layout.getPlid(), segmentsExperienceId,
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				layout.getPlid(), segmentsExperienceId,
 				layoutStructure.toString());
 	}
 

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
@@ -144,6 +144,7 @@ import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.servlet.HttpMethods;
+import com.liferay.portal.kernel.servlet.PortletServlet;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
@@ -195,6 +196,8 @@ import com.liferay.template.test.util.TemplateTestUtil;
 
 import jakarta.portlet.ActionRequest;
 import jakarta.portlet.ActionResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 import java.io.Serializable;
 
@@ -3178,10 +3181,24 @@ public class RenderLayoutStructureTagTest {
 			ContentLayoutTestUtil.getMVCActionCommand(
 				"/layout_content_page_editor/add_segments_experience");
 
+		Company company = _companyLocalService.getCompany(
+			_group.getCompanyId());
+
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			ContentLayoutTestUtil.getMockLiferayPortletActionRequest(
-				_companyLocalService.getCompany(_group.getCompanyId()), _group,
-				layout);
+				company, _group, layout);
+
+		HttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY,
+			ContentLayoutTestUtil.getThemeDisplay(company, _group, layout));
+		mockHttpServletRequest.setAttribute(
+			WebKeys.USER_ID, TestPropsValues.getUserId());
+
+		mockLiferayPortletActionRequest.setAttribute(
+			PortletServlet.PORTLET_SERVLET_REQUEST, mockHttpServletRequest);
 
 		mockLiferayPortletActionRequest.setParameter(
 			"groupId", String.valueOf(layout.getGroupId()));

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/test/ExportImportPerformanceTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/test/ExportImportPerformanceTest.java
@@ -406,8 +406,8 @@ public class ExportImportPerformanceTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				_group.getGroupId(), draftLayout.getPlid(),
-				defaultSegmentsExperienceId,
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				draftLayout.getPlid(), defaultSegmentsExperienceId,
 				_generateContentLayoutStructureJSONObject(draftLayout));
 
 		_layoutLocalService.copyLayoutContent(draftLayout, layout);

--- a/modules/apps/login/login-test/src/testIntegration/java/com/liferay/login/internal/portlet/action/test/UpdatePasswordActionTest.java
+++ b/modules/apps/login/login-test/src/testIntegration/java/com/liferay/login/internal/portlet/action/test/UpdatePasswordActionTest.java
@@ -171,8 +171,9 @@ public class UpdatePasswordActionTest {
 
 		_layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
-				group.getGroupId(), layout.getPlid(),
-				defaultSegmentsExperienceId, dataJSONObject.toString());
+				serviceContext.getUserId(), group.getGroupId(),
+				layout.getPlid(), defaultSegmentsExperienceId,
+				dataJSONObject.toString());
 
 		return layoutUtilityPageEntry;
 	}

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -2863,9 +2863,9 @@ public class BundleSiteInitializer implements SiteInitializer {
 
 				for (int i = 0; i < jsonArray.length(); i++) {
 					_layoutsImporter.importPageElement(
-						draftLayout, layoutStructure,
-						layoutStructure.getMainItemId(), jsonArray.getString(i),
-						i, true, segmentsExperienceId);
+						serviceContext.getUserId(), draftLayout,
+						layoutStructure, layoutStructure.getMainItemId(),
+						jsonArray.getString(i), i, true, segmentsExperienceId);
 				}
 			}
 		}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/util/ActionUtil.java
@@ -166,7 +166,8 @@ public class ActionUtil {
 
 		LayoutPageTemplateStructureLocalServiceUtil.
 			updateLayoutPageTemplateStructureData(
-				layout.getGroupId(), layout.getPlid(), segmentsExperienceId,
+				serviceContext.getUserId(), layout.getGroupId(),
+				layout.getPlid(), segmentsExperienceId,
 				layoutStructure.toString());
 
 		for (FragmentEntryLink addedFragmentEntryLink :


### PR DESCRIPTION
Motivation
-----
Avoid usage of GuestOrUserUtil class in *LocalServiceImpl, more information in https://liferay.slack.com/archives/C01FP01V5L0/p1708446324972219?thread_ts=1708444263.392559&cid=C01FP01V5L0
In some situations it is dealing in the following error: "**Principal is null**"

[Link to the ticket](https://liferay.atlassian.net/browse/LPD-63830)

Proposed Solution
-----
Includes userId as parameter in method definition, in that way we are avoiding the dependency with GuestOrUserUtil and PrincipalThreadLocal.

Please let me know if you have any question.

**NOTE:** Tests were previously executed here: https://github.com/ealonso/liferay-portal/pull/3499#issuecomment-3228171711