### PR TITLE
LPD-65761 Boolean Field does not update on Object entry

### DIFF
--- a/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/request/helper/InfoRequestFieldValuesProviderHelper.java
+++ b/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/request/helper/InfoRequestFieldValuesProviderHelper.java
@@ -157,7 +157,8 @@ public class InfoRequestFieldValuesProviderHelper {
 			if (regularParameters == null) {
 				if ((infoField.getInfoFieldType() instanceof
 						BooleanInfoFieldType) &&
-					ArrayUtil.contains(checkboxNames, infoField.getName())) {
+					ArrayUtil.contains(
+						checkboxNames, infoField.getUniqueId())) {
 
 					infoFieldValues.put(
 						infoField.getUniqueId(),
@@ -169,7 +170,8 @@ public class InfoRequestFieldValuesProviderHelper {
 
 				if ((infoField.getInfoFieldType() instanceof
 						MultiselectInfoFieldType) &&
-					ArrayUtil.contains(checkboxNames, infoField.getName())) {
+					ArrayUtil.contains(
+						checkboxNames, infoField.getUniqueId())) {
 
 					infoFieldValues.put(
 						infoField.getUniqueId(),

--- a/modules/apps/info/info-test/src/testIntegration/java/com/liferay/info/request/struts/test/EditInfoItemStrutsActionTest.java
+++ b/modules/apps/info/info-test/src/testIntegration/java/com/liferay/info/request/struts/test/EditInfoItemStrutsActionTest.java
@@ -610,7 +610,8 @@ public class EditInfoItemStrutsActionTest {
 		ObjectEntry objectEntry = objectEntries.get(0);
 
 		regularParameters.put(
-			"checkboxNames", Collections.singletonList("myBoolean"));
+			"checkboxNames",
+			Collections.singletonList("ObjectField_myBoolean"));
 		regularParameters.put(
 			"classNameId", Collections.singletonList(_classNameId));
 		regularParameters.put(


### PR DESCRIPTION
# What is this trying to solve?

Boolean field values were not updating correctly when set to false within a Form Container on a Display Page.

# How am I fixing it?

The issue was caused because checkboxNames contained the uniqueId instead of the name, which caused the update to fail. I updated the logic to use the correct identifier.

# How can you verify that it works?

Run the included automated tests. The tests have been updated to use the proper unique ID, where this scenario was already covered.