### PR TITLE
LPD-65050 Return layouts with any status to circumvent publications limitations

### DIFF
--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/test/LayoutCTTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/test/LayoutCTTest.java
@@ -20,6 +20,8 @@ import com.liferay.change.tracking.service.CTProcessLocalService;
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.expando.kernel.model.ExpandoColumnConstants;
 import com.liferay.expando.kernel.util.ExpandoBridgeFactoryUtil;
+import com.liferay.layout.manager.LayoutLockManager;
+import com.liferay.layout.model.LockedLayout;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.layout.util.BulkLayoutConverter;
 import com.liferay.petra.lang.SafeCloseable;
@@ -29,10 +31,12 @@ import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.change.tracking.CTRequiredModelException;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.exception.NoSuchResourcePermissionException;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
@@ -43,6 +47,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.LayoutPermission;
 import com.liferay.portal.kernel.service.persistence.impl.BasePersistenceImpl;
+import com.liferay.portal.kernel.test.portlet.MockActionRequest;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -50,9 +55,12 @@ import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparatorFactoryUtil;
 import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
@@ -408,6 +416,40 @@ public class LayoutCTTest {
 					throwable.getClass());
 			}
 		}
+	}
+
+	@Test
+	public void testGetLockedLayoutsInProductionWithModificationInPublication()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout draftLayout;
+
+		try (SafeCloseable safeCloseable1 =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					_ctCollection.getCtCollectionId())) {
+
+			draftLayout = layout.fetchDraftLayout();
+
+			draftLayout.setStatus(WorkflowConstants.STATUS_DRAFT);
+
+			draftLayout = _layoutLocalService.updateLayout(draftLayout);
+
+			_lockLayout(draftLayout, TestPropsValues.getUser());
+		}
+
+		List<LockedLayout> lockedLayouts = _layoutLockManager.getLockedLayouts(
+			TestPropsValues.getCompanyId(), _group.getGroupId(),
+			LocaleUtil.getDefault());
+
+		Assert.assertEquals(lockedLayouts.toString(), 1, lockedLayouts.size());
+
+		Assert.assertEquals(
+			draftLayout.getPlid(),
+			lockedLayouts.get(
+				0
+			).getPlid());
 	}
 
 	@Test
@@ -1321,6 +1363,19 @@ public class LayoutCTTest {
 		}
 	}
 
+	private void _lockLayout(Layout layout, User user) throws PortalException {
+		MockActionRequest mockActionRequest = new MockActionRequest();
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setLayout(layout);
+		themeDisplay.setUser(user);
+
+		mockActionRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
+
+		_layoutLockManager.getLock(mockActionRequest);
+	}
+
 	@Inject
 	private static AssetEntryLocalService _assetEntryLocalService;
 
@@ -1358,5 +1413,8 @@ public class LayoutCTTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private LayoutLockManager _layoutLockManager;
 
 }

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/manager/LayoutLockManagerImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/manager/LayoutLockManagerImpl.java
@@ -44,7 +44,6 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.lock.model.LockTable;
 import com.liferay.portal.lock.service.LockLocalService;
 import com.liferay.portal.model.impl.LayoutModelImpl;
@@ -156,9 +155,6 @@ public class LayoutLockManagerImpl implements LayoutLockManager {
 						LayoutTable.INSTANCE.hidden.eq(true)
 					).and(
 						LayoutTable.INSTANCE.system.eq(true)
-					).and(
-						LayoutTable.INSTANCE.status.eq(
-							WorkflowConstants.STATUS_DRAFT)
 					).and(
 						LayoutTable.INSTANCE.type.in(
 							new String[] {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-65050

Hello team, would you please help me determine if this change would cause any regressions.

The issue I'm trying to solve is due to locked entries not being change tracked. We would like to solve this issue by allowing a locked entry to be listed in the Locked Layout list regardless of which publication it was locked in. 

The reason this query isn't working is because all queries run through an sql transformer to add a filter with the related ctCollectionId. In this scenario, the page was locked in publication P1 so that layout status will be set to "draft" but when the second user accesses the locked layouts in Production, the layout in that context has a status of "published" so it will not be returned in this query.

I removed the "status" filter because I figured if a layout has an associated locked entry, then we don't really need to check the status to confirm the layout is under "draft".