### PR TITLE
LPD-85590 Prevent error toasts on /image/* 404 utility pages

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -5991,8 +5991,16 @@ public class PortalImpl implements Portal {
 			if (exception instanceof PrincipalException) {
 				status = HttpServletResponse.SC_FORBIDDEN;
 			}
-			else if (exception instanceof NoSuchModelException) {
-				status = HttpServletResponse.SC_NOT_FOUND;
+			else {
+				Class<?> clazz = exception.getClass();
+
+				String name = clazz.getName();
+
+				name = name.substring(name.lastIndexOf(CharPool.PERIOD) + 1);
+
+				if (name.startsWith("NoSuch") && name.endsWith("Exception")) {
+					status = HttpServletResponse.SC_NOT_FOUND;
+				}
 			}
 
 			if (status == 0) {

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.exception.ImageTypeException;
 import com.liferay.portal.kernel.exception.NoSuchGroupException;
 import com.liferay.portal.kernel.exception.NoSuchImageException;
 import com.liferay.portal.kernel.exception.NoSuchLayoutException;
+import com.liferay.portal.kernel.exception.NoSuchModelException;
 import com.liferay.portal.kernel.exception.NoSuchUserException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.RSSFeedException;
@@ -6075,7 +6076,13 @@ public class PortalImpl implements Portal {
 
 			httpServletResponse.setStatus(status);
 
-			SessionErrors.add(httpSession, exception.getClass(), exception);
+			if (exception instanceof NoSuchModelException) {
+				httpServletRequest.setAttribute(
+					NoSuchLayoutException.class.getName(), Boolean.TRUE);
+			}
+			else {
+				SessionErrors.add(httpSession, exception.getClass(), exception);
+			}
 
 			ServletContext servletContext = httpSession.getServletContext();
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -5991,16 +5991,8 @@ public class PortalImpl implements Portal {
 			if (exception instanceof PrincipalException) {
 				status = HttpServletResponse.SC_FORBIDDEN;
 			}
-			else {
-				Class<?> clazz = exception.getClass();
-
-				String name = clazz.getName();
-
-				name = name.substring(name.lastIndexOf(CharPool.PERIOD) + 1);
-
-				if (name.startsWith("NoSuch") && name.endsWith("Exception")) {
-					status = HttpServletResponse.SC_NOT_FOUND;
-				}
+			else if (exception instanceof NoSuchModelException) {
+				status = HttpServletResponse.SC_NOT_FOUND;
 			}
 
 			if (status == 0) {

--- a/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/util/PortalImplUnitTest.java
@@ -5,9 +5,11 @@
 
 package com.liferay.portal.util;
 
+import com.liferay.document.library.kernel.exception.NoSuchFileException;
 import com.liferay.petra.io.BigEndianCodec;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
@@ -21,6 +23,7 @@ import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.servlet.DummyHttpServletResponse;
 import com.liferay.portal.kernel.servlet.DynamicServletRequest;
 import com.liferay.portal.kernel.servlet.PersistentHttpServletRequestWrapper;
+import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -58,6 +61,7 @@ import jakarta.portlet.WindowState;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -80,6 +84,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 /**
  * @author Miguel Pastor
@@ -811,6 +816,34 @@ public class PortalImplUnitTest {
 
 			Assert.assertFalse(_portalImpl.isValidResourceId("%view.jsp"));
 		}
+	}
+
+	@Test
+	public void testSendErrorForNoSuchModelExceptionSetsLayoutAttribute()
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		_portalImpl.sendError(
+			0, new NoSuchFileException("test"), mockHttpServletRequest,
+			mockHttpServletResponse);
+
+		Assert.assertEquals(
+			HttpServletResponse.SC_NOT_FOUND,
+			mockHttpServletResponse.getStatus());
+
+		Assert.assertEquals(
+			Boolean.TRUE,
+			mockHttpServletRequest.getAttribute(
+				NoSuchLayoutException.class.getName()));
+
+		Assert.assertFalse(
+			SessionErrors.contains(
+				mockHttpServletRequest.getSession(),
+				NoSuchFileException.class));
 	}
 
 	@Test


### PR DESCRIPTION
# What is this trying to solve?

Ticket: https://liferay.atlassian.net/browse/LPD-85590.

Accessing a non-existent resource under `/image/*` redirects correctly to Error 404 Utility page but shows an error toast notification (“Your request failed to complete”) also. This notification must not show.

# How am I fixing it?

In `PortalImpl.sendError`, `NoSuchModelException` responses no longer push the exception into `SessionErrors`. Instead they set the `NoSuchLayoutException` request attribute so the 404 is rendered through the standard "page not found" path without leaking into the next page's session state.   

# How can you verify that it works?

Run the included automated tests. 