### PR TITLE
LPD-63068 Adding Collection Filter fails with SQL Exception

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinkMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinkMVCActionCommandTest.java
@@ -11,6 +11,7 @@ import com.liferay.fragment.exception.NoSuchEntryException;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.fragment.service.FragmentCollectionLocalService;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.fragment.service.FragmentEntryLocalService;
@@ -252,6 +253,25 @@ public class AddFragmentEntryLinkMVCActionCommandTest {
 			LayoutContentPageEditorWebPortletKeys.
 				LAYOUT_CONTENT_PAGE_EDITOR_WEB_TEST_PORTLET,
 			true);
+	}
+
+	@Test
+	public void testAddFragmentEntryLinkWithFragmentRenderer()
+		throws Exception {
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest(_group.getGroupId());
+
+		mockLiferayPortletActionRequest.addParameter(
+			"fragmentEntryKey", _fragmentRenderer.getKey());
+
+		FragmentEntryLink fragmentEntryLink = ReflectionTestUtil.invoke(
+			_mvcActionCommand, "addFragmentEntryLink",
+			new Class<?>[] {ActionRequest.class},
+			mockLiferayPortletActionRequest);
+
+		Assert.assertEquals(
+			_fragmentRenderer.getKey(), fragmentEntryLink.getRendererKey());
 	}
 
 	private FragmentEntry _addFragmentEntry(String html) throws Exception {
@@ -502,6 +522,11 @@ public class AddFragmentEntryLinkMVCActionCommandTest {
 
 	@Inject
 	private FragmentEntryLocalService _fragmentEntryLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.fragment.renderer.collection.filter.internal.CollectionAppliedFiltersFragmentRenderer"
+	)
+	private FragmentRenderer _fragmentRenderer;
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinkMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinkMVCActionCommandTest.java
@@ -265,6 +265,9 @@ public class AddFragmentEntryLinkMVCActionCommandTest {
 		mockLiferayPortletActionRequest.addParameter(
 			"fragmentEntryKey", _fragmentRenderer.getKey());
 
+		_addFragmentEntry(
+			RandomTestUtil.randomString(), _fragmentRenderer.getKey());
+
 		FragmentEntryLink fragmentEntryLink = ReflectionTestUtil.invoke(
 			_mvcActionCommand, "addFragmentEntryLink",
 			new Class<?>[] {ActionRequest.class},
@@ -272,9 +275,18 @@ public class AddFragmentEntryLinkMVCActionCommandTest {
 
 		Assert.assertEquals(
 			_fragmentRenderer.getKey(), fragmentEntryLink.getRendererKey());
+
+		Assert.assertEquals("", fragmentEntryLink.getHtml());
 	}
 
 	private FragmentEntry _addFragmentEntry(String html) throws Exception {
+		return _addFragmentEntry(html, RandomTestUtil.randomString());
+	}
+
+	private FragmentEntry _addFragmentEntry(
+			String html, String fragmentEntryKey)
+		throws Exception {
+
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext();
 
@@ -285,11 +297,10 @@ public class AddFragmentEntryLinkMVCActionCommandTest {
 
 		return _fragmentEntryLocalService.addFragmentEntry(
 			null, TestPropsValues.getUserId(), _group.getGroupId(),
-			fragmentCollection.getFragmentCollectionId(),
-			StringUtil.randomString(), StringUtil.randomString(),
-			RandomTestUtil.randomString(), html, RandomTestUtil.randomString(),
-			false, "{fieldSets: []}", null, 0, false, false,
-			FragmentConstants.TYPE_COMPONENT, null,
+			fragmentCollection.getFragmentCollectionId(), fragmentEntryKey,
+			StringUtil.randomString(), RandomTestUtil.randomString(), html,
+			RandomTestUtil.randomString(), false, "{fieldSets: []}", null, 0,
+			false, false, FragmentConstants.TYPE_COMPONENT, null,
 			WorkflowConstants.STATUS_APPROVED, serviceContext);
 	}
 
@@ -524,7 +535,7 @@ public class AddFragmentEntryLinkMVCActionCommandTest {
 	private FragmentEntryLocalService _fragmentEntryLocalService;
 
 	@Inject(
-		filter = "component.name=com.liferay.fragment.renderer.collection.filter.internal.CollectionAppliedFiltersFragmentRenderer"
+		filter = "component.name=com.liferay.fragment.internal.renderer.SaveContentFragmentRenderer"
 	)
 	private FragmentRenderer _fragmentRenderer;
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FragmentEntryLinkManager.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FragmentEntryLinkManager.java
@@ -589,6 +589,14 @@ public class FragmentEntryLinkManager {
 		FragmentEntryLink fragmentEntryLink, Locale locale) {
 
 		if (fragmentEntryLink.getFragmentEntryId() <= 0) {
+			FragmentRenderer fragmentRenderer =
+				_fragmentRendererRegistry.getFragmentRenderer(
+					fragmentEntryLink.getRendererKey());
+
+			if (fragmentRenderer != null) {
+				return null;
+			}
+
 			return getFragmentEntry(
 				fragmentEntryLink.getGroupId(),
 				fragmentEntryLink.getRendererKey(), locale);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentEntryLinkMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentEntryLinkMVCActionCommand.java
@@ -70,14 +70,14 @@ public class AddFragmentEntryLinkMVCActionCommand
 		String fragmentEntryKey = ParamUtil.getString(
 			actionRequest, "fragmentEntryKey");
 
-		ServiceContext serviceContext = ServiceContextFactory.getInstance(
-			actionRequest);
-
 		FragmentRenderer fragmentRenderer =
 			_fragmentRendererRegistry.getFragmentRenderer(fragmentEntryKey);
 
 		long segmentsExperienceId = ParamUtil.getLong(
 			actionRequest, "segmentsExperienceId");
+
+		ServiceContext serviceContext = ServiceContextFactory.getInstance(
+			actionRequest);
 
 		if (fragmentRenderer != null) {
 			DefaultFragmentRendererContext defaultFragmentRendererContext =

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentEntryLinkMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentEntryLinkMVCActionCommand.java
@@ -67,56 +67,56 @@ public class AddFragmentEntryLinkMVCActionCommand
 			ActionRequest actionRequest)
 		throws PortalException {
 
-		long groupId = ParamUtil.getLong(actionRequest, "groupId");
 		String fragmentEntryKey = ParamUtil.getString(
 			actionRequest, "fragmentEntryKey");
 
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			actionRequest);
 
+		FragmentRenderer fragmentRenderer =
+			_fragmentRendererRegistry.getFragmentRenderer(fragmentEntryKey);
+
+		long segmentsExperienceId = ParamUtil.getLong(
+			actionRequest, "segmentsExperienceId");
+
+		if (fragmentRenderer != null) {
+			DefaultFragmentRendererContext defaultFragmentRendererContext =
+				new DefaultFragmentRendererContext(null);
+
+			return _fragmentEntryLinkService.addFragmentEntryLink(
+				null, serviceContext.getScopeGroupId(), 0, 0,
+				segmentsExperienceId, serviceContext.getPlid(),
+				StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
+				_jsonFactory.toString(
+					fragmentRenderer.getConfigurationJSONObject(
+						defaultFragmentRendererContext)),
+				StringPool.BLANK, StringPool.BLANK, 0, fragmentEntryKey,
+				fragmentRenderer.getType(), serviceContext);
+		}
+
+		long groupId = ParamUtil.getLong(actionRequest, "groupId");
+
 		FragmentEntry fragmentEntry =
 			_fragmentEntryLinkManager.getFragmentEntry(
 				groupId, fragmentEntryKey, serviceContext.getLocale());
-
-		FragmentRenderer fragmentRenderer =
-			_fragmentRendererRegistry.getFragmentRenderer(fragmentEntryKey);
 
 		if ((fragmentEntry == null) && (fragmentRenderer == null)) {
 			throw new NoSuchEntryException();
 		}
 
-		long segmentsExperienceId = ParamUtil.getLong(
-			actionRequest, "segmentsExperienceId");
+		String contributedRendererKey = null;
 
-		if (fragmentEntry != null) {
-			String contributedRendererKey = null;
-
-			if (fragmentEntry.getFragmentEntryId() == 0) {
-				contributedRendererKey = fragmentEntryKey;
-			}
-
-			return _fragmentEntryLinkService.addFragmentEntryLink(
-				null, serviceContext.getScopeGroupId(), 0,
-				fragmentEntry.getFragmentEntryId(), segmentsExperienceId,
-				serviceContext.getPlid(), fragmentEntry.getCss(),
-				fragmentEntry.getHtml(), fragmentEntry.getJs(),
-				fragmentEntry.getConfiguration(), null, StringPool.BLANK, 0,
-				contributedRendererKey, fragmentEntry.getType(),
-				serviceContext);
+		if (fragmentEntry.getFragmentEntryId() == 0) {
+			contributedRendererKey = fragmentEntryKey;
 		}
 
-		DefaultFragmentRendererContext defaultFragmentRendererContext =
-			new DefaultFragmentRendererContext(null);
-
 		return _fragmentEntryLinkService.addFragmentEntryLink(
-			null, serviceContext.getScopeGroupId(), 0, 0, segmentsExperienceId,
-			serviceContext.getPlid(), StringPool.BLANK, StringPool.BLANK,
-			StringPool.BLANK,
-			_jsonFactory.toString(
-				fragmentRenderer.getConfigurationJSONObject(
-					defaultFragmentRendererContext)),
-			StringPool.BLANK, StringPool.BLANK, 0, fragmentEntryKey,
-			fragmentRenderer.getType(), serviceContext);
+			null, serviceContext.getScopeGroupId(), 0,
+			fragmentEntry.getFragmentEntryId(), segmentsExperienceId,
+			serviceContext.getPlid(), fragmentEntry.getCss(),
+			fragmentEntry.getHtml(), fragmentEntry.getJs(),
+			fragmentEntry.getConfiguration(), null, StringPool.BLANK, 0,
+			contributedRendererKey, fragmentEntry.getType(), serviceContext);
 	}
 
 	@Override

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddStepperFragmentEntryLinkMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddStepperFragmentEntryLinkMVCActionCommand.java
@@ -69,56 +69,56 @@ public class AddStepperFragmentEntryLinkMVCActionCommand
 			ActionRequest actionRequest)
 		throws PortalException {
 
-		long groupId = ParamUtil.getLong(actionRequest, "groupId");
 		String fragmentEntryKey = ParamUtil.getString(
 			actionRequest, "fragmentEntryKey");
 
+		long segmentsExperienceId = ParamUtil.getLong(
+			actionRequest, "segmentsExperienceId");
+
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			actionRequest);
+
+		FragmentRenderer fragmentRenderer =
+			_fragmentRendererRegistry.getFragmentRenderer(fragmentEntryKey);
+
+		if (fragmentRenderer != null) {
+			DefaultFragmentRendererContext defaultFragmentRendererContext =
+				new DefaultFragmentRendererContext(null);
+
+			return _fragmentEntryLinkService.addFragmentEntryLink(
+				null, serviceContext.getScopeGroupId(), 0, 0,
+				segmentsExperienceId, serviceContext.getPlid(),
+				StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
+				_jsonFactory.toString(
+					fragmentRenderer.getConfigurationJSONObject(
+						defaultFragmentRendererContext)),
+				StringPool.BLANK, StringPool.BLANK, 0, fragmentEntryKey,
+				fragmentRenderer.getType(), serviceContext);
+		}
+
+		long groupId = ParamUtil.getLong(actionRequest, "groupId");
 
 		FragmentEntry fragmentEntry =
 			_fragmentEntryLinkManager.getFragmentEntry(
 				groupId, fragmentEntryKey, serviceContext.getLocale());
 
-		FragmentRenderer fragmentRenderer =
-			_fragmentRendererRegistry.getFragmentRenderer(fragmentEntryKey);
-
 		if ((fragmentEntry == null) && (fragmentRenderer == null)) {
 			throw new NoSuchEntryException();
 		}
 
-		long segmentsExperienceId = ParamUtil.getLong(
-			actionRequest, "segmentsExperienceId");
+		String contributedRendererKey = null;
 
-		if (fragmentEntry != null) {
-			String contributedRendererKey = null;
-
-			if (fragmentEntry.getFragmentEntryId() == 0) {
-				contributedRendererKey = fragmentEntryKey;
-			}
-
-			return _fragmentEntryLinkService.addFragmentEntryLink(
-				null, serviceContext.getScopeGroupId(), 0,
-				fragmentEntry.getFragmentEntryId(), segmentsExperienceId,
-				serviceContext.getPlid(), fragmentEntry.getCss(),
-				fragmentEntry.getHtml(), fragmentEntry.getJs(),
-				fragmentEntry.getConfiguration(), null, StringPool.BLANK, 0,
-				contributedRendererKey, fragmentEntry.getType(),
-				serviceContext);
+		if (fragmentEntry.getFragmentEntryId() == 0) {
+			contributedRendererKey = fragmentEntryKey;
 		}
 
-		DefaultFragmentRendererContext defaultFragmentRendererContext =
-			new DefaultFragmentRendererContext(null);
-
 		return _fragmentEntryLinkService.addFragmentEntryLink(
-			null, serviceContext.getScopeGroupId(), 0, 0, segmentsExperienceId,
-			serviceContext.getPlid(), StringPool.BLANK, StringPool.BLANK,
-			StringPool.BLANK,
-			_jsonFactory.toString(
-				fragmentRenderer.getConfigurationJSONObject(
-					defaultFragmentRendererContext)),
-			StringPool.BLANK, StringPool.BLANK, 0, fragmentEntryKey,
-			fragmentRenderer.getType(), serviceContext);
+			null, serviceContext.getScopeGroupId(), 0,
+			fragmentEntry.getFragmentEntryId(), segmentsExperienceId,
+			serviceContext.getPlid(), fragmentEntry.getCss(),
+			fragmentEntry.getHtml(), fragmentEntry.getJs(),
+			fragmentEntry.getConfiguration(), null, StringPool.BLANK, 0,
+			contributedRendererKey, fragmentEntry.getType(), serviceContext);
 	}
 
 	@Override

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetFragmentEntryInputFieldTypesMVCResourceCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetFragmentEntryInputFieldTypesMVCResourceCommand.java
@@ -89,6 +89,13 @@ public class GetFragmentEntryInputFieldTypesMVCResourceCommand
 	private String _getFragmentTypeOptions(
 		String fragmentEntryKey, long groupId) {
 
+		FragmentRenderer fragmentRenderer =
+			_fragmentRendererRegistry.getFragmentRenderer(fragmentEntryKey);
+
+		if (fragmentRenderer != null) {
+			return fragmentRenderer.getTypeOptions();
+		}
+
 		FragmentEntry fragmentEntry =
 			_fragmentEntryLocalService.fetchFragmentEntry(
 				groupId, fragmentEntryKey);
@@ -101,13 +108,6 @@ public class GetFragmentEntryInputFieldTypesMVCResourceCommand
 
 		if (fragmentEntry != null) {
 			return fragmentEntry.getTypeOptions();
-		}
-
-		FragmentRenderer fragmentRenderer =
-			_fragmentRendererRegistry.getFragmentRenderer(fragmentEntryKey);
-
-		if (fragmentRenderer != null) {
-			return fragmentRenderer.getTypeOptions();
 		}
 
 		return StringPool.BLANK;

--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/RenderFragmentEntryLinkMVCResourceCommand.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/portlet/action/RenderFragmentEntryLinkMVCResourceCommand.java
@@ -10,7 +10,9 @@ import com.liferay.fragment.entry.processor.constants.FragmentEntryProcessorCons
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.renderer.DefaultFragmentRendererContext;
+import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.fragment.renderer.FragmentRendererController;
+import com.liferay.fragment.renderer.FragmentRendererRegistry;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.fragment.service.FragmentEntryLocalService;
 import com.liferay.petra.string.StringPool;
@@ -131,10 +133,17 @@ public class RenderFragmentEntryLinkMVCResourceCommand
 	}
 
 	private FragmentEntry _getFragmentEntry(ResourceRequest resourceRequest) {
-		long groupId = ParamUtil.getLong(resourceRequest, "groupId");
-
 		String fragmentEntryKey = ParamUtil.getString(
 			resourceRequest, "fragmentEntryKey");
+
+		FragmentRenderer fragmentRenderer =
+			_fragmentRendererRegistry.getFragmentRenderer(fragmentEntryKey);
+
+		if (fragmentRenderer != null) {
+			return null;
+		}
+
+		long groupId = ParamUtil.getLong(resourceRequest, "groupId");
 
 		FragmentEntry fragmentEntry =
 			_fragmentEntryLocalService.fetchFragmentEntry(
@@ -161,6 +170,9 @@ public class RenderFragmentEntryLinkMVCResourceCommand
 
 	@Reference
 	private FragmentRendererController _fragmentRendererController;
+
+	@Reference
+	private FragmentRendererRegistry _fragmentRendererRegistry;
 
 	@Reference
 	private JSONFactory _jsonFactory;


### PR DESCRIPTION
Issue:
When using DB2,  if a search is performed on the FragmentEntry table,  the query will fail due to the size of the column.
The main cause are the fragment renderers that  get added to the page which have a fragmentEntryKeys longer than 75 characters.

Solution:
Search for the fragment renderer first to avoid searching for non-existent entries.

Ticket:
https://liferay.atlassian.net/issues/?filter=13037&selectedIssue=LPD-63068
cc/
@achaparro 