### PR TITLE
LPD-79374 Error in fragments after upgrade from 7.3 to 2025.q3.10

### DIFF
--- a/modules/apps/layout/layout-page-template-service/bnd.bnd
+++ b/modules/apps/layout/layout-page-template-service/bnd.bnd
@@ -5,6 +5,6 @@ Import-Package:\
 	com.liferay.layout.page.template.util.comparator,\
 	\
 	*
-Liferay-Require-SchemaVersion: 5.8.0
+Liferay-Require-SchemaVersion: 5.8.1
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/registry/LayoutPageTemplateServiceUpgradeStepRegistrator.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/registry/LayoutPageTemplateServiceUpgradeStepRegistrator.java
@@ -17,6 +17,7 @@ import com.liferay.layout.page.template.internal.upgrade.v3_1_4.ResourcePermissi
 import com.liferay.layout.page.template.internal.upgrade.v3_3_0.LayoutPageTemplateStructureRelUpgradeProcess;
 import com.liferay.layout.page.template.internal.upgrade.v3_4_1.FragmentEntryLinkEditableValuesUpgradeProcess;
 import com.liferay.layout.page.template.internal.upgrade.v5_3_0.LayoutPageTemplateCollectionUpgradeProcess;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutPrototypeLocalService;
@@ -253,6 +254,21 @@ public class LayoutPageTemplateServiceUpgradeStepRegistrator
 			"5.7.1", "5.8.0",
 			UpgradeProcessFactory.addColumns(
 				"LayoutPageTemplateEntry", "classTypeKey VARCHAR(75) null"));
+
+		registry.register(
+			"5.8.0", "5.8.1",
+			UpgradeProcessFactory.runSQL(
+				StringBundler.concat(
+					"update FragmentEntryLink set segmentsExperienceId = ( ",
+					"select SegmentsExperience.segmentsExperienceId from ",
+					"SegmentsExperience where FragmentEntryLink.groupId = ",
+					"SegmentsExperience.groupId and FragmentEntryLink.plid = ",
+					"SegmentsExperience.plid ) where exists ( select 1 from ",
+					"SegmentsExperience where FragmentEntryLink.plid = ",
+					"SegmentsExperience.plid and FragmentEntryLink.groupId = ",
+					"SegmentsExperience.groupId group by ",
+					"SegmentsExperience.groupId, SegmentsExperience.plid ",
+					"having count(*) = 1 )")));
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v5_1_0/LayoutPageTemplateStructureUpgradeProcess.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v5_1_0/LayoutPageTemplateStructureUpgradeProcess.java
@@ -121,7 +121,7 @@ public class LayoutPageTemplateStructureUpgradeProcess extends UpgradeProcess {
 		}
 
 		_updateFragmentEntryLinks(
-			defaultSegmentsExperienceId, draftClassPK, publishedClassPK);
+			defaultSegmentsExperienceId, layout.getPlid());
 
 		_updateLayoutPageTemplateStructureRels(
 			defaultSegmentsExperienceId, layoutPageTemplateStructureId);
@@ -134,17 +134,15 @@ public class LayoutPageTemplateStructureUpgradeProcess extends UpgradeProcess {
 	}
 
 	private void _updateFragmentEntryLinks(
-			long defaultSegmentsExperienceId, long draftPlid,
-			long publishedPlid)
+			long defaultSegmentsExperienceId, long layoutPLid)
 		throws Exception {
 
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"update FragmentEntryLink set segmentsExperienceId = ? where " +
-					"segmentsExperienceId = 0 and (plid = ? or plid = ?)")) {
+					"segmentsExperienceId = 0 and plid = ?")) {
 
 			preparedStatement.setLong(1, defaultSegmentsExperienceId);
-			preparedStatement.setLong(2, draftPlid);
-			preparedStatement.setLong(3, publishedPlid);
+			preparedStatement.setLong(2, layoutPLid);
 
 			preparedStatement.executeUpdate();
 		}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-79374

After upgrading, the fragments dropped in master page template and in pages were throrowing error.

# How am I fixing it?

Fix the upgrade process wehre it was updateing the segmentsExperienceId and wrote a new upgrade process to update it correctly in the newer version.

# How can you verify that it works?

Run the included automated tests.