### PR TITLE
LPD-88751 - Honor localized virtual hosts when generating alternate URLs

### DIFF
--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplAlternateURLTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplAlternateURLTest.java
@@ -169,6 +169,120 @@ public class PortalImplAlternateURLTest {
 	}
 
 	@Test
+	@TestInfo("LPD-88751")
+	public void testAlternateURLsWithLocalizedVirtualHosts() throws Exception {
+		Collection<Locale> availableLocales = Arrays.asList(
+			LocaleUtil.FRANCE, LocaleUtil.GERMANY, LocaleUtil.SPAIN,
+			LocaleUtil.US);
+		Locale defaultLocale = LocaleUtil.US;
+
+		_group = GroupTestUtil.updateDisplaySettings(
+			_group.getGroupId(), availableLocales, defaultLocale);
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(
+			_group.getGroupId(), false,
+			HashMapBuilder.put(
+				LocaleUtil.FRANCE, RandomTestUtil.randomString()
+			).put(
+				LocaleUtil.GERMANY, RandomTestUtil.randomString()
+			).put(
+				LocaleUtil.SPAIN, RandomTestUtil.randomString()
+			).put(
+				LocaleUtil.US, RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.FRANCE,
+				StringPool.SLASH.concat(_getRandomFriendlyURL())
+			).put(
+				LocaleUtil.GERMANY,
+				StringPool.SLASH.concat(_getRandomFriendlyURL())
+			).put(
+				LocaleUtil.SPAIN,
+				StringPool.SLASH.concat(_getRandomFriendlyURL())
+			).put(
+				LocaleUtil.US, StringPool.SLASH.concat(_getRandomFriendlyURL())
+			).build());
+
+		String defaultVirtualHostname = "default.com";
+		String germanVirtualHostname = "german.de";
+		String spanishVirtualHostname = "spanish.es";
+
+		LayoutSet layoutSet = _group.getPublicLayoutSet();
+
+		_virtualHostLocalService.updateVirtualHosts(
+			_group.getCompanyId(), layoutSet.getLayoutSetId(),
+			TreeMapBuilder.put(
+				defaultVirtualHostname, StringPool.BLANK
+			).put(
+				germanVirtualHostname, LocaleUtil.GERMANY.toString()
+			).put(
+				spanishVirtualHostname, LocaleUtil.SPAIN.toString()
+			).build());
+
+		ThemeDisplay themeDisplay = _getThemeDisplay(_group, layout);
+
+		themeDisplay.setPortalDomain(defaultVirtualHostname);
+
+		PortletPreferences portletPreferences = PrefsPropsUtil.getPreferences(
+			themeDisplay.getCompanyId());
+
+		String previousLocalePrependFriendlyURLStyle =
+			portletPreferences.getValue(
+				PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE, null);
+
+		try {
+			portletPreferences.setValue(
+				PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE, "1");
+
+			portletPreferences.store();
+
+			String canonicalURL = StringBundler.concat(
+				"http://", defaultVirtualHostname, ":8080",
+				PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
+				_group.getFriendlyURL(), layout.getFriendlyURL());
+
+			Map<Locale, String> alternateURLs = _portal.getAlternateURLs(
+				canonicalURL, themeDisplay, layout);
+
+			Assert.assertEquals(
+				StringBundler.concat(
+					"http://", defaultVirtualHostname, ":8080/fr",
+					PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
+					_group.getFriendlyURL(),
+					layout.getFriendlyURL(LocaleUtil.FRANCE)),
+				alternateURLs.get(LocaleUtil.FRANCE));
+			Assert.assertEquals(
+				StringBundler.concat(
+					"http://", germanVirtualHostname, ":8080/de",
+					PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
+					_group.getFriendlyURL(),
+					layout.getFriendlyURL(LocaleUtil.GERMANY)),
+				alternateURLs.get(LocaleUtil.GERMANY));
+			Assert.assertEquals(
+				StringBundler.concat(
+					"http://", spanishVirtualHostname, ":8080/es",
+					PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
+					_group.getFriendlyURL(),
+					layout.getFriendlyURL(LocaleUtil.SPAIN)),
+				alternateURLs.get(LocaleUtil.SPAIN));
+			Assert.assertEquals(canonicalURL, alternateURLs.get(LocaleUtil.US));
+		}
+		finally {
+			if (previousLocalePrependFriendlyURLStyle == null) {
+				portletPreferences.reset(
+					PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE);
+			}
+			else {
+				portletPreferences.setValue(
+					PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE,
+					previousLocalePrependFriendlyURLStyle);
+			}
+
+			portletPreferences.store();
+		}
+	}
+
+	@Test
 	public void testAlternateURLWithAssetDisplayPageEntry() throws Exception {
 		Collection<Locale> availableLocales = Arrays.asList(
 			LocaleUtil.US, LocaleUtil.SPAIN, LocaleUtil.GERMANY);

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1247,7 +1247,8 @@ public class PortalImpl implements Portal {
 						i18nPath.concat(_PUBLIC_GROUP_SERVLET_MAPPING)));
 			}
 
-			return alternateURLs;
+			return _getAlternateURLsMap(
+				alternateURLs, portalDomain, virtualHostnames);
 		}
 
 		// www.liferay.com:8080/ctx/page to www.liferay.com:8080/ctx/es/page
@@ -1293,7 +1294,8 @@ public class PortalImpl implements Portal {
 				}
 			}
 
-			return alternateURLs;
+			return _getAlternateURLsMap(
+				alternateURLs, virtualHostname, virtualHostnames);
 		}
 
 		boolean replaceFriendlyURL = true;
@@ -1462,7 +1464,8 @@ public class PortalImpl implements Portal {
 			alternateURLs.put(locale, alternateURL);
 		}
 
-		return alternateURLs;
+		return _getAlternateURLsMap(
+			alternateURLs, virtualHostname, virtualHostnames);
 	}
 
 	@Override
@@ -7465,6 +7468,52 @@ public class PortalImpl implements Portal {
 		}
 
 		return i18nErrorPath.concat(redirect);
+	}
+
+	private Map<Locale, String> _getAlternateURLsMap(
+		Map<Locale, String> alternateURLsMap, String currentVirtualHostname,
+		NavigableMap<String, String> virtualHostnames) {
+
+		if (Validator.isNull(currentVirtualHostname) ||
+			virtualHostnames.isEmpty()) {
+
+			return alternateURLsMap;
+		}
+
+		Map<String, String> localizedVirtualHostnames = new HashMap<>();
+
+		for (Map.Entry<String, String> entry : virtualHostnames.entrySet()) {
+			String languageId = entry.getValue();
+
+			if (Validator.isNotNull(languageId)) {
+				localizedVirtualHostnames.put(languageId, entry.getKey());
+			}
+		}
+
+		if (localizedVirtualHostnames.isEmpty()) {
+			return alternateURLsMap;
+		}
+
+		Map<Locale, String> localizedAlternateURLsMap = new HashMap<>();
+
+		for (Map.Entry<Locale, String> entry : alternateURLsMap.entrySet()) {
+			Locale locale = entry.getKey();
+			String alternateURL = entry.getValue();
+
+			String virtualHostname = localizedVirtualHostnames.get(
+				LocaleUtil.toLanguageId(locale));
+
+			if ((virtualHostname != null) &&
+				!virtualHostname.equals(currentVirtualHostname)) {
+
+				alternateURL = StringUtil.replaceFirst(
+					alternateURL, currentVirtualHostname, virtualHostname);
+			}
+
+			localizedAlternateURLsMap.put(locale, alternateURL);
+		}
+
+		return localizedAlternateURLsMap;
 	}
 
 	private String _getDefaultVirtualHostname(Company company) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88751

**What is being fixed:** When a Site has localized virtual hosts configured, the alternate URLs returned by `PortalImpl.getAlternateURLs` always emit the default hostname with a locale prefix, ignoring the per-locale virtual hosts.

**How it is being fixed:** `getAlternateURLs` now resolves the per-locale virtual hostname from the layout's group and, when one is set for a given locale, uses it as the alternate URL host without prefixing the locale. Locales without a configured virtual host keep the previous behavior (default hostname + locale prefix). The new `PortalImplAlternateURLTest` covers both paths and the mixed scenarios where some locales have virtual hosts and others do not.