### PR TITLE
LPD-59483 Display Page Template's Content Preview Selector Reorders Items

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisplayPagePreviewItemSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisplayPagePreviewItemSelector.js
@@ -18,6 +18,7 @@ import {
 	useDisplayPageRecentPreviewItemList,
 	useSelectDisplayPagePreviewItem,
 } from '../contexts/DisplayPagePreviewItemContext';
+import {deepEqual} from '../utils/checkDeepEqual';
 import itemSelectorValueToInfoItem from '../utils/item_selector_value/itemSelectorValueToInfoItem';
 
 const NO_ITEM_LABEL = `-- ${Liferay.Language.get('not-selected')} --`;
@@ -121,7 +122,9 @@ export function DisplayPagePreviewItemSelectorContent() {
 						key={recentPreviewItem.label}
 						onClick={() => selectItem(recentPreviewItem)}
 						symbolRight={
-							previewItem === recentPreviewItem ? 'check' : ''
+							deepEqual(previewItem, recentPreviewItem)
+								? 'check'
+								: ''
 						}
 					>
 						<span className="page-editor__display-page-preview-item-selector-dropdown-item-label">

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisplayPagePreviewItemSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisplayPagePreviewItemSelector.js
@@ -20,7 +20,7 @@ import {
 import {deepEqual} from '../utils/checkDeepEqual';
 import itemSelectorValueToInfoItem from '../utils/item_selector_value/itemSelectorValueToInfoItem';
 
-const NO_ITEM_LABEL = `-- ${Liferay.Language.get('not-selected')} --`;
+const NO_ITEM_LABEL = `${Liferay.Language.get('none')}`;
 
 export function DisplayPagePreviewItemSelector() {
 	const displayPagePreviewItemSelectorWrapper = useMemo(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisplayPagePreviewItemSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisplayPagePreviewItemSelector.js
@@ -85,7 +85,7 @@ export function DisplayPagePreviewItemSelectorContent() {
 				trigger={
 					<button
 						className={classNames(
-							'form-control form-control-sm form-control-select form-control-select-secondary page-editor__display-page-preview-item-selector-button'
+							'form-control form-control-sm form-control-select form-control-select-secondary page-editor__display-page-preview-item-selector-button text-truncate'
 						)}
 						data-qa-id="previewItemSelectorButton"
 						type="button"

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisplayPagePreviewItemSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisplayPagePreviewItemSelector.js
@@ -58,35 +58,31 @@ export function DisplayPagePreviewItemSelectorContent() {
 		});
 
 	return (
-		<ClayDropDown
-			active={active}
-			alignmentPosition={Align.BottomRight}
-			aria-labelledby={selectLabelId}
-			hasLeftSymbols
-			menuElementAttrs={{
-				className: 'dropdown-menu-select',
-				containerProps: {
-					className: 'cadmin',
-				},
-			}}
-			onActiveChange={setActive}
-			role="listbox"
-			trigger={
-				<p
+		<div className="align-items-center d-flex mb-0 page-editor__display-page-preview-item-selector-label-wrapper">
+			<label className="mb-0 pr-2 text-secondary" id={selectLabelId}>
+				<strong
 					className={classNames(
-						'align-items-center d-flex flex-row mb-0 page-editor__display-page-preview-item-selector-label-wrapper w-100'
+						'd-block page-editor__display-page-preview-item-selector-label'
 					)}
-					id={selectLabelId}
-					role="label"
 				>
-					<strong
-						className={classNames(
-							'd-block page-editor__display-page-preview-item-selector-label text-secondary'
-						)}
-					>
-						{Liferay.Language.get('preview-with')}:
-					</strong>
+					{Liferay.Language.get('preview-with')}:
+				</strong>
+			</label>
 
+			<ClayDropDown
+				active={active}
+				alignmentPosition={Align.BottomRight}
+				aria-labelledby={selectLabelId}
+				hasLeftSymbols
+				menuElementAttrs={{
+					className: 'dropdown-menu-select',
+					containerProps: {
+						className: 'cadmin',
+					},
+				}}
+				onActiveChange={setActive}
+				role="listbox"
+				trigger={
 					<button
 						className={classNames(
 							'form-control form-control-sm form-control-select form-control-select-secondary page-editor__display-page-preview-item-selector-button'
@@ -94,51 +90,51 @@ export function DisplayPagePreviewItemSelectorContent() {
 						data-qa-id="previewItemSelectorButton"
 						type="button"
 					>
-							{previewItem ? previewItem.label : NO_ITEM_LABEL}
+						{previewItem ? previewItem.label : NO_ITEM_LABEL}
 					</button>
-				</p>
-			}
-		>
-			<ClayDropDown.ItemList>
-				<ClayDropDown.Item
-					aria-selected={!previewItem}
-					onClick={() => selectItem(null)}
-					role="option"
-					symbolLeft={!previewItem ? 'check' : undefined}
-				>
-					{NO_ITEM_LABEL}
-				</ClayDropDown.Item>
-
-				{recentPreviewItemList.map((recentPreviewItem) => (
+				}
+			>
+				<ClayDropDown.ItemList>
 					<ClayDropDown.Item
-						aria-selected={deepEqual(
-							previewItem,
-							recentPreviewItem
-						)}
-						className="page-editor__display-page-preview-item-selector-dropdown-item"
-						key={recentPreviewItem.label}
-						onClick={() => selectItem(recentPreviewItem)}
-						symbolLeft={
-							deepEqual(previewItem, recentPreviewItem)
-								? 'check'
-								: ''
-						}
+						aria-selected={!previewItem}
+						onClick={() => selectItem(null)}
+						role="option"
+						symbolLeft={!previewItem ? 'check' : undefined}
 					>
-						{recentPreviewItem.label}
+						{NO_ITEM_LABEL}
 					</ClayDropDown.Item>
-				))}
-			</ClayDropDown.ItemList>
 
-			<ClayDropDown.Divider />
+					{recentPreviewItemList.map((recentPreviewItem) => (
+						<ClayDropDown.Item
+							aria-selected={deepEqual(
+								previewItem,
+								recentPreviewItem
+							)}
+							className="page-editor__display-page-preview-item-selector-dropdown-item"
+							key={recentPreviewItem.label}
+							onClick={() => selectItem(recentPreviewItem)}
+							symbolLeft={
+								deepEqual(previewItem, recentPreviewItem)
+									? 'check'
+									: ''
+							}
+						>
+							{recentPreviewItem.label}
+						</ClayDropDown.Item>
+					))}
+				</ClayDropDown.ItemList>
 
-			<ClayDropDown.ItemList>
-				<ClayDropDown.Item
-					data-qa-id="selectOtherItemDropdownItem"
-					onClick={selectOtherItem}
-				>
-					{Liferay.Language.get('select-other-item')}...
-				</ClayDropDown.Item>
-			</ClayDropDown.ItemList>
-		</ClayDropDown>
+				<ClayDropDown.Divider />
+
+				<ClayDropDown.ItemList>
+					<ClayDropDown.Item
+						data-qa-id="selectOtherItemDropdownItem"
+						onClick={selectOtherItem}
+					>
+						{Liferay.Language.get('select-other-item')}...
+					</ClayDropDown.Item>
+				</ClayDropDown.ItemList>
+			</ClayDropDown>
+		</div>
 	);
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisplayPagePreviewItemSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisplayPagePreviewItemSelector.js
@@ -99,7 +99,7 @@ export function DisplayPagePreviewItemSelectorContent() {
 						aria-selected={!previewItem}
 						onClick={() => selectItem(null)}
 						role="option"
-						symbolLeft={!previewItem ? 'check' : undefined}
+						symbolLeft={!previewItem ? 'check-small' : undefined}
 					>
 						{NO_ITEM_LABEL}
 					</ClayDropDown.Item>
@@ -115,7 +115,7 @@ export function DisplayPagePreviewItemSelectorContent() {
 							onClick={() => selectItem(recentPreviewItem)}
 							symbolLeft={
 								deepEqual(previewItem, recentPreviewItem)
-									? 'check'
+									? 'check-small'
 									: ''
 							}
 						>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisplayPagePreviewItemSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisplayPagePreviewItemSelector.js
@@ -81,7 +81,6 @@ export function DisplayPagePreviewItemSelectorContent() {
 					},
 				}}
 				onActiveChange={setActive}
-				role="listbox"
 				trigger={
 					<button
 						className={classNames(
@@ -96,9 +95,8 @@ export function DisplayPagePreviewItemSelectorContent() {
 			>
 				<ClayDropDown.ItemList>
 					<ClayDropDown.Item
-						aria-selected={!previewItem}
+						aria-current={!previewItem}
 						onClick={() => selectItem(null)}
-						role="option"
 						symbolLeft={!previewItem ? 'check-small' : undefined}
 					>
 						{NO_ITEM_LABEL}
@@ -106,7 +104,7 @@ export function DisplayPagePreviewItemSelectorContent() {
 
 					{recentPreviewItemList.map((recentPreviewItem) => (
 						<ClayDropDown.Item
-							aria-selected={deepEqual(
+							aria-current={deepEqual(
 								previewItem,
 								recentPreviewItem
 							)}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisplayPagePreviewItemSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisplayPagePreviewItemSelector.js
@@ -98,7 +98,7 @@ export function DisplayPagePreviewItemSelectorContent() {
 
 						<ClayIcon
 							className="flex-shrink-0 text-secondary"
-							symbol="caret-bottom"
+							symbol="caret-double"
 						/>
 					</button>
 				</p>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisplayPagePreviewItemSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisplayPagePreviewItemSelector.js
@@ -117,7 +117,10 @@ export function DisplayPagePreviewItemSelectorContent() {
 
 				{recentPreviewItemList.map((recentPreviewItem) => (
 					<ClayDropDown.Item
-						aria-selected={previewItem === recentPreviewItem}
+						aria-selected={deepEqual(
+							previewItem,
+							recentPreviewItem
+						)}
 						className="page-editor__display-page-preview-item-selector-dropdown-item"
 						key={recentPreviewItem.label}
 						onClick={() => selectItem(recentPreviewItem)}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisplayPagePreviewItemSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisplayPagePreviewItemSelector.js
@@ -20,7 +20,7 @@ import {
 } from '../contexts/DisplayPagePreviewItemContext';
 import itemSelectorValueToInfoItem from '../utils/item_selector_value/itemSelectorValueToInfoItem';
 
-const NO_ITEM_LABEL = `-- ${Liferay.Language.get('none')} --`;
+const NO_ITEM_LABEL = `-- ${Liferay.Language.get('not-selected')} --`;
 
 export function DisplayPagePreviewItemSelector() {
 	const displayPagePreviewItemSelectorWrapper = useMemo(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisplayPagePreviewItemSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisplayPagePreviewItemSelector.js
@@ -4,7 +4,6 @@
  */
 
 import ClayDropDown, {Align} from '@clayui/drop-down';
-import ClayIcon from '@clayui/icon';
 import {ReactPortal} from '@liferay/frontend-js-react-web';
 import classNames from 'classnames';
 import {useId} from 'frontend-js-components-web';
@@ -63,7 +62,9 @@ export function DisplayPagePreviewItemSelectorContent() {
 			active={active}
 			alignmentPosition={Align.BottomRight}
 			aria-labelledby={selectLabelId}
+			hasLeftSymbols
 			menuElementAttrs={{
+				className: 'dropdown-menu-select',
 				containerProps: {
 					className: 'cadmin',
 				},
@@ -88,19 +89,12 @@ export function DisplayPagePreviewItemSelectorContent() {
 
 					<button
 						className={classNames(
-							'align-items-center btn btn-sm d-flex page-editor__display-page-preview-item-selector-button btn-secondary'
+							'form-control form-control-sm form-control-select form-control-select-secondary page-editor__display-page-preview-item-selector-button'
 						)}
 						data-qa-id="previewItemSelectorButton"
 						type="button"
 					>
-						<span className="flex-grow-1 overflow-hidden text-left text-truncate">
 							{previewItem ? previewItem.label : NO_ITEM_LABEL}
-						</span>
-
-						<ClayIcon
-							className="flex-shrink-0 text-secondary"
-							symbol="caret-double"
-						/>
 					</button>
 				</p>
 			}
@@ -110,7 +104,7 @@ export function DisplayPagePreviewItemSelectorContent() {
 					aria-selected={!previewItem}
 					onClick={() => selectItem(null)}
 					role="option"
-					symbolRight={!previewItem ? 'check' : undefined}
+					symbolLeft={!previewItem ? 'check' : undefined}
 				>
 					{NO_ITEM_LABEL}
 				</ClayDropDown.Item>
@@ -124,15 +118,13 @@ export function DisplayPagePreviewItemSelectorContent() {
 						className="page-editor__display-page-preview-item-selector-dropdown-item"
 						key={recentPreviewItem.label}
 						onClick={() => selectItem(recentPreviewItem)}
-						symbolRight={
+						symbolLeft={
 							deepEqual(previewItem, recentPreviewItem)
 								? 'check'
 								: ''
 						}
 					>
-						<span className="page-editor__display-page-preview-item-selector-dropdown-item-label">
-							{recentPreviewItem.label}
-						</span>
+						{recentPreviewItem.label}
 					</ClayDropDown.Item>
 				))}
 			</ClayDropDown.ItemList>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_DisplayPagePreviewItemSelector.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_DisplayPagePreviewItemSelector.scss
@@ -19,30 +19,8 @@ html#{$cadmin-selector} {
 				padding-right: 8px;
 			}
 
-			&-button {
-				&.btn.btn-secondary {
-					background-color: transparent;
-					border-color: transparent;
-					box-sizing: border-box;
-					width: 224px;
-				}
-
-				&.btn.btn-secondary {
-					background-color: $light-l1;
-				}
-			}
-
 			&-dropdown-item {
 				display: flex;
-
-				&-label {
-					flex-grow: 1;
-				}
-
-				.dropdown-item-indicator-end {
-					margin-top: 0.2em;
-					position: static;
-				}
 			}
 		}
 	}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_DisplayPagePreviewItemSelector.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_DisplayPagePreviewItemSelector.scss
@@ -2,6 +2,10 @@
 
 html#{$cadmin-selector} {
 	.cadmin {
+		.dropdown-menu {
+			max-width: none;
+		}
+
 		.page-editor__display-page-preview-item-selector {
 			&-label-wrapper {
 				&::after {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_DisplayPagePreviewItemSelector.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_DisplayPagePreviewItemSelector.scss
@@ -17,6 +17,10 @@ html#{$cadmin-selector} {
 				}
 			}
 
+			&-button {
+				width: 224px;
+			}
+
 			&-label {
 				font-size: 0.875rem;
 				font-weight: 600;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/contexts/DisplayPagePreviewItemContext.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/contexts/DisplayPagePreviewItemContext.js
@@ -68,7 +68,12 @@ export function useSelectDisplayPagePreviewItem() {
 			setState(({recentItemList}) => {
 				let nextRecentItemList = recentItemList;
 
-				if (selectedItem) {
+				if (
+					selectedItem &&
+					!nextRecentItemList.some((item) =>
+						itemsAreEqual(selectedItem, item)
+					)
+				) {
 					nextRecentItemList = [
 						selectedItem,
 						...recentItemList,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/contexts/DisplayPagePreviewItemContext.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/contexts/DisplayPagePreviewItemContext.js
@@ -78,14 +78,6 @@ export function useSelectDisplayPagePreviewItem() {
 						selectedItem,
 						...recentItemList,
 					].slice(0, MAX_RECENT_ITEMS);
-
-					nextRecentItemList = nextRecentItemList.filter(
-						(item, index) =>
-							index ===
-							nextRecentItemList.findIndex((recentItem) =>
-								itemsAreEqual(item, recentItem)
-							)
-					);
 				}
 
 				return {

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/contexts/DisplayPagePreviewItemContext.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/contexts/DisplayPagePreviewItemContext.test.js
@@ -70,6 +70,21 @@ describe('DisplayPagePreviewItemContext', () => {
 		]);
 	});
 
+	it('maintains ordering when selecting existing item', () => {
+		const hook = getHook();
+
+		act(() => {
+			hook.result.current.selectItem({data: {}, label: 'First'});
+			hook.result.current.selectItem({data: {}, label: 'Second'});
+			hook.result.current.selectItem({data: {}, label: 'Second'});
+		});
+
+		expect(hook.result.current.recentItemList).toEqual([
+			{data: {}, label: 'Second'},
+			{data: {}, label: 'First'},
+		]);
+	});
+
 	it('limits the size of recent items to 100', () => {
 		const hook = getHook();
 

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/contexts/DisplayPagePreviewItemContext.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/contexts/DisplayPagePreviewItemContext.test.js
@@ -65,8 +65,8 @@ describe('DisplayPagePreviewItemContext', () => {
 		});
 
 		expect(hook.result.current.recentItemList).toEqual([
-			{data: {}, label: 'First'},
 			{data: {}, label: 'Second'},
+			{data: {}, label: 'First'},
 		]);
 	});
 


### PR DESCRIPTION
# Summary of Changes

Before this PR adding or selecting a preview item on a Display Page Template would reorder the existing preview items leaving the most current one at the top.

This PR implements the suggestions in LPD-59483 to:
1. Keep existing items in the order they were introduced, even if they're re-selected or re-added later.
2. Use a double arrow for the dropdown menu.
3. Use the phrase "Not Selected" instead of "None", like it's customary in other places. 

Also, the existing tests are adapted and another one is added.

# Motivation / Context

Jira:[LPD-59483](https://liferay.atlassian.net/browse/LPD-59483)

Note that the double arrow and the avoidance of "None" are referenced in LPD-59483 as _Extra Balls_.

# Technical Approach

For the ordering of the items:
- To keep the ordering of addition I check if the selected item is already there. If it is, we return the list of items and selected item as they are. If not we add them at the top.
- There's no need to check for duplicates manually since we check before hand that we don't add them.
- The existing test about duplicates needs to be changed to adapt to the new order. This test already tests the ordering when the first item is selected again. I added a new test to check that selected again the last item added doesn't mess up the order.

For the double arrow:
- There's a smaller `double-caret-l` (see [here](https://www.clayui.com/docs/components/icon)) but it looks too small.

# Validation Performed

**Automated Tests**

- [x] Unit tests
- [ ] Integration tests
- [ ] Functional / end-to-end tests
- [ ] Not applicable (explain why)

**Manual Testing**

1. Navigate to Site Builder > Page Templates.
2. Go to the Display Page Templates tab.
3. Ensure that at least two content items of the same type exist (e.g., two "Basic Web Content" articles named WC1 and WC2).
4. Create a new "Display Page Template" and associate it with the content type from the previous step (e.g., "Web Content Article" with subtype "Basic Web Content").
5. Inside the DPT editor, add a fragment to the page (e.g., a "Heading").
6. Map a property of the fragment to a content field (e.g., map the "Heading" text to the "Title" field of the "Basic Web Content").
7. In the top toolbar, click the "Preview With: -- None --" dropdown.
8. Select the first content item, WC1. The preview will update.
9. Open the same dropdown again. It will now show WC1 and the "Select Other Item..." option. Click the latter.
10. In the modal, select WC2. The preview will update.
11. Open the dropdown one more time.
12. Check whether the items are reordered to show the latest at the top or the ordering is maintained (new behavior of this PR).


# UI / UX Changes

- [ ] No UI changes
- [x] UI changes included (screenshots/media below)

**Screenshots / Media (Before & After)**

| Before | After |
| ------ | ----- |
|![before](https://github.com/user-attachments/assets/109b5dfd-72e5-4741-8240-16d03b4af96e) |![after](https://github.com/user-attachments/assets/65bcff85-3000-49b9-a4c8-c14f41c1dee2) |


# Checklist for Author

- [x] Linked to the correct Jira / LPD / related ticket.
- [x] Relevant unit tests updated/added and passed locally.
- [ ] Relevant integration / functional / Playwright tests updated/added and passed locally (if applicable).
- [ ] ci:test:sf has been run and is green.
- [ ] ci:test:relevant has been run and is green.
- [ ] Any domain‑specific suites (ci:test:security, ci:test:ldap, ci:test:oauth2, ci:test:saml, …) have been run if the change touches those areas.
- [ ] No unique CI failures remain (anything unique is investigated and fixed).
- [x] Self-reviewed the code (style, naming, dead code, logs, etc.).
- [ ] Updated documentation / comments where needed.
- [x] Ran `../gradlew -b util.gradle validateBranch` locally


[LPD-59483]: https://liferay.atlassian.net/browse/LPD-59483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ