### PR TITLE
LPD-66394 FragmentEntryLink editable values don't update the vocabularyId when publishing to live

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/EditableValuesMappingExportImportContentProcessor.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/EditableValuesMappingExportImportContentProcessor.java
@@ -5,6 +5,8 @@
 
 package com.liferay.fragment.internal.exportimport.content.processor;
 
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
 import com.liferay.dynamic.data.mapping.service.DDMTemplateLocalService;
@@ -87,6 +89,25 @@ public class EditableValuesMappingExportImportContentProcessor
 
 	@Override
 	public void validateContentReferences(long groupId, JSONObject jsonObject) {
+	}
+
+	private void _exportAssetVocabularyReference(
+			String mappedField, PortletDataContext portletDataContext,
+			StagedModel stagedModel)
+		throws Exception {
+
+		long assetVocabularyId = GetterUtil.getLong(
+			mappedField.substring(_ASSET_VOCABULARY.length()));
+
+		AssetVocabulary assetVocabulary =
+			_assetVocabularyLocalService.fetchAssetVocabulary(
+				assetVocabularyId);
+
+		if (assetVocabulary != null) {
+			StagedModelDataHandlerUtil.exportReferenceStagedModel(
+				portletDataContext, stagedModel, assetVocabulary,
+				PortletDataContext.REFERENCE_TYPE_DEPENDENCY);
+		}
 	}
 
 	private void _exportLayoutPageTemplateEntryReference(
@@ -244,8 +265,12 @@ public class EditableValuesMappingExportImportContentProcessor
 			GetterUtil.getString(
 				mappedField, editableJSONObject.getString("fieldId")));
 
-		if (mappedField.startsWith(
-				PortletDisplayTemplate.DISPLAY_STYLE_PREFIX)) {
+		if (mappedField.startsWith(_ASSET_VOCABULARY)) {
+			_exportAssetVocabularyReference(
+				mappedField, portletDataContext, stagedModel);
+		}
+		else if (mappedField.startsWith(
+					PortletDisplayTemplate.DISPLAY_STYLE_PREFIX)) {
 
 			_exportTemplateReference(
 				mappedField, portletDataContext, stagedModel);
@@ -282,8 +307,22 @@ public class EditableValuesMappingExportImportContentProcessor
 
 		String mappedField = editableJSONObject.getString(key);
 
-		if (mappedField.startsWith(
-				PortletDisplayTemplate.DISPLAY_STYLE_PREFIX)) {
+		if (mappedField.startsWith(_ASSET_VOCABULARY)) {
+			long assetVocabularyId = GetterUtil.getLong(
+				mappedField.substring(_ASSET_VOCABULARY.length()));
+
+			Map<Long, Long> assetVocabularyIds =
+				(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+					AssetVocabulary.class);
+
+			long importedAssetVocabularyId = MapUtil.getLong(
+				assetVocabularyIds, assetVocabularyId, assetVocabularyId);
+
+			editableJSONObject.put(
+				key, _ASSET_VOCABULARY + importedAssetVocabularyId);
+		}
+		else if (mappedField.startsWith(
+					PortletDisplayTemplate.DISPLAY_STYLE_PREFIX)) {
 
 			editableJSONObject.put(
 				key,
@@ -317,12 +356,18 @@ public class EditableValuesMappingExportImportContentProcessor
 		}
 	}
 
+	private static final String _ASSET_VOCABULARY =
+		AssetVocabulary.class.getSimpleName() + StringPool.UNDERLINE;
+
 	private static final String _LAYOUT_PAGE_TEMPLATE_ENTRY =
 		LayoutPageTemplateEntry.class.getSimpleName() + StringPool.UNDERLINE;
 
 	private static final String _TEMPLATE =
 		PortletDisplayTemplate.DISPLAY_STYLE_PREFIX + StringPool.UNDERLINE +
 			PortletDisplayTemplate.DISPLAY_STYLE_PREFIX;
+
+	@Reference
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
 
 	@Reference
 	private DDMTemplateLocalService _ddmTemplateLocalService;

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/exportimport/content/processor/test/EditableValuesExportImportContentProcessorTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/exportimport/content/processor/test/EditableValuesExportImportContentProcessorTest.java
@@ -6,6 +6,10 @@
 package com.liferay.fragment.internal.exportimport.content.processor.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
@@ -24,6 +28,7 @@ import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.fragment.service.FragmentEntryLocalService;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleLocalService;
+import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
@@ -82,6 +87,106 @@ public class EditableValuesExportImportContentProcessorTest {
 		_layout = LayoutTestUtil.addTypeContentLayout(_stagingGroup);
 
 		_draftLayout = _layout.fetchDraftLayout();
+	}
+
+	@Test
+	public void testEditableValuesWithAssetVocabulary() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_stagingGroup.getGroupId());
+
+		AssetVocabulary assetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), _stagingGroup.getGroupId(),
+				RandomTestUtil.randomString(), serviceContext);
+
+		AssetCategory assetCategory = _assetCategoryLocalService.addCategory(
+			TestPropsValues.getUserId(), _stagingGroup.getGroupId(),
+			RandomTestUtil.randomString(), assetVocabulary.getVocabularyId(),
+			serviceContext);
+
+		serviceContext.setAssetCategoryIds(
+			new long[] {assetCategory.getCategoryId()});
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_stagingGroup.getGroupId(), 0);
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_stagingGroup);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		FragmentEntryLink draftFragmentEntryLink =
+			ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+				JSONUtil.put(
+					FragmentEntryProcessorConstants.
+						KEY_EDITABLE_FRAGMENT_ENTRY_PROCESSOR,
+					JSONUtil.put(
+						"element-text",
+						JSONUtil.put(
+							"classNameId",
+							_portal.getClassNameId(JournalArticle.class)
+						).put(
+							"classPK",
+							String.valueOf(journalArticle.getResourcePrimKey())
+						).put(
+							"classTypeId",
+							String.valueOf(journalArticle.getDDMStructureId())
+						).put(
+							"defaultValue",
+							" A paragraph is a self-contained..."
+						).put(
+							"externalReferenceCode",
+							journalArticle.getExternalReferenceCode()
+						).put(
+							"fieldId",
+							"AssetVocabulary_" +
+								assetVocabulary.getVocabularyId()
+						).put(
+							"itemSubtype", "Basic Web Content"
+						).put(
+							"itemType", "Web ContentArticle"
+						).put(
+							"title", "Title"
+						))
+				).toString(),
+				_fragmentRendererRegistry.getFragmentRenderer(
+					"com.liferay.fragment.internal.renderer." +
+						"ContentObjectFragmentRenderer"),
+				draftLayout, null, 0,
+				_segmentsExperienceLocalService.
+					fetchDefaultSegmentsExperienceId(draftLayout.getPlid()));
+
+		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
+
+		FragmentEntryLink fragmentEntryLink =
+			_fragmentEntryLinkLocalService.getFragmentEntryLink(
+				layout.getGroupId(),
+				draftFragmentEntryLink.getFragmentEntryLinkId(),
+				layout.getPlid());
+
+		_publishLayouts();
+
+		AssetVocabulary importedAssetVocabulary =
+			_assetVocabularyLocalService.getAssetVocabularyByUuidAndGroupId(
+				assetVocabulary.getUuid(), _liveGroup.getGroupId());
+
+		FragmentEntryLink importedFragmentEntryLink =
+			_fragmentEntryLinkLocalService.getFragmentEntryLinkByUuidAndGroupId(
+				fragmentEntryLink.getUuid(), _liveGroup.getGroupId());
+
+		JSONObject jsonObject =
+			importedFragmentEntryLink.getEditableValuesJSONObject();
+
+		JSONObject editableJSONObject = jsonObject.getJSONObject(
+			FragmentEntryProcessorConstants.
+				KEY_EDITABLE_FRAGMENT_ENTRY_PROCESSOR);
+
+		JSONObject elementTextJSONObject = editableJSONObject.getJSONObject(
+			"element-text");
+
+		Assert.assertEquals(
+			"AssetVocabulary_" + importedAssetVocabulary.getVocabularyId(),
+			elementTextJSONObject.get("fieldId"));
 	}
 
 	@Test
@@ -509,6 +614,12 @@ public class EditableValuesExportImportContentProcessorTest {
 			TestPropsValues.getUserId(), _stagingGroup.getGroupId(),
 			_liveGroup.getGroupId(), false, parameterMap);
 	}
+
+	@Inject
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@Inject
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
 
 	@Inject
 	private DDMStructureLocalService _ddmStructureLocalService;


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-66394

The vocabularyId is not updated to the live vocabularyId when publishing to staging.

# How am I fixing it?

Taking into account the vocabularyId that can be present in the FragmentEntryLink and exporting/importing it when performing a staging publication.

# How can you verify that it works?

Run the included automated tests
