### PR TITLE
LPD-87827 Wait for widget preview before confirming insertion in addWidget

### DIFF
--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -288,6 +288,11 @@ export class PageEditorPage {
 			await this.page.getByLabel(`Add ${name}`).first().focus();
 
 			await this.page.keyboard.press('Enter');
+
+			await expect(
+				this.page.locator('#content').getByText(name, {exact: true})
+			).toBeVisible();
+
 			await this.page.keyboard.press('Enter');
 		}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87827

**What is being fixed:** The `mySitesWidget.spec.ts` test was flaky, with `beforeEach` timing out after 90 seconds waiting for the "Saved" label after `addWidget('Community', 'My Sites')`. In `PageEditorPage.addWidget`, two consecutive `Enter` key presses raced the widget preview render: when the second press fired before `#content` reflected the new widget, focus was wrong, the insertion never happened, and `waitForChangesSaved` never saw the "Saved" label.

**How it is being fixed:** Wait for the widget name to appear inside `#content` between the two `Enter` presses, mirroring the fix LPD-82302 already applied to `addFragment` for the same race.