### PR TITLE
LPD-87682 Fix integration tests broken by service-context-dependent code paths

### DIFF
--- a/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/portlet/action/test/DeleteLayoutUtilityPageEntryPreviewMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/portlet/action/test/DeleteLayoutUtilityPageEntryPreviewMVCActionCommandTest.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -177,6 +178,8 @@ public class DeleteLayoutUtilityPageEntryPreviewMVCActionCommandTest {
 
 		ThemeDisplay themeDisplay = new ThemeDisplay();
 
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(_group.getCompanyId()));
 		themeDisplay.setPermissionChecker(
 			PermissionCheckerFactoryUtil.create(user));
 		themeDisplay.setScopeGroupId(_group.getGroupId());
@@ -193,6 +196,9 @@ public class DeleteLayoutUtilityPageEntryPreviewMVCActionCommandTest {
 
 		return mockLiferayPortletActionRequest;
 	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
 
 	@Inject(
 		filter = "mvc.command.name=/layout_admin/delete_layout_utility_page_entry_preview"

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
@@ -251,18 +251,10 @@ public class LayoutsImporterTest {
 			new long[] {layoutPageTemplateEntry.getLayoutPageTemplateEntryId()},
 			LayoutPageTemplateEntryTypeConstants.BASIC);
 
-		List<LayoutsImporterResultEntry> layoutsImporterResultEntries = null;
-
-		ServiceContextThreadLocal.pushServiceContext(_serviceContext2);
-
-		try {
-			layoutsImporterResultEntries = _layoutsImporter.importFile(
-				TestPropsValues.getUserId(), _group2.getGroupId(), 0, file,
-				LayoutsImportStrategy.DO_NOT_OVERWRITE, true);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		List<LayoutsImporterResultEntry> layoutsImporterResultEntries =
+			_importFile(
+				file, LayoutsImportStrategy.DO_NOT_OVERWRITE, 0,
+				_serviceContext2);
 
 		LayoutsImporterResultEntry layoutsImporterResultEntry =
 			layoutsImporterResultEntries.get(0);
@@ -327,19 +319,10 @@ public class LayoutsImporterTest {
 			}
 		}
 
-		List<LayoutsImporterResultEntry> layoutsImporterResultEntries = null;
-
-		ServiceContextThreadLocal.pushServiceContext(_serviceContext2);
-
-		try {
-			layoutsImporterResultEntries = _layoutsImporter.importFile(
-				TestPropsValues.getUserId(), _group2.getGroupId(), 0,
-				zipWriter.getFile(), LayoutsImportStrategy.DO_NOT_OVERWRITE,
-				true);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		List<LayoutsImporterResultEntry> layoutsImporterResultEntries =
+			_importFile(
+				zipWriter.getFile(), LayoutsImportStrategy.DO_NOT_OVERWRITE, 0,
+				_serviceContext2);
 
 		Assert.assertEquals(
 			layoutsImporterResultEntries.toString(), 2,
@@ -374,19 +357,10 @@ public class LayoutsImporterTest {
 
 	@Test
 	public void testImportDisplayPageTemplates() throws Exception {
-		List<LayoutsImporterResultEntry> layoutsImporterResultEntries = null;
-
-		ServiceContextThreadLocal.pushServiceContext(_serviceContext1);
-
-		try {
-			layoutsImporterResultEntries = _layoutsImporter.importFile(
-				TestPropsValues.getUserId(), _group1.getGroupId(), 0,
+		List<LayoutsImporterResultEntry> layoutsImporterResultEntries =
+			_importFile(
 				_getFile(_RESOURCES_PATH_DISPLAY_PAGE_TEMPLATES),
-				LayoutsImportStrategy.DO_NOT_OVERWRITE, true);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+				LayoutsImportStrategy.DO_NOT_OVERWRITE, 0, _serviceContext1);
 
 		Assert.assertEquals(
 			layoutsImporterResultEntries.toString(), 3,
@@ -427,18 +401,10 @@ public class LayoutsImporterTest {
 
 		_addFragmentEntry(html, key, name, _serviceContext2);
 
-		List<LayoutsImporterResultEntry> layoutsImporterResultEntries = null;
-
-		ServiceContextThreadLocal.pushServiceContext(_serviceContext2);
-
-		try {
-			layoutsImporterResultEntries = _layoutsImporter.importFile(
-				TestPropsValues.getUserId(), _group2.getGroupId(), 0, file,
-				LayoutsImportStrategy.DO_NOT_OVERWRITE, true);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		List<LayoutsImporterResultEntry> layoutsImporterResultEntries =
+			_importFile(
+				file, LayoutsImportStrategy.DO_NOT_OVERWRITE, 0,
+				_serviceContext2);
 
 		Assert.assertEquals(
 			layoutsImporterResultEntries.toString(), 1,
@@ -514,18 +480,9 @@ public class LayoutsImporterTest {
 			new long[] {layoutPageTemplateEntry.getLayoutPageTemplateEntryId()},
 			LayoutPageTemplateEntryTypeConstants.BASIC);
 
-		List<LayoutsImporterResultEntry> layoutsImporterResultEntries = null;
-
-		ServiceContextThreadLocal.pushServiceContext(_serviceContext1);
-
-		try {
-			layoutsImporterResultEntries = _layoutsImporter.importFile(
-				TestPropsValues.getUserId(), _group1.getGroupId(), 0, file,
-				LayoutsImportStrategy.OVERWRITE, true);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		List<LayoutsImporterResultEntry> layoutsImporterResultEntries =
+			_importFile(
+				file, LayoutsImportStrategy.OVERWRITE, 0, _serviceContext1);
 
 		_assertLayoutPageTemplateEntry(
 			fragmentEntryLink,
@@ -563,19 +520,12 @@ public class LayoutsImporterTest {
 	public void testImportLayoutPageTemplateEntryWithMasterLayoutAndChildLayout()
 		throws Exception {
 
-		ServiceContextThreadLocal.pushServiceContext(_serviceContext1);
-
-		try {
-			_layoutsImporter.importFile(
-				TestPropsValues.getUserId(), _group1.getGroupId(),
-				LayoutPageTemplateConstants.
-					PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
-				_getFile(_RESOURCES_PATH_MASTER_PAGES),
-				LayoutsImportStrategy.OVERWRITE, true);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		_importFile(
+			_getFile(_RESOURCES_PATH_MASTER_PAGES),
+			LayoutsImportStrategy.OVERWRITE,
+			LayoutPageTemplateConstants.
+				PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
+			_serviceContext1);
 
 		LayoutPageTemplateEntry masterLayoutPageTemplateEntry =
 			_layoutPageTemplateEntryLocalService.fetchLayoutPageTemplateEntry(
@@ -615,19 +565,12 @@ public class LayoutsImporterTest {
 		Assert.assertEquals(
 			portletPreferences.toString(), 1, portletPreferences.size());
 
-		ServiceContextThreadLocal.pushServiceContext(_serviceContext1);
-
-		try {
-			_layoutsImporter.importFile(
-				TestPropsValues.getUserId(), _group1.getGroupId(),
-				LayoutPageTemplateConstants.
-					PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
-				_getFile(_RESOURCES_PATH_MASTER_PAGES),
-				LayoutsImportStrategy.OVERWRITE, true);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		_importFile(
+			_getFile(_RESOURCES_PATH_MASTER_PAGES),
+			LayoutsImportStrategy.OVERWRITE,
+			LayoutPageTemplateConstants.
+				PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
+			_serviceContext1);
 
 		portletPreferences =
 			_portletPreferencesLocalService.getPortletPreferences(
@@ -704,18 +647,10 @@ public class LayoutsImporterTest {
 			new long[] {layoutPageTemplateEntry.getLayoutPageTemplateEntryId()},
 			LayoutPageTemplateEntryTypeConstants.BASIC);
 
-		List<LayoutsImporterResultEntry> layoutsImporterResultEntries = null;
-
-		ServiceContextThreadLocal.pushServiceContext(_serviceContext2);
-
-		try {
-			layoutsImporterResultEntries = _layoutsImporter.importFile(
-				TestPropsValues.getUserId(), _group2.getGroupId(), 0, file,
-				LayoutsImportStrategy.DO_NOT_OVERWRITE, true);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		List<LayoutsImporterResultEntry> layoutsImporterResultEntries =
+			_importFile(
+				file, LayoutsImportStrategy.DO_NOT_OVERWRITE, 0,
+				_serviceContext2);
 
 		LayoutsImporterResultEntry layoutsImporterResultEntry =
 			layoutsImporterResultEntries.get(0);
@@ -775,18 +710,10 @@ public class LayoutsImporterTest {
 			new long[] {layoutPageTemplateEntry.getLayoutPageTemplateEntryId()},
 			LayoutPageTemplateEntryTypeConstants.BASIC);
 
-		List<LayoutsImporterResultEntry> layoutsImporterResultEntries = null;
-
-		ServiceContextThreadLocal.pushServiceContext(_serviceContext2);
-
-		try {
-			layoutsImporterResultEntries = _layoutsImporter.importFile(
-				TestPropsValues.getUserId(), _group2.getGroupId(), 0, file,
-				LayoutsImportStrategy.DO_NOT_OVERWRITE, true);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		List<LayoutsImporterResultEntry> layoutsImporterResultEntries =
+			_importFile(
+				file, LayoutsImportStrategy.DO_NOT_OVERWRITE, 0,
+				_serviceContext2);
 
 		LayoutsImporterResultEntry layoutsImporterResultEntry =
 			layoutsImporterResultEntries.get(0);
@@ -862,18 +789,10 @@ public class LayoutsImporterTest {
 		StyleBookEntry curStyleBookEntry = _addStyleBookEntry(
 			_serviceContext2, styleBookEntry.getStyleBookEntryKey());
 
-		List<LayoutsImporterResultEntry> layoutsImporterResultEntries = null;
-
-		ServiceContextThreadLocal.pushServiceContext(_serviceContext2);
-
-		try {
-			layoutsImporterResultEntries = _layoutsImporter.importFile(
-				TestPropsValues.getUserId(), _group2.getGroupId(), 0, file,
-				LayoutsImportStrategy.DO_NOT_OVERWRITE, true);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		List<LayoutsImporterResultEntry> layoutsImporterResultEntries =
+			_importFile(
+				file, LayoutsImportStrategy.DO_NOT_OVERWRITE, 0,
+				_serviceContext2);
 
 		Assert.assertEquals(
 			layoutsImporterResultEntries.toString(), 1,
@@ -945,18 +864,10 @@ public class LayoutsImporterTest {
 		FragmentEntry curFragmentEntry = _addFragmentEntry(
 			fragmentEntry, _serviceContext2);
 
-		List<LayoutsImporterResultEntry> layoutsImporterResultEntries = null;
-
-		ServiceContextThreadLocal.pushServiceContext(_serviceContext2);
-
-		try {
-			layoutsImporterResultEntries = _layoutsImporter.importFile(
-				TestPropsValues.getUserId(), _group2.getGroupId(), 0, file,
-				LayoutsImportStrategy.DO_NOT_OVERWRITE, true);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		List<LayoutsImporterResultEntry> layoutsImporterResultEntries =
+			_importFile(
+				file, LayoutsImportStrategy.DO_NOT_OVERWRITE, 0,
+				_serviceContext2);
 
 		_assertLayoutPageTemplateEntry(
 			configurationJSONObject, editableValuesJSONObject, curFragmentEntry,
@@ -1115,19 +1026,12 @@ public class LayoutsImporterTest {
 	public void testImportUtilityPageEntryIsApprovedAndCanBeSetAsDefault()
 		throws Exception {
 
-		ServiceContextThreadLocal.pushServiceContext(_serviceContext1);
-
-		try {
-			_layoutsImporter.importFile(
-				TestPropsValues.getUserId(), _group1.getGroupId(),
-				LayoutPageTemplateConstants.
-					PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
-				_getFile(_RESOURCES_PATH_UTILITY_PAGES),
-				LayoutsImportStrategy.OVERWRITE, true);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		_importFile(
+			_getFile(_RESOURCES_PATH_UTILITY_PAGES),
+			LayoutsImportStrategy.OVERWRITE,
+			LayoutPageTemplateConstants.
+				PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
+			_serviceContext1);
 
 		LayoutUtilityPageEntry layoutUtilityPageEntry =
 			_layoutUtilityPageEntryLocalService.
@@ -2273,6 +2177,24 @@ public class LayoutsImporterTest {
 		return JSONUtil.put("successMessage", successMessageJSONObject);
 	}
 
+	private List<LayoutsImporterResultEntry> _importFile(
+			File file, LayoutsImportStrategy layoutsImportStrategy,
+			long layoutPageTemplateCollectionId, ServiceContext serviceContext)
+		throws Exception {
+
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+		try {
+			return _layoutsImporter.importFile(
+				TestPropsValues.getUserId(), serviceContext.getScopeGroupId(),
+				layoutPageTemplateCollectionId, file, layoutsImportStrategy,
+				true);
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
+	}
+
 	private String _read(String fileName) throws Exception {
 		return new String(
 			FileUtil.getBytes(getClass(), "dependencies/" + fileName));
@@ -2351,18 +2273,10 @@ public class LayoutsImporterTest {
 		FragmentEntry curFragmentEntry = _addFragmentEntry(
 			fragmentEntry, _serviceContext2);
 
-		ServiceContextThreadLocal.pushServiceContext(_serviceContext2);
-
-		List<LayoutsImporterResultEntry> layoutsImporterResultEntries;
-
-		try {
-			layoutsImporterResultEntries = _layoutsImporter.importFile(
-				TestPropsValues.getUserId(), _group2.getGroupId(), 0, file,
-				LayoutsImportStrategy.DO_NOT_OVERWRITE, true);
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		List<LayoutsImporterResultEntry> layoutsImporterResultEntries =
+			_importFile(
+				file, LayoutsImportStrategy.DO_NOT_OVERWRITE, 0,
+				_serviceContext2);
 
 		_assertLayoutPageTemplateEntry(
 			configurationJSONObject,

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
@@ -251,10 +251,18 @@ public class LayoutsImporterTest {
 			new long[] {layoutPageTemplateEntry.getLayoutPageTemplateEntryId()},
 			LayoutPageTemplateEntryTypeConstants.BASIC);
 
-		List<LayoutsImporterResultEntry> layoutsImporterResultEntries =
-			_layoutsImporter.importFile(
+		List<LayoutsImporterResultEntry> layoutsImporterResultEntries = null;
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext2);
+
+		try {
+			layoutsImporterResultEntries = _layoutsImporter.importFile(
 				TestPropsValues.getUserId(), _group2.getGroupId(), 0, file,
 				LayoutsImportStrategy.DO_NOT_OVERWRITE, true);
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
 
 		LayoutsImporterResultEntry layoutsImporterResultEntry =
 			layoutsImporterResultEntries.get(0);
@@ -319,11 +327,19 @@ public class LayoutsImporterTest {
 			}
 		}
 
-		List<LayoutsImporterResultEntry> layoutsImporterResultEntries =
-			_layoutsImporter.importFile(
+		List<LayoutsImporterResultEntry> layoutsImporterResultEntries = null;
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext2);
+
+		try {
+			layoutsImporterResultEntries = _layoutsImporter.importFile(
 				TestPropsValues.getUserId(), _group2.getGroupId(), 0,
 				zipWriter.getFile(), LayoutsImportStrategy.DO_NOT_OVERWRITE,
 				true);
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
 
 		Assert.assertEquals(
 			layoutsImporterResultEntries.toString(), 2,
@@ -498,10 +514,18 @@ public class LayoutsImporterTest {
 			new long[] {layoutPageTemplateEntry.getLayoutPageTemplateEntryId()},
 			LayoutPageTemplateEntryTypeConstants.BASIC);
 
-		List<LayoutsImporterResultEntry> layoutsImporterResultEntries =
-			_layoutsImporter.importFile(
+		List<LayoutsImporterResultEntry> layoutsImporterResultEntries = null;
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext1);
+
+		try {
+			layoutsImporterResultEntries = _layoutsImporter.importFile(
 				TestPropsValues.getUserId(), _group1.getGroupId(), 0, file,
 				LayoutsImportStrategy.OVERWRITE, true);
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
 
 		_assertLayoutPageTemplateEntry(
 			fragmentEntryLink,
@@ -680,10 +704,18 @@ public class LayoutsImporterTest {
 			new long[] {layoutPageTemplateEntry.getLayoutPageTemplateEntryId()},
 			LayoutPageTemplateEntryTypeConstants.BASIC);
 
-		List<LayoutsImporterResultEntry> layoutsImporterResultEntries =
-			_layoutsImporter.importFile(
+		List<LayoutsImporterResultEntry> layoutsImporterResultEntries = null;
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext2);
+
+		try {
+			layoutsImporterResultEntries = _layoutsImporter.importFile(
 				TestPropsValues.getUserId(), _group2.getGroupId(), 0, file,
 				LayoutsImportStrategy.DO_NOT_OVERWRITE, true);
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
 
 		LayoutsImporterResultEntry layoutsImporterResultEntry =
 			layoutsImporterResultEntries.get(0);
@@ -743,10 +775,18 @@ public class LayoutsImporterTest {
 			new long[] {layoutPageTemplateEntry.getLayoutPageTemplateEntryId()},
 			LayoutPageTemplateEntryTypeConstants.BASIC);
 
-		List<LayoutsImporterResultEntry> layoutsImporterResultEntries =
-			_layoutsImporter.importFile(
+		List<LayoutsImporterResultEntry> layoutsImporterResultEntries = null;
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext2);
+
+		try {
+			layoutsImporterResultEntries = _layoutsImporter.importFile(
 				TestPropsValues.getUserId(), _group2.getGroupId(), 0, file,
 				LayoutsImportStrategy.DO_NOT_OVERWRITE, true);
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
 
 		LayoutsImporterResultEntry layoutsImporterResultEntry =
 			layoutsImporterResultEntries.get(0);
@@ -822,10 +862,18 @@ public class LayoutsImporterTest {
 		StyleBookEntry curStyleBookEntry = _addStyleBookEntry(
 			_serviceContext2, styleBookEntry.getStyleBookEntryKey());
 
-		List<LayoutsImporterResultEntry> layoutsImporterResultEntries =
-			_layoutsImporter.importFile(
+		List<LayoutsImporterResultEntry> layoutsImporterResultEntries = null;
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext2);
+
+		try {
+			layoutsImporterResultEntries = _layoutsImporter.importFile(
 				TestPropsValues.getUserId(), _group2.getGroupId(), 0, file,
 				LayoutsImportStrategy.DO_NOT_OVERWRITE, true);
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
 
 		Assert.assertEquals(
 			layoutsImporterResultEntries.toString(), 1,
@@ -897,10 +945,18 @@ public class LayoutsImporterTest {
 		FragmentEntry curFragmentEntry = _addFragmentEntry(
 			fragmentEntry, _serviceContext2);
 
-		List<LayoutsImporterResultEntry> layoutsImporterResultEntries =
-			_layoutsImporter.importFile(
+		List<LayoutsImporterResultEntry> layoutsImporterResultEntries = null;
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext2);
+
+		try {
+			layoutsImporterResultEntries = _layoutsImporter.importFile(
 				TestPropsValues.getUserId(), _group2.getGroupId(), 0, file,
 				LayoutsImportStrategy.DO_NOT_OVERWRITE, true);
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
 
 		_assertLayoutPageTemplateEntry(
 			configurationJSONObject, editableValuesJSONObject, curFragmentEntry,
@@ -2295,10 +2351,18 @@ public class LayoutsImporterTest {
 		FragmentEntry curFragmentEntry = _addFragmentEntry(
 			fragmentEntry, _serviceContext2);
 
-		List<LayoutsImporterResultEntry> layoutsImporterResultEntries =
-			_layoutsImporter.importFile(
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext2);
+
+		List<LayoutsImporterResultEntry> layoutsImporterResultEntries;
+
+		try {
+			layoutsImporterResultEntries = _layoutsImporter.importFile(
 				TestPropsValues.getUserId(), _group2.getGroupId(), 0, file,
 				LayoutsImportStrategy.DO_NOT_OVERWRITE, true);
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
 
 		_assertLayoutPageTemplateEntry(
 			configurationJSONObject,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87682

**What is being fixed:** Three integration tests in `layout-admin-web-test` and `layout-page-template-admin-web-test` were exercising code paths that now require a non-null `ServiceContextThreadLocal` (e.g. `LayoutPageTemplate*ServiceImpl.add*` reads `serviceContext.getUuid()`, `MVCActionCommand`s build their own `ServiceContext` via `ServiceContextFactory.getInstance(className, actionRequest)` which derives `companyId` from the request's theme display, etc.). The tests didn't push a service context (or didn't put enough on the mock theme display), and started failing as those server-side paths tightened up their assumptions.

**How it is being fixed:**

- `DeleteLayoutUtilityPageEntryPreviewMVCActionCommandTest`: set the company on the theme display in `_getMockLiferayPortletActionRequest`, so `ServiceContextFactory.getInstance(...)` derives a valid `companyId` from it and the resulting `ServiceContext` is usable downstream.
- `LayoutsImporterTest`: every `_layoutsImporter.importFile(...)` call now runs with the matching service context active on the thread local. The first commit wraps each call in an explicit `pushServiceContext(...)` / `popServiceContext()`. The second commit collapses all those wrappers into a single `_importFile(File, LayoutsImportStrategy, long, ServiceContext)` helper that does the push/pop and derives the group ID from `serviceContext.getScopeGroupId()`. The one call inside the existing `CTCollectionThreadLocal` block is left as-is, since the surrounding push/pop there also covers `addCTCollection` / `deleteCTCollection`.

**Testing:**

- The three tests above pass locally with the change applied.