### PR TITLE
[LPD-63947] Info Template "Item Type" list needs to be sorted

### DIFF
--- a/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/display/context/InformationTemplatesManagementToolbarDisplayContext.java
+++ b/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/display/context/InformationTemplatesManagementToolbarDisplayContext.java
@@ -16,9 +16,11 @@ import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.info.item.provider.InfoItemFormVariationsProvider;
 import com.liferay.info.permission.provider.InfoPermissionProvider;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.json.JSONArrayImpl;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
@@ -26,6 +28,7 @@ import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.CollatorUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -36,7 +39,10 @@ import com.liferay.template.web.internal.security.permissions.resource.TemplateE
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.text.Collator;
+
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -232,12 +238,48 @@ public class InformationTemplatesManagementToolbarDisplayContext
 			}
 		}
 
-		return itemTypesJSONArray;
+		return _sortJSONArray(itemTypesJSONArray, new ItemTypesComparator());
+	}
+
+	private JSONArray _sortJSONArray(
+		JSONArray jsonArray, Comparator<Object> comparator) {
+
+		List<Object> objects = JSONUtil.toObjectList(jsonArray);
+
+		Collections.sort(objects, comparator);
+
+		jsonArray = new JSONArrayImpl();
+
+		for (Object object : objects) {
+			jsonArray.put(object);
+		}
+
+		return jsonArray;
 	}
 
 	private final InfoItemServiceRegistry _infoItemServiceRegistry;
 	private final InformationTemplatesTemplateDisplayContext
 		_informationTemplatesTemplateDisplayContext;
 	private final ThemeDisplay _themeDisplay;
+
+	private class ItemTypesComparator implements Comparator<Object> {
+
+		@Override
+		public int compare(Object object1, Object object2) {
+			JSONObject jsonObject1 = (JSONObject)object1;
+
+			String itemTypeLabel1 = jsonObject1.getString("label");
+
+			JSONObject jsonObject2 = (JSONObject)object2;
+
+			String itemTypeLabel2 = jsonObject2.getString("label");
+
+			Collator collator = CollatorUtil.getInstance(
+				_themeDisplay.getLocale());
+
+			return collator.compare(itemTypeLabel1, itemTypeLabel2);
+		}
+
+	}
 
 }

--- a/modules/apps/template/template-web/src/test/java/com/liferay/template/web/internal/display/context/InformationTemplatesManagementToolbarDisplayContextTest.java
+++ b/modules/apps/template/template-web/src/test/java/com/liferay/template/web/internal/display/context/InformationTemplatesManagementToolbarDisplayContextTest.java
@@ -32,6 +32,8 @@ import jakarta.portlet.PortletURL;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.AfterClass;
@@ -122,6 +124,12 @@ public class InformationTemplatesManagementToolbarDisplayContextTest {
 		String label = RandomTestUtil.randomString();
 
 		_testGetItemTypesJSONArray(label, label);
+
+	@Test
+	public void testSortedGetItemTypesJSONArray() {
+		_testGetItemTypesJSONArray(
+			Arrays.asList("EarlierInTheAlphabet", "LaterInTheAlphabet"),
+			Arrays.asList("LaterInTheAlphabet", "EarlierInTheAlphabet"));
 	}
 
 	private InfoItemClassDetails _mockInfoItemClassDetails() {
@@ -170,6 +178,65 @@ public class InformationTemplatesManagementToolbarDisplayContextTest {
 		themeDisplay.setLocale(LocaleUtil.CANADA);
 
 		return themeDisplay;
+	}
+
+	private void _testGetItemTypesJSONArray(
+		List<String> expectedLabels, List<String> labels) {
+
+		List<InfoItemFormVariation> informationItemFormVariations =
+			new ArrayList<>();
+		List<String> keys = new ArrayList<>();
+
+		for (String label : labels) {
+			String key = RandomTestUtil.randomString();
+
+			keys.add(key);
+
+			informationItemFormVariations.add(
+				_mockInfoItemFormVariation(key, label));
+		}
+
+		Mockito.when(
+			_infoItemFormVariationsProvider.getInfoItemFormVariations(0)
+		).thenReturn(
+			informationItemFormVariations
+		);
+
+		JSONArray jsonArray = ReflectionTestUtil.invoke(
+			_informationTemplatesManagementToolbarDisplayContext,
+			"_getItemTypesJSONArray", new Class<?>[0]);
+
+		Assert.assertEquals(jsonArray.toString(), 1, jsonArray.length());
+
+		JSONObject jsonObject = jsonArray.getJSONObject(0);
+
+		Assert.assertEquals(_CLASS_NAME, jsonObject.getString("value"));
+		Assert.assertEquals(_LABEL, jsonObject.getString("label"));
+
+		Assert.assertTrue(jsonObject.has("subtypes"));
+
+		JSONArray subtypesJSONArray = jsonObject.getJSONArray("subtypes");
+
+		Assert.assertEquals(
+			subtypesJSONArray.toString(), labels.size(),
+			subtypesJSONArray.length());
+
+		for (int i = 0; i < labels.size(); i++) {
+			JSONObject subtypesJSONObject = subtypesJSONArray.getJSONObject(i);
+
+			String expectedLabel = expectedLabels.get(i);
+
+			int index = labels.indexOf(expectedLabel);
+
+			if ((index < 0) && StringPool.BLANK.equals(expectedLabel)) {
+				index = labels.indexOf(null);
+			}
+
+			Assert.assertEquals(
+				keys.get(index), subtypesJSONObject.getString("value"));
+			Assert.assertEquals(
+				expectedLabel, subtypesJSONObject.getString("label"));
+		}
 	}
 
 	private void _testGetItemTypesJSONArray(

--- a/modules/apps/template/template-web/src/test/java/com/liferay/template/web/internal/display/context/InformationTemplatesManagementToolbarDisplayContextTest.java
+++ b/modules/apps/template/template-web/src/test/java/com/liferay/template/web/internal/display/context/InformationTemplatesManagementToolbarDisplayContextTest.java
@@ -34,6 +34,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.AfterClass;
@@ -119,11 +120,15 @@ public class InformationTemplatesManagementToolbarDisplayContextTest {
 	@Test
 	@TestInfo("LPD-56468")
 	public void testGetItemTypesJSONArray() {
-		_testGetItemTypesJSONArray(StringPool.BLANK, null);
+		_testGetItemTypesJSONArray(
+			Collections.singletonList(StringPool.BLANK),
+			Collections.singletonList(null));
 
 		String label = RandomTestUtil.randomString();
 
-		_testGetItemTypesJSONArray(label, label);
+		_testGetItemTypesJSONArray(
+			Collections.singletonList(label), Collections.singletonList(label));
+	}
 
 	@Test
 	public void testSortedGetItemTypesJSONArray() {
@@ -237,45 +242,6 @@ public class InformationTemplatesManagementToolbarDisplayContextTest {
 			Assert.assertEquals(
 				expectedLabel, subtypesJSONObject.getString("label"));
 		}
-	}
-
-	private void _testGetItemTypesJSONArray(
-		String expectedLabel, String label) {
-
-		String key = RandomTestUtil.randomString();
-
-		InfoItemFormVariation informationItemFormVariation =
-			_mockInfoItemFormVariation(key, label);
-
-		Mockito.when(
-			_infoItemFormVariationsProvider.getInfoItemFormVariations(0)
-		).thenReturn(
-			List.of(informationItemFormVariation)
-		);
-
-		JSONArray jsonArray = ReflectionTestUtil.invoke(
-			_informationTemplatesManagementToolbarDisplayContext,
-			"_getItemTypesJSONArray", new Class<?>[0]);
-
-		Assert.assertEquals(jsonArray.toString(), 1, jsonArray.length());
-
-		JSONObject jsonObject = jsonArray.getJSONObject(0);
-
-		Assert.assertEquals(_CLASS_NAME, jsonObject.getString("value"));
-		Assert.assertEquals(_LABEL, jsonObject.getString("label"));
-
-		Assert.assertTrue(jsonObject.has("subtypes"));
-
-		JSONArray subtypesJSONArray = jsonObject.getJSONArray("subtypes");
-
-		Assert.assertEquals(
-			subtypesJSONArray.toString(), 1, subtypesJSONArray.length());
-
-		JSONObject subtypesJSONObject = subtypesJSONArray.getJSONObject(0);
-
-		Assert.assertEquals(key, subtypesJSONObject.getString("value"));
-		Assert.assertEquals(
-			expectedLabel, subtypesJSONObject.getString("label"));
 	}
 
 	private static final String _CLASS_NAME = RandomTestUtil.randomString();


### PR DESCRIPTION
# Summary of Changes

Added a private sorting method with a custom comparator on the item type labels taking into account the current locale.
Added relevant test and unified duplicate code.

# Motivation / Context

Jira: [LPD-63947](https://liferay.atlassian.net/browse/LPD-63947)

- Trying to find an item type when creating an Information Template is difficult if the options are not sorted alphabetically. This solution fixes that problem.

# Technical Approach

- The method `com.liferay.template.web.internal.display.context.InformationTemplatesManagementToolbarDisplayContext#_getItemTypesJSONArray` calculates the item types, so before returning them we sort them.
- The sorting method is based on `com.liferay.source.formatter.check.util.JsonSourceUtil#sortJSONArray`, which might suggest moving that functionality to another class, but I didn't do that.

# Validation Performed

**Automated Tests**

- [x] Unit tests
- [ ] Integration tests
- [ ] Functional / end-to-end tests
- [ ] Not applicable (explain why)

**Manual Testing**

- Environment: (e.g. local bundle, UAT, specific DB, cluster config)
- Steps:
  1. Go to Site Menu → Design → Templates → Information Templates.
  2. Click “New” → display “Item List” dropdown.
- Expected result: The options are sorted alphabetically according to the language in use.
- Actual result: The options are not sorted at all.

Note that more options can be added by creating custom objects.

# UI / UX Changes

- [x] No UI changes
- [ ] UI changes included (screenshots/media below)

# Checklist for Author

- [x] Linked to the correct Jira / LPD / related ticket.
- [x] Relevant unit tests updated/added and passed locally.
- [ ] Relevant integration / functional / Playwright tests updated/added and passed locally (if applicable). Not applicable.
- [x] ci:test:sf has been run and is green.
- [ ] ci:test:relevant has been run and is green.
- [ ] Any domain‑specific suites (ci:test:security, ci:test:ldap, ci:test:oauth2, ci:test:saml, …) have been run if the change touches those areas.
- [ ] No unique CI failures remain (anything unique is investigated and fixed).
- [x] Self-reviewed the code (style, naming, dead code, logs, etc.).
- [ ] Updated documentation / comments where needed.
- [x] `../gradlew -b util.gradle validateBranch` has been run and is green.

[LPD-63947]: https://liferay.atlassian.net/browse/LPD-63947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ