### PR TITLE
LPD-85565 Can not import a page when one of its portlets is undeployed

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/layout/structure/item/importer/WidgetInstanceLayoutStructureItemImporter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/layout/structure/item/importer/WidgetInstanceLayoutStructureItemImporter.java
@@ -228,7 +228,7 @@ public class WidgetInstanceLayoutStructureItemImporter
 	private String _getInstanceId(String widgetInstanceId, String widgetName) {
 		Portlet portlet = PortletLocalServiceUtil.getPortletById(widgetName);
 
-		if (portlet.isInstanceable()) {
+		if ((portlet != null) && portlet.isInstanceable()) {
 			return widgetInstanceId;
 		}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
@@ -376,6 +376,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		_testPutSitePageSpecificationPageExperiencePageElementWithFormContainerPageElement();
 		_testPutSitePageSpecificationPageExperiencePageElementWithFragmentPageElement();
 		_testPutSitePageSpecificationPageExperiencePageElementWithGridPageElement();
+		_testPutSitePageSpecificationPageExperiencePageElementWithUndeployedPortletWidgetPageElement();
 		_testPutSitePageSpecificationPageExperiencePageElementWithWidgetPageElement();
 	}
 
@@ -4228,6 +4229,43 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 
 		_testPutSitePageSpecificationPageExperiencePageElement(
 			_getGridPageElementDefaultValues(externalReferenceCode));
+	}
+
+	private void _testPutSitePageSpecificationPageExperiencePageElementWithUndeployedPortletWidgetPageElement()
+		throws Exception {
+
+		String draftWidgetInstanceExternalReferenceCode =
+			RandomTestUtil.randomString();
+		String namespace = RandomTestUtil.randomString();
+
+		_addFragmentEntryLink(
+			draftWidgetInstanceExternalReferenceCode, namespace);
+
+		String undeployedPortletName =
+			"com_liferay_test_UndeployedPortlet_" +
+				RandomTestUtil.randomString();
+
+		PageElement pageElement = _getWidgetPageElement(
+			null, RandomTestUtil.randomStrings(RandomTestUtil.randomInt(1, 10)),
+			draftWidgetInstanceExternalReferenceCode, false,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			_getWidgetConfig(), RandomTestUtil.randomString(), namespace,
+			undeployedPortletName, _getWidgetPermissions());
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				testGroup.getGroupId(), SegmentsExperienceConstants.KEY_DEFAULT,
+				_layout.getPlid());
+
+		PageElement putPageElement =
+			pageElementResource.
+				putSitePageSpecificationPageExperiencePageElement(
+					testGroup.getExternalReferenceCode(),
+					_draftLayout.getExternalReferenceCode(),
+					segmentsExperience.getExternalReferenceCode(),
+					pageElement.getExternalReferenceCode(), pageElement);
+
+		assertValid(putPageElement);
 	}
 
 	private void _testPutSitePageSpecificationPageExperiencePageElementWithWidgetPageElement()

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
@@ -362,44 +362,8 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		_testPostSitePageSpecificationPageExperiencePageElementWithFormContainerPageElement();
 		_testPostSitePageSpecificationPageExperiencePageElementWithFragmentPageElement();
 		_testPostSitePageSpecificationPageExperiencePageElementWithGridPageElement();
+		_testPostSitePageSpecificationPageExperiencePageElementWithUndeployedPortletWidgetPageElement();
 		_testPostSitePageSpecificationPageExperiencePageElementWithWidgetPageElement();
-	}
-
-	@Test
-	public void testPostSitePageSpecificationPageExperiencePageElementWithUndeployedPortlet()
-		throws Exception {
-
-		String draftWidgetInstanceExternalReferenceCode =
-			RandomTestUtil.randomString();
-		String namespace = RandomTestUtil.randomString();
-
-		_addFragmentEntryLink(
-			draftWidgetInstanceExternalReferenceCode, namespace);
-
-		String undeployedPortletName =
-			"com_liferay_test_UndeployedPortlet_" +
-				RandomTestUtil.randomString();
-
-		PageElement pageElement = _getWidgetPageElement(
-			null, RandomTestUtil.randomStrings(RandomTestUtil.randomInt(1, 10)),
-			draftWidgetInstanceExternalReferenceCode, false,
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			_getWidgetConfig(), RandomTestUtil.randomString(), namespace,
-			undeployedPortletName, _getWidgetPermissions());
-
-		SegmentsExperience segmentsExperience =
-			_segmentsExperienceLocalService.fetchSegmentsExperience(
-				testGroup.getGroupId(), SegmentsExperienceConstants.KEY_DEFAULT,
-				_layout.getPlid());
-
-		PageElement postPageElement =
-			pageElementResource.
-				postSitePageSpecificationPageExperiencePageElement(
-					testGroup.getExternalReferenceCode(),
-					_draftLayout.getExternalReferenceCode(),
-					segmentsExperience.getExternalReferenceCode(), pageElement);
-
-		assertValid(postPageElement);
 	}
 
 	@Override
@@ -2545,6 +2509,42 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		_assertStyledLayoutStructureItemBackgroundImage(
 			backgroundImageValue, journalArticle.getResourcePrimKey(),
 			journalArticle, pageElement.getExternalReferenceCode());
+	}
+
+	private void _testPostSitePageSpecificationPageExperiencePageElementWithUndeployedPortletWidgetPageElement()
+		throws Exception {
+
+		String draftWidgetInstanceExternalReferenceCode =
+			RandomTestUtil.randomString();
+		String namespace = RandomTestUtil.randomString();
+
+		_addFragmentEntryLink(
+			draftWidgetInstanceExternalReferenceCode, namespace);
+
+		String undeployedPortletName =
+			"com_liferay_test_UndeployedPortlet_" +
+				RandomTestUtil.randomString();
+
+		PageElement pageElement = _getWidgetPageElement(
+			null, RandomTestUtil.randomStrings(RandomTestUtil.randomInt(1, 10)),
+			draftWidgetInstanceExternalReferenceCode, false,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			_getWidgetConfig(), RandomTestUtil.randomString(), namespace,
+			undeployedPortletName, _getWidgetPermissions());
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				testGroup.getGroupId(), SegmentsExperienceConstants.KEY_DEFAULT,
+				_layout.getPlid());
+
+		PageElement postPageElement =
+			pageElementResource.
+				postSitePageSpecificationPageExperiencePageElement(
+					testGroup.getExternalReferenceCode(),
+					_draftLayout.getExternalReferenceCode(),
+					segmentsExperience.getExternalReferenceCode(), pageElement);
+
+		assertValid(postPageElement);
 	}
 
 	private void _testPostSitePageSpecificationPageExperiencePageElementWithWidgetPageElement()

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
@@ -2546,6 +2546,17 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 					segmentsExperience.getExternalReferenceCode(), pageElement);
 
 		assertValid(postPageElement);
+
+		WidgetInstancePageElementDefinition
+			postWidgetInstancePageElementDefinition =
+				(WidgetInstancePageElementDefinition)
+					postPageElement.getPageElementDefinition();
+
+		WidgetInstance postWidgetInstance =
+			postWidgetInstancePageElementDefinition.getWidgetInstance();
+
+		Assert.assertEquals(
+			undeployedPortletName, postWidgetInstance.getWidgetName());
 	}
 
 	private void _testPostSitePageSpecificationPageExperiencePageElementWithWidgetPageElement()
@@ -4266,6 +4277,17 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 					pageElement.getExternalReferenceCode(), pageElement);
 
 		assertValid(putPageElement);
+
+		WidgetInstancePageElementDefinition
+			putWidgetInstancePageElementDefinition =
+				(WidgetInstancePageElementDefinition)
+					putPageElement.getPageElementDefinition();
+
+		WidgetInstance putWidgetInstance =
+			putWidgetInstancePageElementDefinition.getWidgetInstance();
+
+		Assert.assertEquals(
+			undeployedPortletName, putWidgetInstance.getWidgetName());
 	}
 
 	private void _testPutSitePageSpecificationPageExperiencePageElementWithWidgetPageElement()

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
@@ -366,7 +366,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 	}
 
 	@Test
-	public void testPostSitePageSpecificationPageExperiencePageElementWithUndeployedWidget()
+	public void testPostSitePageSpecificationPageExperiencePageElementWithUndeployedPortlet()
 		throws Exception {
 
 		String draftWidgetInstanceExternalReferenceCode =
@@ -376,8 +376,8 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		_addFragmentEntryLink(
 			draftWidgetInstanceExternalReferenceCode, namespace);
 
-		String undeployedWidgetName =
-			"com_liferay_test_undeployed_NonexistentPortlet_" +
+		String undeployedPortletName =
+			"com_liferay_test_UndeployedPortlet_" +
 				RandomTestUtil.randomString();
 
 		PageElement pageElement = _getWidgetPageElement(
@@ -385,7 +385,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 			draftWidgetInstanceExternalReferenceCode, false,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			_getWidgetConfig(), RandomTestUtil.randomString(), namespace,
-			undeployedWidgetName, _getWidgetPermissions());
+			undeployedPortletName, _getWidgetPermissions());
 
 		SegmentsExperience segmentsExperience =
 			_segmentsExperienceLocalService.fetchSegmentsExperience(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
@@ -365,6 +365,43 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		_testPostSitePageSpecificationPageExperiencePageElementWithWidgetPageElement();
 	}
 
+	@Test
+	public void testPostSitePageSpecificationPageExperiencePageElementWithUndeployedWidget()
+		throws Exception {
+
+		String draftWidgetInstanceExternalReferenceCode =
+			RandomTestUtil.randomString();
+		String namespace = RandomTestUtil.randomString();
+
+		_addFragmentEntryLink(
+			draftWidgetInstanceExternalReferenceCode, namespace);
+
+		String undeployedWidgetName =
+			"com_liferay_test_undeployed_NonexistentPortlet_" +
+				RandomTestUtil.randomString();
+
+		PageElement pageElement = _getWidgetPageElement(
+			null, RandomTestUtil.randomStrings(RandomTestUtil.randomInt(1, 10)),
+			draftWidgetInstanceExternalReferenceCode, false,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			_getWidgetConfig(), RandomTestUtil.randomString(), namespace,
+			undeployedWidgetName, _getWidgetPermissions());
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				testGroup.getGroupId(), SegmentsExperienceConstants.KEY_DEFAULT,
+				_layout.getPlid());
+
+		PageElement postPageElement =
+			pageElementResource.
+				postSitePageSpecificationPageExperiencePageElement(
+					testGroup.getExternalReferenceCode(),
+					_draftLayout.getExternalReferenceCode(),
+					segmentsExperience.getExternalReferenceCode(), pageElement);
+
+		assertValid(postPageElement);
+	}
+
 	@Override
 	@Test
 	public void testPutSitePageSpecificationPageExperiencePageElement()


### PR DESCRIPTION
[LPD-85565](https://liferay.atlassian.net/browse/LPD-85565)

This change fixes the scenario of importing a page, that contains a portlet, which is not deployed in the current instance. The import will be successful and a warning would be shown on the page in the place of the widget.

This issue was found while executing `liferay.com` testing.

cc: @4lejandrito

Forwarding from: https://github.com/liferay-headless/liferay-portal/pull/3684

[LPD-85565]: https://liferay.atlassian.net/browse/LPD-85565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ