### PR TITLE
LPD-60822 Show add button in content page editor card items only for keyboard interaction like with list items

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabItem.js
@@ -258,7 +258,7 @@ const CardItem = ({
 				'page-editor__fragments-widgets__tab-card-item',
 				{
 					disabled,
-					'page-editor__fragments-widgets__tab-list-item--active':
+					'page-editor__fragments-widgets__tab-card-item--active':
 						isActive,
 				}
 			)}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_TabItem.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_TabItem.scss
@@ -5,14 +5,16 @@ html#{$cadmin-selector} .cadmin .page-editor__fragments-widgets__tab {
 		cursor: grab;
 		transition: transform ease 0.3s;
 
-		&:focus-visible {
+		&:focus-visible,
+		&--active {
 			.page-editor__fragments-widgets__tab__add-button {
 				opacity: 1;
 			}
 		}
 
 		&:hover:not(.disabled),
-		&:focus-visible {
+		&:focus-visible,
+		&--active {
 			box-shadow: 0 4px 8px fade_out($cadmin-gray-900, 0.9);
 			outline: none;
 			transform: translateY(-4px);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_TabItem.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_TabItem.scss
@@ -5,17 +5,14 @@ html#{$cadmin-selector} .cadmin .page-editor__fragments-widgets__tab {
 		cursor: grab;
 		transition: transform ease 0.3s;
 
-		&:focus-within {
-			transform: translateY(-4px);
-
-			.page-editor__fragments-widgets__tab__highlight-button,
+		&:focus-visible {
 			.page-editor__fragments-widgets__tab__add-button {
 				opacity: 1;
 			}
 		}
 
 		&:hover:not(.disabled),
-		&:focus {
+		&:focus-visible {
 			box-shadow: 0 4px 8px fade_out($cadmin-gray-900, 0.9);
 			outline: none;
 			transform: translateY(-4px);


### PR DESCRIPTION
# Summary of Changes

After correcting a typo in a CSS class used for card items, I followed the same scss changes performed in [LPS-175831](https://liferay.atlassian.net/browse/LPS-175831) to show the + button only when interacting via the keyboard (since it's not intended to be interactive with the mouse; drag-and-drop is used in that case). 

As a  side effect, clicking on a card item won't leave it selected. This behavior doesn't happen with list items so the behavior is uniform now.

# Motivation / Context

[LPD-60822](https://liferay.atlassian.net/browse/LPD-60822)
- When editing a content page the fragments can be shown as cards or as list items. List items will only show the + button  when interacting via the keyboard. When using the mouse you have to drag and drop the fragment into the interactive area. Card items did show the + button when clicking on the card but the + button is not interactive via the mouse. 
- The solution is to make the behavior of both cards and list items parallel. The correct behavior for list items was implemented in [LPS-175831](https://liferay.atlassian.net/browse/LPS-175831). The solution for cards is analogous.

# Technical Approach

- Leverage the directive `focus-visible` instead of `focus-within` while keeping the style when the card is active.

# Validation Performed

**Automated Tests**

- [ ] Unit tests
- [ ] Integration tests
- [ ] Functional / end-to-end tests
- [x] Not applicable (explain why)

I've tried to add a test in `test/page_editor/app/plugins/fragments_and_widgets/components/TabCollection.test.js` to check that the add button is not visible in mouse interactions but the method `toBeVisible` returns `true`. I think this is due to how the jest library computes this method and in particular `isStyleVisible` (see [code](https://github.com/testing-library/jest-dom/blob/main/src/to-be-visible.js)). Please let me know if there's some way to create a useful test for this.

**Manual Testing**

- Steps:
  1. Edit a content page.
  2. Open the Components section on the left hand side to show the fragments available.
  3. Click on the 3-dot menu > Switch to Card View.
  4. Click on a card.
- Expected result: The + button to add the fragment is not shown since interaction is via drag-and-drop. It should only show when interacting with the keyboard.
- Actual result: The + button to add the fragment is shown.

# UI / UX Changes

- [ ] No UI changes
- [x] UI changes included (screenshots/media below)

**Screenshots / Media (Before & After)**

| Before | After |
| ------ | ----- |
|![before](https://github.com/user-attachments/assets/b4e8c64b-27bf-4437-83d6-751267fd3b22) |![after](https://github.com/user-attachments/assets/74bcaa41-8471-4c62-8cfa-07eded0c27ee) |


# Checklist for Author

- [x] Linked to the correct Jira / LPD / related ticket.
- [ ] Relevant unit tests updated/added and passed locally.
- [ ] Relevant integration / functional / Playwright tests updated/added and passed locally (if applicable).
- [ ] ci:test:sf has been run and is green.
- [ ] ci:test:relevant has been run and is green.
- [ ] Any domain‑specific suites (ci:test:security, ci:test:ldap, ci:test:oauth2, ci:test:saml, …) have been run if the change touches those areas.
- [ ] No unique CI failures remain (anything unique is investigated and fixed).
- [x] Self-reviewed the code (style, naming, dead code, logs, etc.).
- [ ] Updated documentation / comments where needed.


[LPS-175831]: https://liferay.atlassian.net/browse/LPS-175831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-60822]: https://liferay.atlassian.net/browse/LPD-60822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPS-175831]: https://liferay.atlassian.net/browse/LPS-175831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ