### PR TITLE
LPD-86505 Master pages are not properly updated when deploying site initializers

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
@@ -2002,6 +2002,14 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 		_updateLayoutPageTemplateStructure(draftLayout, layoutStructure);
 
 		_layoutLocalService.copyLayoutContent(draftLayout, layout);
+
+		_layoutLocalService.updateStatus(
+			userId, draftLayout.getPlid(), WorkflowConstants.STATUS_APPROVED,
+			ServiceContextThreadLocal.getServiceContext());
+
+		_layoutLocalService.updateStatus(
+			userId, plid, WorkflowConstants.STATUS_APPROVED,
+			ServiceContextThreadLocal.getServiceContext());
 	}
 
 	private boolean _processPageElement(

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
@@ -2185,23 +2185,6 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 		}
 	}
 
-	private void _updateLayouts(long plid, long userId) throws Exception {
-		Layout layout = _layoutLocalService.fetchLayout(plid);
-
-		Layout draftLayout = layout.fetchDraftLayout();
-
-		draftLayout = _layoutLocalService.copyLayoutContent(
-			layout, draftLayout);
-
-		_layoutLocalService.updateStatus(
-			userId, draftLayout.getPlid(), WorkflowConstants.STATUS_APPROVED,
-			ServiceContextThreadLocal.getServiceContext());
-
-		_layoutLocalService.updateStatus(
-			userId, plid, WorkflowConstants.STATUS_APPROVED,
-			ServiceContextThreadLocal.getServiceContext());
-	}
-
 	private Layout _updateLayoutSettings(
 		long userId, Layout layout, Settings settings) {
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
@@ -1635,7 +1635,7 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 			if (added) {
 				Set<String> warningMessages = new HashSet<>();
 
-				_processPageDefinitionViaDraft(
+				_processPageDefinition(
 					layoutPageTemplateEntry.getPlid(), pageDefinition,
 					preserveItemIds, userId, warningMessages);
 
@@ -1810,7 +1810,7 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 			if (added) {
 				Set<String> warningMessages = new HashSet<>();
 
-				_processPageDefinitionViaDraft(
+				_processPageDefinition(
 					layoutUtilityPageEntry.getPlid(), pageDefinition,
 					preserveItemIds, userId, warningMessages);
 
@@ -1944,6 +1944,14 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 
 		Layout layout = _layoutLocalService.getLayout(plid);
 
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		_fragmentEntryLinkLocalService.
+			deleteLayoutPageTemplateEntryFragmentEntryLinks(
+				draftLayout.getGroupId(), draftLayout.getPlid());
+
+		_deleteExistingPortletPreferences(draftLayout.getPlid());
+
 		LayoutStructure layoutStructure = new LayoutStructure();
 
 		if (pageDefinition != null) {
@@ -1963,13 +1971,13 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 						pageElement.getPageElements()) {
 
 					if (_processPageElement(
-							new ArrayList<>(), layout, layoutStructure,
+							new ArrayList<>(), draftLayout, layoutStructure,
 							pageDefinitionVersion, childPageElement,
 							rootLayoutStructureItem.getItemId(), position,
 							preserveItemIds,
 							_segmentsExperienceLocalService.
 								fetchDefaultSegmentsExperienceId(
-									layout.getPlid()),
+									draftLayout.getPlid()),
 							warningMessages)) {
 
 						position++;
@@ -1986,49 +1994,19 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 
 			Settings settings = pageDefinition.getSettings();
 
-			layout = _layoutLocalService.fetchLayout(layout.getPlid());
+			draftLayout = _layoutLocalService.getLayout(draftLayout.getPlid());
 
-			layout = _updateLayoutSettings(userId, layout, settings);
+			draftLayout = _updateLayoutSettings(userId, draftLayout, settings);
 		}
 		else {
 			layoutStructure.addRootLayoutStructureItem();
 		}
 
-		_updateLayoutPageTemplateStructure(layout, layoutStructure);
-	}
-
-	private void _processPageDefinitionViaDraft(
-			long plid, PageDefinition pageDefinition, boolean preserveItemIds,
-			long userId, Set<String> warningMessages)
-		throws Exception {
-
-		Layout layout = _layoutLocalService.fetchLayout(plid);
-
-		Layout draftLayout =
-			(layout == null) ? null : layout.fetchDraftLayout();
-
-		if (draftLayout == null) {
-			_processPageDefinition(
-				plid, pageDefinition, preserveItemIds, userId, warningMessages);
-
-			_updateLayouts(plid, userId);
-
-			return;
-		}
-
-		_fragmentEntryLinkLocalService.
-			deleteLayoutPageTemplateEntryFragmentEntryLinks(
-				draftLayout.getGroupId(), draftLayout.getPlid());
-
-		_deleteExistingPortletPreferences(draftLayout.getPlid());
-
-		_processPageDefinition(
-			draftLayout.getPlid(), pageDefinition, preserveItemIds, userId,
-			warningMessages);
+		_updateLayoutPageTemplateStructure(draftLayout, layoutStructure);
 
 		_layoutLocalService.copyLayoutContent(
-			_layoutLocalService.fetchLayout(draftLayout.getPlid()),
-			_layoutLocalService.fetchLayout(layout.getPlid()));
+			_layoutLocalService.getLayout(draftLayout.getPlid()),
+			_layoutLocalService.getLayout(layout.getPlid()));
 	}
 
 	private boolean _processPageElement(

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
@@ -1992,11 +1992,8 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 				}
 			}
 
-			Settings settings = pageDefinition.getSettings();
-
-			draftLayout = _layoutLocalService.getLayout(draftLayout.getPlid());
-
-			draftLayout = _updateLayoutSettings(userId, draftLayout, settings);
+			draftLayout = _updateLayoutSettings(
+				userId, draftLayout, pageDefinition.getSettings());
 		}
 		else {
 			layoutStructure.addRootLayoutStructureItem();
@@ -2004,9 +2001,7 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 
 		_updateLayoutPageTemplateStructure(draftLayout, layoutStructure);
 
-		_layoutLocalService.copyLayoutContent(
-			_layoutLocalService.getLayout(draftLayout.getPlid()),
-			_layoutLocalService.getLayout(layout.getPlid()));
+		_layoutLocalService.copyLayoutContent(draftLayout, layout);
 	}
 
 	private boolean _processPageElement(

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
@@ -1622,14 +1622,6 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 						LayoutsImportStrategy.OVERWRITE,
 						layoutsImportStrategy)) {
 
-				_fragmentEntryLinkLocalService.
-					deleteLayoutPageTemplateEntryFragmentEntryLinks(
-						layoutPageTemplateEntry.getGroupId(),
-						layoutPageTemplateEntry.getPlid());
-
-				_deleteExistingPortletPreferences(
-					layoutPageTemplateEntry.getPlid());
-
 				layoutPageTemplateEntry =
 					_layoutPageTemplateEntryService.
 						updateLayoutPageTemplateEntry(
@@ -1643,7 +1635,7 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 			if (added) {
 				Set<String> warningMessages = new HashSet<>();
 
-				_processPageDefinition(
+				_processPageDefinitionViaDraft(
 					layoutPageTemplateEntry.getPlid(), pageDefinition,
 					preserveItemIds, userId, warningMessages);
 
@@ -1807,14 +1799,6 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 						LayoutsImportStrategy.OVERWRITE,
 						layoutsImportStrategy)) {
 
-				_fragmentEntryLinkLocalService.
-					deleteLayoutPageTemplateEntryFragmentEntryLinks(
-						layoutUtilityPageEntry.getGroupId(),
-						layoutUtilityPageEntry.getPlid());
-
-				_deleteExistingPortletPreferences(
-					layoutUtilityPageEntry.getPlid());
-
 				layoutUtilityPageEntry =
 					_layoutUtilityPageEntryService.updateLayoutUtilityPageEntry(
 						layoutUtilityPageEntry.getLayoutUtilityPageEntryId(),
@@ -1826,7 +1810,7 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 			if (added) {
 				Set<String> warningMessages = new HashSet<>();
 
-				_processPageDefinition(
+				_processPageDefinitionViaDraft(
 					layoutUtilityPageEntry.getPlid(), pageDefinition,
 					preserveItemIds, userId, warningMessages);
 
@@ -2011,8 +1995,40 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 		}
 
 		_updateLayoutPageTemplateStructure(layout, layoutStructure);
+	}
 
-		_updateLayouts(plid, userId);
+	private void _processPageDefinitionViaDraft(
+			long plid, PageDefinition pageDefinition, boolean preserveItemIds,
+			long userId, Set<String> warningMessages)
+		throws Exception {
+
+		Layout layout = _layoutLocalService.fetchLayout(plid);
+
+		Layout draftLayout =
+			(layout == null) ? null : layout.fetchDraftLayout();
+
+		if (draftLayout == null) {
+			_processPageDefinition(
+				plid, pageDefinition, preserveItemIds, userId, warningMessages);
+
+			_updateLayouts(plid, userId);
+
+			return;
+		}
+
+		_fragmentEntryLinkLocalService.
+			deleteLayoutPageTemplateEntryFragmentEntryLinks(
+				draftLayout.getGroupId(), draftLayout.getPlid());
+
+		_deleteExistingPortletPreferences(draftLayout.getPlid());
+
+		_processPageDefinition(
+			draftLayout.getPlid(), pageDefinition, preserveItemIds, userId,
+			warningMessages);
+
+		_layoutLocalService.copyLayoutContent(
+			_layoutLocalService.fetchLayout(draftLayout.getPlid()),
+			_layoutLocalService.fetchLayout(layout.getPlid()));
 	}
 
 	private boolean _processPageElement(

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
@@ -2001,15 +2001,7 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 
 		_updateLayoutPageTemplateStructure(draftLayout, layoutStructure);
 
-		_layoutLocalService.copyLayoutContent(draftLayout, layout);
-
-		_layoutLocalService.updateStatus(
-			userId, draftLayout.getPlid(), WorkflowConstants.STATUS_APPROVED,
-			ServiceContextThreadLocal.getServiceContext());
-
-		_layoutLocalService.updateStatus(
-			userId, plid, WorkflowConstants.STATUS_APPROVED,
-			ServiceContextThreadLocal.getServiceContext());
+		_publishLayout(draftLayout, layout, userId);
 	}
 
 	private boolean _processPageElement(
@@ -2120,6 +2112,20 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 								"values-in-its-page-definition")));
 			}
 		}
+	}
+
+	private void _publishLayout(Layout draftLayout, Layout layout, long userId)
+		throws Exception {
+
+		_layoutLocalService.copyLayoutContent(draftLayout, layout);
+
+		_layoutLocalService.updateStatus(
+			userId, draftLayout.getPlid(), WorkflowConstants.STATUS_APPROVED,
+			ServiceContextThreadLocal.getServiceContext());
+
+		_layoutLocalService.updateStatus(
+			userId, layout.getPlid(), WorkflowConstants.STATUS_APPROVED,
+			ServiceContextThreadLocal.getServiceContext());
 	}
 
 	private String _toTypeName(int layoutPageTemplateEntryType) {

--- a/modules/apps/layout/layout-page-template-admin-web-test/build.gradle
+++ b/modules/apps/layout/layout-page-template-admin-web-test/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:layout:layout-page-template-test-util")
 	testIntegrationImplementation project(":apps:layout:layout-set-prototype-api")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
+	testIntegrationImplementation project(":apps:layout:layout-utility-page-api")
 	testIntegrationImplementation project(":apps:object:object-api")
 	testIntegrationImplementation project(":apps:object:object-test-util")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
@@ -85,6 +85,7 @@ import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
@@ -573,6 +574,11 @@ public class LayoutsImporterTest {
 		Layout childLayout = LayoutTestUtil.addTypeContentLayout(
 			_group1, false, false,
 			masterLayoutPageTemplateEntry.getExternalReferenceCode());
+
+		PortletPreferencesFactoryUtil.getLayoutPortletSetup(
+			childLayout,
+			LayoutPageTemplateAdminWebPortletKeys.
+				LAYOUT_PAGE_TEMPLATE_ADMIN_WEB_NONINSTANCEABLE_TEST_PORTLET);
 
 		Assert.assertEquals(
 			1,

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
@@ -534,7 +534,7 @@ public class LayoutsImporterTest {
 
 	@Test
 	@TestInfo("LPD-86505")
-	public void testImportLayoutPageTemplateEntryWithMasterChildLayout()
+	public void testImportLayoutPageTemplateEntryWithMasterLayoutAndChildLayout()
 		throws Exception {
 
 		ServiceContextThreadLocal.pushServiceContext(_serviceContext1);

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
@@ -91,6 +91,7 @@ import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
@@ -111,6 +112,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.ScopeUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -526,6 +528,79 @@ public class LayoutsImporterTest {
 
 		_testImportLayoutPageTemplateEntryWithItemSelectorTypeFragmentConfigurationField(
 			_jsonFactory.createJSONObject());
+	}
+
+	@Test
+	@TestInfo("LPD-86505")
+	public void testImportLayoutPageTemplateEntryWithMasterChildLayout()
+		throws Exception {
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext1);
+
+		try {
+			_layoutsImporter.importFile(
+				TestPropsValues.getUserId(), _group1.getGroupId(),
+				LayoutPageTemplateConstants.
+					PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
+				_getFile(_RESOURCES_PATH_MASTER_PAGES),
+				LayoutsImportStrategy.OVERWRITE, true);
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
+
+		LayoutPageTemplateEntry masterLayoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.fetchLayoutPageTemplateEntry(
+				_group1.getGroupId(),
+				LayoutPageTemplateConstants.
+					PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
+				"Default Master Page",
+				LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT);
+
+		Layout masterPublishedLayout = _layoutLocalService.getLayout(
+			masterLayoutPageTemplateEntry.getPlid());
+
+		Layout masterDraftLayout = masterPublishedLayout.fetchDraftLayout();
+
+		ContentLayoutTestUtil.addPortletToLayout(
+			masterDraftLayout,
+			LayoutPageTemplateAdminWebPortletKeys.
+				LAYOUT_PAGE_TEMPLATE_ADMIN_WEB_NONINSTANCEABLE_TEST_PORTLET);
+
+		ContentLayoutTestUtil.publishLayout(
+			masterDraftLayout, masterPublishedLayout);
+
+		Layout childLayout = LayoutTestUtil.addTypeContentLayout(
+			_group1, false, false,
+			masterLayoutPageTemplateEntry.getExternalReferenceCode());
+
+		Assert.assertEquals(
+			1,
+			_portletPreferencesLocalService.getPortletPreferences(
+				PortletKeys.PREFS_OWNER_ID_DEFAULT,
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, childLayout.getPlid()
+			).size());
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext1);
+
+		try {
+			_layoutsImporter.importFile(
+				TestPropsValues.getUserId(), _group1.getGroupId(),
+				LayoutPageTemplateConstants.
+					PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
+				_getFile(_RESOURCES_PATH_MASTER_PAGES),
+				LayoutsImportStrategy.OVERWRITE, true);
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
+
+		Assert.assertEquals(
+			0,
+			_portletPreferencesLocalService.getPortletPreferences(
+				PortletKeys.PREFS_OWNER_ID_DEFAULT,
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, childLayout.getPlid()
+			).size());
 	}
 
 	@Test
@@ -2471,6 +2546,9 @@ public class LayoutsImporterTest {
 
 	@Inject
 	private Portal _portal;
+
+	@Inject
+	private PortletPreferencesLocalService _portletPreferencesLocalService;
 
 	@Inject
 	private ResourcePermissionLocalService _resourcePermissionLocalService;

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
@@ -60,6 +60,8 @@ import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.layout.util.structure.RowStyledLayoutStructureItem;
+import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
+import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
@@ -1050,6 +1052,44 @@ public class LayoutsImporterTest {
 		finally {
 			ServiceContextThreadLocal.popServiceContext();
 		}
+	}
+
+	@Test
+	@TestInfo("LPD-86505")
+	public void testImportUtilityPageEntryIsApprovedAndCanBeSetAsDefault()
+		throws Exception {
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext1);
+
+		try {
+			_layoutsImporter.importFile(
+				TestPropsValues.getUserId(), _group1.getGroupId(),
+				LayoutPageTemplateConstants.
+					PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
+				_getFile(_RESOURCES_PATH_UTILITY_PAGES),
+				LayoutsImportStrategy.OVERWRITE, true);
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
+
+		LayoutUtilityPageEntry layoutUtilityPageEntry =
+			_layoutUtilityPageEntryLocalService.
+				getLayoutUtilityPageEntryByExternalReferenceCode(
+					"test-default-utility-page", _group1.getGroupId());
+
+		Layout layout = _layoutLocalService.getLayout(
+			layoutUtilityPageEntry.getPlid());
+
+		Assert.assertTrue(layout.isPublished());
+
+		layoutUtilityPageEntry =
+			_layoutUtilityPageEntryLocalService.
+				setDefaultLayoutUtilityPageEntry(
+					layoutUtilityPageEntry.getLayoutUtilityPageEntryId());
+
+		Assert.assertTrue(
+			layoutUtilityPageEntry.isDefaultLayoutUtilityPageEntry());
 	}
 
 	@Test
@@ -2481,6 +2521,10 @@ public class LayoutsImporterTest {
 		"com/liferay/layout/page/template/admin/web/internal/importer/test" +
 			"/dependencies/page-templates";
 
+	private static final String _RESOURCES_PATH_UTILITY_PAGES =
+		"com/liferay/layout/page/template/admin/web/internal/importer/test" +
+			"/dependencies/utility-pages";
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		LayoutsImporterTest.class);
 
@@ -2552,6 +2596,10 @@ public class LayoutsImporterTest {
 
 	@Inject
 	private LayoutStructureProvider _layoutStructureProvider;
+
+	@Inject
+	private LayoutUtilityPageEntryLocalService
+		_layoutUtilityPageEntryLocalService;
 
 	@Inject
 	private Portal _portal;

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
@@ -80,6 +80,7 @@ import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.model.PortletPreferences;
 import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
@@ -580,12 +581,13 @@ public class LayoutsImporterTest {
 			LayoutPageTemplateAdminWebPortletKeys.
 				LAYOUT_PAGE_TEMPLATE_ADMIN_WEB_NONINSTANCEABLE_TEST_PORTLET);
 
-		Assert.assertEquals(
-			1,
+		List<PortletPreferences> portletPreferences =
 			_portletPreferencesLocalService.getPortletPreferences(
 				PortletKeys.PREFS_OWNER_ID_DEFAULT,
-				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, childLayout.getPlid()
-			).size());
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, childLayout.getPlid());
+
+		Assert.assertEquals(
+			portletPreferences.toString(), 1, portletPreferences.size());
 
 		ServiceContextThreadLocal.pushServiceContext(_serviceContext1);
 
@@ -601,12 +603,13 @@ public class LayoutsImporterTest {
 			ServiceContextThreadLocal.popServiceContext();
 		}
 
-		Assert.assertEquals(
-			0,
+		portletPreferences =
 			_portletPreferencesLocalService.getPortletPreferences(
 				PortletKeys.PREFS_OWNER_ID_DEFAULT,
-				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, childLayout.getPlid()
-			).size());
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, childLayout.getPlid());
+
+		Assert.assertEquals(
+			portletPreferences.toString(), 0, portletPreferences.size());
 	}
 
 	@Test

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/importer/test/dependencies/utility-pages/default-utility-page/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/importer/test/dependencies/utility-pages/default-utility-page/page-definition.json
@@ -1,0 +1,20 @@
+{
+	"pageElement": {
+		"pageElements": [
+			{
+				"definition": {
+					"indexed": true,
+					"layout": {
+					}
+				},
+				"type": "Section"
+			}
+		],
+		"type": "Root"
+	},
+	"settings": {
+		"colorSchemeName": "01",
+		"themeName": "Classic"
+	},
+	"version": 1.1
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/importer/test/dependencies/utility-pages/default-utility-page/utility-page.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/importer/test/dependencies/utility-pages/default-utility-page/utility-page.json
@@ -1,0 +1,6 @@
+{
+	"defaultTemplate": false,
+	"externalReferenceCode": "test-default-utility-page",
+	"name": "Test Default Utility Page",
+	"type": "ErrorCode404"
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86505

Follow-up to https://github.com/brianchandotcom/liferay-portal/pull/173255. The original PR has been merged in Brian's repo but master is not syncing due to the `BundleSiteInitializerTest` failure discussed in this thread: https://liferay.slack.com/archives/CLCD3DQLF/p1776968780715329.

**What is being fixed:** Master pages and utility pages imported through site initializers are left in a non-approved state after the refactor in PR 173255, which causes `setDefaultLayoutUtilityPageEntry` to fail with `DefaultLayoutUtilityPageEntryException` during `BundleSiteInitializer._setDefaultLayoutUtilityPageEntries`. This breaks `BundleSiteInitializerTest` and is blocking the sync to master. The original PR also leaves orphaned portlet preferences in master child layouts when portlets are removed from master pages via a site initializer — addressed by the routing through draft-then-publish (the commits coming from PR 173255, included here so this branch applies cleanly on top of master).

**How it is being fixed:** Route the master page template and utility page imports through the draft-then-publish flow so the centralized cleanup in `LayoutLocalServiceWrapper` runs, and restore the `updateStatus(STATUS_APPROVED)` step on both the draft and live layouts after `copyLayoutContent` — previously provided by the now-removed `_updateLayouts` helper — extracting the sequence into a small `_publishLayout` helper for clarity. Add a regression integration test in `LayoutsImporterTest` that imports a utility page and asserts `setDefaultLayoutUtilityPageEntry` succeeds.

Verified locally:

- `BundleSiteInitializerTest` (3 tests) fails with `DefaultLayoutUtilityPageEntryException` when PR 173255 is applied alone, and passes once the fix is added on top.
- `LayoutsImporterTest` compiles and runs with the new regression test.