### PR TITLE
LPD-86647 Fix module layout-utility-page-test compilation failures

### DIFF
--- a/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/search/test/LayoutUtilityPageEntryIndexerReindexTest.java
+++ b/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/search/test/LayoutUtilityPageEntryIndexerReindexTest.java
@@ -71,7 +71,7 @@ public class LayoutUtilityPageEntryIndexerReindexTest {
 		layoutUtilityPageEntry =
 			_layoutUtilityPageEntryLocalService.updateLayoutUtilityPageEntry(
 				layoutUtilityPageEntry.getLayoutUtilityPageEntryId(),
-				layoutUtilityPageEntry.getName());
+				layoutUtilityPageEntry.getName(), serviceContext);
 
 		name = layoutUtilityPageEntry.getName();
 

--- a/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/test/LayoutUtilityPageEntryLocalServiceTest.java
+++ b/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/test/LayoutUtilityPageEntryLocalServiceTest.java
@@ -292,7 +292,8 @@ public class LayoutUtilityPageEntryLocalServiceTest {
 		String name = RandomTestUtil.randomString();
 
 		_layoutUtilityPageEntryService.updateLayoutUtilityPageEntry(
-			layoutUtilityPageEntry.getLayoutUtilityPageEntryId(), name);
+			layoutUtilityPageEntry.getLayoutUtilityPageEntryId(), name,
+			_serviceContext);
 
 		layout = _layoutLocalService.getLayout(
 			layoutUtilityPageEntry.getPlid());

--- a/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/test/LayoutUtilityPageEntryServiceTest.java
+++ b/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/test/LayoutUtilityPageEntryServiceTest.java
@@ -516,7 +516,7 @@ public class LayoutUtilityPageEntryServiceTest {
 		layoutUtilityPageEntry =
 			_layoutUtilityPageEntryLocalService.updateLayoutUtilityPageEntry(
 				layoutUtilityPageEntry.getLayoutUtilityPageEntryId(),
-				RandomTestUtil.randomString());
+				RandomTestUtil.randomString(), _serviceContext);
 
 		Layout draftLayout = _layoutLocalService.fetchDraftLayout(
 			layoutUtilityPageEntry.getPlid());


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86647

**What is being fixed:** Compilation failures in the `layout-utility-page-test` module after the `updateLayoutUtilityPageEntry` signatures were harmonized to accept a `ServiceContext`.

**How it is being fixed:** Adjust the test call sites to use the new signatures that accept a `ServiceContext`.