### PR TITLE
LPD-83633 Cannot import fragments with resources multiple times

### DIFF
--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
@@ -233,6 +233,31 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 		return true;
 	}
 
+	private void _addFileEntry(
+			long fragmentCollectionId, long groupId,
+			Map<String, Long> folderIdsMap, String path, Repository repository,
+			long userId, ZipFile zipFile, String zipEntryName)
+		throws Exception {
+
+		String fileName = path;
+		String folderPath = StringPool.BLANK;
+
+		int index = fileName.lastIndexOf(StringPool.SLASH);
+
+		if (index != -1) {
+			folderPath = fileName.substring(0, index);
+			fileName = fileName.substring(index + 1);
+		}
+
+		PortletFileRepositoryUtil.addPortletFileEntry(
+			null, groupId, userId, FragmentCollection.class.getName(),
+			fragmentCollectionId, FragmentPortletKeys.FRAGMENT,
+			_getOrCreateFolderId(
+				folderIdsMap, folderPath, repository.getRepositoryId(), userId),
+			_getInputStream(zipFile, zipEntryName), fileName,
+			MimeTypesUtil.getContentType(fileName), false);
+	}
+
 	private FragmentCollection _addFragmentCollection(
 			long groupId, String fragmentCollectionKey, String name,
 			String description, FragmentsImportStrategy fragmentsImportStrategy,
@@ -451,28 +476,10 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 						PortletFileRepositoryUtil.deletePortletFileEntry(
 							fileEntry.getFileEntryId());
 
-						String fileName = entry.getKey();
-						String folderPath = StringPool.BLANK;
-
-						int index = fileName.lastIndexOf(StringPool.SLASH);
-
-						if (index != -1) {
-							folderPath = fileName.substring(0, index);
-							fileName = fileName.substring(index + 1);
-						}
-
-						PortletFileRepositoryUtil.addPortletFileEntry(
-							null, groupId, userId,
-							FragmentCollection.class.getName(),
+						_addFileEntry(
 							fragmentCollection.getFragmentCollectionId(),
-							FragmentPortletKeys.FRAGMENT,
-							_getOrCreateFolderId(
-								folderIdsMap, folderPath,
-								repository.getRepositoryId(), userId),
-							_getInputStream(
-								zipFile, zipEntryNames.get(fileEntryPath)),
-							fileName, MimeTypesUtil.getContentType(fileName),
-							false);
+							groupId, folderIdsMap, fileEntryPath, repository,
+							userId, zipFile, zipEntryNames.get(fileEntryPath));
 
 						zipEntryNames.remove(fileEntryPath);
 					}
@@ -513,25 +520,10 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 		}
 
 		for (Map.Entry<String, String> entry : zipEntryNames.entrySet()) {
-			String fileName = entry.getKey();
-			String folderPath = StringPool.BLANK;
-
-			int index = fileName.lastIndexOf(StringPool.SLASH);
-
-			if (index != -1) {
-				folderPath = fileName.substring(0, index);
-				fileName = fileName.substring(index + 1);
-			}
-
-			PortletFileRepositoryUtil.addPortletFileEntry(
-				null, groupId, userId, FragmentCollection.class.getName(),
-				fragmentCollection.getFragmentCollectionId(),
-				FragmentPortletKeys.FRAGMENT,
-				_getOrCreateFolderId(
-					folderIdsMap, folderPath, repository.getRepositoryId(),
-					userId),
-				_getInputStream(zipFile, entry.getValue()), fileName,
-				MimeTypesUtil.getContentType(fileName), false);
+			_addFileEntry(
+				fragmentCollection.getFragmentCollectionId(), groupId,
+				folderIdsMap, entry.getKey(), repository, userId, zipFile,
+				entry.getValue());
 		}
 	}
 

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
@@ -482,7 +482,7 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 						int index = fileEntryPath.lastIndexOf(StringPool.SLASH);
 
 						if (index != -1) {
-							folderPath = fileEntryPath.substring(0, index);
+							folderPath = fileEntryPath.substring(0, index + 1);
 						}
 
 						String newFileName =

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
@@ -234,9 +234,9 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 	}
 
 	private void _addFileEntry(
-			long fragmentCollectionId, long groupId,
-			Map<String, Long> folderIdsMap, String path, Repository repository,
-			long userId, ZipFile zipFile, String zipEntryName)
+			Map<String, Long> folderIdsMap, long fragmentCollectionId,
+			long groupId, String path, Repository repository, long userId,
+			String zipEntryName, ZipFile zipFile)
 		throws Exception {
 
 		String fileName = path;
@@ -477,9 +477,10 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 							fileEntry.getFileEntryId());
 
 						_addFileEntry(
+							folderIdsMap,
 							fragmentCollection.getFragmentCollectionId(),
-							groupId, folderIdsMap, fileEntryPath, repository,
-							userId, zipFile, zipEntryNames.get(fileEntryPath));
+							groupId, fileEntryPath, repository, userId,
+							zipEntryNames.get(fileEntryPath), zipFile);
 
 						zipEntryNames.remove(fileEntryPath);
 					}
@@ -521,9 +522,9 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 
 		for (Map.Entry<String, String> entry : zipEntryNames.entrySet()) {
 			_addFileEntry(
-				fragmentCollection.getFragmentCollectionId(), groupId,
-				folderIdsMap, entry.getKey(), repository, userId, zipFile,
-				entry.getValue());
+				folderIdsMap, fragmentCollection.getFragmentCollectionId(),
+				groupId, entry.getKey(), repository, userId, entry.getValue(),
+				zipFile);
 		}
 	}
 

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
@@ -470,11 +470,11 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 								folderIdsMap, folderPath,
 								repository.getRepositoryId(), userId),
 							_getInputStream(
-								zipFile, zipEntryNames.get(fileName)),
+								zipFile, zipEntryNames.get(fileEntryPath)),
 							fileName, MimeTypesUtil.getContentType(fileName),
 							false);
 
-						zipEntryNames.remove(fileEntry.getFileName());
+						zipEntryNames.remove(fileEntryPath);
 					}
 					else {
 						String folderPath = StringPool.BLANK;

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
@@ -583,7 +583,7 @@ public class FragmentsImporterTest {
 	@Test
 	@TestInfo("LPS-151013")
 	public void testImportFragmentEntriesWithResources() throws Exception {
-		_testResources(2, "[resources:image (1).png]");
+		_testImportFragmentEntriesWithResources(2, "[resources:image (1).png]");
 	}
 
 	@Test
@@ -600,7 +600,7 @@ public class FragmentsImporterTest {
 							"propagateChanges", true
 						).build())) {
 
-			_testResources(1, "[resources:image.png]");
+			_testImportFragmentEntriesWithResources(1, "[resources:image.png]");
 		}
 	}
 
@@ -995,7 +995,7 @@ public class FragmentsImporterTest {
 		}
 	}
 
-	private void _testResources(
+	private void _testImportFragmentEntriesWithResources(
 			int expectedNumberOfResources, String resourceReference)
 		throws Exception {
 

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
@@ -844,15 +844,9 @@ public class FragmentsImporterTest {
 	private File _generateZipFileWithFolderResources() throws Exception {
 		ZipWriter zipWriter = _zipWriterFactory.getZipWriter();
 
-		URL collectionURL = _bundle.getEntry(
-			_PATH_FRAGMENTS_WITH_FOLDER_RESOURCES +
-				FragmentExportImportConstants.FILE_NAME_COLLECTION);
-
-		try (InputStream inputStream = collectionURL.openStream()) {
-			zipWriter.addEntry(
-				FragmentExportImportConstants.FILE_NAME_COLLECTION,
-				inputStream);
-		}
+		_addZipWriterEntry(
+			zipWriter, _PATH_DEPENDENCIES + "fragments-with-folder-resources",
+			FragmentExportImportConstants.FILE_NAME_COLLECTION);
 
 		_addZipWriterEntry(
 			zipWriter, _PATH_FRAGMENTS_WITH_FOLDER_RESOURCES + "resources",

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
@@ -856,7 +856,6 @@ public class FragmentsImporterTest {
 		_addZipWriterEntry(
 			zipWriter, _PATH_DEPENDENCIES + "fragments-with-folder-resources",
 			FragmentExportImportConstants.FILE_NAME_COLLECTION);
-
 		_addZipWriterEntry(
 			zipWriter, _PATH_FRAGMENTS_WITH_FOLDER_RESOURCES + "resources",
 			"image1.png");

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
@@ -253,71 +253,17 @@ public class FragmentsImporterTest {
 
 		File fileWithFolderResources = _generateZipFileWithFolderResources();
 
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
-		try {
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0,
-				fileWithFolderResources, FragmentsImportStrategy.OVERWRITE,
-				false);
-
-			List<FragmentCollection> fragmentCollections =
-				_fragmentCollectionLocalService.getFragmentCollections(
-					_group.getGroupId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
-
-			Assert.assertEquals(
-				fragmentCollections.toString(), 1, fragmentCollections.size());
-
-			FragmentCollection fragmentCollection = fragmentCollections.get(0);
-
-			Map<String, FileEntry> resourcesMap =
-				fragmentCollection.getResourcesMap();
-
-			Assert.assertEquals(
-				resourcesMap.toString(), 2, resourcesMap.size());
-
-			Assert.assertNotNull(resourcesMap.get("image1.png"));
-			Assert.assertNotNull(resourcesMap.get("folder1/image2.png"));
-
-			FileEntry fileEntry = resourcesMap.get("image1.png");
-
-			Assert.assertEquals("image1.png", fileEntry.getTitle());
-
-			fileEntry = resourcesMap.get("folder1/image2.png");
-
-			Assert.assertEquals("image2.png", fileEntry.getTitle());
-
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0,
-				fileWithFolderResources, FragmentsImportStrategy.OVERWRITE,
-				false);
-
-			fragmentCollection =
-				_fragmentCollectionLocalService.fetchFragmentCollection(
-					fragmentCollection.getFragmentCollectionId());
-
-			resourcesMap = fragmentCollection.getResourcesMap();
-
-			Assert.assertEquals(
-				resourcesMap.toString(), 4, resourcesMap.size());
-
-			Assert.assertNotNull(resourcesMap.get("image1.png"));
-			Assert.assertNotNull(resourcesMap.get("image1 (1).png"));
-			Assert.assertNotNull(resourcesMap.get("folder1/image2.png"));
-			Assert.assertNotNull(resourcesMap.get("folder1/image2 (1).png"));
-
-			fileEntry = resourcesMap.get("image1 (1).png");
-
-			Assert.assertEquals("image1 (1).png", fileEntry.getTitle());
-
-			fileEntry = resourcesMap.get("folder1/image2 (1).png");
-
-			Assert.assertEquals("image2 (1).png", fileEntry.getTitle());
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		_testFolderResources(
+			fileWithFolderResources,
+			Map.of(
+				"folder1/image2.png", "image2.png", "image1.png",
+				"image1.png"));
+		_testFolderResources(
+			fileWithFolderResources,
+			Map.of(
+				"folder1/image2 (1).png", "image2 (1).png",
+				"folder1/image2.png", "image2.png", "image1 (1).png",
+				"image1 (1).png", "image1.png", "image1.png"));
 
 		FileUtil.delete(fileWithFolderResources);
 	}
@@ -328,9 +274,6 @@ public class FragmentsImporterTest {
 
 		File fileWithFolderResources = _generateZipFileWithFolderResources();
 
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
 		_configurationProvider.saveCompanyConfiguration(
 			FragmentServiceConfiguration.class, _group.getCompanyId(),
 			HashMapDictionaryBuilder.<String, Object>put(
@@ -338,61 +281,16 @@ public class FragmentsImporterTest {
 			).build());
 
 		try {
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0,
-				fileWithFolderResources, FragmentsImportStrategy.OVERWRITE,
-				false);
-
-			List<FragmentCollection> fragmentCollections =
-				_fragmentCollectionLocalService.getFragmentCollections(
-					_group.getGroupId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
-
-			Assert.assertEquals(
-				fragmentCollections.toString(), 1, fragmentCollections.size());
-
-			FragmentCollection fragmentCollection = fragmentCollections.get(0);
-
-			Map<String, FileEntry> resourcesMap =
-				fragmentCollection.getResourcesMap();
-
-			Assert.assertEquals(
-				resourcesMap.toString(), 2, resourcesMap.size());
-
-			Assert.assertNotNull(resourcesMap.get("image1.png"));
-			Assert.assertNotNull(resourcesMap.get("folder1/image2.png"));
-
-			FileEntry fileEntry = resourcesMap.get("image1.png");
-
-			Assert.assertEquals("image1.png", fileEntry.getTitle());
-
-			fileEntry = resourcesMap.get("folder1/image2.png");
-
-			Assert.assertEquals("image2.png", fileEntry.getTitle());
-
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0,
-				fileWithFolderResources, FragmentsImportStrategy.OVERWRITE,
-				false);
-
-			fragmentCollection =
-				_fragmentCollectionLocalService.fetchFragmentCollection(
-					fragmentCollection.getFragmentCollectionId());
-
-			resourcesMap = fragmentCollection.getResourcesMap();
-
-			Assert.assertEquals(
-				resourcesMap.toString(), 2, resourcesMap.size());
-
-			Assert.assertNotNull(resourcesMap.get("image1.png"));
-			Assert.assertNotNull(resourcesMap.get("folder1/image2.png"));
-
-			fileEntry = resourcesMap.get("image1.png");
-
-			Assert.assertEquals("image1.png", fileEntry.getTitle());
-
-			fileEntry = resourcesMap.get("folder1/image2.png");
-
-			Assert.assertEquals("image2.png", fileEntry.getTitle());
+			_testFolderResources(
+				fileWithFolderResources,
+				Map.of(
+					"folder1/image2.png", "image2.png", "image1.png",
+					"image1.png"));
+			_testFolderResources(
+				fileWithFolderResources,
+				Map.of(
+					"folder1/image2.png", "image2.png", "image1.png",
+					"image1.png"));
 		}
 		finally {
 			_configurationProvider.saveCompanyConfiguration(
@@ -400,8 +298,6 @@ public class FragmentsImporterTest {
 				HashMapDictionaryBuilder.<String, Object>put(
 					"propagateChanges", false
 				).build());
-
-			ServiceContextThreadLocal.popServiceContext();
 		}
 
 		FileUtil.delete(fileWithFolderResources);
@@ -1062,6 +958,44 @@ public class FragmentsImporterTest {
 			_addZipWriterEntry(
 				zipWriter, path,
 				jsonObject.getString("fragmentCompositionDefinitionPath"));
+		}
+	}
+
+	private void _testFolderResources(
+			File fileWithFolderResources, Map<String, String> expectedResources)
+		throws Exception {
+
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		try {
+			_fragmentsImporter.importFragmentEntries(
+				_user.getUserId(), _group.getGroupId(), 0,
+				fileWithFolderResources, FragmentsImportStrategy.OVERWRITE,
+				false);
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
+
+		List<FragmentCollection> fragmentCollections =
+			_fragmentCollectionLocalService.getFragmentCollections(
+				_group.getGroupId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		FragmentCollection fragmentCollection = fragmentCollections.get(0);
+
+		Map<String, FileEntry> resourcesMap =
+			fragmentCollection.getResourcesMap();
+
+		Assert.assertEquals(
+			resourcesMap.toString(), expectedResources.size(),
+			resourcesMap.size());
+
+		for (Map.Entry<String, String> entry : expectedResources.entrySet()) {
+			FileEntry fileEntry = resourcesMap.get(entry.getKey());
+
+			Assert.assertNotNull(fileEntry);
+			Assert.assertEquals(entry.getValue(), fileEntry.getTitle());
 		}
 	}
 

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
@@ -270,12 +270,6 @@ public class FragmentsImporterTest {
 			).put(
 				"image1.png", "image1.png"
 			).build());
-	}
-
-	@Test
-	public void testImportFragmentEntriesWithFolderResourcesPropagation()
-		throws Exception {
-
 		_testImportFragmentEntriesWithFolderResources(
 			true,
 			HashMapBuilder.put(
@@ -786,6 +780,16 @@ public class FragmentsImporterTest {
 		}
 	}
 
+	private void _deleteFragmentCollections(
+			List<FragmentCollection> fragmentCollections)
+		throws Exception {
+
+		for (FragmentCollection fragmentCollection : fragmentCollections) {
+			_fragmentCollectionLocalService.deleteFragmentCollection(
+				fragmentCollection);
+		}
+	}
+
 	private File _generateResourcesZipFile() throws Exception {
 		ZipWriter zipWriter = _zipWriterFactory.getZipWriter();
 
@@ -952,6 +956,10 @@ public class FragmentsImporterTest {
 				_testImportFragmentEntriesWithFolderResources(
 					expectedResourcesMap, zipFile);
 			}
+
+			_deleteFragmentCollections(
+				_fragmentCollectionLocalService.getFragmentCollections(
+					_group.getGroupId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS));
 		}
 		finally {
 			ServiceContextThreadLocal.popServiceContext();

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
@@ -251,6 +251,7 @@ public class FragmentsImporterTest {
 	}
 
 	@Test
+	@TestInfo("LPD-83633")
 	public void testImportFragmentEntriesWithFolderResources()
 		throws Exception {
 

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
@@ -104,6 +104,8 @@ public class FragmentsImporterTest {
 	@After
 	public void tearDown() throws Exception {
 		FileUtil.delete(_file);
+
+		FileUtil.delete(_resourcesFile);
 	}
 
 	@Test
@@ -254,26 +256,29 @@ public class FragmentsImporterTest {
 
 		File zipFile = _generateZipFileWithFolderResources();
 
-		_testImportFragmentEntriesWithFolderResources(
-			HashMapBuilder.put(
-				"folder1/image2.png", "image2.png"
-			).put(
-				"image1.png", "image1.png"
-			).build(),
-			zipFile);
-		_testImportFragmentEntriesWithFolderResources(
-			HashMapBuilder.put(
-				"folder1/image2 (1).png", "image2 (1).png"
-			).put(
-				"folder1/image2.png", "image2.png"
-			).put(
-				"image1 (1).png", "image1 (1).png"
-			).put(
-				"image1.png", "image1.png"
-			).build(),
-			zipFile);
-
-		FileUtil.delete(zipFile);
+		try {
+			_testImportFragmentEntriesWithFolderResources(
+				HashMapBuilder.put(
+					"folder1/image2.png", "image2.png"
+				).put(
+					"image1.png", "image1.png"
+				).build(),
+				zipFile);
+			_testImportFragmentEntriesWithFolderResources(
+				HashMapBuilder.put(
+					"folder1/image2 (1).png", "image2 (1).png"
+				).put(
+					"folder1/image2.png", "image2.png"
+				).put(
+					"image1 (1).png", "image1 (1).png"
+				).put(
+					"image1.png", "image1.png"
+				).build(),
+				zipFile);
+		}
+		finally {
+			FileUtil.delete(zipFile);
+		}
 	}
 
 	@Test

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
@@ -30,7 +30,6 @@ import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.FileEntry;
-import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -99,10 +98,15 @@ public class FragmentsImporterTest {
 		_file = _generateZipFile(_PATH_DEPENDENCIES + "fragments");
 
 		_resourcesFile = _generateResourcesZipFile();
+
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 	}
 
 	@After
 	public void tearDown() throws Exception {
+		ServiceContextThreadLocal.popServiceContext();
+
 		FileUtil.delete(_file);
 
 		FileUtil.delete(_resourcesFile);
@@ -122,17 +126,9 @@ public class FragmentsImporterTest {
 		Assert.assertEquals(
 			fragmentCollections.toString(), 0, fragmentCollections.size());
 
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
-		try {
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0, _file,
-				FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		_fragmentsImporter.importFragmentEntries(
+			_user.getUserId(), _group.getGroupId(), 0, _file,
+			FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
 
 		fragmentCollections =
 			_fragmentCollectionLocalService.getFragmentCollections(
@@ -162,19 +158,11 @@ public class FragmentsImporterTest {
 		Assert.assertEquals(
 			fragmentCollections.toString(), 0, fragmentCollections.size());
 
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
 		_file = _generateZipFile(_PATH_FRAGMENTS_WITH_FIELD_SETS + "fragments");
 
-		try {
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0, _file,
-				FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		_fragmentsImporter.importFragmentEntries(
+			_user.getUserId(), _group.getGroupId(), 0, _file,
+			FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
 
 		fragmentCollections =
 			_fragmentCollectionLocalService.getFragmentCollections(
@@ -218,20 +206,9 @@ public class FragmentsImporterTest {
 
 		long initialFragmentCollectionsCount = fragmentCollections.size();
 
-		ServiceContext serviceContext = new ServiceContext();
-
-		serviceContext.setCompanyId(_user.getCompanyId());
-
-		ServiceContextThreadLocal.pushServiceContext(serviceContext);
-
-		try {
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), CompanyConstants.SYSTEM, 0, _file,
-				FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		_fragmentsImporter.importFragmentEntries(
+			_user.getUserId(), CompanyConstants.SYSTEM, 0, _file,
+			FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
 
 		fragmentCollections =
 			_fragmentCollectionLocalService.getFragmentCollections(
@@ -294,17 +271,9 @@ public class FragmentsImporterTest {
 		Assert.assertEquals(
 			fragmentCollections.toString(), 0, fragmentCollections.size());
 
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
-		try {
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0, _file,
-				FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		_fragmentsImporter.importFragmentEntries(
+			_user.getUserId(), _group.getGroupId(), 0, _file,
+			FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
 
 		fragmentCollections =
 			_fragmentCollectionLocalService.getFragmentCollections(
@@ -334,17 +303,9 @@ public class FragmentsImporterTest {
 	public void testImportFragmentEntriesWithInvalidConfiguration()
 		throws Exception {
 
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
-		try {
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0, _file,
-				FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		_fragmentsImporter.importFragmentEntries(
+			_user.getUserId(), _group.getGroupId(), 0, _file,
+			FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
 
 		List<FragmentCollection> fragmentCollections =
 			_fragmentCollectionLocalService.getFragmentCollections(
@@ -370,17 +331,9 @@ public class FragmentsImporterTest {
 
 	@Test
 	public void testImportFragmentEntriesWithInvalidHTML() throws Exception {
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
-		try {
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0, _file,
-				FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		_fragmentsImporter.importFragmentEntries(
+			_user.getUserId(), _group.getGroupId(), 0, _file,
+			FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
 
 		List<FragmentCollection> fragmentCollections =
 			_fragmentCollectionLocalService.getFragmentCollections(
@@ -407,36 +360,28 @@ public class FragmentsImporterTest {
 	public void testImportFragmentEntriesWithInvalidReactConfiguration()
 		throws Exception {
 
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+		List<FragmentsImporterResultEntry>
+			filteredFragmentsImporterResultEntries = ListUtil.filter(
+				_fragmentsImporter.importFragmentEntries(
+					_user.getUserId(), _group.getGroupId(), 0, _file,
+					FragmentsImportStrategy.DO_NOT_OVERWRITE, false),
+				fragmentsImporterResultEntry -> Objects.equals(
+					fragmentsImporterResultEntry.getName(),
+					"React Fragment With Invalid Configuration"));
 
-		try {
-			List<FragmentsImporterResultEntry>
-				filteredFragmentsImporterResultEntries = ListUtil.filter(
-					_fragmentsImporter.importFragmentEntries(
-						_user.getUserId(), _group.getGroupId(), 0, _file,
-						FragmentsImportStrategy.DO_NOT_OVERWRITE, false),
-					fragmentsImporterResultEntry -> Objects.equals(
-						fragmentsImporterResultEntry.getName(),
-						"React Fragment With Invalid Configuration"));
+		Assert.assertEquals(
+			filteredFragmentsImporterResultEntries.toString(), 1,
+			filteredFragmentsImporterResultEntries.size());
 
-			Assert.assertEquals(
-				filteredFragmentsImporterResultEntries.toString(), 1,
-				filteredFragmentsImporterResultEntries.size());
+		FragmentsImporterResultEntry fragmentsImporterResultEntry =
+			filteredFragmentsImporterResultEntries.get(0);
 
-			FragmentsImporterResultEntry fragmentsImporterResultEntry =
-				filteredFragmentsImporterResultEntries.get(0);
-
-			Assert.assertEquals(
-				FragmentsImporterResultEntry.Status.INVALID,
-				fragmentsImporterResultEntry.getStatus());
-			Assert.assertEquals(
-				FragmentsImporterResultEntry.Type.FRAGMENT,
-				fragmentsImporterResultEntry.getType());
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		Assert.assertEquals(
+			FragmentsImporterResultEntry.Status.INVALID,
+			fragmentsImporterResultEntry.getStatus());
+		Assert.assertEquals(
+			FragmentsImporterResultEntry.Type.FRAGMENT,
+			fragmentsImporterResultEntry.getType());
 	}
 
 	@Test
@@ -448,20 +393,12 @@ public class FragmentsImporterTest {
 		Assert.assertEquals(
 			fragmentCollections.toString(), 0, fragmentCollections.size());
 
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
 		_file = _generateZipFile(
 			_PATH_FRAGMENTS_WITH_UPDATED_NAME + "import-1/fragments");
 
-		try {
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0, _file,
-				FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		_fragmentsImporter.importFragmentEntries(
+			_user.getUserId(), _group.getGroupId(), 0, _file,
+			FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
 
 		fragmentCollections =
 			_fragmentCollectionLocalService.getFragmentCollections(
@@ -492,14 +429,9 @@ public class FragmentsImporterTest {
 		_file = _generateZipFile(
 			_PATH_FRAGMENTS_WITH_UPDATED_NAME + "import-2/fragments");
 
-		try {
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0, _file,
-				FragmentsImportStrategy.OVERWRITE, false);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		_fragmentsImporter.importFragmentEntries(
+			_user.getUserId(), _group.getGroupId(), 0, _file,
+			FragmentsImportStrategy.OVERWRITE, false);
 
 		fragmentCollections =
 			_fragmentCollectionLocalService.getFragmentCollections(
@@ -528,17 +460,9 @@ public class FragmentsImporterTest {
 
 	@Test
 	public void testImportFragmentEntriesWithReservedNames() throws Exception {
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
-		try {
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0, _file,
-				FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		_fragmentsImporter.importFragmentEntries(
+			_user.getUserId(), _group.getGroupId(), 0, _file,
+			FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
 
 		List<FragmentCollection> fragmentCollections =
 			_fragmentCollectionLocalService.getFragmentCollections(
@@ -572,9 +496,6 @@ public class FragmentsImporterTest {
 
 	@Test
 	public void testImportFragmentEntriesWithThumbnail() throws Exception {
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
 		try (CompanyConfigurationTemporarySwapper
 				companyConfigurationTemporarySwapper =
 					new CompanyConfigurationTemporarySwapper(
@@ -626,32 +547,23 @@ public class FragmentsImporterTest {
 	@Test
 	@TestInfo("LPS-96113")
 	public void testImportFragmentEntriesWithValidation() throws Exception {
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+		_fragmentsImporter.importFragmentEntries(
+			_user.getUserId(), _group.getGroupId(), 0,
+			_generateZipFile(
+				_PATH_DEPENDENCIES + "fragments-collection/collection-name"),
+			FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
 
-		try {
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0,
-				_generateZipFile(
-					_PATH_DEPENDENCIES +
-						"fragments-collection/collection-name"),
-				FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
+		_fragmentsImporter.importFragmentEntries(
+			_user.getUserId(), _group.getGroupId(), 0,
+			_generateZipFile(
+				_PATH_DEPENDENCIES + "fragments-collection/freemarker"),
+			FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
 
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0,
-				_generateZipFile(
-					_PATH_DEPENDENCIES + "fragments-collection/freemarker"),
-				FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
-
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0,
-				_generateZipFile(
-					_PATH_DEPENDENCIES + "fragments-collection/widgets"),
-				FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		_fragmentsImporter.importFragmentEntries(
+			_user.getUserId(), _group.getGroupId(), 0,
+			_generateZipFile(
+				_PATH_DEPENDENCIES + "fragments-collection/widgets"),
+			FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
 	}
 
 	@Test
@@ -665,17 +577,9 @@ public class FragmentsImporterTest {
 		Assert.assertEquals(
 			fragmentCollections.toString(), 0, fragmentCollections.size());
 
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
-		try {
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0, _file,
-				FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		_fragmentsImporter.importFragmentEntries(
+			_user.getUserId(), _group.getGroupId(), 0, _file,
+			FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
 
 		fragmentCollections =
 			_fragmentCollectionLocalService.getFragmentCollections(
@@ -718,36 +622,28 @@ public class FragmentsImporterTest {
 	public void testImportInvalidEntriesWithFragmentComposition()
 		throws Exception {
 
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+		List<FragmentsImporterResultEntry>
+			filteredFragmentsImporterResultEntries = ListUtil.filter(
+				_fragmentsImporter.importFragmentEntries(
+					_user.getUserId(), _group.getGroupId(), 0, _file,
+					FragmentsImportStrategy.DO_NOT_OVERWRITE, false),
+				fragmentsImporterResultEntry -> Objects.equals(
+					fragmentsImporterResultEntry.getName(),
+					"Fragment./Composition"));
 
-		try {
-			List<FragmentsImporterResultEntry>
-				filteredFragmentsImporterResultEntries = ListUtil.filter(
-					_fragmentsImporter.importFragmentEntries(
-						_user.getUserId(), _group.getGroupId(), 0, _file,
-						FragmentsImportStrategy.DO_NOT_OVERWRITE, false),
-					fragmentsImporterResultEntry -> Objects.equals(
-						fragmentsImporterResultEntry.getName(),
-						"Fragment./Composition"));
+		Assert.assertEquals(
+			filteredFragmentsImporterResultEntries.toString(), 1,
+			filteredFragmentsImporterResultEntries.size());
 
-			Assert.assertEquals(
-				filteredFragmentsImporterResultEntries.toString(), 1,
-				filteredFragmentsImporterResultEntries.size());
+		FragmentsImporterResultEntry fragmentsImporterResultEntry =
+			filteredFragmentsImporterResultEntries.get(0);
 
-			FragmentsImporterResultEntry fragmentsImporterResultEntry =
-				filteredFragmentsImporterResultEntries.get(0);
-
-			Assert.assertEquals(
-				FragmentsImporterResultEntry.Status.INVALID,
-				fragmentsImporterResultEntry.getStatus());
-			Assert.assertEquals(
-				FragmentsImporterResultEntry.Type.COMPOSITION,
-				fragmentsImporterResultEntry.getType());
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		Assert.assertEquals(
+			FragmentsImporterResultEntry.Status.INVALID,
+			fragmentsImporterResultEntry.getStatus());
+		Assert.assertEquals(
+			FragmentsImporterResultEntry.Type.COMPOSITION,
+			fragmentsImporterResultEntry.getType());
 	}
 
 	private void _addFragmentEntryType(JSONObject jsonObject) {
@@ -843,17 +739,9 @@ public class FragmentsImporterTest {
 	}
 
 	private void _importFragmentsByType(int type) throws Exception {
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
-		try {
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0, _file,
-				FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		_fragmentsImporter.importFragmentEntries(
+			_user.getUserId(), _group.getGroupId(), 0, _file,
+			FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
 
 		List<FragmentCollection> fragmentCollections =
 			_fragmentCollectionLocalService.getFragmentCollections(
@@ -939,9 +827,6 @@ public class FragmentsImporterTest {
 
 		File zipFile = _generateZipFileWithFolderResources();
 
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
 		try (CompanyConfigurationTemporarySwapper
 				companyConfigurationTemporarySwapper =
 					new CompanyConfigurationTemporarySwapper(
@@ -963,8 +848,6 @@ public class FragmentsImporterTest {
 					_group.getGroupId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS));
 		}
 		finally {
-			ServiceContextThreadLocal.popServiceContext();
-
 			FileUtil.delete(zipFile);
 		}
 	}
@@ -1005,9 +888,6 @@ public class FragmentsImporterTest {
 			String resourceReference)
 		throws Exception {
 
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
 		try (CompanyConfigurationTemporarySwapper
 				companyConfigurationTemporarySwapper =
 					new CompanyConfigurationTemporarySwapper(
@@ -1031,17 +911,9 @@ public class FragmentsImporterTest {
 
 			Assert.assertEquals(fileEntries.toString(), 1, fileEntries.size());
 
-			ServiceContextThreadLocal.pushServiceContext(
-				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
-			try {
-				_fragmentsImporter.importFragmentEntries(
-					_user.getUserId(), _group.getGroupId(), 0, _resourcesFile,
-					FragmentsImportStrategy.OVERWRITE, false);
-			}
-			finally {
-				ServiceContextThreadLocal.popServiceContext();
-			}
+			_fragmentsImporter.importFragmentEntries(
+				_user.getUserId(), _group.getGroupId(), 0, _resourcesFile,
+				FragmentsImportStrategy.OVERWRITE, false);
 
 			fragmentCollections =
 				_fragmentCollectionLocalService.getFragmentCollections(
@@ -1071,9 +943,6 @@ public class FragmentsImporterTest {
 			String html = fragmentEntry.getHtml();
 
 			Assert.assertTrue(html, html.contains(resourceReference));
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
 		}
 	}
 

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
@@ -21,7 +21,7 @@ import com.liferay.fragment.service.FragmentEntryLocalService;
 import com.liferay.fragment.util.comparator.FragmentEntryCreateDateComparator;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
+import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -282,13 +282,15 @@ public class FragmentsImporterTest {
 
 		File zipFile = _generateZipFileWithFolderResources();
 
-		_configurationProvider.saveCompanyConfiguration(
-			FragmentServiceConfiguration.class, _group.getCompanyId(),
-			HashMapDictionaryBuilder.<String, Object>put(
-				"propagateChanges", true
-			).build());
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						_group.getCompanyId(),
+						FragmentServiceConfiguration.class.getName(),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"propagateChanges", true
+						).build())) {
 
-		try {
 			_testImportFragmentEntriesWithFolderResources(
 				HashMapBuilder.put(
 					"folder1/image2.png", "image2.png"
@@ -305,14 +307,8 @@ public class FragmentsImporterTest {
 				zipFile);
 		}
 		finally {
-			_configurationProvider.saveCompanyConfiguration(
-				FragmentServiceConfiguration.class, _group.getCompanyId(),
-				HashMapDictionaryBuilder.<String, Object>put(
-					"propagateChanges", false
-				).build());
+			FileUtil.delete(zipFile);
 		}
-
-		FileUtil.delete(zipFile);
 	}
 
 	@Test
@@ -595,36 +591,33 @@ public class FragmentsImporterTest {
 	public void testImportFragmentEntriesWithResourcesPropagation()
 		throws Exception {
 
-		_configurationProvider.saveCompanyConfiguration(
-			FragmentServiceConfiguration.class, _group.getCompanyId(),
-			HashMapDictionaryBuilder.<String, Object>put(
-				"propagateChanges", true
-			).build());
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						_group.getCompanyId(),
+						FragmentServiceConfiguration.class.getName(),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"propagateChanges", true
+						).build())) {
 
-		try {
 			_testResources(1, "[resources:image.png]");
-		}
-		finally {
-			_configurationProvider.saveCompanyConfiguration(
-				FragmentServiceConfiguration.class, _group.getCompanyId(),
-				HashMapDictionaryBuilder.<String, Object>put(
-					"propagateChanges", false
-				).build());
 		}
 	}
 
 	@Test
 	public void testImportFragmentEntriesWithThumbnail() throws Exception {
-		_configurationProvider.saveCompanyConfiguration(
-			FragmentServiceConfiguration.class, _group.getCompanyId(),
-			HashMapDictionaryBuilder.<String, Object>put(
-				"propagateChanges", true
-			).build());
-
 		ServiceContextThreadLocal.pushServiceContext(
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
-		try {
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						_group.getCompanyId(),
+						FragmentServiceConfiguration.class.getName(),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"propagateChanges", true
+						).build())) {
+
 			_fragmentsImporter.importFragmentEntries(
 				_user.getUserId(), _group.getGroupId(), 0, _file,
 				FragmentsImportStrategy.OVERWRITE, false);
@@ -656,15 +649,6 @@ public class FragmentsImporterTest {
 					fragmentEntryLink.getFragmentEntryLinkId());
 
 			Assert.assertTrue(fragmentEntryLink.isLatestVersion());
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-
-			_configurationProvider.saveCompanyConfiguration(
-				FragmentServiceConfiguration.class, _group.getCompanyId(),
-				HashMapDictionaryBuilder.<String, Object>put(
-					"propagateChanges", false
-				).build());
 		}
 	}
 
@@ -1098,10 +1082,6 @@ public class FragmentsImporterTest {
 		_PATH_DEPENDENCIES + "resources-collection/";
 
 	private Bundle _bundle;
-
-	@Inject
-	private ConfigurationProvider _configurationProvider;
-
 	private File _file;
 
 	@Inject

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
@@ -254,66 +254,40 @@ public class FragmentsImporterTest {
 	public void testImportFragmentEntriesWithFolderResources()
 		throws Exception {
 
-		File zipFile = _generateZipFileWithFolderResources();
-
-		try {
-			_testImportFragmentEntriesWithFolderResources(
-				HashMapBuilder.put(
-					"folder1/image2.png", "image2.png"
-				).put(
-					"image1.png", "image1.png"
-				).build(),
-				zipFile);
-			_testImportFragmentEntriesWithFolderResources(
-				HashMapBuilder.put(
-					"folder1/image2 (1).png", "image2 (1).png"
-				).put(
-					"folder1/image2.png", "image2.png"
-				).put(
-					"image1 (1).png", "image1 (1).png"
-				).put(
-					"image1.png", "image1.png"
-				).build(),
-				zipFile);
-		}
-		finally {
-			FileUtil.delete(zipFile);
-		}
+		_testImportFragmentEntriesWithFolderResources(
+			false,
+			HashMapBuilder.put(
+				"folder1/image2.png", "image2.png"
+			).put(
+				"image1.png", "image1.png"
+			).build(),
+			HashMapBuilder.put(
+				"folder1/image2 (1).png", "image2 (1).png"
+			).put(
+				"folder1/image2.png", "image2.png"
+			).put(
+				"image1 (1).png", "image1 (1).png"
+			).put(
+				"image1.png", "image1.png"
+			).build());
 	}
 
 	@Test
 	public void testImportFragmentEntriesWithFolderResourcesPropagation()
 		throws Exception {
 
-		File zipFile = _generateZipFileWithFolderResources();
-
-		try (CompanyConfigurationTemporarySwapper
-				companyConfigurationTemporarySwapper =
-					new CompanyConfigurationTemporarySwapper(
-						_group.getCompanyId(),
-						FragmentServiceConfiguration.class.getName(),
-						HashMapDictionaryBuilder.<String, Object>put(
-							"propagateChanges", true
-						).build())) {
-
-			_testImportFragmentEntriesWithFolderResources(
-				HashMapBuilder.put(
-					"folder1/image2.png", "image2.png"
-				).put(
-					"image1.png", "image1.png"
-				).build(),
-				zipFile);
-			_testImportFragmentEntriesWithFolderResources(
-				HashMapBuilder.put(
-					"folder1/image2.png", "image2.png"
-				).put(
-					"image1.png", "image1.png"
-				).build(),
-				zipFile);
-		}
-		finally {
-			FileUtil.delete(zipFile);
-		}
+		_testImportFragmentEntriesWithFolderResources(
+			true,
+			HashMapBuilder.put(
+				"folder1/image2.png", "image2.png"
+			).put(
+				"image1.png", "image1.png"
+			).build(),
+			HashMapBuilder.put(
+				"folder1/image2.png", "image2.png"
+			).put(
+				"image1.png", "image1.png"
+			).build());
 	}
 
 	@Test
@@ -588,7 +562,8 @@ public class FragmentsImporterTest {
 	@Test
 	@TestInfo("LPS-151013")
 	public void testImportFragmentEntriesWithResources() throws Exception {
-		_testImportFragmentEntriesWithResources(2, "[resources:image (1).png]");
+		_testImportFragmentEntriesWithResources(
+			2, false, "[resources:image (1).png]");
 	}
 
 	@Test
@@ -596,17 +571,8 @@ public class FragmentsImporterTest {
 	public void testImportFragmentEntriesWithResourcesPropagation()
 		throws Exception {
 
-		try (CompanyConfigurationTemporarySwapper
-				companyConfigurationTemporarySwapper =
-					new CompanyConfigurationTemporarySwapper(
-						_group.getCompanyId(),
-						FragmentServiceConfiguration.class.getName(),
-						HashMapDictionaryBuilder.<String, Object>put(
-							"propagateChanges", true
-						).build())) {
-
-			_testImportFragmentEntriesWithResources(1, "[resources:image.png]");
-		}
+		_testImportFragmentEntriesWithResources(
+			1, true, "[resources:image.png]");
 	}
 
 	@Test
@@ -962,20 +928,45 @@ public class FragmentsImporterTest {
 	}
 
 	private void _testImportFragmentEntriesWithFolderResources(
-			Map<String, String> expectedResourcesMap, File zipFile)
+			boolean propagateChanges,
+			Map<String, String>... expectedResourcesMaps)
 		throws Exception {
+
+		File zipFile = _generateZipFileWithFolderResources();
 
 		ServiceContextThreadLocal.pushServiceContext(
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
-		try {
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0, zipFile,
-				FragmentsImportStrategy.OVERWRITE, false);
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						_group.getCompanyId(),
+						FragmentServiceConfiguration.class.getName(),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"propagateChanges", propagateChanges
+						).build())) {
+
+			for (Map<String, String> expectedResourcesMap :
+					expectedResourcesMaps) {
+
+				_testImportFragmentEntriesWithFolderResources(
+					expectedResourcesMap, zipFile);
+			}
 		}
 		finally {
 			ServiceContextThreadLocal.popServiceContext();
+
+			FileUtil.delete(zipFile);
 		}
+	}
+
+	private void _testImportFragmentEntriesWithFolderResources(
+			Map<String, String> expectedResourcesMap, File zipFile)
+		throws Exception {
+
+		_fragmentsImporter.importFragmentEntries(
+			_user.getUserId(), _group.getGroupId(), 0, zipFile,
+			FragmentsImportStrategy.OVERWRITE, false);
 
 		List<FragmentCollection> fragmentCollections =
 			_fragmentCollectionLocalService.getFragmentCollections(
@@ -1001,71 +992,80 @@ public class FragmentsImporterTest {
 	}
 
 	private void _testImportFragmentEntriesWithResources(
-			int expectedNumberOfResources, String resourceReference)
+			int expectedNumberOfResources, boolean propagateChanges,
+			String resourceReference)
 		throws Exception {
 
 		ServiceContextThreadLocal.pushServiceContext(
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
-		try {
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						_group.getCompanyId(),
+						FragmentServiceConfiguration.class.getName(),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"propagateChanges", propagateChanges
+						).build())) {
+
 			_fragmentsImporter.importFragmentEntries(
 				_user.getUserId(), _group.getGroupId(), 0, _resourcesFile,
 				FragmentsImportStrategy.OVERWRITE, false);
+
+			List<FragmentCollection> fragmentCollections =
+				_fragmentCollectionLocalService.getFragmentCollections(
+					_group.getGroupId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+			FragmentCollection fragmentCollection = fragmentCollections.get(0);
+
+			List<FileEntry> fileEntries = fragmentCollection.getResources();
+
+			Assert.assertEquals(fileEntries.toString(), 1, fileEntries.size());
+
+			ServiceContextThreadLocal.pushServiceContext(
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+			try {
+				_fragmentsImporter.importFragmentEntries(
+					_user.getUserId(), _group.getGroupId(), 0, _resourcesFile,
+					FragmentsImportStrategy.OVERWRITE, false);
+			}
+			finally {
+				ServiceContextThreadLocal.popServiceContext();
+			}
+
+			fragmentCollections =
+				_fragmentCollectionLocalService.getFragmentCollections(
+					_group.getGroupId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+			fragmentCollection = fragmentCollections.get(0);
+
+			fileEntries = fragmentCollection.getResources();
+
+			Assert.assertEquals(
+				fileEntries.toString(), expectedNumberOfResources,
+				fileEntries.size());
+
+			List<FragmentEntry> fragmentEntries =
+				_fragmentEntryLocalService.getFragmentEntries(
+					_group.getGroupId(),
+					fragmentCollection.getFragmentCollectionId(), "resource",
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+					FragmentEntryCreateDateComparator.getInstance(true));
+
+			FragmentEntry fragmentEntry = fragmentEntries.get(0);
+
+			String css = fragmentEntry.getCss();
+
+			Assert.assertTrue(css, css.contains(resourceReference));
+
+			String html = fragmentEntry.getHtml();
+
+			Assert.assertTrue(html, html.contains(resourceReference));
 		}
 		finally {
 			ServiceContextThreadLocal.popServiceContext();
 		}
-
-		List<FragmentCollection> fragmentCollections =
-			_fragmentCollectionLocalService.getFragmentCollections(
-				_group.getGroupId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
-
-		FragmentCollection fragmentCollection = fragmentCollections.get(0);
-
-		List<FileEntry> fileEntries = fragmentCollection.getResources();
-
-		Assert.assertEquals(fileEntries.toString(), 1, fileEntries.size());
-
-		ServiceContextThreadLocal.pushServiceContext(
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-
-		try {
-			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0, _resourcesFile,
-				FragmentsImportStrategy.OVERWRITE, false);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
-
-		fragmentCollections =
-			_fragmentCollectionLocalService.getFragmentCollections(
-				_group.getGroupId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
-
-		fragmentCollection = fragmentCollections.get(0);
-
-		fileEntries = fragmentCollection.getResources();
-
-		Assert.assertEquals(
-			fileEntries.toString(), expectedNumberOfResources,
-			fileEntries.size());
-
-		List<FragmentEntry> fragmentEntries =
-			_fragmentEntryLocalService.getFragmentEntries(
-				_group.getGroupId(),
-				fragmentCollection.getFragmentCollectionId(), "resource",
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-				FragmentEntryCreateDateComparator.getInstance(true));
-
-		FragmentEntry fragmentEntry = fragmentEntries.get(0);
-
-		String css = fragmentEntry.getCss();
-
-		Assert.assertTrue(css, css.contains(resourceReference));
-
-		String html = fragmentEntry.getHtml();
-
-		Assert.assertTrue(html, html.contains(resourceReference));
 	}
 
 	private static final String _PATH_DEPENDENCIES =

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
@@ -251,28 +251,27 @@ public class FragmentsImporterTest {
 	public void testImportFragmentEntriesWithFolderResources()
 		throws Exception {
 
-		File fileWithFolderResources = _generateZipFileWithFolderResources();
+		File zipFile = _generateZipFileWithFolderResources();
 
-		_testFolderResources(
-			fileWithFolderResources,
+		_testImportFragmentEntriesWithFolderResources(
 			Map.of(
-				"folder1/image2.png", "image2.png", "image1.png",
-				"image1.png"));
-		_testFolderResources(
-			fileWithFolderResources,
+				"folder1/image2.png", "image2.png", "image1.png", "image1.png"),
+			zipFile);
+		_testImportFragmentEntriesWithFolderResources(
 			Map.of(
 				"folder1/image2 (1).png", "image2 (1).png",
 				"folder1/image2.png", "image2.png", "image1 (1).png",
-				"image1 (1).png", "image1.png", "image1.png"));
+				"image1 (1).png", "image1.png", "image1.png"),
+			zipFile);
 
-		FileUtil.delete(fileWithFolderResources);
+		FileUtil.delete(zipFile);
 	}
 
 	@Test
 	public void testImportFragmentEntriesWithFolderResourcesPropagation()
 		throws Exception {
 
-		File fileWithFolderResources = _generateZipFileWithFolderResources();
+		File zipFile = _generateZipFileWithFolderResources();
 
 		_configurationProvider.saveCompanyConfiguration(
 			FragmentServiceConfiguration.class, _group.getCompanyId(),
@@ -281,16 +280,16 @@ public class FragmentsImporterTest {
 			).build());
 
 		try {
-			_testFolderResources(
-				fileWithFolderResources,
+			_testImportFragmentEntriesWithFolderResources(
 				Map.of(
 					"folder1/image2.png", "image2.png", "image1.png",
-					"image1.png"));
-			_testFolderResources(
-				fileWithFolderResources,
+					"image1.png"),
+				zipFile);
+			_testImportFragmentEntriesWithFolderResources(
 				Map.of(
 					"folder1/image2.png", "image2.png", "image1.png",
-					"image1.png"));
+					"image1.png"),
+				zipFile);
 		}
 		finally {
 			_configurationProvider.saveCompanyConfiguration(
@@ -300,7 +299,7 @@ public class FragmentsImporterTest {
 				).build());
 		}
 
-		FileUtil.delete(fileWithFolderResources);
+		FileUtil.delete(zipFile);
 	}
 
 	@Test
@@ -960,8 +959,8 @@ public class FragmentsImporterTest {
 		}
 	}
 
-	private void _testFolderResources(
-			File fileWithFolderResources, Map<String, String> expectedResources)
+	private void _testImportFragmentEntriesWithFolderResources(
+			Map<String, String> expectedResourcesMap, File zipFile)
 		throws Exception {
 
 		ServiceContextThreadLocal.pushServiceContext(
@@ -969,9 +968,8 @@ public class FragmentsImporterTest {
 
 		try {
 			_fragmentsImporter.importFragmentEntries(
-				_user.getUserId(), _group.getGroupId(), 0,
-				fileWithFolderResources, FragmentsImportStrategy.OVERWRITE,
-				false);
+				_user.getUserId(), _group.getGroupId(), 0, zipFile,
+				FragmentsImportStrategy.OVERWRITE, false);
 		}
 		finally {
 			ServiceContextThreadLocal.popServiceContext();
@@ -987,10 +985,12 @@ public class FragmentsImporterTest {
 			fragmentCollection.getResourcesMap();
 
 		Assert.assertEquals(
-			resourcesMap.toString(), expectedResources.size(),
+			resourcesMap.toString(), expectedResourcesMap.size(),
 			resourcesMap.size());
 
-		for (Map.Entry<String, String> entry : expectedResources.entrySet()) {
+		for (Map.Entry<String, String> entry :
+				expectedResourcesMap.entrySet()) {
+
 			FileEntry fileEntry = resourcesMap.get(entry.getKey());
 
 			Assert.assertNotNull(fileEntry);

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
@@ -261,35 +261,148 @@ public class FragmentsImporterTest {
 				_user.getUserId(), _group.getGroupId(), 0,
 				fileWithFolderResources, FragmentsImportStrategy.OVERWRITE,
 				false);
+
+			List<FragmentCollection> fragmentCollections =
+				_fragmentCollectionLocalService.getFragmentCollections(
+					_group.getGroupId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+			Assert.assertEquals(
+				fragmentCollections.toString(), 1, fragmentCollections.size());
+
+			FragmentCollection fragmentCollection = fragmentCollections.get(0);
+
+			Map<String, FileEntry> resourcesMap =
+				fragmentCollection.getResourcesMap();
+
+			Assert.assertEquals(
+				resourcesMap.toString(), 2, resourcesMap.size());
+
+			Assert.assertNotNull(resourcesMap.get("image1.png"));
+			Assert.assertNotNull(resourcesMap.get("folder1/image2.png"));
+
+			FileEntry fileEntry = resourcesMap.get("image1.png");
+
+			Assert.assertEquals("image1.png", fileEntry.getTitle());
+
+			fileEntry = resourcesMap.get("folder1/image2.png");
+
+			Assert.assertEquals("image2.png", fileEntry.getTitle());
+
+			_fragmentsImporter.importFragmentEntries(
+				_user.getUserId(), _group.getGroupId(), 0,
+				fileWithFolderResources, FragmentsImportStrategy.OVERWRITE,
+				false);
+
+			fragmentCollection =
+				_fragmentCollectionLocalService.fetchFragmentCollection(
+					fragmentCollection.getFragmentCollectionId());
+
+			resourcesMap = fragmentCollection.getResourcesMap();
+
+			Assert.assertEquals(
+				resourcesMap.toString(), 4, resourcesMap.size());
+
+			Assert.assertNotNull(resourcesMap.get("image1.png"));
+			Assert.assertNotNull(resourcesMap.get("image1 (1).png"));
+			Assert.assertNotNull(resourcesMap.get("folder1/image2.png"));
+			Assert.assertNotNull(resourcesMap.get("folder1/image2 (1).png"));
+
+			fileEntry = resourcesMap.get("image1 (1).png");
+
+			Assert.assertEquals("image1 (1).png", fileEntry.getTitle());
+
+			fileEntry = resourcesMap.get("folder1/image2 (1).png");
+
+			Assert.assertEquals("image2 (1).png", fileEntry.getTitle());
 		}
 		finally {
 			ServiceContextThreadLocal.popServiceContext();
 		}
 
-		List<FragmentCollection> fragmentCollections =
-			_fragmentCollectionLocalService.getFragmentCollections(
-				_group.getGroupId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+		FileUtil.delete(fileWithFolderResources);
+	}
 
-		Assert.assertEquals(
-			fragmentCollections.toString(), 1, fragmentCollections.size());
+	@Test
+	public void testImportFragmentEntriesWithFolderResourcesPropagation()
+		throws Exception {
 
-		FragmentCollection fragmentCollection = fragmentCollections.get(0);
+		File fileWithFolderResources = _generateZipFileWithFolderResources();
 
-		Map<String, FileEntry> resourcesMap =
-			fragmentCollection.getResourcesMap();
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
-		Assert.assertEquals(resourcesMap.toString(), 2, resourcesMap.size());
+		_configurationProvider.saveCompanyConfiguration(
+			FragmentServiceConfiguration.class, _group.getCompanyId(),
+			HashMapDictionaryBuilder.<String, Object>put(
+				"propagateChanges", true
+			).build());
 
-		Assert.assertNotNull(resourcesMap.get("image1.png"));
-		Assert.assertNotNull(resourcesMap.get("folder1/image2.png"));
+		try {
+			_fragmentsImporter.importFragmentEntries(
+				_user.getUserId(), _group.getGroupId(), 0,
+				fileWithFolderResources, FragmentsImportStrategy.OVERWRITE,
+				false);
 
-		FileEntry fileEntry = resourcesMap.get("image1.png");
+			List<FragmentCollection> fragmentCollections =
+				_fragmentCollectionLocalService.getFragmentCollections(
+					_group.getGroupId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
-		Assert.assertEquals("image1.png", fileEntry.getTitle());
+			Assert.assertEquals(
+				fragmentCollections.toString(), 1, fragmentCollections.size());
 
-		fileEntry = resourcesMap.get("folder1/image2.png");
+			FragmentCollection fragmentCollection = fragmentCollections.get(0);
 
-		Assert.assertEquals("image2.png", fileEntry.getTitle());
+			Map<String, FileEntry> resourcesMap =
+				fragmentCollection.getResourcesMap();
+
+			Assert.assertEquals(
+				resourcesMap.toString(), 2, resourcesMap.size());
+
+			Assert.assertNotNull(resourcesMap.get("image1.png"));
+			Assert.assertNotNull(resourcesMap.get("folder1/image2.png"));
+
+			FileEntry fileEntry = resourcesMap.get("image1.png");
+
+			Assert.assertEquals("image1.png", fileEntry.getTitle());
+
+			fileEntry = resourcesMap.get("folder1/image2.png");
+
+			Assert.assertEquals("image2.png", fileEntry.getTitle());
+
+			_fragmentsImporter.importFragmentEntries(
+				_user.getUserId(), _group.getGroupId(), 0,
+				fileWithFolderResources, FragmentsImportStrategy.OVERWRITE,
+				false);
+
+			fragmentCollection =
+				_fragmentCollectionLocalService.fetchFragmentCollection(
+					fragmentCollection.getFragmentCollectionId());
+
+			resourcesMap = fragmentCollection.getResourcesMap();
+
+			Assert.assertEquals(
+				resourcesMap.toString(), 2, resourcesMap.size());
+
+			Assert.assertNotNull(resourcesMap.get("image1.png"));
+			Assert.assertNotNull(resourcesMap.get("folder1/image2.png"));
+
+			fileEntry = resourcesMap.get("image1.png");
+
+			Assert.assertEquals("image1.png", fileEntry.getTitle());
+
+			fileEntry = resourcesMap.get("folder1/image2.png");
+
+			Assert.assertEquals("image2.png", fileEntry.getTitle());
+		}
+		finally {
+			_configurationProvider.saveCompanyConfiguration(
+				FragmentServiceConfiguration.class, _group.getCompanyId(),
+				HashMapDictionaryBuilder.<String, Object>put(
+					"propagateChanges", false
+				).build());
+
+			ServiceContextThreadLocal.popServiceContext();
+		}
 
 		FileUtil.delete(fileWithFolderResources);
 	}

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ScopeUtil;
@@ -254,14 +255,22 @@ public class FragmentsImporterTest {
 		File zipFile = _generateZipFileWithFolderResources();
 
 		_testImportFragmentEntriesWithFolderResources(
-			Map.of(
-				"folder1/image2.png", "image2.png", "image1.png", "image1.png"),
+			HashMapBuilder.put(
+				"folder1/image2.png", "image2.png"
+			).put(
+				"image1.png", "image1.png"
+			).build(),
 			zipFile);
 		_testImportFragmentEntriesWithFolderResources(
-			Map.of(
-				"folder1/image2 (1).png", "image2 (1).png",
-				"folder1/image2.png", "image2.png", "image1 (1).png",
-				"image1 (1).png", "image1.png", "image1.png"),
+			HashMapBuilder.put(
+				"folder1/image2 (1).png", "image2 (1).png"
+			).put(
+				"folder1/image2.png", "image2.png"
+			).put(
+				"image1 (1).png", "image1 (1).png"
+			).put(
+				"image1.png", "image1.png"
+			).build(),
 			zipFile);
 
 		FileUtil.delete(zipFile);
@@ -281,14 +290,18 @@ public class FragmentsImporterTest {
 
 		try {
 			_testImportFragmentEntriesWithFolderResources(
-				Map.of(
-					"folder1/image2.png", "image2.png", "image1.png",
-					"image1.png"),
+				HashMapBuilder.put(
+					"folder1/image2.png", "image2.png"
+				).put(
+					"image1.png", "image1.png"
+				).build(),
 				zipFile);
 			_testImportFragmentEntriesWithFolderResources(
-				Map.of(
-					"folder1/image2.png", "image2.png", "image1.png",
-					"image1.png"),
+				HashMapBuilder.put(
+					"folder1/image2.png", "image2.png"
+				).put(
+					"image1.png", "image1.png"
+				).build(),
 				zipFile);
 		}
 		finally {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-83633

@ak-ragnor

Original PR description:

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-83633

Fixes an issue where fragment resource files were imported into incorrect folders, leading to duplicate file creation.

# How am I fixing it?

Use `FragmentsImportStrategy` to determine behavior: overwrite existing files or ignore them if they already exist, ensuring correct folder placement.

# How can you verify that it works?

Run the included automated tests.

