### PR TITLE
LPD-XXX Create resource command that returns layoutData

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/GetLayoutDataMVCResourceCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/GetLayoutDataMVCResourceCommandTest.java
@@ -1,0 +1,258 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.page.editor.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.segments.model.SegmentsEntry;
+import com.liferay.segments.model.SegmentsExperience;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
+import com.liferay.segments.test.util.SegmentsTestUtil;
+
+import java.io.ByteArrayOutputStream;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Víctor Galán
+ */
+@RunWith(Arquillian.class)
+public class GetLayoutDataMVCResourceCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		_serviceContext = new ServiceContext();
+
+		_serviceContext.setScopeGroupId(_group.getGroupId());
+		_serviceContext.setUserId(TestPropsValues.getUserId());
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext);
+	}
+
+	@After
+	public void tearDown() {
+		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	public void testGetLayoutData() throws Exception {
+		long defaultSegmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				_layout.getPlid());
+
+		JSONObject jsonObject = _serveResource(defaultSegmentsExperienceId);
+
+		Assert.assertTrue(jsonObject.has("items"));
+		Assert.assertTrue(jsonObject.has("rootItems"));
+
+		JSONObject rootItemsJSONObject = jsonObject.getJSONObject("rootItems");
+
+		String mainItemId = rootItemsJSONObject.getString("main");
+
+		Assert.assertNotNull(mainItemId);
+
+		JSONObject itemsJSONObject = jsonObject.getJSONObject("items");
+
+		Assert.assertTrue(itemsJSONObject.has(mainItemId));
+	}
+
+	@Test
+	public void testGetLayoutDataWithFragmentEntryLink() throws Exception {
+		long defaultSegmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				_layout.getPlid());
+
+		FragmentEntryLink fragmentEntryLink =
+			ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+				StringPool.BLANK, _layout, defaultSegmentsExperienceId);
+
+		JSONObject jsonObject = _serveResource(defaultSegmentsExperienceId);
+
+		JSONObject itemsJSONObject = jsonObject.getJSONObject("items");
+
+		Assert.assertTrue(
+			_hasFragmentEntryLink(itemsJSONObject, fragmentEntryLink));
+	}
+
+	@Test
+	public void testGetLayoutDataWithSegmentsExperience() throws Exception {
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId());
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.addSegmentsExperience(
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
+				segmentsEntry.getExternalReferenceCode(), null,
+				_layout.getPlid(),
+				HashMapBuilder.put(
+					LocaleUtil.getDefault(), RandomTestUtil.randomString()
+				).build(),
+				true, new UnicodeProperties(true), _serviceContext);
+
+		long defaultSegmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				_layout.getPlid());
+
+		FragmentEntryLink defaultFragmentEntryLink =
+			ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+				StringPool.BLANK, _layout, defaultSegmentsExperienceId);
+
+		FragmentEntryLink experienceFragmentEntryLink =
+			ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+				StringPool.BLANK, _layout,
+				segmentsExperience.getSegmentsExperienceId());
+
+		JSONObject defaultJSONObject = _serveResource(
+			defaultSegmentsExperienceId);
+
+		JSONObject defaultItemsJSONObject = defaultJSONObject.getJSONObject(
+			"items");
+
+		Assert.assertTrue(
+			_hasFragmentEntryLink(
+				defaultItemsJSONObject, defaultFragmentEntryLink));
+		Assert.assertFalse(
+			_hasFragmentEntryLink(
+				defaultItemsJSONObject, experienceFragmentEntryLink));
+
+		JSONObject experienceJSONObject = _serveResource(
+			segmentsExperience.getSegmentsExperienceId());
+
+		JSONObject experienceItemsJSONObject =
+			experienceJSONObject.getJSONObject("items");
+
+		Assert.assertTrue(
+			_hasFragmentEntryLink(
+				experienceItemsJSONObject, experienceFragmentEntryLink));
+		Assert.assertFalse(
+			_hasFragmentEntryLink(
+				experienceItemsJSONObject, defaultFragmentEntryLink));
+	}
+
+	private MockLiferayResourceRequest _getMockLiferayResourceRequest(
+			long segmentsExperienceId)
+		throws Exception {
+
+		MockLiferayResourceRequest mockLiferayResourceRequest =
+			new MockLiferayResourceRequest();
+
+		mockLiferayResourceRequest.setAttribute(
+			WebKeys.THEME_DISPLAY,
+			ContentLayoutTestUtil.getThemeDisplay(
+				_companyLocalService.fetchCompany(_group.getCompanyId()),
+				_group, _layout));
+
+		mockLiferayResourceRequest.setParameter(
+			"segmentsExperienceId", String.valueOf(segmentsExperienceId));
+
+		return mockLiferayResourceRequest;
+	}
+
+	private boolean _hasFragmentEntryLink(
+		JSONObject itemsJSONObject, FragmentEntryLink fragmentEntryLink) {
+
+		String fragmentEntryLinkId = String.valueOf(
+			fragmentEntryLink.getFragmentEntryLinkId());
+
+		for (String itemId : itemsJSONObject.keySet()) {
+			JSONObject itemJSONObject = itemsJSONObject.getJSONObject(itemId);
+
+			JSONObject configJSONObject = itemJSONObject.getJSONObject(
+				"config");
+
+			if (configJSONObject == null) {
+				continue;
+			}
+
+			if (fragmentEntryLinkId.equals(
+					configJSONObject.getString("fragmentEntryLinkId"))) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private JSONObject _serveResource(long segmentsExperienceId)
+		throws Exception {
+
+		MockLiferayResourceResponse mockLiferayResourceResponse =
+			new MockLiferayResourceResponse();
+
+		_mvcResourceCommand.serveResource(
+			_getMockLiferayResourceRequest(segmentsExperienceId),
+			mockLiferayResourceResponse);
+
+		ByteArrayOutputStream byteArrayOutputStream =
+			(ByteArrayOutputStream)
+				mockLiferayResourceResponse.getPortletOutputStream();
+
+		return JSONFactoryUtil.createJSONObject(
+			byteArrayOutputStream.toString());
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Layout _layout;
+
+	@Inject(
+		filter = "mvc.command.name=/layout_content_page_editor/get_layout_data"
+	)
+	private MVCResourceCommand _mvcResourceCommand;
+
+	@Inject
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
+
+	private ServiceContext _serviceContext;
+
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -563,6 +563,9 @@ public class ContentPageEditorDisplayContext {
 					"/layout_content_page_editor" +
 						"/get_info_item_one_to_many_relationships")
 			).put(
+				"getLayoutDataURL",
+				_getResourceURL("/layout_content_page_editor/get_layout_data")
+			).put(
 				"getLayoutFriendlyURL",
 				_getResourceURL(
 					"/layout_content_page_editor/get_layout_friendly_url")

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetLayoutDataMVCResourceCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetLayoutDataMVCResourceCommand.java
@@ -1,0 +1,55 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.page.editor.web.internal.portlet.action;
+
+import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
+import com.liferay.layout.content.page.editor.web.internal.util.layout.structure.LayoutStructureUtil;
+import com.liferay.layout.util.structure.LayoutStructure;
+import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import jakarta.portlet.ResourceRequest;
+import jakarta.portlet.ResourceResponse;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Víctor Galán
+ */
+@Component(
+	property = {
+		"jakarta.portlet.name=" + ContentPageEditorPortletKeys.CONTENT_PAGE_EDITOR_PORTLET,
+		"mvc.command.name=/layout_content_page_editor/get_layout_data"
+	},
+	service = MVCResourceCommand.class
+)
+public class GetLayoutDataMVCResourceCommand extends BaseMVCResourceCommand {
+
+	@Override
+	protected void doServeResource(
+			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)resourceRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		long segmentsExperienceId = ParamUtil.getLong(
+			resourceRequest, "segmentsExperienceId");
+
+		LayoutStructure layoutStructure =
+			LayoutStructureUtil.getLayoutStructure(
+				themeDisplay.getScopeGroupId(), themeDisplay.getPlid(),
+				segmentsExperienceId);
+
+		JSONPortletResponseUtil.writeJSON(
+			resourceRequest, resourceResponse, layoutStructure.toJSONObject());
+	}
+
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/types/config.d.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/types/config.d.ts
@@ -170,6 +170,7 @@ export interface Config {
 	getInfoItemActionErrorMessageURL: string;
 	getInfoItemFieldValueURL: string;
 	getInfoItemOneToManyRelationshipsURL: string;
+	getLayoutDataURL: string;
 	getLayoutFriendlyURL: string;
 	getLayoutPageTemplateCollectionsURL: string;
 	getPageContentsURL: string;


### PR DESCRIPTION
**What is being fixed:** The page editor needs a way to fetch the current `layoutData` (LayoutStructure JSON) on demand from the client side.

**How it is being fixed:** A new `MVCResourceCommand` is added at `/layout_content_page_editor/get_layout_data` that returns `LayoutStructure.toJSONObject()` for the current layout. It requires `segmentsExperienceId` as a request parameter. The URL is exposed in the page editor config as `getLayoutDataURL` (wired through `ContentPageEditorDisplayContext` and added to `config.d.ts`).