### PR TITLE
LPD-65298 Implement edit button in the alert banner of the empty page preview

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/SelectLayoutPageTemplateEntryDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/SelectLayoutPageTemplateEntryDisplayContext.java
@@ -271,7 +271,9 @@ public class SelectLayoutPageTemplateEntryDisplayContext {
 				LayoutTypeController layoutTypeController =
 					LayoutTypeControllerTracker.getLayoutTypeController(type);
 
-				if (isEmptyPage()) {
+				if (isEmptyPage() &&
+					ParamUtil.getBoolean(_httpServletRequest, "editAction")) {
+
 					return layoutTypeController.isInstanceable() &&
 						   !layoutTypeController.isPrimaryType() &&
 						   !type.equals(LayoutConstants.TYPE_URL) &&

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-empty/build.gradle
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-empty/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
+	compileOnly project(":apps:layout:layout-admin-api")
 	compileOnly project(":apps:layout:layout-api")
 	compileOnly project(":apps:layout:layout-content-page-editor-api")
 	compileOnly project(":apps:layout:layout-taglib")

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-empty/src/main/java/com/liferay/layout/type/controller/empty/internal/layout/type/controller/EmptyLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-empty/src/main/java/com/liferay/layout/type/controller/empty/internal/layout/type/controller/EmptyLayoutTypeController.java
@@ -5,6 +5,7 @@
 
 package com.liferay.layout.type.controller.empty.internal.layout.type.controller;
 
+import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.layout.type.controller.BaseLayoutTypeControllerImpl;
 import com.liferay.petra.io.unsync.UnsyncStringWriter;
 import com.liferay.petra.string.StringPool;
@@ -12,10 +13,16 @@ import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutTypeController;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.service.permission.LayoutPermission;
 import com.liferay.portal.kernel.servlet.PipingServletResponse;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+
+import jakarta.portlet.PortletRequest;
 
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletResponse;
@@ -68,6 +75,45 @@ public class EmptyLayoutTypeController extends BaseLayoutTypeControllerImpl {
 
 			throw new NoSuchLayoutException();
 		}
+
+		String backURL = ParamUtil.getString(
+			_portal.getOriginalServletRequest(httpServletRequest),
+			"p_l_back_url", themeDisplay.getURLCurrent());
+
+		httpServletRequest.setAttribute(
+			"editURL",
+			PortletURLBuilder.create(
+				_portal.getControlPanelPortletURL(
+					httpServletRequest, LayoutAdminPortletKeys.GROUP_PAGES,
+					PortletRequest.RENDER_PHASE)
+			).setMVCRenderCommandName(
+				"/layout_admin/select_layout_page_template_entry"
+			).setRedirect(
+				() -> {
+					String redirect = ParamUtil.getString(
+						httpServletRequest, "redirect");
+
+					if (Validator.isNull(redirect)) {
+						redirect = _portal.escapeRedirect(backURL);
+					}
+
+					return redirect;
+				}
+			).setBackURL(
+				backURL
+			).setParameter(
+				"editAction", Boolean.TRUE
+			).setParameter(
+				"externalReferenceCode", layout.getExternalReferenceCode()
+			).setParameter(
+				"groupId", layout.getGroupId()
+			).setParameter(
+				"initialType", LayoutConstants.TYPE_EMPTY
+			).setParameter(
+				"privateLayout", layout.isPrivateLayout()
+			).setParameter(
+				"selPlid", layout.getPlid()
+			).buildString());
 
 		return super.includeLayoutContent(
 			httpServletRequest, httpServletResponse, layout);
@@ -131,6 +177,9 @@ public class EmptyLayoutTypeController extends BaseLayoutTypeControllerImpl {
 
 	@Reference
 	private LayoutPermission _layoutPermission;
+
+	@Reference
+	private Portal _portal;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.layout.type.controller.empty)"

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-empty/src/main/resources/META-INF/resources/layout/init.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-empty/src/main/resources/META-INF/resources/layout/init.jsp
@@ -10,6 +10,7 @@ taglib uri="http://liferay.com/tld/layout" prefix="liferay-layout" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
-<%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %>
+<%@ page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
+page import="com.liferay.portal.kernel.util.HtmlUtil" %>
 
 <liferay-theme:defineObjects />

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-empty/src/main/resources/META-INF/resources/layout/view/empty.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-empty/src/main/resources/META-INF/resources/layout/view/empty.jsp
@@ -17,9 +17,11 @@
 
 		<clay:button
 			cssClass="alert-btn btn flex-shrink-0 ml-4"
+			data-testid="editEmptyLayoutButton"
 			displayType="secondary"
 			id="editButton"
 			label='<%= LanguageUtil.format(locale, "edit-x", "page") %>'
+			onClick='<%= "location.href='" + HtmlUtil.escapeJS((String)request.getAttribute("editURL")) + "';" %>'
 		/>
 	</div>
 </clay:alert>

--- a/modules/test/playwright/tests/layout-admin-web/main/emptyPage.spec.ts
+++ b/modules/test/playwright/tests/layout-admin-web/main/emptyPage.spec.ts
@@ -124,4 +124,31 @@ test('Empty pages show correct label in UI and correct alert in view mode', asyn
 			'This page was automatically generated during the import process to ensure the correct hierarchy of imported elements. Edit the page to configure.'
 		)
 	).toBeVisible();
+
+	// Assert that the edit button in the dummy page's alert banner goes to the select layout template page
+
+	await page.getByTestId('editEmptyLayoutButton').click();
+
+	await expect(page.locator('//h1[@data-qa-id="headerTitle"]')).toHaveText(
+		'Select Template'
+	);
+	await expect(page.getByText('Page Template Sets')).toBeVisible();
+	await expect(page.locator('.card-page-item').first()).toBeVisible();
+
+	// Assert that templates that should be hidden when editing an empty page are not present
+
+	const basicTemplatesNavItem = page.getByRole('menuitem', {
+		name: 'Basic Templates',
+	});
+
+	if ((await basicTemplatesNavItem.getAttribute('aria-current')) === null) {
+		await basicTemplatesNavItem.click();
+	}
+
+	await expect(
+		page.locator('.card-page-item', {hasText: 'Embedded'})
+	).toBeHidden();
+	await expect(
+		page.locator('.card-page-item', {hasText: 'Link to URL'})
+	).toBeHidden();
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-65298

Sort of depends on https://github.com/liferay-page-management/liferay-portal/pull/17636 since that fully implements editing/converting an empty page, but this can be merged before that PR. 

<img width="1885" height="600" alt="image" src="https://github.com/user-attachments/assets/dda79d1c-ccc5-4a9f-9607-7ba94bdc7f2f" />


This PR adds the link to the edit button in alert banner that allows the user to convert the empty page. The link goes to the correct page and state but without https://github.com/liferay-page-management/liferay-portal/pull/17636, it creates a child page instead of replacing the empty page. No further work should be needed to adapt this PR when the dependency merges - I tested this by rebasing onto https://github.com/liferay-page-management/liferay-portal/pull/17636. 

I added onto the existing playwright test to assert that clicking the edit button takes the user to the right page but left out testing the actual editing/creation since that falls under the scope of the other PR.

Thanks!

