### PR TITLE
LPD-87022 Exclude tests from page-management

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -4987,9 +4987,12 @@
     playwright.projects.includes[playwright-js-tomcat101-*][page-management]=${page.management.playwright.projects}
 
     test.batch.class.names.excludes[page-management]=\
+        **/commerce/commerce-fragment/**/*Test.java,\
         **/journal-test/**/*Test.java,\
         **/layout-set-prototype-**/**/*Test.java,\
-        **/portal-fragment-bundle-watcher-test/**/*Test.java
+        **/portal-fragment-bundle-watcher-test/**/*Test.java,\
+        **/site/site-cms-site-initializer-test/**/fragment/renderer/**/*Test.java,\
+        **/site-cmp-site-initializer-**/**/*Test.java
 
     test.batch.class.names.includes[page-management]=\
         ${page.management.headless.admin.site.integration.tests},\


### PR DESCRIPTION
The purpose of this pr is to exclude the following tests from the page-management routine:
```
commerce/commerce-fragment/commerce-fragment-impl/src/test/java/com/liferay/commerce/fragment/internal/frontend/data/set/url/AccountEntryFDSAPIURLResolverTest.java
site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/CommentsComponentSectionFragmentRendererTest.java
site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/EditorToolbarComponentSectionFragmentRendererTest.java
site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/HistoryComponentSectionFragmentRendererTest.java
site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/ProjectBreadcrumbComponentSectionFragmentRendererTest.java
site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/ProjectSelectorComponentSectionFragmentRendererTest.java
site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/StateSelectorComponentSectionFragmentRendererTest.java
site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/TagsComponentSectionFragmentRendererTest.java
site/site-cmp-site-initializer-test/src/testIntegration/java/com/liferay/site/cmp/site/initializer/internal/fragment/renderer/test/TaskBreadcrumbComponentSectionFragmentRendererTest.java
site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/test/BreadcrumbComponentSectionFragmentRendererTest.java
site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/test/ContentEditorToolbarComponentSectionFragmentRendererTest.java
``` 
The exclusions of module `site-cms-site-initializer-test` are more specific not to exclude StructureBuilder tests https://github.com/liferay/liferay-portal/blob/94b6c39b0db94a46c340226f91f4f13a559ea08b/test.properties#L4969

