### PR TITLE
LPD-81794 fix web content feeds export import

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalFeedExportImportContentProcessor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalFeedExportImportContentProcessor.java
@@ -169,42 +169,7 @@ public class JournalFeedExportImportContentProcessor
 			feed.setTargetLayoutFriendlyUrl(
 				friendlyURLPath + targetLayoutGroup.getFriendlyURL() +
 					targetLayout.getFriendlyURL());
-
-			return content;
 		}
-
-		Group group = _groupLocalService.getGroup(
-			portletDataContext.getScopeGroupId());
-
-		String newGroupFriendlyURL = group.getFriendlyURL();
-
-		newGroupFriendlyURL = newGroupFriendlyURL.substring(1);
-
-		String newTargetLayoutFriendlyURL = StringUtil.replace(
-			feed.getTargetLayoutFriendlyUrl(), _DATA_HANDLER_GROUP_FRIENDLY_URL,
-			newGroupFriendlyURL);
-
-		long plid = _portal.getPlidFromFriendlyURL(
-			portletDataContext.getCompanyId(), newTargetLayoutFriendlyURL);
-
-		if (plid <= 0) {
-			Group oldGroup = _groupLocalService.fetchGroup(
-				portletDataContext.getSourceGroupId());
-
-			if (oldGroup == null) {
-				return content;
-			}
-
-			String oldGroupFriendlyURL = oldGroup.getFriendlyURL();
-
-			oldGroupFriendlyURL = oldGroupFriendlyURL.substring(1);
-
-			newTargetLayoutFriendlyURL = StringUtil.replace(
-				feed.getTargetLayoutFriendlyUrl(),
-				_DATA_HANDLER_GROUP_FRIENDLY_URL, oldGroupFriendlyURL);
-		}
-
-		feed.setTargetLayoutFriendlyUrl(newTargetLayoutFriendlyURL);
 
 		return content;
 	}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalFeedExportImportContentProcessor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalFeedExportImportContentProcessor.java
@@ -83,10 +83,6 @@ public class JournalFeedExportImportContentProcessor
 			feed.setTargetLayoutFriendlyUrl(targetLayoutFriendlyURL);
 		}
 
-		Group targetLayoutGroup = _groupLocalService.fetchFriendlyURLGroup(
-			portletDataContext.getCompanyId(),
-			StringPool.SLASH + oldGroupFriendlyURL);
-
 		boolean privateLayout = false;
 
 		if (!PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING.equals(
@@ -99,6 +95,10 @@ public class JournalFeedExportImportContentProcessor
 		String targetLayoutFriendlyURL = null;
 
 		if (friendlyURLParts.length > 3) {
+			Group targetLayoutGroup = _groupLocalService.fetchFriendlyURLGroup(
+				portletDataContext.getCompanyId(),
+				StringPool.SLASH + oldGroupFriendlyURL);
+
 			targetLayoutFriendlyURL = StringUtil.merge(
 				Arrays.copyOfRange(
 					friendlyURLParts, 3, friendlyURLParts.length),
@@ -161,10 +161,9 @@ public class JournalFeedExportImportContentProcessor
 			Group targetLayoutGroup = _groupLocalService.getGroup(
 				targetLayout.getGroupId());
 
-			String friendlyURLPath =
-				targetLayout.isPrivateLayout() ?
-					_portal.getPathFriendlyURLPrivateGroup() :
-						_portal.getPathFriendlyURLPublic();
+			String friendlyURLPath = targetLayout.isPrivateLayout() ?
+				_portal.getPathFriendlyURLPrivateGroup() :
+					_portal.getPathFriendlyURLPublic();
 
 			feed.setTargetLayoutFriendlyUrl(
 				friendlyURLPath + targetLayoutGroup.getFriendlyURL() +

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalFeedExportImportContentProcessor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalFeedExportImportContentProcessor.java
@@ -7,7 +7,6 @@ package com.liferay.journal.internal.exportimport.content.processor;
 
 import com.liferay.exportimport.content.processor.ExportImportContentProcessor;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
-import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.journal.model.JournalFeed;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -23,6 +22,8 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.xml.Element;
 
 import java.util.Arrays;
 
@@ -131,27 +132,10 @@ public class JournalFeedExportImportContentProcessor
 			throw new NoSuchLayoutException();
 		}
 
-		if (exportReferencedContent) {
-			try {
-				StagedModelDataHandlerUtil.exportReferenceStagedModel(
-					portletDataContext, feed, targetLayout,
-					PortletDataContext.REFERENCE_TYPE_DEPENDENCY);
-			}
-			catch (PortalException portalException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(
-						"Unable to export target layout " +
-							targetLayout.getLayoutId(),
-						portalException);
-				}
-			}
-		}
-		else {
-			portletDataContext.addReferenceElement(
-				feed, portletDataContext.getExportDataElement(feed),
-				targetLayout, PortletDataContext.REFERENCE_TYPE_DEPENDENCY,
-				true);
-		}
+		Element feedElement = portletDataContext.getExportDataElement(feed);
+
+		feedElement.addAttribute(
+			"targetLayoutERC", targetLayout.getExternalReferenceCode());
 
 		return content;
 	}
@@ -163,6 +147,31 @@ public class JournalFeedExportImportContentProcessor
 		throws Exception {
 
 		JournalFeed feed = (JournalFeed)stagedModel;
+
+		Element feedElement =
+			portletDataContext.getImportDataStagedModelElement(feed);
+
+		String targetLayoutERC = feedElement.attributeValue("targetLayoutERC");
+
+		if (Validator.isNotNull(targetLayoutERC)) {
+			Layout targetLayout =
+				_layoutLocalService.getLayoutByExternalReferenceCode(
+					targetLayoutERC, portletDataContext.getGroupId());
+
+			Group targetLayoutGroup = _groupLocalService.getGroup(
+				targetLayout.getGroupId());
+
+			String friendlyURLPath =
+				targetLayout.isPrivateLayout() ?
+					_portal.getPathFriendlyURLPrivateGroup() :
+						_portal.getPathFriendlyURLPublic();
+
+			feed.setTargetLayoutFriendlyUrl(
+				friendlyURLPath + targetLayoutGroup.getFriendlyURL() +
+					targetLayout.getFriendlyURL());
+
+			return content;
+		}
 
 		Group group = _groupLocalService.getGroup(
 			portletDataContext.getScopeGroupId());

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalFeedExportImportContentProcessor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalFeedExportImportContentProcessor.java
@@ -7,6 +7,7 @@ package com.liferay.journal.internal.exportimport.content.processor;
 
 import com.liferay.exportimport.content.processor.ExportImportContentProcessor;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.journal.model.JournalFeed;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -22,7 +23,6 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.xml.Element;
 
 import java.util.Arrays;
 
@@ -131,11 +131,27 @@ public class JournalFeedExportImportContentProcessor
 			throw new NoSuchLayoutException();
 		}
 
-		Element feedElement = portletDataContext.getExportDataElement(feed);
-
-		portletDataContext.addReferenceElement(
-			feed, feedElement, targetLayout,
-			PortletDataContext.REFERENCE_TYPE_DEPENDENCY, true);
+		if (exportReferencedContent) {
+			try {
+				StagedModelDataHandlerUtil.exportReferenceStagedModel(
+					portletDataContext, feed, targetLayout,
+					PortletDataContext.REFERENCE_TYPE_DEPENDENCY);
+			}
+			catch (PortalException portalException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						"Unable to export target layout " +
+							targetLayout.getLayoutId(),
+						portalException);
+				}
+			}
+		}
+		else {
+			portletDataContext.addReferenceElement(
+				feed, portletDataContext.getExportDataElement(feed),
+				targetLayout, PortletDataContext.REFERENCE_TYPE_DEPENDENCY,
+				true);
+		}
 
 		return content;
 	}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalFeedStagedModelDataHandlerTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalFeedStagedModelDataHandlerTest.java
@@ -13,6 +13,8 @@ import com.liferay.dynamic.data.mapping.service.DDMTemplateLocalServiceUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMTemplateTestUtil;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.exportimport.kernel.lar.PortletDataException;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.test.util.lar.BaseStagedModelDataHandlerTestCase;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalFeed;
@@ -20,6 +22,7 @@ import com.liferay.journal.service.JournalFeedLocalServiceUtil;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -29,6 +32,7 @@ import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortalPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -76,11 +80,11 @@ public class JournalFeedStagedModelDataHandlerTest
 		serviceContext.setUuid(_layout.getUuid());
 
 		LayoutLocalServiceUtil.addLayout(
-			null, TestPropsValues.getUserId(), liveGroup.getGroupId(),
-			_layout.isPrivateLayout(), _layout.getParentLayoutId(),
-			_layout.getName(), _layout.getTitle(), _layout.getDescription(),
-			_layout.getType(), _layout.isHidden(), _layout.getFriendlyURL(),
-			serviceContext);
+			_layout.getExternalReferenceCode(), TestPropsValues.getUserId(),
+			liveGroup.getGroupId(), _layout.isPrivateLayout(),
+			_layout.getParentLayoutId(), _layout.getName(), _layout.getTitle(),
+			_layout.getDescription(), _layout.getType(), _layout.isHidden(),
+			_layout.getFriendlyURL(), serviceContext);
 
 		serviceContext.setCompanyId(TestPropsValues.getCompanyId());
 
@@ -190,26 +194,83 @@ public class JournalFeedStagedModelDataHandlerTest
 	}
 
 	@Test
-	public void testExportStagedModelLayoutReference() throws Exception {
+	public void testExportImport() throws Exception {
 		StagedModel stagedModel = addStagedModel(
 			stagingGroup, addDependentStagedModelsMap(stagingGroup));
 
 		exportStagedModel(stagedModel);
 
+		Layout liveGroupLayout =
+			LayoutLocalServiceUtil.getLayoutByExternalReferenceCode(
+				_layout.getExternalReferenceCode(), liveGroup.getGroupId());
+
+		LayoutLocalServiceUtil.deleteLayout(liveGroupLayout);
+
 		try (SafeCloseable safeCloseable = initImportWithSafeCloseable()) {
-			List<Element> referenceElements =
-				portletDataContext.getReferenceElements(
-					stagedModel, Layout.class);
+			Element feedElement =
+				portletDataContext.getImportDataStagedModelElement(stagedModel);
 
 			Assert.assertEquals(
-				referenceElements.toString(), 1, referenceElements.size());
-			Assert.assertEquals(
-				"false",
-				referenceElements.get(
-					0
-				).attributeValue(
-					"missing"
-				));
+				_layout.getExternalReferenceCode(),
+				feedElement.attributeValue("targetLayoutERC"));
+
+			StagedModel exportedStagedModel = readExportedStagedModel(
+				stagedModel);
+
+			Assert.assertNotNull(exportedStagedModel);
+
+			ExportImportThreadLocal.setPortletImportInProcess(true);
+
+			try {
+				AssertUtils.assertFailure(
+					PortletDataException.class,
+					StringBundler.concat(
+						"No Layout exists with the key ",
+						"{externalReferenceCode=",
+						_layout.getExternalReferenceCode(), ", groupId=",
+						liveGroup.getGroupId(), "}"),
+					() -> StagedModelDataHandlerUtil.importStagedModel(
+						portletDataContext, exportedStagedModel));
+			}
+			finally {
+				ExportImportThreadLocal.setPortletImportInProcess(false);
+			}
+		}
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setUuid(_layout.getUuid());
+
+		LayoutLocalServiceUtil.addLayout(
+			_layout.getExternalReferenceCode(), TestPropsValues.getUserId(),
+			liveGroup.getGroupId(), _layout.isPrivateLayout(),
+			_layout.getParentLayoutId(), _layout.getName(), _layout.getTitle(),
+			_layout.getDescription(), _layout.getType(), _layout.isHidden(),
+			_layout.getFriendlyURL(), serviceContext);
+
+		try (SafeCloseable safeCloseable = initImportWithSafeCloseable()) {
+			StagedModel exportedStagedModel = readExportedStagedModel(
+				stagedModel);
+
+			Assert.assertNotNull(exportedStagedModel);
+
+			ExportImportThreadLocal.setPortletImportInProcess(true);
+
+			try {
+				StagedModelDataHandlerUtil.importStagedModel(
+					portletDataContext, exportedStagedModel);
+			}
+			finally {
+				ExportImportThreadLocal.setPortletImportInProcess(false);
+			}
+
+			JournalFeed importedFeed =
+				JournalFeedLocalServiceUtil.fetchJournalFeedByUuidAndGroupId(
+					stagedModel.getUuid(), liveGroup.getGroupId());
+
+			Assert.assertNotNull(importedFeed);
+
+			validateImportedStagedModel(stagedModel, importedFeed);
 		}
 	}
 

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalFeedStagedModelDataHandlerTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalFeedStagedModelDataHandlerTest.java
@@ -19,6 +19,7 @@ import com.liferay.journal.model.JournalFeed;
 import com.liferay.journal.service.JournalFeedLocalServiceUtil;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -33,6 +34,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
@@ -184,6 +186,30 @@ public class JournalFeedStagedModelDataHandlerTest
 				stagedModel.getUuid(), liveGroup);
 
 			Assert.assertNotNull(importedStagedModel);
+		}
+	}
+
+	@Test
+	public void testExportStagedModelLayoutReference() throws Exception {
+		StagedModel stagedModel = addStagedModel(
+			stagingGroup, addDependentStagedModelsMap(stagingGroup));
+
+		exportStagedModel(stagedModel);
+
+		try (SafeCloseable safeCloseable = initImportWithSafeCloseable()) {
+			List<Element> referenceElements =
+				portletDataContext.getReferenceElements(
+					stagedModel, Layout.class);
+
+			Assert.assertEquals(
+				referenceElements.toString(), 1, referenceElements.size());
+			Assert.assertEquals(
+				"false",
+				referenceElements.get(
+					0
+				).attributeValue(
+					"missing"
+				));
 		}
 	}
 


### PR DESCRIPTION
Jira Ticket: https://liferay.atlassian.net/browse/LPD-81794

Following the same approach as [LPD-80000](https://github.com/liferay-page-management/liferay-portal/pull/18178), this PR switches                                    
  JournalFeedExportImportContentProcessor to reference the feed's target Layout by its ERC writing a targetLayoutERC attribute on export and resolving the Layout by ERC on import. 

If no Layout with the matching ERC exists in the target group, the import fails with  
  NoSuchLayoutException and the feed is not imported. 


https://github.com/user-attachments/assets/8b925442-9de3-4bdf-b52c-5c2c0a162315



[LPD-80000]: https://liferay.atlassian.net/browse/LPD-80000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ