### PR TITLE
LPD-86116: Export-import utility page modification date on update

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/UtilityPageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/UtilityPageResourceImpl.java
@@ -319,19 +319,22 @@ public class UtilityPageResourceImpl
 			_getServiceContext(groupId, utilityPage),
 			utilityPage.getThumbnailURLReference());
 
+		ServiceContext serviceContext = _getServiceContext(
+			groupId, utilityPage);
+
 		if (previewFileEntryId !=
 				layoutUtilityPageEntry.getPreviewFileEntryId()) {
 
 			layoutUtilityPageEntry =
 				_layoutUtilityPageEntryService.updateLayoutUtilityPageEntry(
 					layoutUtilityPageEntry.getLayoutUtilityPageEntryId(),
-					previewFileEntryId);
+					previewFileEntryId, serviceContext);
 		}
 
 		return _utilityPageDTOConverter.toDTO(
 			_layoutUtilityPageEntryService.updateLayoutUtilityPageEntry(
 				layoutUtilityPageEntry.getLayoutUtilityPageEntryId(),
-				utilityPage.getName()));
+				utilityPage.getName(), serviceContext));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -53,6 +54,8 @@ import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
+
+import java.text.DateFormat;
 
 import java.util.HashMap;
 import java.util.List;
@@ -432,7 +435,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 
 		_testPutSiteUtilityPageWithPageSpecifications();
 		_testPutSiteUtilityPageWithThumbnail();
-		_testPutSiteUtilityPageUpdateWithModificationDate();
+		_testPutSiteUtilityWithModificationDatePreserved();
 	}
 
 	@Override
@@ -1073,28 +1076,6 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 			markedAsDefault, putUtilityPage.getMarkedAsDefault());
 	}
 
-	private void _testPutSiteUtilityPageUpdateWithModificationDate()
-		throws Exception {
-
-		UtilityPage utilityPage = _getUtilityPage(
-			null, Boolean.FALSE, RandomTestUtil.randomString());
-
-		UtilityPage putUtilityPage1 = utilityPageResource.putSiteUtilityPage(
-			testGroup.getExternalReferenceCode(),
-			utilityPage.getExternalReferenceCode(), utilityPage);
-
-		UtilityPage putUtilityPage2 = utilityPageResource.putSiteUtilityPage(
-			testGroup.getExternalReferenceCode(),
-			utilityPage.getExternalReferenceCode(), putUtilityPage1);
-
-		Assert.assertEquals(
-			putUtilityPage1.getDateModified(),
-			putUtilityPage2.getDateModified());
-		Assert.assertEquals(
-			putUtilityPage1.getDateModified(),
-			putUtilityPage2.getDateModified());
-	}
-
 	private void _testPutSiteUtilityPageWithPageSpecifications()
 		throws Exception {
 
@@ -1269,6 +1250,31 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 					thumbnailURLReference.getUrl(),
 				problem.getTitle());
 		}
+	}
+
+	private void _testPutSiteUtilityWithModificationDatePreserved()
+		throws Exception {
+
+		UtilityPage utilityPage = _getUtilityPage(
+			null, Boolean.FALSE, RandomTestUtil.randomString());
+
+		DateFormat dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd");
+
+		utilityPage.setDateCreated(dateFormat.parse("2023-01-01"));
+		utilityPage.setDateModified(dateFormat.parse("2023-02-02"));
+
+		UtilityPage putUtilityPage1 = utilityPageResource.putSiteUtilityPage(
+			testGroup.getExternalReferenceCode(),
+			utilityPage.getExternalReferenceCode(), utilityPage);
+
+		UtilityPage putUtilityPage2 = utilityPageResource.putSiteUtilityPage(
+			testGroup.getExternalReferenceCode(),
+			utilityPage.getExternalReferenceCode(), putUtilityPage1);
+
+		Assert.assertEquals(
+			putUtilityPage1.getDateModified(),
+			putUtilityPage2.getDateModified());
 	}
 
 	@Inject

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
@@ -432,6 +432,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 
 		_testPutSiteUtilityPageWithPageSpecifications();
 		_testPutSiteUtilityPageWithThumbnail();
+		_testPutSiteUtilityPageUpdateWithModificationDate();
 	}
 
 	@Override
@@ -1070,6 +1071,28 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 
 		Assert.assertEquals(
 			markedAsDefault, putUtilityPage.getMarkedAsDefault());
+	}
+
+	private void _testPutSiteUtilityPageUpdateWithModificationDate()
+		throws Exception {
+
+		UtilityPage utilityPage = _getUtilityPage(
+			null, Boolean.FALSE, RandomTestUtil.randomString());
+
+		UtilityPage putUtilityPage1 = utilityPageResource.putSiteUtilityPage(
+			testGroup.getExternalReferenceCode(),
+			utilityPage.getExternalReferenceCode(), utilityPage);
+
+		UtilityPage putUtilityPage2 = utilityPageResource.putSiteUtilityPage(
+			testGroup.getExternalReferenceCode(),
+			utilityPage.getExternalReferenceCode(), putUtilityPage1);
+
+		Assert.assertEquals(
+			putUtilityPage1.getDateModified(),
+			putUtilityPage2.getDateModified());
+		Assert.assertEquals(
+			putUtilityPage1.getDateModified(),
+			putUtilityPage2.getDateModified());
 	}
 
 	private void _testPutSiteUtilityPageWithPageSpecifications()

--- a/modules/apps/layout/layout-utility-page-api/bnd.bnd
+++ b/modules/apps/layout/layout-utility-page-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout Utility Page API
 Bundle-SymbolicName: com.liferay.layout.utility.page.api
-Bundle-Version: 10.0.1
+Bundle-Version: 11.0.0
 Export-Package:\
 	com.liferay.layout.utility.page.constants,\
 	com.liferay.layout.utility.page.converter,\

--- a/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryLocalService.java
+++ b/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryLocalService.java
@@ -425,9 +425,20 @@ public interface LayoutUtilityPageEntryLocalService
 			long layoutUtilityPageEntryId, long previewFileEntryId)
 		throws PortalException;
 
+	public LayoutUtilityPageEntry updateLayoutUtilityPageEntry(
+			long layoutUtilityPageEntryId, long previewFileEntryId,
+			ServiceContext serviceContext)
+		throws PortalException;
+
 	@Indexable(type = IndexableType.REINDEX)
 	public LayoutUtilityPageEntry updateLayoutUtilityPageEntry(
 			long layoutUtilityPageEntryId, String name)
+		throws PortalException;
+
+	@Indexable(type = IndexableType.REINDEX)
+	public LayoutUtilityPageEntry updateLayoutUtilityPageEntry(
+			long layoutUtilityPageEntryId, String name,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	@Override
@@ -446,4 +457,4 @@ public interface LayoutUtilityPageEntryLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1852257661
+// LIFERAY-SERVICE-BUILDER-HASH:2120999174

--- a/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryLocalServiceUtil.java
+++ b/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryLocalServiceUtil.java
@@ -520,11 +520,29 @@ public class LayoutUtilityPageEntryLocalServiceUtil {
 	}
 
 	public static LayoutUtilityPageEntry updateLayoutUtilityPageEntry(
+			long layoutUtilityPageEntryId, long previewFileEntryId,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().updateLayoutUtilityPageEntry(
+			layoutUtilityPageEntryId, previewFileEntryId, serviceContext);
+	}
+
+	public static LayoutUtilityPageEntry updateLayoutUtilityPageEntry(
 			long layoutUtilityPageEntryId, String name)
 		throws PortalException {
 
 		return getService().updateLayoutUtilityPageEntry(
 			layoutUtilityPageEntryId, name);
+	}
+
+	public static LayoutUtilityPageEntry updateLayoutUtilityPageEntry(
+			long layoutUtilityPageEntryId, String name,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().updateLayoutUtilityPageEntry(
+			layoutUtilityPageEntryId, name, serviceContext);
 	}
 
 	public static LayoutUtilityPageEntryLocalService getService() {
@@ -537,4 +555,4 @@ public class LayoutUtilityPageEntryLocalServiceUtil {
 			LayoutUtilityPageEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:565860332
+// LIFERAY-SERVICE-BUILDER-HASH:-1158619279

--- a/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryLocalServiceWrapper.java
@@ -595,11 +595,31 @@ public class LayoutUtilityPageEntryLocalServiceWrapper
 
 	@Override
 	public LayoutUtilityPageEntry updateLayoutUtilityPageEntry(
+			long layoutUtilityPageEntryId, long previewFileEntryId,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _layoutUtilityPageEntryLocalService.updateLayoutUtilityPageEntry(
+			layoutUtilityPageEntryId, previewFileEntryId, serviceContext);
+	}
+
+	@Override
+	public LayoutUtilityPageEntry updateLayoutUtilityPageEntry(
 			long layoutUtilityPageEntryId, String name)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _layoutUtilityPageEntryLocalService.updateLayoutUtilityPageEntry(
 			layoutUtilityPageEntryId, name);
+	}
+
+	@Override
+	public LayoutUtilityPageEntry updateLayoutUtilityPageEntry(
+			long layoutUtilityPageEntryId, String name,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _layoutUtilityPageEntryLocalService.updateLayoutUtilityPageEntry(
+			layoutUtilityPageEntryId, name, serviceContext);
 	}
 
 	@Override
@@ -644,4 +664,4 @@ public class LayoutUtilityPageEntryLocalServiceWrapper
 		_layoutUtilityPageEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-680164322
+// LIFERAY-SERVICE-BUILDER-HASH:-1997412665

--- a/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryService.java
+++ b/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryService.java
@@ -141,8 +141,14 @@ public interface LayoutUtilityPageEntryService extends BaseService {
 		throws PortalException;
 
 	public LayoutUtilityPageEntry updateLayoutUtilityPageEntry(
-			long layoutUtilityPageEntryId, String name)
+			long layoutUtilityPageEntryId, long previewFileEntryId,
+			ServiceContext serviceContext)
+		throws PortalException;
+
+	public LayoutUtilityPageEntry updateLayoutUtilityPageEntry(
+			long layoutUtilityPageEntryId, String name,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1878448636
+// LIFERAY-SERVICE-BUILDER-HASH:1912081820

--- a/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryServiceUtil.java
+++ b/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryServiceUtil.java
@@ -190,11 +190,21 @@ public class LayoutUtilityPageEntryServiceUtil {
 	}
 
 	public static LayoutUtilityPageEntry updateLayoutUtilityPageEntry(
-			long layoutUtilityPageEntryId, String name)
+			long layoutUtilityPageEntryId, long previewFileEntryId,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().updateLayoutUtilityPageEntry(
-			layoutUtilityPageEntryId, name);
+			layoutUtilityPageEntryId, previewFileEntryId, serviceContext);
+	}
+
+	public static LayoutUtilityPageEntry updateLayoutUtilityPageEntry(
+			long layoutUtilityPageEntryId, String name,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().updateLayoutUtilityPageEntry(
+			layoutUtilityPageEntryId, name, serviceContext);
 	}
 
 	public static LayoutUtilityPageEntryService getService() {
@@ -207,4 +217,4 @@ public class LayoutUtilityPageEntryServiceUtil {
 			LayoutUtilityPageEntryService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-977018888
+// LIFERAY-SERVICE-BUILDER-HASH:1833989686

--- a/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryServiceWrapper.java
+++ b/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryServiceWrapper.java
@@ -217,11 +217,22 @@ public class LayoutUtilityPageEntryServiceWrapper
 
 	@Override
 	public LayoutUtilityPageEntry updateLayoutUtilityPageEntry(
-			long layoutUtilityPageEntryId, String name)
+			long layoutUtilityPageEntryId, long previewFileEntryId,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _layoutUtilityPageEntryService.updateLayoutUtilityPageEntry(
-			layoutUtilityPageEntryId, name);
+			layoutUtilityPageEntryId, previewFileEntryId, serviceContext);
+	}
+
+	@Override
+	public LayoutUtilityPageEntry updateLayoutUtilityPageEntry(
+			long layoutUtilityPageEntryId, String name,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _layoutUtilityPageEntryService.updateLayoutUtilityPageEntry(
+			layoutUtilityPageEntryId, name, serviceContext);
 	}
 
 	@Override
@@ -239,4 +250,4 @@ public class LayoutUtilityPageEntryServiceWrapper
 	private LayoutUtilityPageEntryService _layoutUtilityPageEntryService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1353222100
+// LIFERAY-SERVICE-BUILDER-HASH:-1707687394

--- a/modules/apps/layout/layout-utility-page-api/src/main/resources/com/liferay/layout/utility/page/service/packageinfo
+++ b/modules/apps/layout/layout-utility-page-api/src/main/resources/com/liferay/layout/utility/page/service/packageinfo
@@ -1,1 +1,1 @@
-version 9.0.0
+version 10.0.0

--- a/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/http/LayoutUtilityPageEntryServiceHttp.java
+++ b/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/http/LayoutUtilityPageEntryServiceHttp.java
@@ -818,7 +818,8 @@ public class LayoutUtilityPageEntryServiceHttp {
 	public static com.liferay.layout.utility.page.model.LayoutUtilityPageEntry
 			updateLayoutUtilityPageEntry(
 				HttpPrincipal httpPrincipal, long layoutUtilityPageEntryId,
-				String name)
+				long previewFileEntryId,
+				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -828,7 +829,53 @@ public class LayoutUtilityPageEntryServiceHttp {
 				_updateLayoutUtilityPageEntryParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, layoutUtilityPageEntryId, name);
+				methodKey, layoutUtilityPageEntryId, previewFileEntryId,
+				serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.layout.utility.page.model.
+				LayoutUtilityPageEntry)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.layout.utility.page.model.LayoutUtilityPageEntry
+			updateLayoutUtilityPageEntry(
+				HttpPrincipal httpPrincipal, long layoutUtilityPageEntryId,
+				String name,
+				com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				LayoutUtilityPageEntryServiceUtil.class,
+				"updateLayoutUtilityPageEntry",
+				_updateLayoutUtilityPageEntryParameterTypes20);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, layoutUtilityPageEntryId, name, serviceContext);
 
 			Object returnObj = null;
 
@@ -939,8 +986,14 @@ public class LayoutUtilityPageEntryServiceHttp {
 		};
 	private static final Class<?>[]
 		_updateLayoutUtilityPageEntryParameterTypes19 = new Class[] {
-			long.class, String.class
+			long.class, long.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
+		};
+	private static final Class<?>[]
+		_updateLayoutUtilityPageEntryParameterTypes20 = new Class[] {
+			long.class, String.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:600060082
+// LIFERAY-SERVICE-BUILDER-HASH:855886149

--- a/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
@@ -396,11 +396,22 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 			long layoutUtilityPageEntryId, long previewFileEntryId)
 		throws PortalException {
 
+		return updateLayoutUtilityPageEntry(
+			layoutUtilityPageEntryId, previewFileEntryId, new ServiceContext());
+	}
+
+	@Override
+	public LayoutUtilityPageEntry updateLayoutUtilityPageEntry(
+			long layoutUtilityPageEntryId, long previewFileEntryId,
+			ServiceContext serviceContext)
+		throws PortalException {
+
 		LayoutUtilityPageEntry layoutUtilityPageEntry =
 			layoutUtilityPageEntryPersistence.findByPrimaryKey(
 				layoutUtilityPageEntryId);
 
-		layoutUtilityPageEntry.setModifiedDate(new Date());
+		layoutUtilityPageEntry.setModifiedDate(
+			serviceContext.getModifiedDate(new Date()));
 
 		long previousPreviewFileEntryId =
 			layoutUtilityPageEntry.getPreviewFileEntryId();
@@ -424,6 +435,24 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 			long layoutUtilityPageEntryId, String name)
 		throws PortalException {
 
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext == null) {
+			serviceContext = new ServiceContext();
+		}
+
+		return updateLayoutUtilityPageEntry(
+			layoutUtilityPageEntryId, name, serviceContext);
+	}
+
+	@Indexable(type = IndexableType.REINDEX)
+	@Override
+	public LayoutUtilityPageEntry updateLayoutUtilityPageEntry(
+			long layoutUtilityPageEntryId, String name,
+			ServiceContext serviceContext)
+		throws PortalException {
+
 		LayoutUtilityPageEntry layoutUtilityPageEntry =
 			layoutUtilityPageEntryPersistence.fetchByPrimaryKey(
 				layoutUtilityPageEntryId);
@@ -431,6 +460,9 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 		_validateName(
 			layoutUtilityPageEntry.getGroupId(), layoutUtilityPageEntryId, name,
 			layoutUtilityPageEntry.getType());
+
+		layoutUtilityPageEntry.setModifiedDate(
+			serviceContext.getModifiedDate(new Date()));
 
 		layoutUtilityPageEntry.setName(name);
 
@@ -442,13 +474,6 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 
 		Layout draftLayout = _layoutLocalService.fetchDraftLayout(
 			layoutUtilityPageEntry.getPlid());
-
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		if (serviceContext == null) {
-			serviceContext = new ServiceContext();
-		}
 
 		serviceContext.setAttribute(
 			"layout.instanceable.allowed", Boolean.TRUE);

--- a/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryServiceImpl.java
+++ b/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryServiceImpl.java
@@ -284,7 +284,8 @@ public class LayoutUtilityPageEntryServiceImpl
 
 	@Override
 	public LayoutUtilityPageEntry updateLayoutUtilityPageEntry(
-			long layoutUtilityPageEntryId, String name)
+			long layoutUtilityPageEntryId, long previewFileEntryId,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		_layoutUtilityPageEntryModelResourcePermission.check(
@@ -292,7 +293,21 @@ public class LayoutUtilityPageEntryServiceImpl
 			ActionKeys.UPDATE);
 
 		return layoutUtilityPageEntryLocalService.updateLayoutUtilityPageEntry(
-			layoutUtilityPageEntryId, name);
+			layoutUtilityPageEntryId, previewFileEntryId, serviceContext);
+	}
+
+	@Override
+	public LayoutUtilityPageEntry updateLayoutUtilityPageEntry(
+			long layoutUtilityPageEntryId, String name,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		_layoutUtilityPageEntryModelResourcePermission.check(
+			getPermissionChecker(), layoutUtilityPageEntryId,
+			ActionKeys.UPDATE);
+
+		return layoutUtilityPageEntryLocalService.updateLayoutUtilityPageEntry(
+			layoutUtilityPageEntryId, name, serviceContext);
 	}
 
 	@Reference


### PR DESCRIPTION
- https://liferay.atlassian.net/browse/LPD-84210
  - https://liferay.atlassian.net/browse/LPD-86116

Fixes utility page modification date not being transported on import when updating an entry.

This PR is based on the findings in [liferay.com testing epic](https://liferay.atlassian.net/browse/LPD-84210). Please see steps to reproduce in the ticket.
