### PR TITLE
LPD-86817 Master Page fragment contentDisplay configuration lost on full Pages export

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/ContainerLayoutUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/ContainerLayoutUtil.java
@@ -27,6 +27,7 @@ public class ContainerLayoutUtil {
 	public static Layout toLayout(JSONObject jsonObject) {
 		if (JSONUtil.isEmpty(jsonObject) ||
 			((jsonObject.getString("align", null) == null) &&
+			 (jsonObject.getString("contentDisplay", null) == null) &&
 			 (jsonObject.getString("flexWrap", null) == null) &&
 			 (jsonObject.getString("justify", null) == null) &&
 			 (jsonObject.getString("widthType", null) == null))) {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/test/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/ContainerLayoutUtilTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/test/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/ContainerLayoutUtilTest.java
@@ -33,28 +33,18 @@ public class ContainerLayoutUtilTest {
 	}
 
 	@Test
-	public void testToLayoutWithEmptyJSONObject() {
+	public void testToLayout() {
 		Assert.assertNull(ContainerLayoutUtil.toLayout(JSONUtil.put("", "")));
-	}
-
-	@Test
-	public void testToLayoutWithJSONObjectWithoutLayoutFields() {
 		Assert.assertNull(
 			ContainerLayoutUtil.toLayout(JSONUtil.put("other", "value")));
-	}
 
-	@Test
-	public void testToLayoutWithOnlyAlign() {
 		Layout layout = ContainerLayoutUtil.toLayout(
 			JSONUtil.put("align", "align-items-center"));
 
 		Assert.assertNotNull(layout);
 		Assert.assertEquals(Layout.Align.CENTER, layout.getAlign());
-	}
 
-	@Test
-	public void testToLayoutWithOnlyContentDisplay() {
-		Layout layout = ContainerLayoutUtil.toLayout(
+		layout = ContainerLayoutUtil.toLayout(
 			JSONUtil.put("contentDisplay", "flex-row"));
 
 		Assert.assertNotNull(
@@ -64,29 +54,20 @@ public class ContainerLayoutUtilTest {
 			layout);
 		Assert.assertEquals(
 			Layout.ContentDisplay.FLEX_ROW, layout.getContentDisplay());
-	}
 
-	@Test
-	public void testToLayoutWithOnlyFlexWrap() {
-		Layout layout = ContainerLayoutUtil.toLayout(
+		layout = ContainerLayoutUtil.toLayout(
 			JSONUtil.put("flexWrap", "flex-wrap"));
 
 		Assert.assertNotNull(layout);
 		Assert.assertEquals(Layout.FlexWrap.WRAP, layout.getFlexWrap());
-	}
 
-	@Test
-	public void testToLayoutWithOnlyJustify() {
-		Layout layout = ContainerLayoutUtil.toLayout(
+		layout = ContainerLayoutUtil.toLayout(
 			JSONUtil.put("justify", "justify-content-center"));
 
 		Assert.assertNotNull(layout);
 		Assert.assertEquals(Layout.Justify.CENTER, layout.getJustify());
-	}
 
-	@Test
-	public void testToLayoutWithOnlyWidthType() {
-		Layout layout = ContainerLayoutUtil.toLayout(
+		layout = ContainerLayoutUtil.toLayout(
 			JSONUtil.put("widthType", "fixed"));
 
 		Assert.assertNotNull(layout);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/test/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/ContainerLayoutUtilTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/test/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/ContainerLayoutUtilTest.java
@@ -1,0 +1,98 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.dto.v1_0.util;
+
+import com.liferay.headless.admin.site.dto.v1_0.Layout;
+import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Petteri Karttunen
+ */
+public class ContainerLayoutUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
+
+		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
+	}
+
+	@Test
+	public void testToLayoutWithEmptyJSONObject() {
+		Assert.assertNull(ContainerLayoutUtil.toLayout(JSONUtil.put("", "")));
+	}
+
+	@Test
+	public void testToLayoutWithJSONObjectWithoutLayoutFields() {
+		Assert.assertNull(
+			ContainerLayoutUtil.toLayout(JSONUtil.put("other", "value")));
+	}
+
+	@Test
+	public void testToLayoutWithOnlyAlign() {
+		Layout layout = ContainerLayoutUtil.toLayout(
+			JSONUtil.put("align", "align-items-center"));
+
+		Assert.assertNotNull(layout);
+		Assert.assertEquals(Layout.Align.CENTER, layout.getAlign());
+	}
+
+	@Test
+	public void testToLayoutWithOnlyContentDisplay() {
+		Layout layout = ContainerLayoutUtil.toLayout(
+			JSONUtil.put("contentDisplay", "flex-row"));
+
+		Assert.assertNotNull(
+			"Layout must not be null when contentDisplay is the only set " +
+				"field; otherwise the FlexRow master page fragment " +
+					"configuration is lost on full Pages export",
+			layout);
+		Assert.assertEquals(
+			Layout.ContentDisplay.FLEX_ROW, layout.getContentDisplay());
+	}
+
+	@Test
+	public void testToLayoutWithOnlyFlexWrap() {
+		Layout layout = ContainerLayoutUtil.toLayout(
+			JSONUtil.put("flexWrap", "flex-wrap"));
+
+		Assert.assertNotNull(layout);
+		Assert.assertEquals(Layout.FlexWrap.WRAP, layout.getFlexWrap());
+	}
+
+	@Test
+	public void testToLayoutWithOnlyJustify() {
+		Layout layout = ContainerLayoutUtil.toLayout(
+			JSONUtil.put("justify", "justify-content-center"));
+
+		Assert.assertNotNull(layout);
+		Assert.assertEquals(Layout.Justify.CENTER, layout.getJustify());
+	}
+
+	@Test
+	public void testToLayoutWithOnlyWidthType() {
+		Layout layout = ContainerLayoutUtil.toLayout(
+			JSONUtil.put("widthType", "fixed"));
+
+		Assert.assertNotNull(layout);
+		Assert.assertEquals(Layout.WidthType.FIXED, layout.getWidthType());
+	}
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/test/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/ContainerLayoutUtilTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/test/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/ContainerLayoutUtilTest.java
@@ -14,7 +14,6 @@ import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -23,7 +22,6 @@ import org.junit.Test;
 public class ContainerLayoutUtilTest {
 
 	@ClassRule
-	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
@@ -11,9 +11,11 @@ import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.headless.admin.site.client.custom.field.CustomField;
+import com.liferay.headless.admin.site.client.dto.v1_0.ContainerPageElementDefinition;
 import com.liferay.headless.admin.site.client.dto.v1_0.ContentPageSpecification;
 import com.liferay.headless.admin.site.client.dto.v1_0.MasterPage;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageElement;
+import com.liferay.headless.admin.site.client.dto.v1_0.PageElementDefinition;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageExperience;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageSpecification;
 import com.liferay.headless.admin.site.client.dto.v1_0.ThumbnailURLReference;
@@ -633,6 +635,34 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 			TestPropsValues.getUserId(), testGroup, true, false,
 			ServiceContextTestUtil.getServiceContext(
 				testGroup, TestPropsValues.getUserId()));
+	}
+
+	private PageElement _getContainerPageElement() {
+		PageElement pageElement = new PageElement();
+
+		pageElement.setExternalReferenceCode(
+			() -> StringUtil.toLowerCase(RandomTestUtil.randomString()));
+
+		ContainerPageElementDefinition containerPageElementDefinition =
+			new ContainerPageElementDefinition();
+
+		containerPageElementDefinition.setIndexed(Boolean.FALSE);
+		containerPageElementDefinition.setLayout(
+			() -> new com.liferay.headless.admin.site.client.dto.v1_0.Layout() {
+				{
+					setContentDisplay(ContentDisplay.FLEX_ROW);
+				}
+			});
+		containerPageElementDefinition.setType(
+			PageElementDefinition.Type.CONTAINER);
+
+		pageElement.setPageElementDefinition(containerPageElementDefinition);
+
+		pageElement.setPageElements(new PageElement[0]);
+		pageElement.setParentExternalReferenceCode(StringPool.BLANK);
+		pageElement.setPosition(1);
+
+		return pageElement;
 	}
 
 	private MasterPage _getMasterPage(
@@ -1366,6 +1396,12 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 
 			MasterPage putMasterPage = postMasterPage;
 
+			PageElement[] pageElements = {
+				PageElementsTestUtil.getDropZonePageElement(
+					RandomTestUtil.randomString(), testGroup.getGroupId()),
+				_getContainerPageElement()
+			};
+
 			putMasterPage.setPageSpecifications(
 				() -> TransformUtil.transform(
 					putMasterPage.getPageSpecifications(),
@@ -1373,7 +1409,16 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 						pageSpecification.setCustomFields(
 							PageSpecificationsTestUtil.getCustomFields());
 
-						return pageSpecification;
+						ContentPageSpecification contentPageSpecification =
+							(ContentPageSpecification)pageSpecification;
+
+						for (PageExperience pageExperience :
+								contentPageSpecification.getPageExperiences()) {
+
+							pageExperience.setPageElements(pageElements);
+						}
+
+						return contentPageSpecification;
 					},
 					PageSpecification.class));
 
@@ -1388,6 +1433,8 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 					CustomField[].class),
 				testGroup.getGroupId(),
 				updateMasterPage.getPageSpecifications());
+
+			_assertPageElements(pageElements, updateMasterPage);
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
@@ -1338,7 +1338,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 		_testPutSiteMasterPageWithPageSpecifications(
 			PageSpecification.Status.DRAFT, PageSpecification.Status.DRAFT,
 			PageSpecification.Status.APPROVED, PageSpecification.Status.DRAFT);
-		_testPutSiteMasterPageWithPageSpecificationsWithCustomFields();
+		_testPutSiteMasterPageWithPageSpecificationsWithCustomFieldsAndPageElements();
 	}
 
 	private void _testPutSiteMasterPageWithPageSpecifications(
@@ -1382,7 +1382,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 			draftContentPageSpecification, publishedContentPageSpecification);
 	}
 
-	private void _testPutSiteMasterPageWithPageSpecificationsWithCustomFields()
+	private void _testPutSiteMasterPageWithPageSpecificationsWithCustomFieldsAndPageElements()
 		throws Exception {
 
 		try (PageSpecificationsTestUtil.ExpandoTableAutocloseable

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
@@ -382,6 +382,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 
 	@Override
 	@Test
+	@TestInfo("LPD-86817")
 	public void testPutSiteMasterPage() throws Exception {
 		_testPutSiteMasterPage(randomMasterPage());
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86817

@peerkar

## Summary

Fixes a regression where the `contentDisplay` configuration of a Master Page Container fragment was lost on full Pages export.

`ContainerLayoutUtil.toLayout` was returning `null` for any JSON object whose only set field was `contentDisplay` (e.g. a Container with `FlexRow` and no other layout property), so the value never made it back into the Layout DTO and disappeared on round-trip.
This PR is based on @peerkar's [#18374](https://github.com/liferay-page-management/liferay-portal/pull/18374) and adds integration coverage on top.

## Changes

### Fix
- Add `contentDisplay` to the early-return guard in `ContainerLayoutUtil.toLayout` so a Layout populated only with `contentDisplay` is preserved.

### Tests
- **Unit (`ContainerLayoutUtilTest`):** Single `testToLayout` covering each Layout field individually (`align`, `contentDisplay`, `flexWrap`, `justify`, `widthType`) plus the empty / no-layout-fields cases. The `contentDisplay` assertion has an inline message documenting the regression.
- **Integration (`MasterPageResourceTest#testPutSiteMasterPage`):** Asserts that a Container page element configured with only `contentDisplay = FlexRow` survives a POST + PUT round-trip, exercising the export/import paths the unit test doesn't reach.
