### PR TITLE
LPD 82690 Incorrect Web Content is displayed after mapping to a fragment

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemFieldValuesProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemFieldValuesProvider.java
@@ -29,6 +29,7 @@ import com.liferay.journal.model.JournalArticleDisplay;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.util.JournalContent;
 import com.liferay.journal.web.internal.info.item.JournalArticleInfoItemFields;
+import com.liferay.layout.display.page.constants.LayoutDisplayPageWebKeys;
 import com.liferay.layout.page.template.info.item.provider.DisplayPageInfoItemFieldSetProvider;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -298,21 +299,50 @@ public class JournalArticleInfoItemFieldValuesProvider
 				HttpServletRequest httpServletRequest =
 					themeDisplay.getRequest();
 
-				InfoItemDetailsProvider infoItemDetailsProvider =
-					_infoItemServiceRegistry.getFirstInfoItemService(
-						InfoItemDetailsProvider.class,
-						JournalArticle.class.getName());
+				Object currentInfoItem = httpServletRequest.getAttribute(
+					InfoDisplayWebKeys.INFO_ITEM);
+				Object currentInfoItemDetail = httpServletRequest.getAttribute(
+					InfoDisplayWebKeys.INFO_ITEM_DETAILS);
+				Object currentLayoutDisplayPageObjectProvider =
+					httpServletRequest.getAttribute(
+						LayoutDisplayPageWebKeys.
+							LAYOUT_DISPLAY_PAGE_OBJECT_PROVIDER);
+				Object currentLayoutDisplayPageProvider =
+					httpServletRequest.getAttribute(
+						LayoutDisplayPageWebKeys.LAYOUT_DISPLAY_PAGE_PROVIDER);
 
-				httpServletRequest.setAttribute(
-					InfoDisplayWebKeys.INFO_ITEM_DETAILS,
-					infoItemDetailsProvider.getInfoItemDetails(journalArticle));
+				try {
+					InfoItemDetailsProvider infoItemDetailsProvider =
+						_infoItemServiceRegistry.getFirstInfoItemService(
+							InfoItemDetailsProvider.class,
+							JournalArticle.class.getName());
 
-				for (InfoDisplayRequestAttributesContributor
-						infoDisplayRequestAttributesContributor :
-							_infoDisplayRequestAttributesContributors) {
+					httpServletRequest.setAttribute(
+						InfoDisplayWebKeys.INFO_ITEM_DETAILS,
+						infoItemDetailsProvider.getInfoItemDetails(
+							journalArticle));
 
-					infoDisplayRequestAttributesContributor.addAttributes(
-						httpServletRequest);
+					for (InfoDisplayRequestAttributesContributor
+							infoDisplayRequestAttributesContributor :
+								_infoDisplayRequestAttributesContributors) {
+
+						infoDisplayRequestAttributesContributor.addAttributes(
+							httpServletRequest);
+					}
+				}
+				finally {
+					httpServletRequest.setAttribute(
+						InfoDisplayWebKeys.INFO_ITEM, currentInfoItem);
+					httpServletRequest.setAttribute(
+						InfoDisplayWebKeys.INFO_ITEM_DETAILS,
+						currentInfoItemDetail);
+					httpServletRequest.setAttribute(
+						LayoutDisplayPageWebKeys.
+							LAYOUT_DISPLAY_PAGE_OBJECT_PROVIDER,
+						currentLayoutDisplayPageObjectProvider);
+					httpServletRequest.setAttribute(
+						LayoutDisplayPageWebKeys.LAYOUT_DISPLAY_PAGE_PROVIDER,
+						currentLayoutDisplayPageProvider);
 				}
 
 				PortletRequestModel portletRequestModel = null;

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
@@ -39,8 +39,10 @@ import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.renderer.FragmentRendererRegistry;
 import com.liferay.fragment.service.FragmentCollectionLocalService;
+import com.liferay.fragment.service.FragmentCollectionService;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.fragment.service.FragmentEntryLocalService;
+import com.liferay.fragment.service.FragmentEntryService;
 import com.liferay.headless.delivery.dto.v1_0.MessageBoardMessage;
 import com.liferay.info.collection.provider.CollectionQuery;
 import com.liferay.info.collection.provider.InfoCollectionProvider;
@@ -89,6 +91,7 @@ import com.liferay.layout.taglib.servlet.taglib.RenderLayoutStructureTag;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutFriendlyURLRandomizerBumper;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.layout.util.LayoutServiceContextHelper;
 import com.liferay.layout.util.constants.LayoutDataItemTypeConstants;
 import com.liferay.layout.util.structure.ContainerStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.FormStyledLayoutStructureItem;
@@ -3163,6 +3166,102 @@ public class RenderLayoutStructureTagTest {
 	}
 
 	@Test
+	@TestInfo("LPD-82690")
+	public void testRenderJournalArticle() throws Exception {
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		ContentLayoutTestUtil.publishLayout(layout.fetchDraftLayout(), layout);
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		JournalArticle basicJournalArticle =
+			JournalTestUtil.addArticleWithXMLContent(
+				_read("journal_article_content.xml"), "BASIC-WEB-CONTENT",
+				null);
+
+		FragmentCollection fragmentCollection =
+			_fragmentCollectionService.addFragmentCollection(
+				null, _group.getGroupId(), RandomTestUtil.randomString(),
+				StringPool.BLANK, _serviceContext);
+
+		FragmentEntry editableFragment = _addFragmentEntry();
+
+		FragmentEntry configurableFragment = _addFragmentEntry(
+			"journal_article_item_selector.json", fragmentCollection,
+			"journal_article_item_selector.html",
+			RandomTestUtil.randomString());
+
+		ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+			JSONUtil.put(
+				"com.liferay.fragment.entry.processor.freemarker." +
+					"FreeMarkerFragmentEntryProcessor",
+				JSONUtil.put(
+					"contentSelector",
+					JSONUtil.put(
+						"className", JournalArticle.class.getName()
+					).put(
+						"classNameId",
+						String.valueOf(
+							_portal.getClassNameId(
+								JournalArticle.class.getName()))
+					).put(
+						"classPK",
+						String.valueOf(basicJournalArticle.getResourcePrimKey())
+					).put(
+						"classTypeId",
+						String.valueOf(basicJournalArticle.getDDMStructureId())
+					))
+			).toString(),
+			configurableFragment.getCss(),
+			configurableFragment.getConfiguration(),
+			configurableFragment.getExternalReferenceCode(), null,
+			configurableFragment.getHtml(), configurableFragment.getJs(),
+			layout, null, FragmentConstants.TYPE_COMPONENT, null, 0,
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				layout.getPlid()));
+
+		ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+			JSONUtil.put(
+				"com.liferay.fragment.entry.processor.editable." +
+					"EditableFragmentEntryProcessor",
+				JSONUtil.put(
+					"template_1",
+					JSONUtil.put(
+						"className", JournalArticle.class.getName()
+					).put(
+						"classNameId",
+						String.valueOf(
+							_portal.getClassNameId(
+								JournalArticle.class.getName()))
+					).put(
+						"classPK",
+						String.valueOf(journalArticle.getResourcePrimKey())
+					).put(
+						"classTypeId",
+						String.valueOf(journalArticle.getDDMStructureId())
+					).put(
+						"fieldId",
+						"_ddmTemplate_" + journalArticle.getDDMTemplateKey()
+					))
+			).toString(),
+			editableFragment.getCss(), editableFragment.getConfiguration(),
+			editableFragment.getExternalReferenceCode(), null,
+			editableFragment.getHtml(), editableFragment.getJs(), layout, null,
+			FragmentConstants.TYPE_COMPONENT, null, 0,
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				layout.getPlid()));
+
+		String html = ContentLayoutTestUtil.getRenderLayoutHTML(
+			layout, _layoutServiceContextHelper, _layoutStructureProvider,
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				layout.getPlid()));
+
+		Assert.assertTrue(html.contains(basicJournalArticle.getTitle()));
+	}
+
+	@Test
 	@TestInfo("LPD-41653")
 	public void testViewAssertAnalyticsTargetableCollectionIdForCollectionStyledLayoutStructureItem()
 		throws Exception {
@@ -3459,6 +3558,20 @@ public class RenderLayoutStructureTagTest {
 				"data-lfr-editable-type=\"text\">Heading Example</h1>",
 			StringPool.BLANK, false, StringPool.BLANK, null, 0, false, false,
 			FragmentConstants.TYPE_COMPONENT, null,
+			WorkflowConstants.STATUS_APPROVED, _serviceContext);
+	}
+
+	private FragmentEntry _addFragmentEntry(
+			String configFile, FragmentCollection fragmentCollection,
+			String htmlFile, String name)
+		throws Exception {
+
+		return _fragmentEntryService.addFragmentEntry(
+			null, _group.getGroupId(),
+			fragmentCollection.getFragmentCollectionId(), null, name, null,
+			_read(htmlFile), null, false,
+			(configFile != null) ? _read(configFile) : null, null, 0, false,
+			false, FragmentConstants.TYPE_COMPONENT, null,
 			WorkflowConstants.STATUS_APPROVED, _serviceContext);
 	}
 
@@ -4295,6 +4408,9 @@ public class RenderLayoutStructureTagTest {
 	private FragmentCollectionLocalService _fragmentCollectionLocalService;
 
 	@Inject
+	private FragmentCollectionService _fragmentCollectionService;
+
+	@Inject
 	private FragmentEntryLinkListenerRegistry
 		_fragmentEntryLinkListenerRegistry;
 
@@ -4303,6 +4419,9 @@ public class RenderLayoutStructureTagTest {
 
 	@Inject
 	private FragmentEntryLocalService _fragmentEntryLocalService;
+
+	@Inject
+	private FragmentEntryService _fragmentEntryService;
 
 	@Inject
 	private FragmentRendererRegistry _fragmentRendererRegistry;
@@ -4347,6 +4466,9 @@ public class RenderLayoutStructureTagTest {
 	@Inject
 	private LayoutPageTemplateStructureLocalService
 		_layoutPageTemplateStructureLocalService;
+
+	@Inject
+	private LayoutServiceContextHelper _layoutServiceContextHelper;
 
 	@Inject
 	private LayoutStructureProvider _layoutStructureProvider;

--- a/modules/apps/layout/layout-test/src/testIntegration/resources/com/liferay/layout/taglib/test/dependencies/journal_article_content.xml
+++ b/modules/apps/layout/layout-test/src/testIntegration/resources/com/liferay/layout/taglib/test/dependencies/journal_article_content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+
+<root available-locales="en_US" default-locale="en_US">
+	<dynamic-element name="content" type="text_area">
+		<dynamic-content language-id="en_US">
+			<![CDATA[Hello from Liferay!]]></dynamic-content>
+	</dynamic-element>
+</root>

--- a/modules/apps/layout/layout-test/src/testIntegration/resources/com/liferay/layout/taglib/test/dependencies/journal_article_item_selector.html
+++ b/modules/apps/layout/layout-test/src/testIntegration/resources/com/liferay/layout/taglib/test/dependencies/journal_article_item_selector.html
@@ -1,0 +1,5 @@
+<div class="col-12 fragment-page-content">
+	[#if contentSelectorObject.getTitle()?has_content]
+		<h3 class="text-primary"> ${contentSelectorObject.getTitle()}</h3>
+	[/#if]
+</div>

--- a/modules/apps/layout/layout-test/src/testIntegration/resources/com/liferay/layout/taglib/test/dependencies/journal_article_item_selector.json
+++ b/modules/apps/layout/layout-test/src/testIntegration/resources/com/liferay/layout/taglib/test/dependencies/journal_article_item_selector.json
@@ -1,0 +1,16 @@
+{
+	"fieldSets": [
+		{
+			"fields": [
+				{
+					"label": "select-content",
+					"name": "contentSelector",
+					"type": "itemSelector",
+					"typeOptions": {
+						"itemType": "com.liferay.journal.model.JournalArticle"
+					}
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
# What is this trying to solve?

[LPD-82690](https://liferay.atlassian.net/browse/LPD-82690)

After publish web content is not rendering properly.

# How am I fixing it?

By  removing already evaluated web content data from httpRequest

# How can you verify that it works?

Run the included automated tests.

[LPD-82690]: https://liferay.atlassian.net/browse/LPD-82690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ