### PR TITLE
LPD-88520 Fix Enter on tree item dropdown

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/components/StructureTree.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/components/StructureTree.tsx
@@ -325,6 +325,18 @@ export default function StructureTree({search}: {search: string}) {
 											{childItem.actions?.length ? (
 												<ClayDropDownWithItems
 													items={childItem.actions}
+													menuElementAttrs={{
+														onKeyDown: (event) => {
+															if (
+																event.key ===
+																	'Enter' ||
+																event.key ===
+																	' '
+															) {
+																event.stopPropagation();
+															}
+														},
+													}}
 													trigger={
 														<ClayButtonWithIcon
 															aria-label={Liferay.Language.get(

--- a/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/repeatableGroups.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/repeatableGroups.spec.ts
@@ -108,10 +108,18 @@ test(
 			label: 'Repeatable Group 3',
 		});
 
-		await structureBuilderPage.clickFieldAction(
+		// Assert keyboard behavior
+
+		await structureBuilderPage.selectFields([
 			{label: 'Repeatable Group 3'},
-			'Ungroup'
-		);
+		]);
+
+		await page
+			.getByRole('treeitem', {name: 'Repeatable Group 3'})
+			.getByRole('button', {name: 'Field Options'})
+			.click();
+
+		await page.getByRole('menuitem', {name: 'Ungroup'}).press('Enter');
 
 		await expect(
 			page.locator('.treeview-link', {hasText: 'Repeatable Group 2'})


### PR DESCRIPTION
**Ticket**: [LPD-88520](https://liferay.atlassian.net/browse/LPD-88520)

## Summary

- Stop `Enter`/`Space` propagation from a tree item's dropdown menu so the row's `keydown` handler in `ClayTreeView` no longer suppresses the browser's default click on the focused option.

## Tests

- Adapted the existing `Groups can be created, persisted and ungrouped` Playwright test to activate the `Ungroup` option with `Enter` instead of clicking it.

[LPD-88520]: https://liferay.atlassian.net/browse/LPD-88520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ