### PR TITLE
LPD-87954 Don't auto-rename locked fields on label change

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/contexts/StateContext.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/contexts/StateContext.tsx
@@ -1090,7 +1090,11 @@ function getNextName({
 		return action.name!;
 	}
 
-	if (!action.label || modifiedNames.has(item.uuid)) {
+	if (
+		!action.label ||
+		modifiedNames.has(item.uuid) ||
+		('locked' in item && item.locked)
+	) {
 		return item.name;
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/contexts/StateContext.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/contexts/StateContext.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {act, renderHook} from '@testing-library/react';
+import React, {ReactNode} from 'react';
+
+import StateContextProvider, {
+	State,
+	useSelector,
+	useStateDispatch,
+} from '../../../../src/main/resources/META-INF/resources/js/structure_builder/contexts/StateContext';
+import {Field} from '../../../../src/main/resources/META-INF/resources/js/structure_builder/utils/field';
+import getUuid from '../../../../src/main/resources/META-INF/resources/js/structure_builder/utils/getUuid';
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/structure_builder/config',
+	() => ({
+		config: {
+			objectFolderExternalReferenceCode: 'L_CMS_CONTENT_STRUCTURES',
+		},
+	})
+);
+
+const STRUCTURE_UUID = getUuid();
+
+function buildField(overrides: Partial<Field> = {}): Field {
+	return {
+		erc: 'field-erc',
+		indexableConfig: {indexed: false},
+		label: {en_US: 'Original Label'},
+		localized: false,
+		locked: false,
+		name: 'originalName',
+		parent: STRUCTURE_UUID,
+		required: false,
+		settings: {},
+		type: 'text',
+		uuid: getUuid(),
+		...overrides,
+	};
+}
+
+function buildInitialState(field: Field): State {
+	const children = new Map();
+
+	children.set(field.uuid, field);
+
+	return {
+		history: {
+			deletedChildren: [],
+			deletedGroupERCs: [],
+			deletedRelationships: [],
+			modifiedNames: new Set(),
+		},
+		invalids: new Map(),
+		publishedChildren: new Set(),
+		renamingItemUuid: null,
+		selection: [],
+		structure: {
+			children,
+			erc: 'structure-erc',
+			label: {en_US: 'Structure'},
+			name: 'myStructure',
+			path: '',
+			spaces: [],
+			status: 'draft',
+			system: false,
+			type: 'L_CMS_CONTENT_STRUCTURES',
+			uuid: STRUCTURE_UUID,
+			workflows: {},
+		},
+		unsavedChanges: false,
+	};
+}
+
+function renderReducerHook(field: Field) {
+	const wrapper = ({children}: {children: ReactNode}) => (
+		<StateContextProvider initialState={buildInitialState(field)}>
+			{children}
+		</StateContextProvider>
+	);
+
+	return renderHook(
+		() => ({
+			dispatch: useStateDispatch(),
+			field: useSelector(
+				(state) => state.structure.children.get(field.uuid) as Field
+			),
+		}),
+		{wrapper}
+	);
+}
+
+describe('StateContext reducer', () => {
+	describe('update-field', () => {
+		it('keeps the name of a locked field when its label changes', () => {
+			const lockedField = buildField({locked: true, name: 'title'});
+
+			const {result} = renderReducerHook(lockedField);
+
+			act(() => {
+				result.current.dispatch({
+					label: {en_US: 'Headline'},
+					type: 'update-field',
+					uuid: lockedField.uuid,
+				});
+			});
+
+			expect(result.current.field.label).toEqual({en_US: 'Headline'});
+			expect(result.current.field.name).toBe('title');
+		});
+
+		it('auto-renames an unlocked field when its label changes', () => {
+			const unlockedField = buildField({
+				locked: false,
+				name: 'originalName',
+			});
+
+			const {result} = renderReducerHook(unlockedField);
+
+			act(() => {
+				result.current.dispatch({
+					label: {en_US: 'Headline'},
+					type: 'update-field',
+					uuid: unlockedField.uuid,
+				});
+			});
+
+			expect(result.current.field.label).toEqual({en_US: 'Headline'});
+			expect(result.current.field.name).toBe('headline');
+		});
+	});
+});


### PR DESCRIPTION
**Ticket**: [LPD-87954](https://liferay.atlassian.net/browse/LPD-87954)

## Summary

- The structure builder reducer auto-derives a field's `name` from its `label` whenever the label changes. Locked fields (the default `title` and `file` of CMS Content / File structures) were not exempt, so renaming their label silently changed their `name`, breaking the `titleObjectField` lookup and producing the "Untitled Asset" symptom.
- Skip the auto-rename in `getNextName` when the item is a locked field, alongside the existing guards (no label change / name manually modified).

## Tests

- New unit tests in `StateContext.test.tsx` cover the `update-field` reducer path: locked fields keep their `name` on label change; unlocked fields still auto-rename.

[LPD-87954]: https://liferay.atlassian.net/browse/LPD-87954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ