### PR TITLE
LPD-87237 Fix PortalLogAssertorTest failures: Optional reference generated for missing entity

### DIFF
--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/staging/test/FragmentEntryLinkStagingTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/staging/test/FragmentEntryLinkStagingTest.java
@@ -6,12 +6,12 @@
 package com.liferay.fragment.staging.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.exportimport.kernel.service.StagingLocalServiceUtil;
+import com.liferay.exportimport.kernel.service.StagingLocalService;
 import com.liferay.fragment.contributor.FragmentCollectionContributorRegistry;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.model.FragmentEntryLink;
-import com.liferay.fragment.service.FragmentCollectionLocalServiceUtil;
+import com.liferay.fragment.service.FragmentCollectionLocalService;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.fragment.service.FragmentEntryLocalService;
 import com.liferay.fragment.test.util.FragmentEntryTestUtil;
@@ -22,7 +22,7 @@ import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -33,7 +33,7 @@ import com.liferay.portal.kernel.util.ScopeUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-import com.liferay.segments.service.SegmentsExperienceLocalServiceUtil;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -81,7 +81,7 @@ public class FragmentEntryLinkStagingTest {
 				fragmentEntry.getHtml(), fragmentEntry.getJs(), _layout,
 				fragmentEntry.getFragmentEntryKey(), fragmentEntry.getType(),
 				null, 0,
-				SegmentsExperienceLocalServiceUtil.
+				_segmentsExperienceLocalService.
 					fetchDefaultSegmentsExperienceId(_layout.getPlid()));
 
 		_stagingGroup = FragmentStagingTestUtil.enableLocalStaging(_liveGroup);
@@ -118,7 +118,7 @@ public class FragmentEntryLinkStagingTest {
 		_fragmentEntryLocalService.deleteFragmentEntry(stagingFragmentEntry);
 
 		FragmentCollection stagingFragmentCollection =
-			FragmentCollectionLocalServiceUtil.
+			_fragmentCollectionLocalService.
 				getFragmentCollectionByUuidAndGroupId(
 					liveFragmentCollection.getUuid(),
 					_stagingGroup.getGroupId());
@@ -128,7 +128,7 @@ public class FragmentEntryLinkStagingTest {
 				stagingFragmentCollection.getFragmentCollectionId(),
 				liveFragmentEntry.getName());
 
-		Layout stagingLayout = LayoutLocalServiceUtil.getLayoutByUuidAndGroupId(
+		Layout stagingLayout = _layoutLocalService.getLayoutByUuidAndGroupId(
 			_layout.getUuid(), _stagingGroup.getGroupId(), false);
 
 		FragmentTestUtil.addFragmentEntryLink(
@@ -154,7 +154,7 @@ public class FragmentEntryLinkStagingTest {
 	public void testPublishFragmentEntryLink() throws Exception {
 		_stagingGroup = FragmentStagingTestUtil.enableLocalStaging(_liveGroup);
 
-		Layout stagingLayout = LayoutLocalServiceUtil.getLayoutByUuidAndGroupId(
+		Layout stagingLayout = _layoutLocalService.getLayoutByUuidAndGroupId(
 			_layout.getUuid(), _stagingGroup.getGroupId(), false);
 
 		Layout draftStagingLayout = stagingLayout.fetchDraftLayout();
@@ -175,7 +175,7 @@ public class FragmentEntryLinkStagingTest {
 				fragmentEntry.getHtml(), fragmentEntry.getJs(),
 				draftStagingLayout, fragmentEntry.getFragmentEntryKey(),
 				fragmentEntry.getType(), null, 0,
-				SegmentsExperienceLocalServiceUtil.
+				_segmentsExperienceLocalService.
 					fetchDefaultSegmentsExperienceId(
 						draftStagingLayout.getPlid()));
 
@@ -223,8 +223,7 @@ public class FragmentEntryLinkStagingTest {
 		Assert.assertEquals(
 			liveFragmentEntryLink.getGroupId(), liveFragmentEntry.getGroupId());
 
-		StagingLocalServiceUtil.disableStaging(
-			_liveGroup, new ServiceContext());
+		_stagingLocalService.disableStaging(_liveGroup, new ServiceContext());
 
 		FragmentEntryLink fragmentEntryLink =
 			_fragmentEntryLinkLocalService.getFragmentEntryLinkByUuidAndGroupId(
@@ -244,6 +243,9 @@ public class FragmentEntryLinkStagingTest {
 		_fragmentCollectionContributorRegistry;
 
 	@Inject
+	private FragmentCollectionLocalService _fragmentCollectionLocalService;
+
+	@Inject
 	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
 
 	@Inject
@@ -251,9 +253,18 @@ public class FragmentEntryLinkStagingTest {
 
 	private Layout _layout;
 
+	@Inject
+	private LayoutLocalService _layoutLocalService;
+
 	@DeleteAfterTestRun
 	private Group _liveGroup;
 
+	@Inject
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
+
 	private Group _stagingGroup;
+
+	@Inject
+	private StagingLocalService _stagingLocalService;
 
 }

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/staging/test/FragmentEntryLinkStagingTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/staging/test/FragmentEntryLinkStagingTest.java
@@ -7,6 +7,7 @@ package com.liferay.fragment.staging.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.kernel.service.StagingLocalServiceUtil;
+import com.liferay.fragment.contributor.FragmentCollectionContributorRegistry;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.model.FragmentEntryLink;
@@ -67,9 +68,19 @@ public class FragmentEntryLinkStagingTest {
 	public void testFragmentEntryLinkCopiedWhenLocalStagingActivated()
 		throws Exception {
 
+		FragmentEntry fragmentEntry =
+			_fragmentCollectionContributorRegistry.getFragmentEntry(
+				"BASIC_COMPONENT-heading");
+
 		FragmentEntryLink liveFragmentEntryLink =
 			ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
-				null, _layout,
+				null, fragmentEntry.getCss(), fragmentEntry.getConfiguration(),
+				fragmentEntry.getExternalReferenceCode(),
+				ScopeUtil.getItemScopeExternalReferenceCode(
+					fragmentEntry.getGroupId(), _layout.getGroupId()),
+				fragmentEntry.getHtml(), fragmentEntry.getJs(), _layout,
+				fragmentEntry.getFragmentEntryKey(), fragmentEntry.getType(),
+				null, 0,
 				SegmentsExperienceLocalServiceUtil.
 					fetchDefaultSegmentsExperienceId(_layout.getPlid()));
 
@@ -148,9 +159,22 @@ public class FragmentEntryLinkStagingTest {
 
 		Layout draftStagingLayout = stagingLayout.fetchDraftLayout();
 
+		_stagingGroup = FragmentStagingTestUtil.enableLocalStaging(_liveGroup);
+
+		FragmentEntry fragmentEntry =
+			_fragmentCollectionContributorRegistry.getFragmentEntry(
+				"BASIC_COMPONENT-heading");
+
 		FragmentEntryLink stagingFragmentEntryLink =
 			ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
-				null, draftStagingLayout,
+				null, fragmentEntry.getCss(), fragmentEntry.getConfiguration(),
+				fragmentEntry.getExternalReferenceCode(),
+				ScopeUtil.getItemScopeExternalReferenceCode(
+					fragmentEntry.getGroupId(),
+					draftStagingLayout.getGroupId()),
+				fragmentEntry.getHtml(), fragmentEntry.getJs(),
+				draftStagingLayout, fragmentEntry.getFragmentEntryKey(),
+				fragmentEntry.getType(), null, 0,
 				SegmentsExperienceLocalServiceUtil.
 					fetchDefaultSegmentsExperienceId(
 						draftStagingLayout.getPlid()));
@@ -214,6 +238,10 @@ public class FragmentEntryLinkStagingTest {
 					fragmentEntryLink.getFragmentEntryScopeERC(),
 					fragmentEntryLink.getGroupId())));
 	}
+
+	@Inject
+	private FragmentCollectionContributorRegistry
+		_fragmentCollectionContributorRegistry;
 
 	@Inject
 	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;

--- a/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/portlet/action/test/ResetPrototypeMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/portlet/action/test/ResetPrototypeMVCActionCommandTest.java
@@ -7,11 +7,8 @@ package com.liferay.layout.admin.web.internal.portlet.action.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
-import com.liferay.fragment.constants.FragmentConstants;
-import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.contributor.FragmentCollectionContributorRegistry;
 import com.liferay.fragment.model.FragmentEntry;
-import com.liferay.fragment.service.FragmentCollectionLocalService;
-import com.liferay.fragment.service.FragmentEntryLocalService;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRel;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
@@ -48,7 +45,6 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ScopeUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -114,7 +110,9 @@ public class ResetPrototypeMVCActionCommandTest {
 
 		Layout draftLayout = layout.fetchDraftLayout();
 
-		FragmentEntry fragmentEntry = _addFragmentEntry();
+		FragmentEntry fragmentEntry =
+			_fragmentCollectionContributorRegistry.getFragmentEntry(
+				"BASIC_COMPONENT-heading");
 
 		ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
 			null, fragmentEntry.getCss(), fragmentEntry.getConfiguration(),
@@ -166,24 +164,6 @@ public class ResetPrototypeMVCActionCommandTest {
 		Assert.assertEquals(
 			fragmentLayoutStructureItems.toString(), 1,
 			fragmentLayoutStructureItems.size());
-	}
-
-	private FragmentEntry _addFragmentEntry() throws Exception {
-		FragmentCollection fragmentCollection =
-			_fragmentCollectionLocalService.addFragmentCollection(
-				null, TestPropsValues.getUserId(),
-				_layoutSetPrototypeGroup.getGroupId(),
-				RandomTestUtil.randomString(), StringPool.BLANK,
-				_serviceContext);
-
-		return _fragmentEntryLocalService.addFragmentEntry(
-			null, TestPropsValues.getUserId(),
-			_layoutSetPrototypeGroup.getGroupId(),
-			fragmentCollection.getFragmentCollectionId(), null,
-			RandomTestUtil.randomString(), StringPool.BLANK,
-			"Fragment Entry HTML", StringPool.BLANK, false, null, null, 0,
-			false, false, FragmentConstants.TYPE_COMPONENT, null,
-			WorkflowConstants.STATUS_APPROVED, _serviceContext);
 	}
 
 	private LayoutStructure _getLayoutStructure(
@@ -360,10 +340,8 @@ public class ResetPrototypeMVCActionCommandTest {
 	}
 
 	@Inject
-	private FragmentCollectionLocalService _fragmentCollectionLocalService;
-
-	@Inject
-	private FragmentEntryLocalService _fragmentEntryLocalService;
+	private FragmentCollectionContributorRegistry
+		_fragmentCollectionContributorRegistry;
 
 	@DeleteAfterTestRun
 	private Group _group;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87237

**What is being fixed:** `PortalLogAssertorTest` occasionally logs an unexpected warning/error about an "Optional reference generated for missing entity" when the fragment-staging integration tests create a fragment on the fly and then import content that references it.

**How it is being fixed:**
- Use a contributed fragment (one already available in the system) instead of creating a new one on the fly, so the import does not end up generating an optional reference to an entity that does not exist yet.
- Replace the remaining `*ServiceUtil` calls in the affected test with injected service references (`@Inject`), matching the convention already followed by the rest of the test.