### PR TITLE
LPD-87857 Pin company locales in two flaky integration tests via @LanguageIds

### DIFF
--- a/modules/apps/layout/layout-seo-web-test/src/testIntegration/java/com/liferay/layout/seo/web/internal/servlet/taglib/test/OpenGraphTopHeadDynamicIncludeTest.java
+++ b/modules/apps/layout/layout-seo-web-test/src/testIntegration/java/com/liferay/layout/seo/web/internal/servlet/taglib/test/OpenGraphTopHeadDynamicIncludeTest.java
@@ -81,6 +81,7 @@ import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LanguageIds;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.translation.info.item.provider.InfoItemLanguagesProvider;
@@ -120,6 +121,10 @@ import org.springframework.mock.web.MockHttpServletResponse;
  * @author Alicia García
  * @author Cristina González
  */
+@LanguageIds(
+	availableLanguageIds = {"ar_SA", "en_US", "es_ES"},
+	defaultLanguageId = "en_US"
+)
 @RunWith(Arquillian.class)
 public class OpenGraphTopHeadDynamicIncludeTest {
 

--- a/modules/apps/portlet-configuration/portlet-configuration-test/src/testIntegration/java/com/liferay/portlet/configuration/web/internal/portlet/test/PortletConfigurationPortletTest.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-test/src/testIntegration/java/com/liferay/portlet/configuration/web/internal/portlet/test/PortletConfigurationPortletTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LanguageIds;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
@@ -77,6 +78,9 @@ import org.springframework.mock.web.MockHttpServletRequest;
 /**
  * @author Mikel Lorza
  */
+@LanguageIds(
+	availableLanguageIds = {"en_US", "ja_JP"}, defaultLanguageId = "en_US"
+)
 @RunWith(Arquillian.class)
 public class PortletConfigurationPortletTest {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87857

**What is being fixed:** OpenGraphTopHeadDynamicIncludeTest and PortletConfigurationPortletTest fail intermittently in CI but pass locally. They assume specific company locale state (en_US default, plus ar_SA / es_ES for the SEO class), but when prior tests in the same JVM run mutate the company locale and do not restore it, those assumptions are violated and translations or hardcoded en_US-keyed preferences stop applying.

**How it is being fixed:** Both classes are annotated with @LanguageIds, which delegates the save/force/restore of the company display language, available locales, JVM default and site default thread local to LanguageIdsTestRule (already wired through LiferayIntegrationTestRule, so no extra rule wiring is needed). The OpenGraph class pins {ar_SA, en_US, es_ES} with en_US as default; PortletConfigurationPortletTest pins {en_US, ja_JP} with en_US as default.