### PR TITLE
LPD-85513 - Allow export/import for Fragment Sets across environments via Batch Headless APIs

### DIFF
--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -79,6 +79,8 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 				fetchFragmentCollectionByExternalReferenceCode(
 					fragmentSet.getExternalReferenceCode(),
 					testGroup.getGroupId()));
+
+		_testDeleteSiteFragmentSetBatch();
 	}
 
 	@Override
@@ -345,6 +347,30 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 
 			return StringUtil.read(zipInputStream);
 		}
+	}
+
+	private void _testDeleteSiteFragmentSetBatch() throws Exception {
+		FragmentSet fragmentSet1 = testPostSiteFragmentSet_addFragmentSet(
+			randomFragmentSet());
+		FragmentSet fragmentSet2 = testPostSiteFragmentSet_addFragmentSet(
+			randomFragmentSet());
+
+		waitForFinish(
+			"COMPLETED",
+			HTTPTestUtil.invokeToJSONObject(
+				_exportFragmentSetsToJSON(testGroup.getExternalReferenceCode()),
+				"headless-admin-fragment/v1.0/sites/" +
+					irrelevantGroup.getExternalReferenceCode() +
+						"/fragment-sets/batch?createStrategy=INSERT",
+				Http.Method.POST));
+
+		testBatchEngineDeleteImportTask_deleteFragmentSet(
+			200, fragmentSet2.getExternalReferenceCode(),
+			"siteExternalReferenceCode",
+			irrelevantGroup.getExternalReferenceCode());
+
+		_assertFragmentCollection(fragmentSet1, irrelevantGroup);
+		_assertFragmentCollectionNull(fragmentSet2, irrelevantGroup);
 	}
 
 	private void _testPostSiteFragmentSetBatch() throws Exception {

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -64,6 +64,14 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 
 	@Override
 	@Test
+	public void testBatchEngineDeleteImportTask() throws Exception {
+		super.testBatchEngineDeleteImportTask();
+
+		_testBatchEngineDeleteImportTask();
+	}
+
+	@Override
+	@Test
 	public void testDeleteSiteFragmentSet() throws Exception {
 		super.testDeleteSiteFragmentSet();
 
@@ -79,8 +87,6 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 				fetchFragmentCollectionByExternalReferenceCode(
 					fragmentSet.getExternalReferenceCode(),
 					testGroup.getGroupId()));
-
-		_testDeleteSiteFragmentSetBatch();
 	}
 
 	@Override
@@ -349,7 +355,7 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 		}
 	}
 
-	private void _testDeleteSiteFragmentSetBatch() throws Exception {
+	private void _testBatchEngineDeleteImportTask() throws Exception {
 		FragmentSet fragmentSet1 = testPostSiteFragmentSet_addFragmentSet(
 			randomFragmentSet());
 		FragmentSet fragmentSet2 = testPostSiteFragmentSet_addFragmentSet(

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -418,6 +418,9 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 				String.valueOf(throwable),
 				throwable instanceof DuplicateFragmentCollectionKeyException);
 		}
+
+		_assertFragmentCollection(fragmentSet1, irrelevantGroup);
+		_assertFragmentCollection(fragmentSet2, irrelevantGroup);
 	}
 
 	private void _testPutSiteFragmentSetBatch() throws Exception {

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -257,15 +257,14 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 			testGroup.getExternalReferenceCode(), fragmentSet);
 	}
 
-	private void _assertFragmentCollection(
-		FragmentSet fragmentSet, Group group) {
+	private void _assertFragmentCollection(FragmentSet fragmentSet, Group group)
+		throws Exception {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.
-				fetchFragmentCollectionByExternalReferenceCode(
+				getFragmentCollectionByExternalReferenceCode(
 					fragmentSet.getExternalReferenceCode(), group.getGroupId());
 
-		Assert.assertNotNull(fragmentCollection);
 		Assert.assertEquals(
 			fragmentSet.getName(), fragmentCollection.getName());
 		Assert.assertEquals(

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -462,6 +462,8 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 		String externalReferenceCode = jsonObject.getString(
 			"externalReferenceCode");
 
+		long time = System.currentTimeMillis() + _EXPORT_TIMEOUT;
+
 		while (true) {
 			jsonObject = HTTPTestUtil.invokeToJSONObject(
 				null,
@@ -478,8 +480,21 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 
 				return jsonObject;
 			}
+
+			if (System.currentTimeMillis() > time) {
+				throw new AssertionError(
+					StringBundler.concat(
+						"Export task ", externalReferenceCode,
+						" did not finish within ", _EXPORT_TIMEOUT, " ms"));
+			}
+
+			Thread.sleep(_EXPORT_POLL_INTERVAL);
 		}
 	}
+
+	private static final long _EXPORT_POLL_INTERVAL = 500;
+
+	private static final long _EXPORT_TIMEOUT = 60000;
 
 	@Inject
 	private FragmentCollectionLocalService _fragmentCollectionLocalService;

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -6,24 +6,41 @@
 package com.liferay.headless.admin.fragment.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.fragment.exception.DuplicateFragmentCollectionKeyException;
+import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.service.FragmentCollectionLocalService;
 import com.liferay.headless.admin.fragment.client.dto.v1_0.FragmentSet;
 import com.liferay.headless.admin.fragment.client.pagination.Page;
 import com.liferay.headless.admin.fragment.client.problem.Problem;
 import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
+import java.io.InputStream;
+
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.ZipInputStream;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -121,6 +138,8 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 			() -> fragmentSetResource.postSiteFragmentSet(
 				testGroup.getExternalReferenceCode(), duplicateKeyFragmentSet),
 			duplicateKeyFragmentSet.getKey());
+
+		_testPostSiteFragmentSetBatch();
 	}
 
 	@Override
@@ -228,6 +247,32 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 			testGroup.getExternalReferenceCode(), fragmentSet);
 	}
 
+	private void _assertFragmentCollection(
+		FragmentSet fragmentSet, Group group) {
+
+		FragmentCollection fragmentCollection =
+			_fragmentCollectionLocalService.
+				fetchFragmentCollectionByExternalReferenceCode(
+					fragmentSet.getExternalReferenceCode(), group.getGroupId());
+
+		Assert.assertNotNull(fragmentCollection);
+		Assert.assertEquals(
+			fragmentSet.getName(), fragmentCollection.getName());
+		Assert.assertEquals(
+			fragmentSet.getDescription(), fragmentCollection.getDescription());
+	}
+
+	private void _assertFragmentCollectionNull(
+		FragmentSet fragmentSet, Group group) {
+
+		FragmentCollection fragmentCollection =
+			_fragmentCollectionLocalService.
+				fetchFragmentCollectionByExternalReferenceCode(
+					fragmentSet.getExternalReferenceCode(), group.getGroupId());
+
+		Assert.assertNull(fragmentCollection);
+	}
+
 	private void _assertGetSiteFragmentSetsPageWithFilter(
 			FragmentSet expectedFragmentSet, String filterString,
 			FragmentSet notExpectedFragmentSet)
@@ -265,6 +310,111 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 				_language.format(
 					LocaleUtil.getDefault(), titleKey, titleArguments),
 				problem.getTitle());
+		}
+	}
+
+	private String _exportFragmentSetsToJSON(String siteExternalReferenceCode)
+		throws Exception {
+
+		JSONObject exportTaskJSONObject = _waitForExportFinish(
+			"COMPLETED",
+			HTTPTestUtil.invokeToJSONObject(
+				null,
+				"headless-admin-fragment/v1.0/sites/" +
+					siteExternalReferenceCode +
+						"/fragment-sets/export-batch?contentType=JSON",
+				Http.Method.POST));
+
+		try (InputStream inputStream = HTTPTestUtil.invokeToInputStream(
+				null,
+				StringBundler.concat(
+					"headless-batch-engine/v1.0/export-task",
+					"/by-external-reference-code/",
+					exportTaskJSONObject.getString("externalReferenceCode"),
+					"/content"),
+				HashMapBuilder.put(
+					HttpHeaders.ACCEPT, ContentTypes.APPLICATION_OCTET_STREAM
+				).build(),
+				Http.Method.GET)) {
+
+			ZipInputStream zipInputStream = new ZipInputStream(inputStream);
+
+			zipInputStream.getNextEntry();
+
+			return StringUtil.read(zipInputStream);
+		}
+	}
+
+	private void _testPostSiteFragmentSetBatch() throws Exception {
+		FragmentSet fragmentSet1 = testPostSiteFragmentSet_addFragmentSet(
+			randomFragmentSet());
+		FragmentSet fragmentSet2 = testPostSiteFragmentSet_addFragmentSet(
+			randomFragmentSet());
+
+		waitForFinish(
+			"COMPLETED",
+			HTTPTestUtil.invokeToJSONObject(
+				_exportFragmentSetsToJSON(testGroup.getExternalReferenceCode()),
+				"headless-admin-fragment/v1.0/sites/" +
+					irrelevantGroup.getExternalReferenceCode() +
+						"/fragment-sets/batch?createStrategy=INSERT",
+				Http.Method.POST));
+
+		_assertFragmentCollection(fragmentSet1, irrelevantGroup);
+		_assertFragmentCollection(fragmentSet2, irrelevantGroup);
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.batch.engine.internal." +
+					"BatchEngineImportTaskExecutorImpl",
+				LoggerTestUtil.ERROR)) {
+
+			waitForFinish(
+				"FAILED",
+				HTTPTestUtil.invokeToJSONObject(
+					_exportFragmentSetsToJSON(
+						testGroup.getExternalReferenceCode()),
+					"headless-admin-fragment/v1.0/sites/" +
+						irrelevantGroup.getExternalReferenceCode() +
+							"/fragment-sets/batch?createStrategy=INSERT",
+					Http.Method.POST));
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertFalse(logEntries.toString(), logEntries.isEmpty());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Throwable throwable = logEntry.getThrowable();
+
+			Assert.assertTrue(
+				String.valueOf(throwable),
+				throwable instanceof DuplicateFragmentCollectionKeyException);
+		}
+	}
+
+	private JSONObject _waitForExportFinish(
+			String expectedExecuteStatus, JSONObject jsonObject)
+		throws Exception {
+
+		String externalReferenceCode = jsonObject.getString(
+			"externalReferenceCode");
+
+		while (true) {
+			jsonObject = HTTPTestUtil.invokeToJSONObject(
+				null,
+				"headless-batch-engine/v1.0/export-task" +
+					"/by-external-reference-code/" + externalReferenceCode,
+				Http.Method.GET);
+
+			String executeStatus = jsonObject.getString("executeStatus");
+
+			if (StringUtil.equals(executeStatus, "COMPLETED") ||
+				StringUtil.equals(executeStatus, "FAILED")) {
+
+				Assert.assertEquals(expectedExecuteStatus, executeStatus);
+
+				return jsonObject;
+			}
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -272,17 +272,6 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 			fragmentSet.getDescription(), fragmentCollection.getDescription());
 	}
 
-	private void _assertFragmentCollectionNull(
-		FragmentSet fragmentSet, Group group) {
-
-		FragmentCollection fragmentCollection =
-			_fragmentCollectionLocalService.
-				fetchFragmentCollectionByExternalReferenceCode(
-					fragmentSet.getExternalReferenceCode(), group.getGroupId());
-
-		Assert.assertNull(fragmentCollection);
-	}
-
 	private void _assertGetSiteFragmentSetsPageWithFilter(
 			FragmentSet expectedFragmentSet, String filterString,
 			FragmentSet notExpectedFragmentSet)
@@ -376,7 +365,12 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 			irrelevantGroup.getExternalReferenceCode());
 
 		_assertFragmentCollection(fragmentSet1, irrelevantGroup);
-		_assertFragmentCollectionNull(fragmentSet2, irrelevantGroup);
+
+		Assert.assertNull(
+			_fragmentCollectionLocalService.
+				fetchFragmentCollectionByExternalReferenceCode(
+					fragmentSet2.getExternalReferenceCode(),
+					irrelevantGroup.getGroupId()));
 	}
 
 	private void _testPostSiteFragmentSetBatch() throws Exception {

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -438,7 +438,7 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 		fragmentSet2.setDescription(RandomTestUtil.randomString());
 		fragmentSet2.setName(RandomTestUtil.randomString());
 
-		FragmentSet putFragmentSet2 = fragmentSetResource.putSiteFragmentSet(
+		FragmentSet putFragmentSet = fragmentSetResource.putSiteFragmentSet(
 			testGroup.getExternalReferenceCode(),
 			fragmentSet2.getExternalReferenceCode(), fragmentSet2);
 
@@ -452,7 +452,7 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 				Http.Method.POST));
 
 		_assertFragmentCollection(fragmentSet1, irrelevantGroup);
-		_assertFragmentCollection(putFragmentSet2, irrelevantGroup);
+		_assertFragmentCollection(putFragmentSet, irrelevantGroup);
 	}
 
 	private JSONObject _waitForExportFinish(

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -210,6 +210,8 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 				duplicateKeyFragmentSet.getExternalReferenceCode(),
 				duplicateKeyFragmentSet),
 			duplicateKeyFragmentSet.getKey());
+
+		_testPutSiteFragmentSetBatch();
 	}
 
 	@Override
@@ -390,6 +392,39 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 				String.valueOf(throwable),
 				throwable instanceof DuplicateFragmentCollectionKeyException);
 		}
+	}
+
+	private void _testPutSiteFragmentSetBatch() throws Exception {
+		FragmentSet fragmentSet1 = testPutSiteFragmentSet_addFragmentSet();
+		FragmentSet fragmentSet2 = testPutSiteFragmentSet_addFragmentSet();
+
+		waitForFinish(
+			"COMPLETED",
+			HTTPTestUtil.invokeToJSONObject(
+				_exportFragmentSetsToJSON(testGroup.getExternalReferenceCode()),
+				"headless-admin-fragment/v1.0/sites/" +
+					irrelevantGroup.getExternalReferenceCode() +
+						"/fragment-sets/batch?createStrategy=INSERT",
+				Http.Method.POST));
+
+		fragmentSet2.setDescription(RandomTestUtil.randomString());
+		fragmentSet2.setName(RandomTestUtil.randomString());
+
+		FragmentSet putFragmentSet2 = fragmentSetResource.putSiteFragmentSet(
+			testGroup.getExternalReferenceCode(),
+			fragmentSet2.getExternalReferenceCode(), fragmentSet2);
+
+		waitForFinish(
+			"COMPLETED",
+			HTTPTestUtil.invokeToJSONObject(
+				_exportFragmentSetsToJSON(testGroup.getExternalReferenceCode()),
+				"headless-admin-fragment/v1.0/sites/" +
+					irrelevantGroup.getExternalReferenceCode() +
+						"/fragment-sets/batch?createStrategy=UPSERT",
+				Http.Method.POST));
+
+		_assertFragmentCollection(fragmentSet1, irrelevantGroup);
+		_assertFragmentCollection(putFragmentSet2, irrelevantGroup);
 	}
 
 	private JSONObject _waitForExportFinish(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85513

**What is being fixed:** Cross-environment export/import for Fragment Sets via the Batch Headless APIs has no integration coverage proving the end-to-end path.