### PR TITLE
LPD-85565 Fix NPE on import when the widget portlet is not deployed

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/layout/structure/item/importer/WidgetInstanceLayoutStructureItemImporter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/layout/structure/item/importer/WidgetInstanceLayoutStructureItemImporter.java
@@ -228,7 +228,7 @@ public class WidgetInstanceLayoutStructureItemImporter
 	private String _getInstanceId(String widgetInstanceId, String widgetName) {
 		Portlet portlet = PortletLocalServiceUtil.getPortletById(widgetName);
 
-		if (portlet.isInstanceable()) {
+		if ((portlet != null) && portlet.isInstanceable()) {
 			return widgetInstanceId;
 		}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/layout/structure/item/importer/WidgetInstanceLayoutStructureItemImporter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/layout/structure/item/importer/WidgetInstanceLayoutStructureItemImporter.java
@@ -228,7 +228,7 @@ public class WidgetInstanceLayoutStructureItemImporter
 	private String _getInstanceId(String widgetInstanceId, String widgetName) {
 		Portlet portlet = PortletLocalServiceUtil.getPortletById(widgetName);
 
-		if ((portlet != null) && portlet.isInstanceable()) {
+		if ((portlet == null) || portlet.isInstanceable()) {
 			return widgetInstanceId;
 		}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
@@ -367,44 +367,8 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		_testPostSitePageSpecificationPageExperiencePageElementWithFormContainerPageElement();
 		_testPostSitePageSpecificationPageExperiencePageElementWithFragmentPageElement();
 		_testPostSitePageSpecificationPageExperiencePageElementWithGridPageElement();
+		_testPostSitePageSpecificationPageExperiencePageElementWithUndeployedPortletWidgetPageElement();
 		_testPostSitePageSpecificationPageExperiencePageElementWithWidgetPageElement();
-	}
-
-	@Test
-	public void testPostSitePageSpecificationPageExperiencePageElementWithUndeployedPortlet()
-		throws Exception {
-
-		String draftWidgetInstanceExternalReferenceCode =
-			RandomTestUtil.randomString();
-		String namespace = RandomTestUtil.randomString();
-
-		_addFragmentEntryLink(
-			draftWidgetInstanceExternalReferenceCode, namespace);
-
-		String undeployedPortletName =
-			"com_liferay_test_UndeployedPortlet_" +
-				RandomTestUtil.randomString();
-
-		PageElement pageElement = _getWidgetPageElement(
-			null, RandomTestUtil.randomStrings(RandomTestUtil.randomInt(1, 10)),
-			draftWidgetInstanceExternalReferenceCode, false,
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			_getWidgetConfig(), RandomTestUtil.randomString(), namespace,
-			undeployedPortletName, _getWidgetPermissions());
-
-		SegmentsExperience segmentsExperience =
-			_segmentsExperienceLocalService.fetchSegmentsExperience(
-				testGroup.getGroupId(), SegmentsExperienceConstants.KEY_DEFAULT,
-				_layout.getPlid());
-
-		PageElement postPageElement =
-			pageElementResource.
-				postSitePageSpecificationPageExperiencePageElement(
-					testGroup.getExternalReferenceCode(),
-					_draftLayout.getExternalReferenceCode(),
-					segmentsExperience.getExternalReferenceCode(), pageElement);
-
-		assertValid(postPageElement);
 	}
 
 	@Override
@@ -2553,6 +2517,42 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		_assertStyledLayoutStructureItemBackgroundImage(
 			backgroundImageValue, journalArticle.getResourcePrimKey(),
 			journalArticle, pageElement.getExternalReferenceCode());
+	}
+
+	private void _testPostSitePageSpecificationPageExperiencePageElementWithUndeployedPortletWidgetPageElement()
+		throws Exception {
+
+		String draftWidgetInstanceExternalReferenceCode =
+			RandomTestUtil.randomString();
+		String namespace = RandomTestUtil.randomString();
+
+		_addFragmentEntryLink(
+			draftWidgetInstanceExternalReferenceCode, namespace);
+
+		String undeployedPortletName =
+			"com_liferay_test_UndeployedPortlet_" +
+				RandomTestUtil.randomString();
+
+		PageElement pageElement = _getWidgetPageElement(
+			null, RandomTestUtil.randomStrings(RandomTestUtil.randomInt(1, 10)),
+			draftWidgetInstanceExternalReferenceCode, false,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			_getWidgetConfig(), RandomTestUtil.randomString(), namespace,
+			undeployedPortletName, _getWidgetPermissions());
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				testGroup.getGroupId(), SegmentsExperienceConstants.KEY_DEFAULT,
+				_layout.getPlid());
+
+		PageElement postPageElement =
+			pageElementResource.
+				postSitePageSpecificationPageExperiencePageElement(
+					testGroup.getExternalReferenceCode(),
+					_draftLayout.getExternalReferenceCode(),
+					segmentsExperience.getExternalReferenceCode(), pageElement);
+
+		assertValid(postPageElement);
 	}
 
 	private void _testPostSitePageSpecificationPageExperiencePageElementWithWidgetPageElement()

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
@@ -367,7 +367,6 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		_testPostSitePageSpecificationPageExperiencePageElementWithFormContainerPageElement();
 		_testPostSitePageSpecificationPageExperiencePageElementWithFragmentPageElement();
 		_testPostSitePageSpecificationPageExperiencePageElementWithGridPageElement();
-		_testPostSitePageSpecificationPageExperiencePageElementWithUndeployedPortletWidgetPageElement();
 		_testPostSitePageSpecificationPageExperiencePageElementWithWidgetPageElement();
 	}
 
@@ -381,7 +380,6 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		_testPutSitePageSpecificationPageExperiencePageElementWithFormContainerPageElement();
 		_testPutSitePageSpecificationPageExperiencePageElementWithFragmentPageElement();
 		_testPutSitePageSpecificationPageExperiencePageElementWithGridPageElement();
-		_testPutSitePageSpecificationPageExperiencePageElementWithUndeployedPortletWidgetPageElement();
 		_testPutSitePageSpecificationPageExperiencePageElementWithWidgetPageElement();
 	}
 
@@ -2520,53 +2518,6 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 			journalArticle, pageElement.getExternalReferenceCode());
 	}
 
-	private void _testPostSitePageSpecificationPageExperiencePageElementWithUndeployedPortletWidgetPageElement()
-		throws Exception {
-
-		String draftWidgetInstanceExternalReferenceCode =
-			RandomTestUtil.randomString();
-		String namespace = RandomTestUtil.randomString();
-
-		_addFragmentEntryLink(
-			draftWidgetInstanceExternalReferenceCode, namespace);
-
-		String undeployedPortletName =
-			"com_liferay_test_UndeployedPortlet_" +
-				RandomTestUtil.randomString();
-
-		PageElement pageElement = _getWidgetPageElement(
-			null, RandomTestUtil.randomStrings(RandomTestUtil.randomInt(1, 10)),
-			draftWidgetInstanceExternalReferenceCode, false,
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			_getWidgetConfig(), RandomTestUtil.randomString(), namespace,
-			undeployedPortletName, _getWidgetPermissions());
-
-		SegmentsExperience segmentsExperience =
-			_segmentsExperienceLocalService.fetchSegmentsExperience(
-				testGroup.getGroupId(), SegmentsExperienceConstants.KEY_DEFAULT,
-				_layout.getPlid());
-
-		PageElement postPageElement =
-			pageElementResource.
-				postSitePageSpecificationPageExperiencePageElement(
-					testGroup.getExternalReferenceCode(),
-					_draftLayout.getExternalReferenceCode(),
-					segmentsExperience.getExternalReferenceCode(), pageElement);
-
-		assertValid(postPageElement);
-
-		WidgetInstancePageElementDefinition
-			postWidgetInstancePageElementDefinition =
-				(WidgetInstancePageElementDefinition)
-					postPageElement.getPageElementDefinition();
-
-		WidgetInstance postWidgetInstance =
-			postWidgetInstancePageElementDefinition.getWidgetInstance();
-
-		Assert.assertEquals(
-			undeployedPortletName, postWidgetInstance.getWidgetName());
-	}
-
 	private void _testPostSitePageSpecificationPageExperiencePageElementWithWidgetPageElement()
 		throws Exception {
 
@@ -2596,6 +2547,44 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 
 		_assertStyledLayoutStructureItemBackgroundImage(
 			backgroundImageValue, 0, null, pageElement);
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				testGroup.getGroupId(), SegmentsExperienceConstants.KEY_DEFAULT,
+				_layout.getPlid());
+
+		String undeployedPortletName =
+			"com_liferay_test_UndeployedPortlet_" +
+				RandomTestUtil.randomString();
+
+		pageElement =
+			pageElementResource.
+				postSitePageSpecificationPageExperiencePageElement(
+					testGroup.getExternalReferenceCode(),
+					_draftLayout.getExternalReferenceCode(),
+					segmentsExperience.getExternalReferenceCode(),
+					_getWidgetPageElement(
+						null,
+						RandomTestUtil.randomStrings(
+							RandomTestUtil.randomInt(1, 10)),
+						draftWidgetInstanceExternalReferenceCode, false,
+						RandomTestUtil.randomString(),
+						RandomTestUtil.randomString(), _getWidgetConfig(),
+						RandomTestUtil.randomString(), namespace,
+						undeployedPortletName, _getWidgetPermissions()));
+
+		assertValid(pageElement);
+
+		WidgetInstancePageElementDefinition
+			widgetInstancePageElementDefinition =
+				(WidgetInstancePageElementDefinition)
+					pageElement.getPageElementDefinition();
+
+		WidgetInstance widgetInstance =
+			widgetInstancePageElementDefinition.getWidgetInstance();
+
+		Assert.assertEquals(
+			undeployedPortletName, widgetInstance.getWidgetName());
 	}
 
 	private PageElement _testPutSitePageSpecificationPageExperiencePageElement(
@@ -4407,54 +4396,6 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 			_getGridPageElementDefaultValues(externalReferenceCode));
 	}
 
-	private void _testPutSitePageSpecificationPageExperiencePageElementWithUndeployedPortletWidgetPageElement()
-		throws Exception {
-
-		String draftWidgetInstanceExternalReferenceCode =
-			RandomTestUtil.randomString();
-		String namespace = RandomTestUtil.randomString();
-
-		_addFragmentEntryLink(
-			draftWidgetInstanceExternalReferenceCode, namespace);
-
-		String undeployedPortletName =
-			"com_liferay_test_UndeployedPortlet_" +
-				RandomTestUtil.randomString();
-
-		PageElement pageElement = _getWidgetPageElement(
-			null, RandomTestUtil.randomStrings(RandomTestUtil.randomInt(1, 10)),
-			draftWidgetInstanceExternalReferenceCode, false,
-			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			_getWidgetConfig(), RandomTestUtil.randomString(), namespace,
-			undeployedPortletName, _getWidgetPermissions());
-
-		SegmentsExperience segmentsExperience =
-			_segmentsExperienceLocalService.fetchSegmentsExperience(
-				testGroup.getGroupId(), SegmentsExperienceConstants.KEY_DEFAULT,
-				_layout.getPlid());
-
-		PageElement putPageElement =
-			pageElementResource.
-				putSitePageSpecificationPageExperiencePageElement(
-					testGroup.getExternalReferenceCode(),
-					_draftLayout.getExternalReferenceCode(),
-					segmentsExperience.getExternalReferenceCode(),
-					pageElement.getExternalReferenceCode(), pageElement);
-
-		assertValid(putPageElement);
-
-		WidgetInstancePageElementDefinition
-			putWidgetInstancePageElementDefinition =
-				(WidgetInstancePageElementDefinition)
-					putPageElement.getPageElementDefinition();
-
-		WidgetInstance putWidgetInstance =
-			putWidgetInstancePageElementDefinition.getWidgetInstance();
-
-		Assert.assertEquals(
-			undeployedPortletName, putWidgetInstance.getWidgetName());
-	}
-
 	private void _testPutSitePageSpecificationPageExperiencePageElementWithWidgetPageElement()
 		throws Exception {
 
@@ -4529,6 +4470,45 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 
 		_assertStyledLayoutStructureItemBackgroundImage(
 			backgroundImageValue, 0, null, externalReferenceCode);
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				testGroup.getGroupId(), SegmentsExperienceConstants.KEY_DEFAULT,
+				_layout.getPlid());
+
+		String undeployedPortletName =
+			"com_liferay_test_UndeployedPortlet_" +
+				RandomTestUtil.randomString();
+
+		PageElement pageElement =
+			pageElementResource.
+				putSitePageSpecificationPageExperiencePageElement(
+					testGroup.getExternalReferenceCode(),
+					_draftLayout.getExternalReferenceCode(),
+					segmentsExperience.getExternalReferenceCode(),
+					externalReferenceCode,
+					_getWidgetPageElement(
+						null,
+						RandomTestUtil.randomStrings(
+							RandomTestUtil.randomInt(1, 10)),
+						draftWidgetInstanceExternalReferenceCode, false,
+						RandomTestUtil.randomString(), externalReferenceCode,
+						_getWidgetConfig(), widgetInstanceExternalReferenceCode,
+						namespace, undeployedPortletName,
+						_getWidgetPermissions()));
+
+		assertValid(pageElement);
+
+		WidgetInstancePageElementDefinition
+			widgetInstancePageElementDefinition =
+				(WidgetInstancePageElementDefinition)
+					pageElement.getPageElementDefinition();
+
+		WidgetInstance widgetInstance =
+			widgetInstancePageElementDefinition.getWidgetInstance();
+
+		Assert.assertEquals(
+			undeployedPortletName, widgetInstance.getWidgetName());
 	}
 
 	@Inject

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
@@ -2553,9 +2553,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 				testGroup.getGroupId(), SegmentsExperienceConstants.KEY_DEFAULT,
 				_layout.getPlid());
 
-		String undeployedPortletName =
-			"com_liferay_test_UndeployedPortlet_" +
-				RandomTestUtil.randomString();
+		String undeployedPortletName = RandomTestUtil.randomString();
 
 		pageElement =
 			pageElementResource.
@@ -4476,9 +4474,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 				testGroup.getGroupId(), SegmentsExperienceConstants.KEY_DEFAULT,
 				_layout.getPlid());
 
-		String undeployedPortletName =
-			"com_liferay_test_UndeployedPortlet_" +
-				RandomTestUtil.randomString();
+		String undeployedPortletName = RandomTestUtil.randomString();
 
 		PageElement pageElement =
 			pageElementResource.

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
@@ -381,6 +381,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		_testPutSitePageSpecificationPageExperiencePageElementWithFormContainerPageElement();
 		_testPutSitePageSpecificationPageExperiencePageElementWithFragmentPageElement();
 		_testPutSitePageSpecificationPageExperiencePageElementWithGridPageElement();
+		_testPutSitePageSpecificationPageExperiencePageElementWithUndeployedPortletWidgetPageElement();
 		_testPutSitePageSpecificationPageExperiencePageElementWithWidgetPageElement();
 	}
 
@@ -4393,6 +4394,43 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 
 		_testPutSitePageSpecificationPageExperiencePageElement(
 			_getGridPageElementDefaultValues(externalReferenceCode));
+	}
+
+	private void _testPutSitePageSpecificationPageExperiencePageElementWithUndeployedPortletWidgetPageElement()
+		throws Exception {
+
+		String draftWidgetInstanceExternalReferenceCode =
+			RandomTestUtil.randomString();
+		String namespace = RandomTestUtil.randomString();
+
+		_addFragmentEntryLink(
+			draftWidgetInstanceExternalReferenceCode, namespace);
+
+		String undeployedPortletName =
+			"com_liferay_test_UndeployedPortlet_" +
+				RandomTestUtil.randomString();
+
+		PageElement pageElement = _getWidgetPageElement(
+			null, RandomTestUtil.randomStrings(RandomTestUtil.randomInt(1, 10)),
+			draftWidgetInstanceExternalReferenceCode, false,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			_getWidgetConfig(), RandomTestUtil.randomString(), namespace,
+			undeployedPortletName, _getWidgetPermissions());
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				testGroup.getGroupId(), SegmentsExperienceConstants.KEY_DEFAULT,
+				_layout.getPlid());
+
+		PageElement putPageElement =
+			pageElementResource.
+				putSitePageSpecificationPageExperiencePageElement(
+					testGroup.getExternalReferenceCode(),
+					_draftLayout.getExternalReferenceCode(),
+					segmentsExperience.getExternalReferenceCode(),
+					pageElement.getExternalReferenceCode(), pageElement);
+
+		assertValid(putPageElement);
 	}
 
 	private void _testPutSitePageSpecificationPageExperiencePageElementWithWidgetPageElement()

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
@@ -145,6 +145,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -359,6 +360,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 
 	@Override
 	@Test
+	@TestInfo("LPD-85565")
 	public void testPostSitePageSpecificationPageExperiencePageElement()
 		throws Exception {
 
@@ -372,6 +374,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 
 	@Override
 	@Test
+	@TestInfo("LPD-85565")
 	public void testPutSitePageSpecificationPageExperiencePageElement()
 		throws Exception {
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
@@ -2554,6 +2554,17 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 					segmentsExperience.getExternalReferenceCode(), pageElement);
 
 		assertValid(postPageElement);
+
+		WidgetInstancePageElementDefinition
+			postWidgetInstancePageElementDefinition =
+				(WidgetInstancePageElementDefinition)
+					postPageElement.getPageElementDefinition();
+
+		WidgetInstance postWidgetInstance =
+			postWidgetInstancePageElementDefinition.getWidgetInstance();
+
+		Assert.assertEquals(
+			undeployedPortletName, postWidgetInstance.getWidgetName());
 	}
 
 	private void _testPostSitePageSpecificationPageExperiencePageElementWithWidgetPageElement()
@@ -4431,6 +4442,17 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 					pageElement.getExternalReferenceCode(), pageElement);
 
 		assertValid(putPageElement);
+
+		WidgetInstancePageElementDefinition
+			putWidgetInstancePageElementDefinition =
+				(WidgetInstancePageElementDefinition)
+					putPageElement.getPageElementDefinition();
+
+		WidgetInstance putWidgetInstance =
+			putWidgetInstancePageElementDefinition.getWidgetInstance();
+
+		Assert.assertEquals(
+			undeployedPortletName, putWidgetInstance.getWidgetName());
 	}
 
 	private void _testPutSitePageSpecificationPageExperiencePageElementWithWidgetPageElement()

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
@@ -371,7 +371,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 	}
 
 	@Test
-	public void testPostSitePageSpecificationPageExperiencePageElementWithUndeployedWidget()
+	public void testPostSitePageSpecificationPageExperiencePageElementWithUndeployedPortlet()
 		throws Exception {
 
 		String draftWidgetInstanceExternalReferenceCode =
@@ -381,8 +381,8 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		_addFragmentEntryLink(
 			draftWidgetInstanceExternalReferenceCode, namespace);
 
-		String undeployedWidgetName =
-			"com_liferay_test_undeployed_NonexistentPortlet_" +
+		String undeployedPortletName =
+			"com_liferay_test_UndeployedPortlet_" +
 				RandomTestUtil.randomString();
 
 		PageElement pageElement = _getWidgetPageElement(
@@ -390,7 +390,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 			draftWidgetInstanceExternalReferenceCode, false,
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			_getWidgetConfig(), RandomTestUtil.randomString(), namespace,
-			undeployedWidgetName, _getWidgetPermissions());
+			undeployedPortletName, _getWidgetPermissions());
 
 		SegmentsExperience segmentsExperience =
 			_segmentsExperienceLocalService.fetchSegmentsExperience(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
@@ -370,6 +370,43 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		_testPostSitePageSpecificationPageExperiencePageElementWithWidgetPageElement();
 	}
 
+	@Test
+	public void testPostSitePageSpecificationPageExperiencePageElementWithUndeployedWidget()
+		throws Exception {
+
+		String draftWidgetInstanceExternalReferenceCode =
+			RandomTestUtil.randomString();
+		String namespace = RandomTestUtil.randomString();
+
+		_addFragmentEntryLink(
+			draftWidgetInstanceExternalReferenceCode, namespace);
+
+		String undeployedWidgetName =
+			"com_liferay_test_undeployed_NonexistentPortlet_" +
+				RandomTestUtil.randomString();
+
+		PageElement pageElement = _getWidgetPageElement(
+			null, RandomTestUtil.randomStrings(RandomTestUtil.randomInt(1, 10)),
+			draftWidgetInstanceExternalReferenceCode, false,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			_getWidgetConfig(), RandomTestUtil.randomString(), namespace,
+			undeployedWidgetName, _getWidgetPermissions());
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				testGroup.getGroupId(), SegmentsExperienceConstants.KEY_DEFAULT,
+				_layout.getPlid());
+
+		PageElement postPageElement =
+			pageElementResource.
+				postSitePageSpecificationPageExperiencePageElement(
+					testGroup.getExternalReferenceCode(),
+					_draftLayout.getExternalReferenceCode(),
+					segmentsExperience.getExternalReferenceCode(), pageElement);
+
+		assertValid(postPageElement);
+	}
+
 	@Override
 	@Test
 	public void testPutSitePageSpecificationPageExperiencePageElement()


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85565

**What is being fixed:** Importing a page element backed by a widget whose portlet is not currently deployed throws an NPE in `WidgetInstanceLayoutStructureItemImporter._getInstanceId` because `Portlet.isInstanceable()` is invoked on a null portlet returned by `PortletLocalServiceUtil.getPortletById`.

**How it is being fixed:** The `_getInstanceId` guard now returns the input `widgetInstanceId` when the portlet cannot be resolved (typically a transient OSGi state), and falls back to `BLANK` only when we can prove the portlet is non-instanceable; the exporter contract guarantees a non-empty id is only emitted for instanceable portlets, so the page element binds back to its existing preferences once the portlet becomes available. The integration tests in `PageElementResourceTest` cover the undeployed-portlet path inline within the `WithWidgetPageElement` POST/PUT variants, with the PUT case exercising a deployed-to-undeployed transition on the same page element. LPD-87940 tracks the follow-up of also persisting and reading back `widgetConfig` and `widgetPermissions` in this scenario.

cc @vendeltoreki @4lejandrito