### PR TITLE
LPD-63964 Nested Application Portlet CSS overrides all styles within portlet

### DIFF
--- a/modules/test/playwright/tests/portlet-configuration-css-web/main/widgetLookAndFeel.spec.ts
+++ b/modules/test/playwright/tests/portlet-configuration-css-web/main/widgetLookAndFeel.spec.ts
@@ -94,3 +94,93 @@ test(
 		);
 	}
 );
+
+test(
+	'Checks background color for nested widgets',
+	{
+		tag: '@LPD-63964',
+	},
+	async ({apiHelpers, page, site, widgetPagePage}) => {
+		const layout = await apiHelpers.jsonWebServicesLayout.addLayout({
+			groupId: site.id,
+			title: getRandomString(),
+		});
+
+		await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyURL}`);
+
+		await widgetPagePage.addPortlet('Nested Applications');
+
+		await widgetPagePage.clickOnAction(
+			'Nested Applications',
+			'Look and Feel Configuration'
+		);
+
+		let lookAndFeelIFrame = page.frameLocator(
+			'iframe[title="Look and Feel Configuration"]'
+		);
+
+		await lookAndFeelIFrame
+			.getByRole('tab', {name: 'Background Styles'})
+			.click();
+
+		await lookAndFeelIFrame
+			.locator('#backgroundStyles')
+			.getByLabel('Color selection is ')
+			.fill('000000');
+
+		await lookAndFeelIFrame.getByRole('button', {name: 'Save'}).click();
+
+		await page.reload();
+
+		await widgetPagePage.addPortlet('Web Content Display');
+
+		await widgetPagePage.clickOnAction(
+			'Web Content Display',
+			'Look and Feel Configuration'
+		);
+
+		lookAndFeelIFrame = page.frameLocator(
+			'iframe[title="Look and Feel Configuration"]'
+		);
+
+		await lookAndFeelIFrame
+			.getByRole('tab', {name: 'Background Styles'})
+			.click();
+
+		await lookAndFeelIFrame
+			.locator('#backgroundStyles')
+			.getByLabel('Color selection is ')
+			.fill('FFFFFF');
+
+		await lookAndFeelIFrame.getByRole('button', {name: 'Save'}).click();
+
+		await page.reload();
+
+		await widgetPagePage.dragPortlet(
+			'Web Content Display',
+			page
+				.locator('.portlet-nested-portlets .portlet-dropzone.empty')
+				.first()
+		);
+
+		await page.reload();
+
+		let portlet = page.locator(
+			'div.portlet-content.portlet-content-editable',
+			{hasText: 'Nested Applications'}
+		);
+
+		await expect(portlet).toHaveCSS('background-color', 'rgb(0, 0, 0)');
+
+		portlet = page
+			.locator('h2.portlet-title-text', {hasText: 'WEB CONTENT DISPLAY'})
+			.locator('..')
+			.locator('..')
+			.locator('..');
+
+		await expect(portlet).toHaveCSS(
+			'background-color',
+			'rgb(255, 255, 255)'
+		);
+	}
+);

--- a/portal-web/docroot/html/common/themes/portlet_css.jspf
+++ b/portal-web/docroot/html/common/themes/portlet_css.jspf
@@ -299,7 +299,7 @@ String customCSS = (advancedDataJSONObject != null) ? advancedDataJSONObject.get
 
 // Generated CSS
 
-out.print("#p_p_id_" + portlet.getPortletId() + "_ .portlet-content");
+out.print("#p_p_id_" + portlet.getPortletId() + "_ > .portlet > .portlet-content");
 
 out.print(" {\n");
 


### PR DESCRIPTION
Issue:
The CSS from the nested application overrides the CSS for any portlet within.

Solution:
Use child combinator when generating the CSS