### PR TITLE
LPD-66496 Avoid usage of GuestOrUserUtil in *LocalServiceImpl classes

### DIFF
--- a/modules/apps/fragment/fragment-api/bnd.bnd
+++ b/modules/apps/fragment/fragment-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Fragment API
 Bundle-SymbolicName: com.liferay.fragment.api
-Bundle-Version: 55.2.1
+Bundle-Version: 56.0.0
 Export-Package:\
 	com.liferay.fragment.cache,\
 	com.liferay.fragment.configuration,\

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalService.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalService.java
@@ -480,7 +480,7 @@ public interface FragmentEntryLinkLocalService
 	public PersistedModel getPersistedModel(Serializable primaryKeyObj)
 		throws PortalException;
 
-	public void updateClassedModel(long plid);
+	public void updateClassedModel(long userId, long plid);
 
 	public FragmentEntryLink updateDeleted(
 			long userId, long fragmentEntryLinkId, boolean deleted)

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceUtil.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceUtil.java
@@ -650,8 +650,8 @@ public class FragmentEntryLinkLocalServiceUtil {
 		return getService().getPersistedModel(primaryKeyObj);
 	}
 
-	public static void updateClassedModel(long plid) {
-		getService().updateClassedModel(plid);
+	public static void updateClassedModel(long userId, long plid) {
+		getService().updateClassedModel(userId, plid);
 	}
 
 	public static FragmentEntryLink updateDeleted(

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceWrapper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceWrapper.java
@@ -751,8 +751,8 @@ public class FragmentEntryLinkLocalServiceWrapper
 	}
 
 	@Override
-	public void updateClassedModel(long plid) {
-		_fragmentEntryLinkLocalService.updateClassedModel(plid);
+	public void updateClassedModel(long userId, long plid) {
+		_fragmentEntryLinkLocalService.updateClassedModel(userId, plid);
 	}
 
 	@Override

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
@@ -1,1 +1,1 @@
-version 14.1.0
+version 15.0.0

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -42,7 +42,6 @@ import com.liferay.portal.kernel.model.LayoutTable;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.FileEntry;
-import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -645,12 +644,11 @@ public class FragmentEntryLinkLocalServiceImpl
 	}
 
 	@Override
-	public void updateClassedModel(long plid) {
+	public void updateClassedModel(long userId, long plid) {
 		if (UpdateLayoutStatusThreadLocal.isUpdateLayoutStatus()) {
 			try {
 				_layoutLocalService.updateStatus(
-					PrincipalThreadLocal.getUserId(), plid,
-					WorkflowConstants.STATUS_DRAFT,
+					userId, plid, WorkflowConstants.STATUS_DRAFT,
 					ServiceContextThreadLocal.getServiceContext());
 			}
 			catch (PortalException portalException) {
@@ -756,7 +754,7 @@ public class FragmentEntryLinkLocalServiceImpl
 		fragmentEntryLink.setEditableValues(editableValues);
 
 		if (updateClassedModel) {
-			updateClassedModel(fragmentEntryLink.getPlid());
+			updateClassedModel(userId, fragmentEntryLink.getPlid());
 		}
 
 		return fragmentEntryLinkPersistence.update(fragmentEntryLink);

--- a/modules/apps/fragment/source-formatter-suppressions.xml
+++ b/modules/apps/fragment/source-formatter-suppressions.xml
@@ -24,6 +24,5 @@
 		<suppress checks="IllegalImportsCheck" files="fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/internal/parser/ActionEditableElementParser.java" />
 		<suppress checks="IllegalImportsCheck" files="fragment-impl/src/main/java/com/liferay/fragment/internal/processor/FragmentEntryProcessorRegistryImpl.java" />
 		<suppress checks="JavaCompanyScopedIdsCheck" files="fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v1_1_0/PortletPreferencesUpgradeProcess\.java" />
-		<suppress checks="JavaLocalServiceImplUserIdUsageCheck" files="fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl\.java" />
 	</source-check>
 </suppressions>

--- a/modules/apps/layout/layout-page-template-api/bnd.bnd
+++ b/modules/apps/layout/layout-page-template-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout Page Template API
 Bundle-SymbolicName: com.liferay.layout.page.template.api
-Bundle-Version: 32.0.2
+Bundle-Version: 33.0.0
 Export-Package:\
 	com.liferay.layout.page.template.constants,\
 	com.liferay.layout.page.template.exception,\

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryLocalService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryLocalService.java
@@ -493,7 +493,8 @@ public interface LayoutPageTemplateEntryLocalService
 		throws PortalException;
 
 	public LayoutPageTemplateEntry updateLayoutPageTemplateEntry(
-			long layoutPageTemplateEntryId, long classNameId, long classTypeId)
+			long userId, long layoutPageTemplateEntryId, long classNameId,
+			long classTypeId)
 		throws PortalException;
 
 	public LayoutPageTemplateEntry updateLayoutPageTemplateEntry(

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryLocalServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryLocalServiceUtil.java
@@ -649,11 +649,12 @@ public class LayoutPageTemplateEntryLocalServiceUtil {
 	}
 
 	public static LayoutPageTemplateEntry updateLayoutPageTemplateEntry(
-			long layoutPageTemplateEntryId, long classNameId, long classTypeId)
+			long userId, long layoutPageTemplateEntryId, long classNameId,
+			long classTypeId)
 		throws PortalException {
 
 		return getService().updateLayoutPageTemplateEntry(
-			layoutPageTemplateEntryId, classNameId, classTypeId);
+			userId, layoutPageTemplateEntryId, classNameId, classTypeId);
 	}
 
 	public static LayoutPageTemplateEntry updateLayoutPageTemplateEntry(

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateEntryLocalServiceWrapper.java
@@ -751,12 +751,13 @@ public class LayoutPageTemplateEntryLocalServiceWrapper
 
 	@Override
 	public LayoutPageTemplateEntry updateLayoutPageTemplateEntry(
-			long layoutPageTemplateEntryId, long classNameId, long classTypeId)
+			long userId, long layoutPageTemplateEntryId, long classNameId,
+			long classTypeId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _layoutPageTemplateEntryLocalService.
 			updateLayoutPageTemplateEntry(
-				layoutPageTemplateEntryId, classNameId, classTypeId);
+				userId, layoutPageTemplateEntryId, classNameId, classTypeId);
 	}
 
 	@Override

--- a/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/packageinfo
+++ b/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/packageinfo
@@ -1,1 +1,1 @@
-version 15.0.1
+version 16.0.0

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
@@ -54,7 +54,6 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
-import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -760,7 +759,8 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 
 	@Override
 	public LayoutPageTemplateEntry updateLayoutPageTemplateEntry(
-			long layoutPageTemplateEntryId, long classNameId, long classTypeId)
+			long userId, long layoutPageTemplateEntryId, long classNameId,
+			long classTypeId)
 		throws PortalException {
 
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
@@ -771,8 +771,7 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 			layoutPageTemplateEntry.getPlid());
 
 		if ((draftLayout != null) &&
-			!draftLayout.isUnlocked(
-				Constants.EDIT, GuestOrUserUtil.getUserId())) {
+			!draftLayout.isUnlocked(Constants.EDIT, userId)) {
 
 			throw new LockedLayoutException();
 		}

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryServiceImpl.java
@@ -977,7 +977,8 @@ public class LayoutPageTemplateEntryServiceImpl
 
 		return layoutPageTemplateEntryLocalService.
 			updateLayoutPageTemplateEntry(
-				layoutPageTemplateEntryId, classNameId, classTypeId);
+				getUserId(), layoutPageTemplateEntryId, classNameId,
+				classTypeId);
 	}
 
 	@Override

--- a/modules/apps/layout/source-formatter-suppressions.xml
+++ b/modules/apps/layout/source-formatter-suppressions.xml
@@ -12,7 +12,4 @@
 		<suppress checks="MethodNamingCheck" files="layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutServiceContextHelperImpl\.java" />
 		<suppress checks="VariableDeclarationAsUsedCheck" files="layout-impl/src/main/java/com/liferay/layout/internal/struts/UpdateLayoutStrutsAction\.java" />
 	</checkstyle>
-	<source-check>
-		<suppress checks="JavaLocalServiceImplUserIdUsageCheck" files="layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl\.java" />
-	</source-check>
 </suppressions>


### PR DESCRIPTION
Motivation
-----
Avoid usage of GuestOrUserUtil class in *LocalServiceImpl, more information in https://liferay.slack.com/archives/C01FP01V5L0/p1708446324972219?thread_ts=1708444263.392559&cid=C01FP01V5L0
In some situations it is dealing in the following error: "**Principal is null**"

[Link to the ticket](https://liferay.atlassian.net/browse/LPD-66496)

Proposed Solution
-----
Includes userId as parameter in method definition, in that way we are avoiding the dependency with GuestOrUserUtil and PrincipalThreadLocal.

Please let me know if you have any question.