### PR TITLE
LPD-87689 Refetch FragmentEntryLink before updateLatestChanges in contributed-fragment propagator

### DIFF
--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/PropagateContributedFragmentEntriesChangesMVCActionCommand.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/PropagateContributedFragmentEntriesChangesMVCActionCommand.java
@@ -120,7 +120,9 @@ public class PropagateContributedFragmentEntriesChangesMVCActionCommand
 			actionableDynamicQuery.setPerformActionMethod(
 				(FragmentEntryLink fragmentEntryLink) ->
 					_fragmentEntryLinkLocalService.updateLatestChanges(
-						fragmentEntry, fragmentEntryLink));
+						fragmentEntry,
+						_fragmentEntryLinkLocalService.getFragmentEntryLink(
+							fragmentEntryLink.getFragmentEntryLinkId())));
 
 			actionableDynamicQuery.performActions();
 		}


### PR DESCRIPTION
LPD-87689 Refetch FragmentEntryLink before updateLatestChanges in contributed-fragment propagator

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-87689

The "Propagate Changes" action for contributed fragments fails partway through with `OptimisticLockException` and rolls back, leaving propagation unfinished. This happens whenever a fragment's nested layout structure has drop-zone slots that don't line up with the IDs in its current rendered HTML — a state that builds up over time in older layouts or imported page templates.

# How am I fixing it?

Inside the propagator's `ActionableDynamicQuery` lambda, refetch each `FragmentEntryLink` from `EntityCache` before calling `updateLatestChanges`. The post-merge `DropZoneFragmentEntryLinkListener` cascade can soft-delete sibling rows mid-walk and bump their `mvccVersion`; refetching ensures the merge always operates on current state instead of a stale bulk-loaded snapshot.

# How can you verify that it works?

Follow the steps described in https://liferay.atlassian.net/browse/LPD-87689.