### PR TITLE
LPD-86294 Analize failling test LayoutPageTemplatePortletDataHandlerTest

### DIFF
--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/exportimport/test/LayoutPageTemplatePortletDataHandlerTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/exportimport/test/LayoutPageTemplatePortletDataHandlerTest.java
@@ -9,8 +9,10 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationSettingsMapFactoryUtil;
 import com.liferay.exportimport.kernel.configuration.constants.ExportImportConfigurationConstants;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
+import com.liferay.exportimport.kernel.model.ExportImportConfiguration;
 import com.liferay.exportimport.kernel.service.ExportImportConfigurationLocalService;
 import com.liferay.exportimport.kernel.service.ExportImportLocalService;
+import com.liferay.journal.model.JournalArticle;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateCollectionTypeConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
@@ -18,15 +20,8 @@ import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeCon
 import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionLocalService;
-import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionLocalServiceUtil;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.json.JSONArray;
-import com.liferay.portal.kernel.json.JSONFactoryUtil;
-import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -34,7 +29,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -42,8 +37,7 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.io.File;
 
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -68,232 +62,261 @@ public class LayoutPageTemplatePortletDataHandlerTest {
 	@Before
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
+		_importedGroup = GroupTestUtil.addGroup();
 	}
 
 	@Test
-	public void testExportLayoutPageTemplateCollectionsDeletions()
+	public void testExportImportLayoutPageTemplateCollectionsDeletions()
 		throws Exception {
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId());
+		LayoutPageTemplateCollection basicLayoutPageTemplateCollection1 =
+			_addLayoutPageTemplateCollection(
+				LayoutPageTemplateCollectionTypeConstants.BASIC);
+		LayoutPageTemplateCollection basicLayoutPageTemplateCollection2 =
+			_addLayoutPageTemplateCollection(
+				LayoutPageTemplateCollectionTypeConstants.BASIC);
+		LayoutPageTemplateCollection displayPageLayoutPageTemplateCollection1 =
+			_addLayoutPageTemplateCollection(
+				LayoutPageTemplateCollectionTypeConstants.DISPLAY_PAGE);
+		LayoutPageTemplateCollection displayPageLayoutPageTemplateCollection2 =
+			_addLayoutPageTemplateCollection(
+				LayoutPageTemplateCollectionTypeConstants.DISPLAY_PAGE);
 
-		LayoutPageTemplateCollection basicLayoutPageTemplateCollection =
-			_layoutPageTemplateCollectionLocalService.
-				addLayoutPageTemplateCollection(
-					null, TestPropsValues.getUserId(), _group.getGroupId(),
-					LayoutPageTemplateConstants.
-						PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
-					null, RandomTestUtil.randomString(),
-					RandomTestUtil.randomString(),
-					LayoutPageTemplateCollectionTypeConstants.BASIC,
-					serviceContext);
-		LayoutPageTemplateCollection displayPageLayoutPageTemplateCollection =
-			_layoutPageTemplateCollectionLocalService.
-				addLayoutPageTemplateCollection(
-					null, TestPropsValues.getUserId(), _group.getGroupId(),
-					LayoutPageTemplateConstants.
-						PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
-					null, RandomTestUtil.randomString(),
-					RandomTestUtil.randomString(),
-					LayoutPageTemplateCollectionTypeConstants.DISPLAY_PAGE,
-					serviceContext);
+		File larFile = _exportLayouts(false, _group.getGroupId());
+
+		_importLayouts(false, _importedGroup.getGroupId(), larFile);
+
+		_assertLayoutPageTemplateCollectionNotNull(
+			basicLayoutPageTemplateCollection1);
+		_assertLayoutPageTemplateCollectionNotNull(
+			basicLayoutPageTemplateCollection2);
+		_assertLayoutPageTemplateCollectionNotNull(
+			displayPageLayoutPageTemplateCollection1);
+		_assertLayoutPageTemplateCollectionNotNull(
+			displayPageLayoutPageTemplateCollection2);
 
 		_layoutPageTemplateCollectionLocalService.
 			deleteLayoutPageTemplateCollection(
-				basicLayoutPageTemplateCollection);
+				basicLayoutPageTemplateCollection2);
 		_layoutPageTemplateCollectionLocalService.
 			deleteLayoutPageTemplateCollection(
-				displayPageLayoutPageTemplateCollection);
+				displayPageLayoutPageTemplateCollection2);
 
-		File larFile = _exportImportLocalService.exportLayoutsAsFile(
-			_exportImportConfigurationLocalService.
-				addDraftExportImportConfiguration(
-					TestPropsValues.getUserId(),
-					ExportImportConfigurationConstants.TYPE_EXPORT_LAYOUT,
-					ExportImportConfigurationSettingsMapFactoryUtil.
-						buildExportLayoutSettingsMap(
-							TestPropsValues.getUser(), _group.getGroupId(),
-							false, new long[0],
-							HashMapBuilder.put(
-								PortletDataHandlerKeys.DELETIONS,
-								new String[] {Boolean.TRUE.toString()}
-							).put(
-								PortletDataHandlerKeys.PORTLET_DATA,
-								new String[] {Boolean.TRUE.toString()}
-							).put(
-								PortletDataHandlerKeys.PORTLET_DATA + "_" +
-									LayoutAdminPortletKeys.GROUP_PAGES,
-								new String[] {Boolean.TRUE.toString()}
-							).build())));
+		larFile = _exportLayouts(true, _group.getGroupId());
 
-		Assert.assertEquals(
-			JSONFactoryUtil.createJSONArray(
-			).put(
-				JSONUtil.put(
-					"externalReferenceCode",
-					basicLayoutPageTemplateCollection.
-						getExternalReferenceCode())
-			).toString(),
-			_getExportedJSONArray(
-				StringBundler.concat(
-					LayoutPageTemplateCollection.class.getName(), "#",
-					LayoutPageTemplateCollectionTypeConstants.BASIC,
-					"_deletions"),
-				_group.getGroupId(), larFile
-			).toString());
-		Assert.assertEquals(
-			JSONFactoryUtil.createJSONArray(
-			).put(
-				JSONUtil.put(
-					"externalReferenceCode",
-					displayPageLayoutPageTemplateCollection.
-						getExternalReferenceCode())
-			).toString(),
-			_getExportedJSONArray(
-				StringBundler.concat(
-					LayoutPageTemplateCollection.class.getName(), "#",
-					LayoutPageTemplateCollectionTypeConstants.DISPLAY_PAGE,
-					"_deletions"),
-				_group.getGroupId(), larFile
-			).toString());
+		_importLayouts(true, _importedGroup.getGroupId(), larFile);
+
+		_assertLayoutPageTemplateCollectionNotNull(
+			basicLayoutPageTemplateCollection1);
+		_assertLayoutPageTemplateCollectionNotNull(
+			displayPageLayoutPageTemplateCollection1);
+
+		_assertLayoutPageTemplateCollectionNull(
+			basicLayoutPageTemplateCollection2);
+		_assertLayoutPageTemplateCollectionNull(
+			displayPageLayoutPageTemplateCollection2);
 	}
 
 	@Test
-	public void testExportLayoutPageTemplateEntriesDeletions()
+	public void testExportImportLayoutPageTemplateEntriesDeletions()
 		throws Exception {
-
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId());
 
 		LayoutPageTemplateCollection layoutPageTemplateCollection =
-			LayoutPageTemplateCollectionLocalServiceUtil.
-				addLayoutPageTemplateCollection(
-					null, TestPropsValues.getUserId(),
-					serviceContext.getScopeGroupId(),
-					LayoutPageTemplateConstants.
-						PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
-					null, RandomTestUtil.randomString(),
-					RandomTestUtil.randomString(),
-					LayoutPageTemplateCollectionTypeConstants.BASIC,
-					serviceContext);
+			_addLayoutPageTemplateCollection(
+				LayoutPageTemplateCollectionTypeConstants.BASIC);
 
-		LayoutPageTemplateEntry basicLayoutPageTemplateEntry =
-			_layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
-				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
-				_group.getGroupId(),
+		LayoutPageTemplateEntry basicLayoutPageTemplateEntry1 =
+			_addLayoutPageTemplateEntry(
+				0,
 				layoutPageTemplateCollection.
 					getLayoutPageTemplateCollectionId(),
-				null, RandomTestUtil.randomString(),
-				LayoutPageTemplateEntryTypeConstants.BASIC, 0,
-				WorkflowConstants.STATUS_APPROVED, serviceContext);
+				LayoutPageTemplateEntryTypeConstants.BASIC);
+		LayoutPageTemplateEntry basicLayoutPageTemplateEntry2 =
+			_addLayoutPageTemplateEntry(
+				0,
+				layoutPageTemplateCollection.
+					getLayoutPageTemplateCollectionId(),
+				LayoutPageTemplateEntryTypeConstants.BASIC);
 
-		LayoutPageTemplateEntry displayPageLayoutPageTemplateEntry =
-			_layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
-				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
-				_group.getGroupId(),
+		long journalArticleClassNameId = _portal.getClassNameId(
+			JournalArticle.class.getName());
+
+		LayoutPageTemplateEntry displayPageLayoutPageTemplateEntry1 =
+			_addLayoutPageTemplateEntry(
+				journalArticleClassNameId,
+				LayoutPageTemplateConstants.
+					PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE);
+		LayoutPageTemplateEntry displayPageLayoutPageTemplateEntry2 =
+			_addLayoutPageTemplateEntry(
+				journalArticleClassNameId,
+				LayoutPageTemplateConstants.
+					PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE);
+
+		LayoutPageTemplateEntry masterLayoutPageTemplateEntry1 =
+			_addLayoutPageTemplateEntry(
+				0,
+				LayoutPageTemplateConstants.
+					PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
+				LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT);
+		LayoutPageTemplateEntry masterLayoutPageTemplateEntry2 =
+			_addLayoutPageTemplateEntry(
+				0,
+				LayoutPageTemplateConstants.
+					PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
+				LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT);
+
+		File larFile = _exportLayouts(false, _group.getGroupId());
+
+		_importLayouts(false, _importedGroup.getGroupId(), larFile);
+
+		_assertLayoutPageTemplateEntryNotNull(basicLayoutPageTemplateEntry1);
+		_assertLayoutPageTemplateEntryNotNull(basicLayoutPageTemplateEntry2);
+		_assertLayoutPageTemplateEntryNotNull(
+			displayPageLayoutPageTemplateEntry1);
+		_assertLayoutPageTemplateEntryNotNull(
+			displayPageLayoutPageTemplateEntry2);
+		_assertLayoutPageTemplateEntryNotNull(masterLayoutPageTemplateEntry1);
+		_assertLayoutPageTemplateEntryNotNull(masterLayoutPageTemplateEntry2);
+
+		_layoutPageTemplateEntryLocalService.deleteLayoutPageTemplateEntry(
+			basicLayoutPageTemplateEntry2);
+		_layoutPageTemplateEntryLocalService.deleteLayoutPageTemplateEntry(
+			displayPageLayoutPageTemplateEntry2);
+		_layoutPageTemplateEntryLocalService.deleteLayoutPageTemplateEntry(
+			masterLayoutPageTemplateEntry2);
+
+		larFile = _exportLayouts(true, _group.getGroupId());
+
+		_importLayouts(true, _importedGroup.getGroupId(), larFile);
+
+		_assertLayoutPageTemplateEntryNotNull(basicLayoutPageTemplateEntry1);
+		_assertLayoutPageTemplateEntryNotNull(
+			displayPageLayoutPageTemplateEntry1);
+		_assertLayoutPageTemplateEntryNotNull(masterLayoutPageTemplateEntry1);
+
+		_assertLayoutPageTemplateEntryNull(basicLayoutPageTemplateEntry2);
+		_assertLayoutPageTemplateEntryNull(displayPageLayoutPageTemplateEntry2);
+		_assertLayoutPageTemplateEntryNull(masterLayoutPageTemplateEntry2);
+	}
+
+	private LayoutPageTemplateCollection _addLayoutPageTemplateCollection(
+			int type)
+		throws Exception {
+
+		return _layoutPageTemplateCollectionLocalService.
+			addLayoutPageTemplateCollection(
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				LayoutPageTemplateConstants.
 					PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
 				null, RandomTestUtil.randomString(),
-				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE, 0,
-				WorkflowConstants.STATUS_APPROVED, serviceContext);
-		LayoutPageTemplateEntry masterLayoutPageTemplateEntry =
-			_layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
-				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
-				_group.getGroupId(),
-				LayoutPageTemplateConstants.
-					PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
-				null, RandomTestUtil.randomString(),
-				LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT, 0,
-				WorkflowConstants.STATUS_APPROVED, serviceContext);
+				RandomTestUtil.randomString(), type,
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId()));
+	}
 
-		_layoutPageTemplateEntryLocalService.deleteLayoutPageTemplateEntry(
-			basicLayoutPageTemplateEntry);
-		_layoutPageTemplateEntryLocalService.deleteLayoutPageTemplateEntry(
-			displayPageLayoutPageTemplateEntry);
-		_layoutPageTemplateEntryLocalService.deleteLayoutPageTemplateEntry(
-			masterLayoutPageTemplateEntry);
+	private LayoutPageTemplateEntry _addLayoutPageTemplateEntry(
+			long classNameId, long layoutPageTemplateCollectionId, int type)
+		throws Exception {
 
-		File larFile = _exportImportLocalService.exportLayoutsAsFile(
+		return _layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			_group.getGroupId(), layoutPageTemplateCollectionId, null,
+			classNameId, null, RandomTestUtil.randomString(), type, 0, false, 0,
+			0, 0, WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private void _assertLayoutPageTemplateCollectionNotNull(
+		LayoutPageTemplateCollection layoutPageTemplateCollection) {
+
+		Assert.assertNotNull(
+			_layoutPageTemplateCollectionLocalService.
+				fetchLayoutPageTemplateCollectionByExternalReferenceCode(
+					layoutPageTemplateCollection.getExternalReferenceCode(),
+					_importedGroup.getGroupId()));
+	}
+
+	private void _assertLayoutPageTemplateCollectionNull(
+		LayoutPageTemplateCollection layoutPageTemplateCollection) {
+
+		Assert.assertNull(
+			_layoutPageTemplateCollectionLocalService.
+				fetchLayoutPageTemplateCollectionByExternalReferenceCode(
+					layoutPageTemplateCollection.getExternalReferenceCode(),
+					_importedGroup.getGroupId()));
+	}
+
+	private void _assertLayoutPageTemplateEntryNotNull(
+		LayoutPageTemplateEntry layoutPageTemplateEntry) {
+
+		Assert.assertNotNull(
+			_layoutPageTemplateEntryLocalService.
+				fetchLayoutPageTemplateEntryByExternalReferenceCode(
+					layoutPageTemplateEntry.getExternalReferenceCode(),
+					_importedGroup.getGroupId()));
+	}
+
+	private void _assertLayoutPageTemplateEntryNull(
+		LayoutPageTemplateEntry layoutPageTemplateEntry) {
+
+		Assert.assertNull(
+			_layoutPageTemplateEntryLocalService.
+				fetchLayoutPageTemplateEntryByExternalReferenceCode(
+					layoutPageTemplateEntry.getExternalReferenceCode(),
+					_importedGroup.getGroupId()));
+	}
+
+	private File _exportLayouts(boolean deletions, long groupId)
+		throws Exception {
+
+		return _exportImportLocalService.exportLayoutsAsFile(
 			_exportImportConfigurationLocalService.
 				addDraftExportImportConfiguration(
 					TestPropsValues.getUserId(),
 					ExportImportConfigurationConstants.TYPE_EXPORT_LAYOUT,
 					ExportImportConfigurationSettingsMapFactoryUtil.
 						buildExportLayoutSettingsMap(
-							TestPropsValues.getUser(), _group.getGroupId(),
-							false, new long[0],
-							HashMapBuilder.put(
-								PortletDataHandlerKeys.DELETIONS,
-								new String[] {Boolean.TRUE.toString()}
-							).put(
-								PortletDataHandlerKeys.PORTLET_DATA,
-								new String[] {Boolean.TRUE.toString()}
-							).put(
-								PortletDataHandlerKeys.PORTLET_DATA + "_" +
-									LayoutAdminPortletKeys.GROUP_PAGES,
-								new String[] {Boolean.TRUE.toString()}
-							).build())));
-
-		Assert.assertEquals(
-			JSONFactoryUtil.createJSONArray(
-			).put(
-				JSONUtil.put(
-					"externalReferenceCode",
-					basicLayoutPageTemplateEntry.getExternalReferenceCode())
-			).toString(),
-			_getExportedJSONArray(
-				StringBundler.concat(
-					LayoutPageTemplateEntry.class.getName(), "#",
-					LayoutPageTemplateEntryTypeConstants.BASIC, "_deletions"),
-				_group.getGroupId(), larFile
-			).toString());
-
-		Assert.assertEquals(
-			JSONFactoryUtil.createJSONArray(
-			).put(
-				JSONUtil.put(
-					"externalReferenceCode",
-					displayPageLayoutPageTemplateEntry.
-						getExternalReferenceCode())
-			).toString(),
-			_getExportedJSONArray(
-				StringBundler.concat(
-					LayoutPageTemplateEntry.class.getName(), "#",
-					LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE,
-					"_deletions"),
-				_group.getGroupId(), larFile
-			).toString());
-		Assert.assertEquals(
-			JSONFactoryUtil.createJSONArray(
-			).put(
-				JSONUtil.put(
-					"externalReferenceCode",
-					masterLayoutPageTemplateEntry.getExternalReferenceCode())
-			).toString(),
-			_getExportedJSONArray(
-				StringBundler.concat(
-					LayoutPageTemplateEntry.class.getName(), "#",
-					LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT,
-					"_deletions"),
-				_group.getGroupId(), larFile
-			).toString());
+							TestPropsValues.getUser(), groupId, false,
+							new long[0], _getParameterMap(deletions))));
 	}
 
-	private JSONArray _getExportedJSONArray(
-			String fileNamePrefix, long groupId, File larFile)
+	private Map<String, String[]> _getParameterMap(boolean deletions) {
+		return HashMapBuilder.put(
+			PortletDataHandlerKeys.DELETIONS,
+			new String[] {Boolean.toString(deletions)}
+		).put(
+			PortletDataHandlerKeys.PORTLET_DATA,
+			new String[] {Boolean.TRUE.toString()}
+		).put(
+			PortletDataHandlerKeys.PORTLET_DATA + "_" +
+				LayoutAdminPortletKeys.GROUP_PAGES,
+			new String[] {Boolean.TRUE.toString()}
+		).build();
+	}
+
+	private void _importLayouts(boolean deletions, long groupId, File larFile)
 		throws Exception {
 
-		try (ZipFile zipFile = new ZipFile(larFile)) {
-			ZipEntry zipEntry = zipFile.getEntry(
-				StringBundler.concat(
-					"group/", groupId, StringPool.FORWARD_SLASH, fileNamePrefix,
-					".json"));
+		ExportImportConfiguration exportImportConfiguration =
+			_exportImportConfigurationLocalService.
+				addDraftExportImportConfiguration(
+					TestPropsValues.getUserId(),
+					ExportImportConfigurationConstants.TYPE_IMPORT_LAYOUT,
+					ExportImportConfigurationSettingsMapFactoryUtil.
+						buildImportLayoutSettingsMap(
+							TestPropsValues.getUser(), groupId, false,
+							new long[0], _getParameterMap(deletions)));
 
-			return JSONFactoryUtil.createJSONArray(
-				StringUtil.read(zipFile.getInputStream(zipEntry)));
+		if (deletions) {
+			_exportImportLocalService.importLayoutsDataDeletions(
+				exportImportConfiguration, larFile);
 		}
+
+		_exportImportLocalService.importLayouts(
+			exportImportConfiguration, larFile);
 	}
 
 	@Inject
@@ -306,6 +329,9 @@ public class LayoutPageTemplatePortletDataHandlerTest {
 	@DeleteAfterTestRun
 	private Group _group;
 
+	@DeleteAfterTestRun
+	private Group _importedGroup;
+
 	@Inject
 	private LayoutPageTemplateCollectionLocalService
 		_layoutPageTemplateCollectionLocalService;
@@ -313,5 +339,8 @@ public class LayoutPageTemplatePortletDataHandlerTest {
 	@Inject
 	private LayoutPageTemplateEntryLocalService
 		_layoutPageTemplateEntryLocalService;
+
+	@Inject
+	private Portal _portal;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86294

Tests of class LayoutPageTemplatePortletDataHandlerTest were failing because it was obtaining specific files from the lar file and these names were changed in https://github.com/brianchandotcom/liferay-portal/pull/172767/changes/636689c10d10a37bc8000df42c4b87fc58f2fd38

The idea of this pr is to make the test less dependent on lar specific implementation details and test the import export functionality at a higher level. As now the full export/import flow is being tested, now the test reproduces a bug that I'm asking for help from the headless team to investigate in: https://liferay.slack.com/archives/C5E1CRLJY/p1776268873056869

This means that the tests `testExportImportLayoutPageTemplateEntriesDeletions` in this pr fails because of a possible bug in the api.