### PR TITLE
LPD-83633 Cannot import fragments with resources multiple times

### DIFF
--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
@@ -233,6 +233,31 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 		return true;
 	}
 
+	private void _addFileEntry(
+			long fragmentCollectionId, long groupId,
+			Map<String, Long> folderIdsMap, String path, Repository repository,
+			long userId, ZipFile zipFile, String zipEntryName)
+		throws Exception {
+
+		String fileName = path;
+		String folderPath = StringPool.BLANK;
+
+		int index = fileName.lastIndexOf(StringPool.SLASH);
+
+		if (index != -1) {
+			folderPath = fileName.substring(0, index);
+			fileName = fileName.substring(index + 1);
+		}
+
+		PortletFileRepositoryUtil.addPortletFileEntry(
+			null, groupId, userId, FragmentCollection.class.getName(),
+			fragmentCollectionId, FragmentPortletKeys.FRAGMENT,
+			_getOrCreateFolderId(
+				folderIdsMap, folderPath, repository.getRepositoryId(), userId),
+			_getInputStream(zipFile, zipEntryName), fileName,
+			MimeTypesUtil.getContentType(fileName), false);
+	}
+
 	private FragmentCollection _addFragmentCollection(
 			long groupId, String fragmentCollectionKey, String name,
 			String description, FragmentsImportStrategy fragmentsImportStrategy,
@@ -451,28 +476,10 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 						PortletFileRepositoryUtil.deletePortletFileEntry(
 							fileEntry.getFileEntryId());
 
-						String fileName = entry.getKey();
-						String folderPath = StringPool.BLANK;
-
-						int index = fileName.lastIndexOf(StringPool.SLASH);
-
-						if (index != -1) {
-							folderPath = fileName.substring(0, index);
-							fileName = fileName.substring(index + 1);
-						}
-
-						PortletFileRepositoryUtil.addPortletFileEntry(
-							null, groupId, userId,
-							FragmentCollection.class.getName(),
+						_addFileEntry(
 							fragmentCollection.getFragmentCollectionId(),
-							FragmentPortletKeys.FRAGMENT,
-							_getOrCreateFolderId(
-								folderIdsMap, folderPath,
-								repository.getRepositoryId(), userId),
-							_getInputStream(
-								zipFile, zipEntryNames.get(fileEntryPath)),
-							fileName, MimeTypesUtil.getContentType(fileName),
-							false);
+							groupId, folderIdsMap, fileEntryPath, repository,
+							userId, zipFile, zipEntryNames.get(fileEntryPath));
 
 						zipEntryNames.remove(fileEntryPath);
 					}
@@ -513,25 +520,10 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 		}
 
 		for (Map.Entry<String, String> entry : zipEntryNames.entrySet()) {
-			String fileName = entry.getKey();
-			String folderPath = StringPool.BLANK;
-
-			int index = fileName.lastIndexOf(StringPool.SLASH);
-
-			if (index != -1) {
-				folderPath = fileName.substring(0, index);
-				fileName = fileName.substring(index + 1);
-			}
-
-			PortletFileRepositoryUtil.addPortletFileEntry(
-				null, groupId, userId, FragmentCollection.class.getName(),
-				fragmentCollection.getFragmentCollectionId(),
-				FragmentPortletKeys.FRAGMENT,
-				_getOrCreateFolderId(
-					folderIdsMap, folderPath, repository.getRepositoryId(),
-					userId),
-				_getInputStream(zipFile, entry.getValue()), fileName,
-				MimeTypesUtil.getContentType(fileName), false);
+			_addFileEntry(
+				fragmentCollection.getFragmentCollectionId(), groupId,
+				folderIdsMap, entry.getKey(), repository, userId, zipFile,
+				entry.getValue());
 		}
 	}
 

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
@@ -482,7 +482,7 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 						int index = fileEntryPath.lastIndexOf(StringPool.SLASH);
 
 						if (index != -1) {
-							folderPath = fileEntryPath.substring(0, index);
+							folderPath = fileEntryPath.substring(0, index + 1);
 						}
 
 						String newFileName =

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
@@ -470,11 +470,11 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 								folderIdsMap, folderPath,
 								repository.getRepositoryId(), userId),
 							_getInputStream(
-								zipFile, zipEntryNames.get(fileName)),
+								zipFile, zipEntryNames.get(fileEntryPath)),
 							fileName, MimeTypesUtil.getContentType(fileName),
 							false);
 
-						zipEntryNames.remove(fileEntry.getFileName());
+						zipEntryNames.remove(fileEntryPath);
 					}
 					else {
 						String folderPath = StringPool.BLANK;

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
@@ -844,15 +844,9 @@ public class FragmentsImporterTest {
 	private File _generateZipFileWithFolderResources() throws Exception {
 		ZipWriter zipWriter = _zipWriterFactory.getZipWriter();
 
-		URL collectionURL = _bundle.getEntry(
-			_PATH_FRAGMENTS_WITH_FOLDER_RESOURCES +
-				FragmentExportImportConstants.FILE_NAME_COLLECTION);
-
-		try (InputStream inputStream = collectionURL.openStream()) {
-			zipWriter.addEntry(
-				FragmentExportImportConstants.FILE_NAME_COLLECTION,
-				inputStream);
-		}
+		_addZipWriterEntry(
+			zipWriter, _PATH_DEPENDENCIES + "fragments-with-folder-resources",
+			FragmentExportImportConstants.FILE_NAME_COLLECTION);
 
 		_addZipWriterEntry(
 			zipWriter, _PATH_FRAGMENTS_WITH_FOLDER_RESOURCES + "resources",

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
@@ -253,71 +253,17 @@ public class FragmentsImporterTest {
 
 		File fileWithFolderResources = _generateZipFileWithFolderResources();
 
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
-		try {
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0,
-				fileWithFolderResources, FragmentsImportStrategy.OVERWRITE,
-				false);
-
-			List<FragmentCollection> fragmentCollections =
-				_fragmentCollectionLocalService.getFragmentCollections(
-					_group.getGroupId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
-
-			Assert.assertEquals(
-				fragmentCollections.toString(), 1, fragmentCollections.size());
-
-			FragmentCollection fragmentCollection = fragmentCollections.get(0);
-
-			Map<String, FileEntry> resourcesMap =
-				fragmentCollection.getResourcesMap();
-
-			Assert.assertEquals(
-				resourcesMap.toString(), 2, resourcesMap.size());
-
-			Assert.assertNotNull(resourcesMap.get("image1.png"));
-			Assert.assertNotNull(resourcesMap.get("folder1/image2.png"));
-
-			FileEntry fileEntry = resourcesMap.get("image1.png");
-
-			Assert.assertEquals("image1.png", fileEntry.getTitle());
-
-			fileEntry = resourcesMap.get("folder1/image2.png");
-
-			Assert.assertEquals("image2.png", fileEntry.getTitle());
-
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0,
-				fileWithFolderResources, FragmentsImportStrategy.OVERWRITE,
-				false);
-
-			fragmentCollection =
-				_fragmentCollectionLocalService.fetchFragmentCollection(
-					fragmentCollection.getFragmentCollectionId());
-
-			resourcesMap = fragmentCollection.getResourcesMap();
-
-			Assert.assertEquals(
-				resourcesMap.toString(), 4, resourcesMap.size());
-
-			Assert.assertNotNull(resourcesMap.get("image1.png"));
-			Assert.assertNotNull(resourcesMap.get("image1 (1).png"));
-			Assert.assertNotNull(resourcesMap.get("folder1/image2.png"));
-			Assert.assertNotNull(resourcesMap.get("folder1/image2 (1).png"));
-
-			fileEntry = resourcesMap.get("image1 (1).png");
-
-			Assert.assertEquals("image1 (1).png", fileEntry.getTitle());
-
-			fileEntry = resourcesMap.get("folder1/image2 (1).png");
-
-			Assert.assertEquals("image2 (1).png", fileEntry.getTitle());
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		_testFolderResources(
+			fileWithFolderResources,
+			Map.of(
+				"folder1/image2.png", "image2.png", "image1.png",
+				"image1.png"));
+		_testFolderResources(
+			fileWithFolderResources,
+			Map.of(
+				"folder1/image2 (1).png", "image2 (1).png",
+				"folder1/image2.png", "image2.png", "image1 (1).png",
+				"image1 (1).png", "image1.png", "image1.png"));
 
 		FileUtil.delete(fileWithFolderResources);
 	}
@@ -328,9 +274,6 @@ public class FragmentsImporterTest {
 
 		File fileWithFolderResources = _generateZipFileWithFolderResources();
 
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
 		_configurationProvider.saveCompanyConfiguration(
 			FragmentServiceConfiguration.class, _group.getCompanyId(),
 			HashMapDictionaryBuilder.<String, Object>put(
@@ -338,61 +281,16 @@ public class FragmentsImporterTest {
 			).build());
 
 		try {
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0,
-				fileWithFolderResources, FragmentsImportStrategy.OVERWRITE,
-				false);
-
-			List<FragmentCollection> fragmentCollections =
-				_fragmentCollectionLocalService.getFragmentCollections(
-					_group.getGroupId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
-
-			Assert.assertEquals(
-				fragmentCollections.toString(), 1, fragmentCollections.size());
-
-			FragmentCollection fragmentCollection = fragmentCollections.get(0);
-
-			Map<String, FileEntry> resourcesMap =
-				fragmentCollection.getResourcesMap();
-
-			Assert.assertEquals(
-				resourcesMap.toString(), 2, resourcesMap.size());
-
-			Assert.assertNotNull(resourcesMap.get("image1.png"));
-			Assert.assertNotNull(resourcesMap.get("folder1/image2.png"));
-
-			FileEntry fileEntry = resourcesMap.get("image1.png");
-
-			Assert.assertEquals("image1.png", fileEntry.getTitle());
-
-			fileEntry = resourcesMap.get("folder1/image2.png");
-
-			Assert.assertEquals("image2.png", fileEntry.getTitle());
-
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0,
-				fileWithFolderResources, FragmentsImportStrategy.OVERWRITE,
-				false);
-
-			fragmentCollection =
-				_fragmentCollectionLocalService.fetchFragmentCollection(
-					fragmentCollection.getFragmentCollectionId());
-
-			resourcesMap = fragmentCollection.getResourcesMap();
-
-			Assert.assertEquals(
-				resourcesMap.toString(), 2, resourcesMap.size());
-
-			Assert.assertNotNull(resourcesMap.get("image1.png"));
-			Assert.assertNotNull(resourcesMap.get("folder1/image2.png"));
-
-			fileEntry = resourcesMap.get("image1.png");
-
-			Assert.assertEquals("image1.png", fileEntry.getTitle());
-
-			fileEntry = resourcesMap.get("folder1/image2.png");
-
-			Assert.assertEquals("image2.png", fileEntry.getTitle());
+			_testFolderResources(
+				fileWithFolderResources,
+				Map.of(
+					"folder1/image2.png", "image2.png", "image1.png",
+					"image1.png"));
+			_testFolderResources(
+				fileWithFolderResources,
+				Map.of(
+					"folder1/image2.png", "image2.png", "image1.png",
+					"image1.png"));
 		}
 		finally {
 			_configurationProvider.saveCompanyConfiguration(
@@ -400,8 +298,6 @@ public class FragmentsImporterTest {
 				HashMapDictionaryBuilder.<String, Object>put(
 					"propagateChanges", false
 				).build());
-
-			ServiceContextThreadLocal.popServiceContext();
 		}
 
 		FileUtil.delete(fileWithFolderResources);
@@ -1062,6 +958,44 @@ public class FragmentsImporterTest {
 			_addZipWriterEntry(
 				zipWriter, path,
 				jsonObject.getString("fragmentCompositionDefinitionPath"));
+		}
+	}
+
+	private void _testFolderResources(
+			File fileWithFolderResources, Map<String, String> expectedResources)
+		throws Exception {
+
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		try {
+			_fragmentsImporter.importFragmentEntries(
+				_user.getUserId(), _group.getGroupId(), 0,
+				fileWithFolderResources, FragmentsImportStrategy.OVERWRITE,
+				false);
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
+
+		List<FragmentCollection> fragmentCollections =
+			_fragmentCollectionLocalService.getFragmentCollections(
+				_group.getGroupId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		FragmentCollection fragmentCollection = fragmentCollections.get(0);
+
+		Map<String, FileEntry> resourcesMap =
+			fragmentCollection.getResourcesMap();
+
+		Assert.assertEquals(
+			resourcesMap.toString(), expectedResources.size(),
+			resourcesMap.size());
+
+		for (Map.Entry<String, String> entry : expectedResources.entrySet()) {
+			FileEntry fileEntry = resourcesMap.get(entry.getKey());
+
+			Assert.assertNotNull(fileEntry);
+			Assert.assertEquals(entry.getValue(), fileEntry.getTitle());
 		}
 	}
 

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
@@ -261,35 +261,148 @@ public class FragmentsImporterTest {
 				_user.getUserId(), _group.getGroupId(), 0,
 				fileWithFolderResources, FragmentsImportStrategy.OVERWRITE,
 				false);
+
+			List<FragmentCollection> fragmentCollections =
+				_fragmentCollectionLocalService.getFragmentCollections(
+					_group.getGroupId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+			Assert.assertEquals(
+				fragmentCollections.toString(), 1, fragmentCollections.size());
+
+			FragmentCollection fragmentCollection = fragmentCollections.get(0);
+
+			Map<String, FileEntry> resourcesMap =
+				fragmentCollection.getResourcesMap();
+
+			Assert.assertEquals(
+				resourcesMap.toString(), 2, resourcesMap.size());
+
+			Assert.assertNotNull(resourcesMap.get("image1.png"));
+			Assert.assertNotNull(resourcesMap.get("folder1/image2.png"));
+
+			FileEntry fileEntry = resourcesMap.get("image1.png");
+
+			Assert.assertEquals("image1.png", fileEntry.getTitle());
+
+			fileEntry = resourcesMap.get("folder1/image2.png");
+
+			Assert.assertEquals("image2.png", fileEntry.getTitle());
+
+			_fragmentsImporter.importFragmentEntries(
+				_user.getUserId(), _group.getGroupId(), 0,
+				fileWithFolderResources, FragmentsImportStrategy.OVERWRITE,
+				false);
+
+			fragmentCollection =
+				_fragmentCollectionLocalService.fetchFragmentCollection(
+					fragmentCollection.getFragmentCollectionId());
+
+			resourcesMap = fragmentCollection.getResourcesMap();
+
+			Assert.assertEquals(
+				resourcesMap.toString(), 4, resourcesMap.size());
+
+			Assert.assertNotNull(resourcesMap.get("image1.png"));
+			Assert.assertNotNull(resourcesMap.get("image1 (1).png"));
+			Assert.assertNotNull(resourcesMap.get("folder1/image2.png"));
+			Assert.assertNotNull(resourcesMap.get("folder1/image2 (1).png"));
+
+			fileEntry = resourcesMap.get("image1 (1).png");
+
+			Assert.assertEquals("image1 (1).png", fileEntry.getTitle());
+
+			fileEntry = resourcesMap.get("folder1/image2 (1).png");
+
+			Assert.assertEquals("image2 (1).png", fileEntry.getTitle());
 		}
 		finally {
 			ServiceContextThreadLocal.popServiceContext();
 		}
 
-		List<FragmentCollection> fragmentCollections =
-			_fragmentCollectionLocalService.getFragmentCollections(
-				_group.getGroupId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+		FileUtil.delete(fileWithFolderResources);
+	}
 
-		Assert.assertEquals(
-			fragmentCollections.toString(), 1, fragmentCollections.size());
+	@Test
+	public void testImportFragmentEntriesWithFolderResourcesPropagation()
+		throws Exception {
 
-		FragmentCollection fragmentCollection = fragmentCollections.get(0);
+		File fileWithFolderResources = _generateZipFileWithFolderResources();
 
-		Map<String, FileEntry> resourcesMap =
-			fragmentCollection.getResourcesMap();
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
-		Assert.assertEquals(resourcesMap.toString(), 2, resourcesMap.size());
+		_configurationProvider.saveCompanyConfiguration(
+			FragmentServiceConfiguration.class, _group.getCompanyId(),
+			HashMapDictionaryBuilder.<String, Object>put(
+				"propagateChanges", true
+			).build());
 
-		Assert.assertNotNull(resourcesMap.get("image1.png"));
-		Assert.assertNotNull(resourcesMap.get("folder1/image2.png"));
+		try {
+			_fragmentsImporter.importFragmentEntries(
+				_user.getUserId(), _group.getGroupId(), 0,
+				fileWithFolderResources, FragmentsImportStrategy.OVERWRITE,
+				false);
 
-		FileEntry fileEntry = resourcesMap.get("image1.png");
+			List<FragmentCollection> fragmentCollections =
+				_fragmentCollectionLocalService.getFragmentCollections(
+					_group.getGroupId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
-		Assert.assertEquals("image1.png", fileEntry.getTitle());
+			Assert.assertEquals(
+				fragmentCollections.toString(), 1, fragmentCollections.size());
 
-		fileEntry = resourcesMap.get("folder1/image2.png");
+			FragmentCollection fragmentCollection = fragmentCollections.get(0);
 
-		Assert.assertEquals("image2.png", fileEntry.getTitle());
+			Map<String, FileEntry> resourcesMap =
+				fragmentCollection.getResourcesMap();
+
+			Assert.assertEquals(
+				resourcesMap.toString(), 2, resourcesMap.size());
+
+			Assert.assertNotNull(resourcesMap.get("image1.png"));
+			Assert.assertNotNull(resourcesMap.get("folder1/image2.png"));
+
+			FileEntry fileEntry = resourcesMap.get("image1.png");
+
+			Assert.assertEquals("image1.png", fileEntry.getTitle());
+
+			fileEntry = resourcesMap.get("folder1/image2.png");
+
+			Assert.assertEquals("image2.png", fileEntry.getTitle());
+
+			_fragmentsImporter.importFragmentEntries(
+				_user.getUserId(), _group.getGroupId(), 0,
+				fileWithFolderResources, FragmentsImportStrategy.OVERWRITE,
+				false);
+
+			fragmentCollection =
+				_fragmentCollectionLocalService.fetchFragmentCollection(
+					fragmentCollection.getFragmentCollectionId());
+
+			resourcesMap = fragmentCollection.getResourcesMap();
+
+			Assert.assertEquals(
+				resourcesMap.toString(), 2, resourcesMap.size());
+
+			Assert.assertNotNull(resourcesMap.get("image1.png"));
+			Assert.assertNotNull(resourcesMap.get("folder1/image2.png"));
+
+			fileEntry = resourcesMap.get("image1.png");
+
+			Assert.assertEquals("image1.png", fileEntry.getTitle());
+
+			fileEntry = resourcesMap.get("folder1/image2.png");
+
+			Assert.assertEquals("image2.png", fileEntry.getTitle());
+		}
+		finally {
+			_configurationProvider.saveCompanyConfiguration(
+				FragmentServiceConfiguration.class, _group.getCompanyId(),
+				HashMapDictionaryBuilder.<String, Object>put(
+					"propagateChanges", false
+				).build());
+
+			ServiceContextThreadLocal.popServiceContext();
+		}
 
 		FileUtil.delete(fileWithFolderResources);
 	}


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-83633

Fixes an issue where fragment resource files were imported into incorrect folders, leading to duplicate file creation.

# How am I fixing it?

Use `FragmentsImportStrategy` to determine behavior: overwrite existing files or ignore them if they already exist, ensuring correct folder placement.

# How can you verify that it works?

Run the included automated tests.