### PR TITLE
LPD-89123 Await dialog interactions in chooseFileFromCMSLibrary

### DIFF
--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/utils/chooseFileFromCMSLibrary.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/utils/chooseFileFromCMSLibrary.ts
@@ -25,10 +25,12 @@ export default async function chooseFileFromCMSLibrary({
 		trigger,
 	});
 
-	await expect(() => {
-		dialog.locator('.card', {hasText: fileName}).click();
+	await expect(async () => {
+		await dialog.locator('.card', {hasText: fileName}).click();
 
-		expect(dialog.getByRole('button', {name: 'Select'})).toBeEnabled();
+		await expect(
+			dialog.getByRole('button', {name: 'Select'})
+		).toBeEnabled();
 	}).toPass();
 
 	await clickAndExpectToBeHidden({


### PR DESCRIPTION
The toPass callback was a synchronous arrow function and the inner locator.click and expect toBeEnabled calls were not awaited. The arrow returned undefined immediately so toPass treated the first iteration as successful, even when the card click had not actually selected a file. The dangling promise rejection eventually surfaced elsewhere as a misleading element-not-found error against an already-closed dialog. Making the callback async and awaiting both calls lets toPass retry on real failures.