### PR TITLE
LPD-85494 Fix asset publisher export/import plid and mapping errors

### DIFF
--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/internal/exportimport/portlet/preferences/processor/test/AssetPublisherExportImportPortletPreferencesProcessorTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/internal/exportimport/portlet/preferences/processor/test/AssetPublisherExportImportPortletPreferencesProcessorTest.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -139,6 +140,71 @@ public class AssetPublisherExportImportPortletPreferencesProcessorTest {
 		Assert.assertEquals(
 			assetVocabulary.getVocabularyId(),
 			GetterUtil.getLong(importedVocabularyId));
+	}
+
+	@Test
+	public void testProcessExportPortletPreferencesWhenPlidIsZero()
+		throws Exception {
+
+		_portletDataContextExport.setPlid(0);
+
+		_portletPreferences.setValue(
+			"scopeIds", String.valueOf(_group.getGroupId()));
+
+		_portletPreferences.store();
+
+		PortletPreferences exportedPortletPreferences =
+			_exportImportPortletPreferencesProcessor.
+				processExportPortletPreferences(
+					_portletDataContextExport, _portletPreferences);
+
+		Assert.assertNotNull(exportedPortletPreferences);
+	}
+
+	@Test
+	public void testProcessImportPortletPreferencesWhenGroupIdMappingsElementIsMissing()
+		throws Exception {
+
+		_portletPreferences.setValue(
+			"scopeIds", String.valueOf(_group.getGroupId()));
+
+		_portletPreferences.store();
+
+		Element importDataRootElement =
+			_portletDataContextImport.getImportDataRootElement();
+
+		Assert.assertNull(importDataRootElement.element("group-id-mappings"));
+
+		PortletPreferences importedPortletPreferences =
+			_exportImportPortletPreferencesProcessor.
+				processImportPortletPreferences(
+					_portletDataContextImport, _portletPreferences);
+
+		Assert.assertNotNull(importedPortletPreferences);
+	}
+
+	@Test
+	public void testProcessImportPortletPreferencesWhenPlidIsZero()
+		throws Exception {
+
+		_portletDataContextImport.setPlid(0);
+
+		_portletPreferences.setValue(
+			"scopeIds", String.valueOf(_group.getGroupId()));
+
+		_portletPreferences.store();
+
+		Element importDataRootElement =
+			_portletDataContextImport.getImportDataRootElement();
+
+		importDataRootElement.addElement("group-id-mappings");
+
+		PortletPreferences importedPortletPreferences =
+			_exportImportPortletPreferencesProcessor.
+				processImportPortletPreferences(
+					_portletDataContextImport, _portletPreferences);
+
+		Assert.assertNotNull(importedPortletPreferences);
 	}
 
 	@Test

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
@@ -1191,7 +1191,7 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 
 		String[] oldValues = portletPreferences.getValues(key, null);
 
-		if (oldValues == null) {
+		if ((oldValues == null) || (plid <= 0)) {
 			return;
 		}
 
@@ -1391,15 +1391,19 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 			return;
 		}
 
-		StagedModelDataHandler<StagedGroup> stagedModelDataHandler =
-			(StagedModelDataHandler<StagedGroup>)
-				StagedModelDataHandlerRegistryUtil.getStagedModelDataHandler(
-					StagedGroup.class.getName());
-
 		Element rootElement = portletDataContext.getImportDataRootElement();
 
 		Element groupIdMappingsElement = rootElement.element(
 			"group-id-mappings");
+
+		if (groupIdMappingsElement == null) {
+			return;
+		}
+
+		StagedModelDataHandler<StagedGroup> stagedModelDataHandler =
+			(StagedModelDataHandler<StagedGroup>)
+				StagedModelDataHandlerRegistryUtil.getStagedModelDataHandler(
+					StagedGroup.class.getName());
 
 		for (Element groupIdMappingElement :
 				groupIdMappingsElement.elements("group-id-mapping")) {
@@ -1408,11 +1412,15 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 				portletDataContext, groupIdMappingElement);
 		}
 
+		Layout layout = layoutLocalService.fetchLayout(plid);
+
+		if (layout == null) {
+			return;
+		}
+
 		Map<Long, Long> groupIds =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
 				Group.class);
-
-		Layout layout = layoutLocalService.getLayout(plid);
 
 		List<String> newValues = TransformUtil.transformToList(
 			oldValues,

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
@@ -473,10 +473,15 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 			PortletPreferences portletPreferences)
 		throws Exception {
 
+		long plid = portletDataContext.getPlid();
+
+		if (plid <= 0) {
+			return;
+		}
+
 		List<AssetEntry> assetEntries = null;
 
-		Layout layout = layoutLocalService.getLayout(
-			portletDataContext.getPlid());
+		Layout layout = layoutLocalService.getLayout(plid);
 
 		String selectionStyle = portletPreferences.getValue(
 			"selectionStyle",
@@ -829,9 +834,15 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 			PortletPreferences portletPreferences)
 		throws Exception {
 
+		long plid = portletDataContext.getPlid();
+
+		if (plid <= 0) {
+			return;
+		}
+
 		PortletPreferences originalPortletPreferences =
 			PortletPreferencesFactoryUtil.getLayoutPortletSetup(
-				layoutLocalService.getLayout(portletDataContext.getPlid()),
+				layoutLocalService.getLayout(plid),
 				portletDataContext.getPortletId());
 
 		String[] values = originalPortletPreferences.getValues(


### PR DESCRIPTION
[LPD-85494](https://liferay.atlassian.net/browse/LPD-85494)

Forwarding from: https://github.com/liferay-headless/liferay-portal/pull/3678

When portlet preferences refer to embedded portlets, the `plid` will be 0. This issue was found while executing `liferay.com` testing.

cc: @4lejandrito

[LPD-85494]: https://liferay.atlassian.net/browse/LPD-85494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ