### PR TITLE
LPD-86447 Remove apiHelpers.headlessSite calls for Page Management

### DIFF
--- a/modules/test/playwright/fixtures/pageManagementSiteTest.ts
+++ b/modules/test/playwright/fixtures/pageManagementSiteTest.ts
@@ -28,7 +28,7 @@ const pageManagementSiteTest = test.extend<{
 			let site: Site;
 
 			try {
-				site = await apiHelpers.headlessSite.getSiteByERC(
+				site = await apiHelpers.headlessAdminSite.getSite(
 					PAGE_MANAGEMENT_SITE_ERC
 				);
 

--- a/modules/test/playwright/tests/setup/page-management-site/main/setup.spec.ts
+++ b/modules/test/playwright/tests/setup/page-management-site/main/setup.spec.ts
@@ -20,7 +20,7 @@ test('Setup: Create site with required data for Page Management tests', async ({
 }) => {
 	const apiHelpers = new ApiHelpers(backendPage);
 
-	const site = await apiHelpers.headlessSite.createSiteFromZip(
+	const site = await apiHelpers.headlessAdminSite.postSiteSiteInitializer(
 		{
 			externalReferenceCode: PAGE_MANAGEMENT_SITE_ERC,
 			name: PAGE_MANAGEMENT_SITE_NAME,

--- a/modules/test/playwright/tests/setup/page-management-site/teardown/teardown.spec.ts
+++ b/modules/test/playwright/tests/setup/page-management-site/teardown/teardown.spec.ts
@@ -18,7 +18,7 @@ test('Teardown: Delete site and data for Page Management tests', async ({
 }) => {
 	const apiHelpers = new ApiHelpers(backendPage);
 
-	const {id: siteId} = await apiHelpers.headlessSite.getSiteByERC(
+	const {id: siteId} = await apiHelpers.headlessAdminSite.getSite(
 		PAGE_MANAGEMENT_SITE_ERC
 	);
 
@@ -51,5 +51,5 @@ test('Teardown: Delete site and data for Page Management tests', async ({
 
 	// Delete site
 
-	await apiHelpers.headlessSite.deleteSiteByERC(PAGE_MANAGEMENT_SITE_ERC);
+	await apiHelpers.headlessAdminSite.deleteSite(PAGE_MANAGEMENT_SITE_ERC);
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86447

### Summary
Standardized Playwright tests by replacing legacy `apiHelpers.headlessSite` with `apiHelpers.headlessAdminSite`.

If you encounter any failures or flakiness related to these changes, please let me know.