### PR TITLE
LPD-86825: Fix fragment collection key getting regenerated on import

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/staged/model/repository/FragmentCollectionStagedModelRepository.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/staged/model/repository/FragmentCollectionStagedModelRepository.java
@@ -9,12 +9,14 @@ import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.StagedModelModifiedDateComparator;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepositoryHelper;
+import com.liferay.fragment.exception.FragmentCollectionNameException;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.service.FragmentCollectionLocalService;
 import com.liferay.portal.kernel.dao.orm.ExportActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.util.List;
 
@@ -45,6 +47,13 @@ public class FragmentCollectionStagedModelRepository
 
 		if (portletDataContext.isDataStrategyMirror()) {
 			serviceContext.setUuid(fragmentCollection.getUuid());
+
+			return _fragmentCollectionLocalService.addFragmentCollection(
+				fragmentCollection.getExternalReferenceCode(), userId,
+				fragmentCollection.getGroupId(),
+				fragmentCollection.getFragmentCollectionKey(),
+				fragmentCollection.getName(),
+				fragmentCollection.getDescription(), false, serviceContext);
 		}
 
 		return _fragmentCollectionLocalService.addFragmentCollection(
@@ -132,9 +141,22 @@ public class FragmentCollectionStagedModelRepository
 			FragmentCollection fragmentCollection)
 		throws PortalException {
 
+		if (Validator.isNull(fragmentCollection.getName())) {
+			throw new FragmentCollectionNameException("Name must not be null");
+		}
+
+		FragmentCollection existingFragmentCollection =
+			_fragmentCollectionLocalService.fetchFragmentCollection(
+				fragmentCollection.getFragmentCollectionId());
+
+		existingFragmentCollection.setFragmentCollectionKey(
+			fragmentCollection.getFragmentCollectionKey());
+		existingFragmentCollection.setName(fragmentCollection.getName());
+		existingFragmentCollection.setDescription(
+			fragmentCollection.getDescription());
+
 		return _fragmentCollectionLocalService.updateFragmentCollection(
-			fragmentCollection.getFragmentCollectionId(),
-			fragmentCollection.getName(), fragmentCollection.getDescription());
+			existingFragmentCollection);
 	}
 
 	@Reference

--- a/modules/apps/fragment/fragment-test/build.gradle
+++ b/modules/apps/fragment/fragment-test/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:document-library:document-library-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")
+	testIntegrationImplementation project(":apps:export-import:export-import-api")
 	testIntegrationImplementation project(":apps:export-import:export-import-test-util")
 	testIntegrationImplementation project(":apps:fragment:fragment-api")
 	testIntegrationImplementation project(":apps:fragment:fragment-entry-processor:fragment-entry-processor-api")

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/exportimport/staged/model/repository/test/FragmentCollectionStagedModelRepositoryTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/exportimport/staged/model/repository/test/FragmentCollectionStagedModelRepositoryTest.java
@@ -1,0 +1,100 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.exportimport.staged.model.repository.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
+import com.liferay.exportimport.staged.model.repository.StagedModelRepositoryRegistryUtil;
+import com.liferay.fragment.exception.FragmentCollectionNameException;
+import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.service.FragmentCollectionLocalService;
+import com.liferay.fragment.test.util.FragmentTestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Petteri Karttunen
+ */
+@RunWith(Arquillian.class)
+public class FragmentCollectionStagedModelRepositoryTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_stagedModelRepository =
+			(StagedModelRepository<FragmentCollection>)
+				StagedModelRepositoryRegistryUtil.getStagedModelRepository(
+					FragmentCollection.class.getName());
+	}
+
+	@Test
+	public void testUpdateStagedModel() throws Exception {
+		FragmentCollection fragmentCollection =
+			FragmentTestUtil.addFragmentCollection(
+				_group.getGroupId(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString());
+
+		String newDescription = RandomTestUtil.randomString();
+		String newFragmentCollectionKey = RandomTestUtil.randomString();
+		String newName = RandomTestUtil.randomString();
+
+		fragmentCollection.setFragmentCollectionKey(newFragmentCollectionKey);
+		fragmentCollection.setName(newName);
+		fragmentCollection.setDescription(newDescription);
+
+		_stagedModelRepository.updateStagedModel(null, fragmentCollection);
+
+		FragmentCollection updatedFragmentCollection =
+			_fragmentCollectionLocalService.getFragmentCollection(
+				fragmentCollection.getFragmentCollectionId());
+
+		Assert.assertEquals(newName, updatedFragmentCollection.getName());
+		Assert.assertEquals(
+			newDescription, updatedFragmentCollection.getDescription());
+		Assert.assertEquals(
+			newFragmentCollectionKey,
+			updatedFragmentCollection.getFragmentCollectionKey());
+	}
+
+	@Test(expected = FragmentCollectionNameException.class)
+	public void testUpdateStagedModelWithNullName() throws Exception {
+		FragmentCollection fragmentCollection =
+			FragmentTestUtil.addFragmentCollection(
+				_group.getGroupId(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString());
+
+		fragmentCollection.setName(null);
+
+		_stagedModelRepository.updateStagedModel(null, fragmentCollection);
+	}
+
+	@Inject
+	private FragmentCollectionLocalService _fragmentCollectionLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private StagedModelRepository<FragmentCollection> _stagedModelRepository;
+
+}


### PR DESCRIPTION
- https://liferay.atlassian.net/browse/LPD-86825

This PR is  based on the findings in [liferay.com testing epic](https://liferay.atlassian.net/browse/LPD-84210). 

  ## Summary
- `FragmentCollectionStagedModelRepository` was dropping `fragmentCollectionKey` on both staging entry points. Mirror-strategy `addStagedModel` set the UUID but fell through to the overload that omits the key, and `updateStagedModel` only synced  name/description. Both paths now propagate the key.
-  Collapsed `updateStagedModel` from **2 fetches + 2 writes** (`fetch → set key →  update → updateFragmentCollection(id, name, desc)` which re-fetches and re-writes) into **1 fetch + 1 write**. The null-name check from the underlying service is inlined to preserve validation behavior.                                                                                                                                           
- Added an integration test covering the update happy-path (key/name/description all persist) and the null-name validation (`FragmentCollectionNameException`).   