### PR TITLE
LPD-87379 Auto translate publish fails with NPE when same fieldName exists as localized JSONObject and boolean

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/helper/LayoutInfoItemFieldValuesProviderHelper.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/helper/LayoutInfoItemFieldValuesProviderHelper.java
@@ -5,6 +5,7 @@
 
 package com.liferay.layout.admin.web.internal.info.item.helper;
 
+import com.liferay.fragment.entry.processor.constants.FragmentEntryProcessorConstants;
 import com.liferay.fragment.renderer.FragmentRendererController;
 import com.liferay.info.field.InfoFieldValue;
 import com.liferay.info.item.InfoItemFieldValues;
@@ -93,7 +94,11 @@ public class LayoutInfoItemFieldValuesProviderHelper {
 			JSONObject processorJSONObject = jsonObject.getJSONObject(
 				processorKey);
 
-			if (!processorJSONObject.has(name)) {
+			if (!processorJSONObject.has(name) ||
+				processorKey.equals(
+					FragmentEntryProcessorConstants.
+						KEY_FREEMARKER_FRAGMENT_ENTRY_PROCESSOR)) {
+
 				continue;
 			}
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/helper/LayoutInfoItemFieldValuesUpdaterHelper.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/helper/LayoutInfoItemFieldValuesUpdaterHelper.java
@@ -5,6 +5,7 @@
 
 package com.liferay.layout.admin.web.internal.info.item.helper;
 
+import com.liferay.fragment.entry.processor.constants.FragmentEntryProcessorConstants;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.info.field.InfoField;
@@ -81,7 +82,11 @@ public class LayoutInfoItemFieldValuesUpdaterHelper {
 			JSONObject processorJSONObject = jsonObject.getJSONObject(
 				processorKey);
 
-			if (!processorJSONObject.has(fieldName)) {
+			if (!processorJSONObject.has(fieldName) ||
+				processorKey.equals(
+					FragmentEntryProcessorConstants.
+						KEY_FREEMARKER_FRAGMENT_ENTRY_PROCESSOR)) {
+
 				continue;
 			}
 

--- a/modules/apps/translation/translation-test/build.gradle
+++ b/modules/apps/translation/translation-test/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-form-field-type-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")
+	testIntegrationImplementation project(":apps:fragment:fragment-api")
 	testIntegrationImplementation project(":apps:info:info-api")
 	testIntegrationImplementation project(":apps:journal:journal-api")
 	testIntegrationImplementation project(":apps:journal:journal-test-util")

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/web/internal/portlet/action/test/UpdateTranslationMVCActionCommandTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/web/internal/portlet/action/test/UpdateTranslationMVCActionCommandTest.java
@@ -9,34 +9,53 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.dynamic.data.mapping.model.Value;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
+import com.liferay.fragment.constants.FragmentConstants;
+import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.service.FragmentCollectionService;
+import com.liferay.fragment.service.FragmentEntryLinkLocalService;
+import com.liferay.fragment.service.FragmentEntryService;
 import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.portlet.MockActionResponse;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
 import com.liferay.translation.constants.TranslationPortletKeys;
 import com.liferay.translation.model.TranslationEntry;
 import com.liferay.translation.service.TranslationEntryLocalService;
@@ -85,7 +104,8 @@ public class UpdateTranslationMVCActionCommandTest {
 
 		_mvcActionCommand.processAction(
 			_getMockActionRequest(
-				journalArticle,
+				_classNameLocalService.getClassNameId(JournalArticle.class),
+				journalArticle.getResourcePrimKey(),
 				HashMapBuilder.put(
 					"infoField--DDMStructure_name--", "name spanish"
 				).put(
@@ -93,7 +113,8 @@ public class UpdateTranslationMVCActionCommandTest {
 					"description spanish"
 				).put(
 					"infoField--JournalArticle_title--", "title spanish"
-				).build()),
+				).build(),
+				journalArticle.getGroupId()),
 			new MockActionResponse());
 
 		journalArticle = _journalArticleLocalService.fetchLatestArticle(
@@ -143,14 +164,16 @@ public class UpdateTranslationMVCActionCommandTest {
 		JournalArticle expectedJournalArticle = _addArticle();
 
 		MockActionRequest mockActionRequest = _getMockActionRequest(
-			expectedJournalArticle,
+			_classNameLocalService.getClassNameId(JournalArticle.class),
+			expectedJournalArticle.getResourcePrimKey(),
 			HashMapBuilder.put(
 				"infoField--DDMStructure_name--", "name spanish"
 			).put(
 				"infoField--JournalArticle_description--", "description spanish"
 			).put(
 				"infoField--JournalArticle_title--", "title spanish"
-			).build());
+			).build(),
+			expectedJournalArticle.getGroupId());
 
 		Date modifiedDate = expectedJournalArticle.getModifiedDate();
 
@@ -200,6 +223,105 @@ public class UpdateTranslationMVCActionCommandTest {
 				LocaleUtil.SPAIN.toString()));
 	}
 
+	@Test
+	@TestInfo("LPD-87379")
+	public void testDoProcessActionWithLayout() throws Exception {
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		ContentLayoutTestUtil.publishLayout(layout.fetchDraftLayout(), layout);
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				TestPropsValues.getGroupId(), TestPropsValues.getUserId());
+
+		FragmentCollection fragmentCollection =
+			_fragmentCollectionService.addFragmentCollection(
+				null, _group.getGroupId(), RandomTestUtil.randomString(),
+				StringPool.BLANK, serviceContext);
+
+		FragmentEntry fragmentEntry = _fragmentEntryService.addFragmentEntry(
+			null, _group.getGroupId(),
+			fragmentCollection.getFragmentCollectionId(), null,
+			RandomTestUtil.randomString(), null, _read("index.html"), null,
+			false, _read("configuration.json"), null, 0, false, false,
+			FragmentConstants.TYPE_COMPONENT, null,
+			WorkflowConstants.STATUS_APPROVED, serviceContext);
+
+		long segmentExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				layout.getPlid());
+
+		ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+			JSONUtil.put(
+				"com.liferay.fragment.entry.processor.editable." +
+					"EditableFragmentEntryProcessor",
+				JSONUtil.put(
+					"paragraph",
+					JSONUtil.put(
+						"defaultValue", RandomTestUtil.randomString()
+					).put(
+						"en_US", RandomTestUtil.randomString()
+					))
+			).put(
+				"com.liferay.fragment.entry.processor.freemarker." +
+					"FreeMarkerFragmentEntryProcessor",
+				JSONUtil.put("paragraph", true)
+			).toString(),
+			fragmentEntry.getCss(), fragmentEntry.getConfiguration(),
+			fragmentEntry.getExternalReferenceCode(), null,
+			fragmentEntry.getHtml(), fragmentEntry.getJs(), layout, null,
+			FragmentConstants.TYPE_COMPONENT, null, 0, segmentExperienceId);
+
+		List<FragmentEntryLink> fragmentEntryLinks =
+			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
+				layout.getGroupId(), layout.getPlid());
+
+		FragmentEntryLink fragmentEntryLink = fragmentEntryLinks.get(0);
+
+		_mvcActionCommand.processAction(
+			_getMockActionRequest(
+				_classNameLocalService.getClassNameId(Layout.class),
+				layout.getPlid(),
+				HashMapBuilder.put(
+					"infoField--Layout_name--", "name spanish"
+				).put(
+					"infoField--FragmentEntryLink_" +
+						fragmentEntryLink.getFragmentEntryLinkId() +
+							":paragraph--",
+					"<p>paragraph spanish</p>"
+				).put(
+					"segmentsExperienceId", String.valueOf(segmentExperienceId)
+				).build(),
+				layout.getGroupId()),
+			new MockActionResponse());
+
+		layout = _layoutLocalService.fetchLayout(layout.getPlid());
+
+		Assert.assertEquals("name spanish", layout.getName(LocaleUtil.SPAIN));
+
+		fragmentEntryLinks =
+			_fragmentEntryLinkLocalService.getFragmentEntryLinksByPlid(
+				layout.getGroupId(), layout.getPlid());
+
+		fragmentEntryLink = fragmentEntryLinks.get(0);
+
+		JSONObject editableValueJSONObject = JSONFactoryUtil.createJSONObject(
+			fragmentEntryLink.getEditableValues());
+
+		JSONObject editableFragmentJSONObject =
+			editableValueJSONObject.getJSONObject(
+				"com.liferay.fragment.entry.processor.editable." +
+					"EditableFragmentEntryProcessor");
+
+		JSONObject paragraphJSONObject =
+			editableFragmentJSONObject.getJSONObject("paragraph");
+
+		String spanishValue = paragraphJSONObject.getString(
+			LocaleUtil.SPAIN.toString());
+
+		Assert.assertEquals("<p>paragraph spanish</p>", spanishValue);
+	}
+
 	private JournalArticle _addArticle() throws Exception {
 		JournalArticle journalArticle = JournalTestUtil.addArticle(
 			_group.getGroupId(),
@@ -211,7 +333,8 @@ public class UpdateTranslationMVCActionCommandTest {
 	}
 
 	private MockActionRequest _getMockActionRequest(
-			JournalArticle journalArticle, Map<String, String> fields)
+			long classNameId, long classPK, Map<String, String> fields,
+			long groupId)
 		throws Exception {
 
 		MockActionRequest mockActionRequest = new MockActionRequest();
@@ -220,13 +343,9 @@ public class UpdateTranslationMVCActionCommandTest {
 			WebKeys.THEME_DISPLAY, _getThemeDisplay());
 
 		mockActionRequest.setParameter(
-			"classNameId",
-			String.valueOf(
-				_classNameLocalService.getClassNameId(JournalArticle.class)));
-		mockActionRequest.setParameter(
-			"classPK", String.valueOf(journalArticle.getResourcePrimKey()));
-		mockActionRequest.setParameter(
-			"groupId", String.valueOf(journalArticle.getGroupId()));
+			"classNameId", String.valueOf(classNameId));
+		mockActionRequest.setParameter("classPK", String.valueOf(classPK));
+		mockActionRequest.setParameter("groupId", String.valueOf(groupId));
 		mockActionRequest.setParameter(
 			"redirect", "http://localhost:8080/content-list");
 		mockActionRequest.setParameter(
@@ -261,8 +380,24 @@ public class UpdateTranslationMVCActionCommandTest {
 		return themeDisplay;
 	}
 
+	private String _read(String fileName) throws Exception {
+		Class<?> clazz = getClass();
+
+		return StringUtil.read(
+			clazz.getResourceAsStream("dependencies/" + fileName));
+	}
+
 	@Inject
 	private ClassNameLocalService _classNameLocalService;
+
+	@Inject
+	private FragmentCollectionService _fragmentCollectionService;
+
+	@Inject
+	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
+
+	@Inject
+	private FragmentEntryService _fragmentEntryService;
 
 	@DeleteAfterTestRun
 	private Group _group;
@@ -270,11 +405,17 @@ public class UpdateTranslationMVCActionCommandTest {
 	@Inject
 	private JournalArticleLocalService _journalArticleLocalService;
 
+	@Inject
+	private LayoutLocalService _layoutLocalService;
+
 	@Inject(filter = "mvc.command.name=/translation/update_translation")
 	private MVCActionCommand _mvcActionCommand;
 
 	@Inject
 	private Portal _portal;
+
+	@Inject
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
 
 	@Inject
 	private TranslationEntryLocalService _translationEntryLocalService;

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/web/internal/portlet/action/test/dependencies/configuration.json
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/web/internal/portlet/action/test/dependencies/configuration.json
@@ -1,0 +1,14 @@
+{
+	"fieldSets": [
+		{
+			"fields": [
+				{
+					"defaultValue": true,
+					"label": "Show paragraph",
+					"name": "paragraph",
+					"type": "checkbox"
+				}
+			]
+		}
+	]
+}

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/web/internal/portlet/action/test/dependencies/index.html
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/web/internal/portlet/action/test/dependencies/index.html
@@ -1,0 +1,5 @@
+[#if configuration.paragraph?? && configuration.paragraph]
+<div data-lfr-editable-id="paragraph" data-lfr-editable-type="rich-text">
+	<p>This is the default text to be translated.</p>
+</div>
+[/#if]


### PR DESCRIPTION
# What is this trying to solve?

[LPD-87379](https://liferay.atlassian.net/browse/LPD-87379)

NPE is coming at time to translation of a layout.

# How am I fixing it?

Skip processing FreeMarkerFragmentEntryProcessor at the time of processing info fields localize values.

# How can you verify that it works?

Run the included automated tests.

[LPD-87379]: https://liferay.atlassian.net/browse/LPD-87379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ