### PR TITLE
LPD-87404 Improve performance of the FragmentEntryLink usage queries backing View Usages

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.petra.sql.dsl.query.FromStep;
 import com.liferay.petra.sql.dsl.query.GroupByStep;
 import com.liferay.petra.sql.dsl.query.LimitStep;
@@ -858,20 +859,7 @@ public class FragmentEntryLinkLocalServiceImpl
 		Predicate predicate = _getFragmentEntryLinksByFragmentEntryPredicate(
 			fragmentEntry, scopeGroupId
 		).and(
-			FragmentEntryLinkTable.INSTANCE.plid.notIn(
-				DSLQueryFactoryUtil.select(
-					LayoutTable.INSTANCE.plid
-				).from(
-					LayoutTable.INSTANCE
-				).innerJoinON(
-					LayoutPageTemplateEntryTable.INSTANCE,
-					LayoutTable.INSTANCE.plid.eq(
-						LayoutPageTemplateEntryTable.INSTANCE.plid
-					).or(
-						LayoutTable.INSTANCE.classPK.eq(
-							LayoutPageTemplateEntryTable.INSTANCE.plid)
-					)
-				))
+			FragmentEntryLinkTable.INSTANCE.plid.notIn(_getPlidsDSLQuery(null))
 		);
 
 		if (maxCreateDatePredicate) {
@@ -897,22 +885,9 @@ public class FragmentEntryLinkLocalServiceImpl
 			fragmentEntry, scopeGroupId
 		).and(
 			FragmentEntryLinkTable.INSTANCE.plid.in(
-				DSLQueryFactoryUtil.select(
-					LayoutTable.INSTANCE.plid
-				).from(
-					LayoutTable.INSTANCE
-				).innerJoinON(
-					LayoutPageTemplateEntryTable.INSTANCE,
-					LayoutTable.INSTANCE.plid.eq(
-						LayoutPageTemplateEntryTable.INSTANCE.plid
-					).or(
-						LayoutTable.INSTANCE.classPK.eq(
-							LayoutPageTemplateEntryTable.INSTANCE.plid)
-					)
-				).where(
+				_getPlidsDSLQuery(
 					LayoutPageTemplateEntryTable.INSTANCE.type.eq(
-						layoutPageTemplateType)
-				))
+						layoutPageTemplateType)))
 		);
 
 		if (maxCreateDatePredicate) {
@@ -969,6 +944,24 @@ public class FragmentEntryLinkLocalServiceImpl
 			return orderByStep.orderBy(
 				FragmentEntryLinkTable.INSTANCE, orderByComparator);
 		};
+	}
+
+	private DSLQuery _getPlidsDSLQuery(Predicate predicate) {
+		return DSLQueryFactoryUtil.select(
+			LayoutTable.INSTANCE.plid
+		).from(
+			LayoutTable.INSTANCE
+		).innerJoinON(
+			LayoutPageTemplateEntryTable.INSTANCE,
+			LayoutTable.INSTANCE.plid.eq(
+				LayoutPageTemplateEntryTable.INSTANCE.plid
+			).or(
+				LayoutTable.INSTANCE.classPK.eq(
+					LayoutPageTemplateEntryTable.INSTANCE.plid)
+			)
+		).where(
+			predicate
+		);
 	}
 
 	private String _getProcessedHTML(

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -26,8 +26,6 @@ import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
-import com.liferay.petra.sql.dsl.Table;
-import com.liferay.petra.sql.dsl.expression.Expression;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.sql.dsl.query.FromStep;
 import com.liferay.petra.sql.dsl.query.GroupByStep;
@@ -857,26 +855,24 @@ public class FragmentEntryLinkLocalServiceImpl
 			boolean maxCreateDatePredicate, long scopeGroupId)
 		throws PortalException {
 
-		Table<LayoutTable> tempLayoutTableTable = DSLQueryFactoryUtil.select(
-			LayoutTable.INSTANCE.plid
-		).from(
-			LayoutTable.INSTANCE
-		).leftJoinOn(
-			LayoutPageTemplateEntryTable.INSTANCE,
-			LayoutTable.INSTANCE.plid.eq(
-				LayoutPageTemplateEntryTable.INSTANCE.plid
-			).or(
-				LayoutTable.INSTANCE.classPK.eq(
-					LayoutPageTemplateEntryTable.INSTANCE.plid)
-			)
-		).where(
-			LayoutPageTemplateEntryTable.INSTANCE.plid.isNull()
-		).as(
-			"tempLayoutTable", LayoutTable.INSTANCE
-		);
-
 		Predicate predicate = _getFragmentEntryLinksByFragmentEntryPredicate(
-			fragmentEntry, scopeGroupId);
+			fragmentEntry, scopeGroupId
+		).and(
+			FragmentEntryLinkTable.INSTANCE.plid.notIn(
+				DSLQueryFactoryUtil.select(
+					LayoutTable.INSTANCE.plid
+				).from(
+					LayoutTable.INSTANCE
+				).innerJoinON(
+					LayoutPageTemplateEntryTable.INSTANCE,
+					LayoutTable.INSTANCE.plid.eq(
+						LayoutPageTemplateEntryTable.INSTANCE.plid
+					).or(
+						LayoutTable.INSTANCE.classPK.eq(
+							LayoutPageTemplateEntryTable.INSTANCE.plid)
+					)
+				))
+		);
 
 		if (maxCreateDatePredicate) {
 			predicate = predicate.and(
@@ -885,10 +881,6 @@ public class FragmentEntryLinkLocalServiceImpl
 
 		return fromStep.from(
 			FragmentEntryLinkTable.INSTANCE
-		).innerJoinON(
-			tempLayoutTableTable,
-			FragmentEntryLinkTable.INSTANCE.plid.eq(
-				(Expression<Long>)tempLayoutTableTable.getColumn("plid"))
 		).where(
 			predicate
 		);
@@ -901,27 +893,27 @@ public class FragmentEntryLinkLocalServiceImpl
 				long scopeGroupId)
 		throws PortalException {
 
-		Table<LayoutTable> tempLayoutTableTable = DSLQueryFactoryUtil.select(
-			LayoutTable.INSTANCE.plid
-		).from(
-			LayoutTable.INSTANCE
-		).innerJoinON(
-			LayoutPageTemplateEntryTable.INSTANCE,
-			LayoutTable.INSTANCE.plid.eq(
-				LayoutPageTemplateEntryTable.INSTANCE.plid
-			).or(
-				LayoutTable.INSTANCE.classPK.eq(
-					LayoutPageTemplateEntryTable.INSTANCE.plid)
-			)
-		).where(
-			LayoutPageTemplateEntryTable.INSTANCE.type.eq(
-				layoutPageTemplateType)
-		).as(
-			"tempLayoutTable", LayoutTable.INSTANCE
-		);
-
 		Predicate predicate = _getFragmentEntryLinksByFragmentEntryPredicate(
-			fragmentEntry, scopeGroupId);
+			fragmentEntry, scopeGroupId
+		).and(
+			FragmentEntryLinkTable.INSTANCE.plid.in(
+				DSLQueryFactoryUtil.select(
+					LayoutTable.INSTANCE.plid
+				).from(
+					LayoutTable.INSTANCE
+				).innerJoinON(
+					LayoutPageTemplateEntryTable.INSTANCE,
+					LayoutTable.INSTANCE.plid.eq(
+						LayoutPageTemplateEntryTable.INSTANCE.plid
+					).or(
+						LayoutTable.INSTANCE.classPK.eq(
+							LayoutPageTemplateEntryTable.INSTANCE.plid)
+					)
+				).where(
+					LayoutPageTemplateEntryTable.INSTANCE.type.eq(
+						layoutPageTemplateType)
+				))
+		);
 
 		if (maxCreateDatePredicate) {
 			predicate = predicate.and(
@@ -930,10 +922,6 @@ public class FragmentEntryLinkLocalServiceImpl
 
 		return fromStep.from(
 			FragmentEntryLinkTable.INSTANCE
-		).innerJoinON(
-			tempLayoutTableTable,
-			FragmentEntryLinkTable.INSTANCE.plid.eq(
-				(Expression<Long>)tempLayoutTableTable.getColumn("plid"))
 		).where(
 			predicate
 		);

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -871,8 +871,8 @@ public class FragmentEntryLinkLocalServiceImpl
 	}
 
 	private GroupByStep _getLayoutFragmentEntryLinksByFragmentEntryGroupByStep(
-			FragmentEntry fragmentEntry, FromStep fromStep,
-			boolean maxCreateDatePredicate, long scopeGroupId)
+			FragmentEntry fragmentEntry, FromStep fromStep, boolean latest,
+			long scopeGroupId)
 		throws PortalException {
 
 		Predicate predicate = _getFragmentEntryLinksByFragmentEntryPredicate(
@@ -880,9 +880,12 @@ public class FragmentEntryLinkLocalServiceImpl
 			FragmentEntryLinkTable.INSTANCE.plid.notIn(_getPlidsDSLQuery(null)),
 			scopeGroupId);
 
-		if (maxCreateDatePredicate) {
-			predicate = predicate.and(
-				_getMaxCreateDatePredicate(fragmentEntry));
+		if (latest) {
+			return fromStep.from(
+				FragmentEntryLinkTable.INSTANCE
+			).where(
+				_getLatestFragmentEntryLinkPredicate(predicate)
+			);
 		}
 
 		return fromStep.from(
@@ -895,8 +898,7 @@ public class FragmentEntryLinkLocalServiceImpl
 	private GroupByStep
 			_getLayoutPageTemplateFragmentEntryLinksByFragmentEntryGroupByStep(
 				FragmentEntry fragmentEntry, FromStep fromStep,
-				int layoutPageTemplateType, boolean maxCreateDatePredicate,
-				long scopeGroupId)
+				int layoutPageTemplateType, boolean latest, long scopeGroupId)
 		throws PortalException {
 
 		Predicate predicate = _getFragmentEntryLinksByFragmentEntryPredicate(
@@ -907,9 +909,12 @@ public class FragmentEntryLinkLocalServiceImpl
 						layoutPageTemplateType))),
 			scopeGroupId);
 
-		if (maxCreateDatePredicate) {
-			predicate = predicate.and(
-				_getMaxCreateDatePredicate(fragmentEntry));
+		if (latest) {
+			return fromStep.from(
+				FragmentEntryLinkTable.INSTANCE
+			).where(
+				_getLatestFragmentEntryLinkPredicate(predicate)
+			);
 		}
 
 		return fromStep.from(
@@ -917,35 +922,6 @@ public class FragmentEntryLinkLocalServiceImpl
 		).where(
 			predicate
 		);
-	}
-
-	private Predicate _getMaxCreateDatePredicate(FragmentEntry fragmentEntry)
-		throws PortalException {
-
-		FragmentEntryLinkTable tempFragmentEntryLinkTable =
-			FragmentEntryLinkTable.INSTANCE.as("tempFragmentEntryLinkTable");
-
-		Predicate predicate = _getAllFragmentEntryLinksByFragmentEntryPredicate(
-			fragmentEntry, tempFragmentEntryLinkTable);
-
-		return FragmentEntryLinkTable.INSTANCE.createDate.in(
-			DSLQueryFactoryUtil.select(
-				DSLFunctionFactoryUtil.max(
-					tempFragmentEntryLinkTable.createDate)
-			).from(
-				tempFragmentEntryLinkTable
-			).where(
-				predicate.and(
-					tempFragmentEntryLinkTable.groupId.eq(
-						FragmentEntryLinkTable.INSTANCE.groupId)
-				).and(
-					tempFragmentEntryLinkTable.classNameId.eq(
-						FragmentEntryLinkTable.INSTANCE.classNameId)
-				).and(
-					tempFragmentEntryLinkTable.classPK.eq(
-						FragmentEntryLinkTable.INSTANCE.classPK)
-				)
-			));
 	}
 
 	private Function<OrderByStep, LimitStep> _getOrderByStepLimitStepFunction(

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -330,16 +330,15 @@ public class FragmentEntryLinkLocalServiceImpl
 			OrderByComparator<FragmentEntryLink> orderByComparator)
 		throws PortalException {
 
-		Predicate predicate = _getAllFragmentEntryLinksByFragmentEntryPredicate(
-			fragmentEntry, FragmentEntryLinkTable.INSTANCE);
-
 		return fragmentEntryLinkPersistence.dslQuery(
 			DSLQueryFactoryUtil.select(
 				FragmentEntryLinkTable.INSTANCE
 			).from(
 				FragmentEntryLinkTable.INSTANCE
 			).where(
-				predicate.and(_getMaxCreateDatePredicate(fragmentEntry))
+				_getLatestFragmentEntryLinkPredicate(
+					_getAllFragmentEntryLinksByFragmentEntryPredicate(
+						fragmentEntry, FragmentEntryLinkTable.INSTANCE))
 			).orderBy(
 				_getOrderByStepLimitStepFunction(orderByComparator)
 			).limit(
@@ -853,6 +852,22 @@ public class FragmentEntryLinkLocalServiceImpl
 		).and(
 			predicate
 		);
+	}
+
+	private Predicate _getLatestFragmentEntryLinkPredicate(
+		Predicate predicate) {
+
+		return FragmentEntryLinkTable.INSTANCE.fragmentEntryLinkId.in(
+			DSLQueryFactoryUtil.select(
+				DSLFunctionFactoryUtil.max(
+					FragmentEntryLinkTable.INSTANCE.fragmentEntryLinkId)
+			).from(
+				FragmentEntryLinkTable.INSTANCE
+			).where(
+				predicate
+			).groupBy(
+				FragmentEntryLinkTable.INSTANCE.plid
+			));
 	}
 
 	private GroupByStep _getLayoutFragmentEntryLinksByFragmentEntryGroupByStep(

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -818,7 +818,7 @@ public class FragmentEntryLinkLocalServiceImpl
 	}
 
 	private Predicate _getFragmentEntryLinksByFragmentEntryPredicate(
-			FragmentEntry fragmentEntry, long scopeGroupId)
+			FragmentEntry fragmentEntry, Predicate predicate, long scopeGroupId)
 		throws PortalException {
 
 		String fragmentEntryScopeERC =
@@ -836,6 +836,8 @@ public class FragmentEntryLinkLocalServiceImpl
 					fragmentEntryScopeERC)
 			).and(
 				FragmentEntryLinkTable.INSTANCE.deleted.eq(false)
+			).and(
+				predicate
 			);
 		}
 
@@ -848,6 +850,8 @@ public class FragmentEntryLinkLocalServiceImpl
 			FragmentEntryLinkTable.INSTANCE.fragmentEntryScopeERC.isNull()
 		).and(
 			FragmentEntryLinkTable.INSTANCE.deleted.eq(false)
+		).and(
+			predicate
 		);
 	}
 
@@ -857,10 +861,9 @@ public class FragmentEntryLinkLocalServiceImpl
 		throws PortalException {
 
 		Predicate predicate = _getFragmentEntryLinksByFragmentEntryPredicate(
-			fragmentEntry, scopeGroupId
-		).and(
-			FragmentEntryLinkTable.INSTANCE.plid.notIn(_getPlidsDSLQuery(null))
-		);
+			fragmentEntry,
+			FragmentEntryLinkTable.INSTANCE.plid.notIn(_getPlidsDSLQuery(null)),
+			scopeGroupId);
 
 		if (maxCreateDatePredicate) {
 			predicate = predicate.and(
@@ -882,13 +885,12 @@ public class FragmentEntryLinkLocalServiceImpl
 		throws PortalException {
 
 		Predicate predicate = _getFragmentEntryLinksByFragmentEntryPredicate(
-			fragmentEntry, scopeGroupId
-		).and(
+			fragmentEntry,
 			FragmentEntryLinkTable.INSTANCE.plid.in(
 				_getPlidsDSLQuery(
 					LayoutPageTemplateEntryTable.INSTANCE.type.eq(
-						layoutPageTemplateType)))
-		);
+						layoutPageTemplateType))),
+			scopeGroupId);
 
 		if (maxCreateDatePredicate) {
 			predicate = predicate.and(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87404

**What is being fixed:** The two DSL helpers in `FragmentEntryLinkLocalServiceImpl` that feed the "View Usages" flow for fragments (`_getLayoutFragmentEntryLinksByFragmentEntryGroupByStep` and `_getLayoutPageTemplateFragmentEntryLinksByFragmentEntryGroupByStep`) build a derived table over `Layout × LayoutPageTemplateEntry` (joined by `Layout.plid = LPE.plid OR Layout.classPK = LPE.plid`) and use it as the driver, with `FragmentEntryLink` joined by `plid` afterwards. The selective `FragmentEntryLink` filters (`groupId`, `fragmentEntryERC`, `fragmentEntryScopeERC`, `deleted`) are applied only at the outer level, so the optimizer cannot push them into the driver — the derived table materializes a very large `plid` set before the selective `FragmentEntryLink` index is reached. The `OR` in the join predicate is also index-hostile. On customer-scale datasets this makes the "View Usages" tab take minutes to render.

**How it is being fixed:**

- Invert the driver table: drive from `FragmentEntryLink` filtered by its selective composite index on `(groupId, fragmentEntryERC, fragmentEntryScopeERC, deleted)`, and express the `Layout × LPE` correlation as an `IN` / `NOT IN` subquery on `plid`. Liferay's DSL does not expose a native `EXISTS`, but `Expression.in(DSLQuery)` is semantically equivalent and lets the planner build the `plid` set once as a materialized hash.

**Testing:**

 **Tests**                                                                                                                                                                                                                                       
  
  Integration tests covering the three paths and their Count* siblings all pass:                                                                                                                                                              
                                                         
  - FragmentEntryLinkLocalServiceTest#testGetAllFragmentEntryLinksByFragmentEntry                                                                                                                                                             
  - FragmentEntryLinkLocalServiceTest#testGetAllFragmentEntryLinksCountByFragmentEntry
  - FragmentEntryLinkLocalServiceTest#testGetLayoutFragmentEntryLinksByFragmentEntry                                                                                                                                                          
  - FragmentEntryLinkLocalServiceTest#testGetLayoutFragmentEntryLinksCountByFragmentEntry                                                                                                                                                     
  - FragmentEntryLinkLocalServiceTest#testGetLayoutPageTemplateFragmentEntryLinksByFragmentEntry                                                                                                                                              
  - FragmentEntryLinkLocalServiceTest#testGetLayoutPageTemplateFragmentEntryLinksCountByFragmentEntry  
  
  **Manual validation:** ran `EXPLAIN ANALYZE`

Measured the three call paths backing the "View Usages" flow against the LRHC customer-scale dataset (~152k FELs, ~5k Layouts, picking a fragment with thousands of usages, equivalent shape to the dataset cited at the top of this PR description):

| Query | Master baseline (`Layout × LPE` driver + correlated `MAX(createDate)`) | This PR (`FEL` driver + `MAX(fragmentEntryLinkId)` `GROUP BY plid`) | Speedup |
|---|---|---|---|
| `getAllFragmentEntryLinksByFragmentEntry` (the "All" tab) | ~575 s | ~10 ms | ~50,000× |
| `getLayoutFragmentEntryLinksByFragmentEntry` (orphan layouts) | ~minutes | <100 ms | ~1,000×+ |
| `getLayoutPageTemplateFragmentEntryLinksByFragmentEntry` (typed pages) | ~minutes | <100 ms | ~1,000×+ |

Total time spent in "View Usages" on the customer environment: **~9 min → < 1 s**.