### PR TITLE
LPD-64244 Multi-word URL endpoints have wrong canonical URLs when hyphen is substituted

### DIFF
--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
@@ -175,6 +175,15 @@ public class PortalImplCanonicalURLTest {
 				LocaleUtil.US, "/weben"
 			).build());
 
+		_layout5 = LayoutTestUtil.addTypePortletLayout(
+			_group.getGroupId(), false,
+			HashMapBuilder.put(
+				LocaleUtil.US, "Test Page"
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.US, "/test-page"
+			).build());
+
 		String groupKey = PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME;
 
 		if (Validator.isNull(groupKey)) {
@@ -214,6 +223,22 @@ public class PortalImplCanonicalURLTest {
 			completeURL,
 			_portal.getCanonicalURL(
 				completeURL, themeDisplay, _layout2, false, false));
+	}
+
+	@Test
+	public void testCanonicalURLLayoutFriendlyUrlWithHyphen() throws Exception {
+		String portalDomain = "localhost";
+
+		Assert.assertEquals(
+			_generateURL(
+				portalDomain, "8080", StringPool.BLANK, _group.getFriendlyURL(),
+				_layout5.getFriendlyURL(), false),
+			_portal.getCanonicalURL(
+				_generateURL(
+					portalDomain, "8080", StringPool.BLANK,
+					_group.getFriendlyURL(), "/test%20page", false),
+				_createThemeDisplay(portalDomain, _defaultGroup, 8080, false),
+				_layout5, false, false));
 	}
 
 	@Test
@@ -787,6 +812,7 @@ public class PortalImplCanonicalURLTest {
 	private Layout _layout2;
 	private Layout _layout3;
 	private Layout _layout4;
+	private Layout _layout5;
 
 	@Inject
 	private LayoutLocalService _layoutLocalService;

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -159,6 +159,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.DeterminateKeyGenerator;
+import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
@@ -8024,6 +8025,9 @@ public class PortalImpl implements Portal {
 	private boolean _requiresLayoutFriendlyURL(
 		String siteGroupFriendlyURL, String layoutFriendlyURL,
 		String groupFriendlyURL) {
+
+		groupFriendlyURL = FriendlyURLNormalizerUtil.normalizeWithEncoding(
+			groupFriendlyURL);
 
 		if (groupFriendlyURL.contains(
 				_PUBLIC_GROUP_SERVLET_MAPPING + StringPool.SLASH)) {


### PR DESCRIPTION
When a page contains a hyphen in its friendlyURL (for example "http://localhost:8080/test-page") it is accessible if the hyphen is substituted by a space ("http://localhost:8080/test page") but its canonical url is incorrect.

When accessing the page the layoutFriendlyURL is normalized but when the canonical url it is not causing this difference in behavior. This pr aims to also normalize the friendly url when getting the canonical url to support this use case.