### PR TITLE
LPD-88286 Simplify ServiceContextThreadLocal scoping in PublishLayoutMVCActionCommandTest

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/PublishLayoutMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/PublishLayoutMVCActionCommandTest.java
@@ -494,35 +494,30 @@ public class PublishLayoutMVCActionCommandTest {
 	public void testPublishedLayoutFragmentEntryLinkWithFreeMarkerEmbeddedPortlet()
 		throws Exception {
 
-		ServiceContext serviceContext =
+		ServiceContextThreadLocal.pushServiceContext(
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId());
+				_group.getGroupId(), TestPropsValues.getUserId()));
 
-		try {
-			ServiceContextThreadLocal.pushServiceContext(serviceContext);
+		_assertPublishedLayoutFragmentEntryLinkWithFreeMarkerEmbeddedPortlet(
+			new String[] {
+				StringBundler.concat(
+					"<div class=\"fragment_1\">[@liferay_portlet.runtime ",
+					"portletName=\"com_liferay_journal_content_web_",
+					"portlet_JournalContentPortlet\" ",
+					"instanceId=\"myInstanceId0\" persistSettings=false /]",
+					"</div>"),
+				StringBundler.concat(
+					"<div class=\"fragment_1\">[@liferay_portlet",
+					"[\"runtime\"] portletName=\"com_liferay_journal_",
+					"content_web_portlet_JournalContentPortlet\" ",
+					"instanceId=\"myInstanceId1\" persistSettings=false /]",
+					"</div>")
+			},
+			(index, namespace) -> PortletIdCodec.encode(
+				JournalContentPortletKeys.JOURNAL_CONTENT,
+				"myInstanceId" + index));
 
-			_assertPublishedLayoutFragmentEntryLinkWithFreeMarkerEmbeddedPortlet(
-				new String[] {
-					StringBundler.concat(
-						"<div class=\"fragment_1\">[@liferay_portlet.runtime ",
-						"portletName=\"com_liferay_journal_content_web_",
-						"portlet_JournalContentPortlet\" ",
-						"instanceId=\"myInstanceId0\" persistSettings=false /]",
-						"</div>"),
-					StringBundler.concat(
-						"<div class=\"fragment_1\">[@liferay_portlet",
-						"[\"runtime\"] portletName=\"com_liferay_journal_",
-						"content_web_portlet_JournalContentPortlet\" ",
-						"instanceId=\"myInstanceId1\" persistSettings=false /]",
-						"</div>")
-				},
-				(index, namespace) -> PortletIdCodec.encode(
-					JournalContentPortletKeys.JOURNAL_CONTENT,
-					"myInstanceId" + index));
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		ServiceContextThreadLocal.popServiceContext();
 	}
 
 	@Test
@@ -530,34 +525,29 @@ public class PublishLayoutMVCActionCommandTest {
 	public void testPublishedLayoutFragmentEntryLinkWithFreeMarkerEmbeddedPortletAndDynamicInstanceId()
 		throws Exception {
 
-		ServiceContext serviceContext =
+		ServiceContextThreadLocal.pushServiceContext(
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), TestPropsValues.getUserId());
+				_group.getGroupId(), TestPropsValues.getUserId()));
 
-		try {
-			ServiceContextThreadLocal.pushServiceContext(serviceContext);
+		_assertPublishedLayoutFragmentEntryLinkWithFreeMarkerEmbeddedPortlet(
+			new String[] {
+				StringBundler.concat(
+					"<div class=\"fragment_1\">[@liferay_portlet.runtime ",
+					"portletName=\"com_liferay_journal_content_web_",
+					"portlet_JournalContentPortlet\" ",
+					"instanceId=\"fragmentEntryLinkNamespace\" ",
+					"persistSettings=false /]</div>"),
+				StringBundler.concat(
+					"<div class=\"fragment_2\">[@liferay_portlet",
+					"[\"runtime\"] portletName=\"com_liferay_journal_",
+					"content_web_portlet_JournalContentPortlet\" ",
+					"instanceId=\"fragmentEntryLinkNamespace\" ",
+					"persistSettings=false /]</div>")
+			},
+			(index, namespace) -> PortletIdCodec.encode(
+				JournalContentPortletKeys.JOURNAL_CONTENT, namespace));
 
-			_assertPublishedLayoutFragmentEntryLinkWithFreeMarkerEmbeddedPortlet(
-				new String[] {
-					StringBundler.concat(
-						"<div class=\"fragment_1\">[@liferay_portlet.runtime ",
-						"portletName=\"com_liferay_journal_content_web_",
-						"portlet_JournalContentPortlet\" ",
-						"instanceId=\"fragmentEntryLinkNamespace\" ",
-						"persistSettings=false /]</div>"),
-					StringBundler.concat(
-						"<div class=\"fragment_2\">[@liferay_portlet",
-						"[\"runtime\"] portletName=\"com_liferay_journal_",
-						"content_web_portlet_JournalContentPortlet\" ",
-						"instanceId=\"fragmentEntryLinkNamespace\" ",
-						"persistSettings=false /]</div>")
-				},
-				(index, namespace) -> PortletIdCodec.encode(
-					JournalContentPortletKeys.JOURNAL_CONTENT, namespace));
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		ServiceContextThreadLocal.popServiceContext();
 	}
 
 	@Test
@@ -761,18 +751,14 @@ public class PublishLayoutMVCActionCommandTest {
 
 		ServiceContextThreadLocal.pushServiceContext(serviceContext);
 
-		try {
-			for (FragmentEntryLinkListener fragmentEntryLinkListener :
-					_fragmentEntryLinkListenerRegistry.
-						getFragmentEntryLinkListeners()) {
+		for (FragmentEntryLinkListener fragmentEntryLinkListener :
+				_fragmentEntryLinkListenerRegistry.
+					getFragmentEntryLinkListeners()) {
 
-				fragmentEntryLinkListener.onAddFragmentEntryLink(
-					fragmentEntryLink);
-			}
+			fragmentEntryLinkListener.onAddFragmentEntryLink(fragmentEntryLink);
 		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+
+		ServiceContextThreadLocal.popServiceContext();
 
 		return fragmentEntryLink;
 	}

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/PublishLayoutMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/PublishLayoutMVCActionCommandTest.java
@@ -436,24 +436,20 @@ public class PublishLayoutMVCActionCommandTest {
 		User user = UserTestUtil.addCompanyAdminUser(
 			_companyLocalService.getCompany(_group.getCompanyId()));
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), user.getUserId());
-
-		ServiceContextThreadLocal.pushServiceContext(serviceContext);
-
 		Layout originalLayout = _layoutLocalService.addLayout(
 			null, user.getUserId(), _group.getGroupId(), false,
 			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID,
 			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
 			LayoutConstants.TYPE_PORTLET, false, StringPool.BLANK,
-			serviceContext);
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), user.getUserId()));
 
 		Assert.assertEquals(user.getUserId(), originalLayout.getUserId());
 		Assert.assertTrue(originalLayout.isTypePortlet());
 
-		serviceContext = ServiceContextTestUtil.getServiceContext(
-			_group.getGroupId(), TestPropsValues.getUserId());
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
 
 		ServiceContextThreadLocal.pushServiceContext(serviceContext);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88286

**What is being fixed:** PublishLayoutMVCActionCommandTest paid the cost of wrapping ServiceContextThreadLocal pushes in try/finally blocks just to guarantee the matching pop, and testPublishConversionDraftCreatedByDeletedUser kept a redundant push around the addLayout call (which already takes the ServiceContext as a parameter). Removing the wrapping try/finally in a previous round had also dropped one of the two pops, leaking a ServiceContext into subsequent tests in the class.

**How it is being fixed:** testPublishConversionDraftCreatedByDeletedUser now passes the ServiceContext directly to addLayout and keeps a single push/pop pair around the admin-scoped section, restoring push/pop balance without try/finally. The two FreeMarker-embedded portlet tests and the _addFragmentEntryLink helper drop their try/finally wrappers as well, leaving sequential push, body, pop. The full class still passes locally (12/12).