### PR TITLE
LPD-89069 - Stop logging spurious 404 WARNs from the thumbnail URL helpers in the page-related resource tests

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateResourceTest.java
@@ -360,12 +360,7 @@ public class DisplayPageTemplateResourceTest
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		expectedDisplayPageTemplate.setThumbnailURLReference(
-			new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						fileEntry.getExternalReferenceCode());
-				}
-			});
+			ThumbnailUtil.thumbnailURLReference(fileEntry));
 
 		_testPatchSiteDisplayPageTemplate(
 			expectedDisplayPageTemplate,
@@ -1206,12 +1201,7 @@ public class DisplayPageTemplateResourceTest
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		randomDisplayPageTemplate.setThumbnailURLReference(
-			() -> new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						fileEntry.getExternalReferenceCode());
-				}
-			});
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry));
 
 		DisplayPageTemplate postDisplayPageTemplate =
 			testPostSiteDisplayPageTemplate_addDisplayPageTemplate(
@@ -1810,12 +1800,7 @@ public class DisplayPageTemplateResourceTest
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		displayPageTemplate.setThumbnailURLReference(
-			() -> new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						fileEntry.getExternalReferenceCode());
-				}
-			});
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry));
 
 		DisplayPageTemplate postDisplayPageTemplate =
 			displayPageTemplateResource.postSiteDisplayPageTemplate(
@@ -2228,12 +2213,7 @@ public class DisplayPageTemplateResourceTest
 		FileEntry fileEntry1 = _addPortletFileEntry(repository.getDlFolderId());
 
 		displayPageTemplate.setThumbnailURLReference(
-			() -> new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						fileEntry1.getExternalReferenceCode());
-				}
-			});
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry1));
 
 		DisplayPageTemplate putDisplayPageTemplate =
 			displayPageTemplateResource.putSiteDisplayPageTemplate(
@@ -2248,12 +2228,7 @@ public class DisplayPageTemplateResourceTest
 		FileEntry fileEntry2 = _addPortletFileEntry(repository.getDlFolderId());
 
 		putDisplayPageTemplate.setThumbnailURLReference(
-			() -> new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						fileEntry2.getExternalReferenceCode());
-				}
-			});
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry2));
 
 		putDisplayPageTemplate =
 			displayPageTemplateResource.putSiteDisplayPageTemplate(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateResourceTest.java
@@ -1487,7 +1487,7 @@ public class DisplayPageTemplateResourceTest
 					setExternalReferenceCode(RandomTestUtil.randomString());
 					setUrl(
 						() ->
-							"http://localhost:8080/" +
+							"http://invalid.example.test/" +
 								RandomTestUtil.randomString());
 				}
 			};
@@ -1840,7 +1840,7 @@ public class DisplayPageTemplateResourceTest
 					setExternalReferenceCode(RandomTestUtil.randomString());
 					setUrl(
 						() ->
-							"http://localhost:8080/" +
+							"http://invalid.example.test/" +
 								RandomTestUtil.randomString());
 				}
 			};
@@ -2299,7 +2299,7 @@ public class DisplayPageTemplateResourceTest
 					setExternalReferenceCode(RandomTestUtil.randomString());
 					setUrl(
 						() ->
-							"http://localhost:8080/" +
+							"http://invalid.example.test/" +
 								RandomTestUtil.randomString());
 				}
 			};

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateResourceTest.java
@@ -360,7 +360,7 @@ public class DisplayPageTemplateResourceTest
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		expectedDisplayPageTemplate.setThumbnailURLReference(
-			ThumbnailUtil.thumbnailURLReference(fileEntry));
+			ThumbnailUtil.thumbnailURLReference(fileEntry, null));
 
 		_testPatchSiteDisplayPageTemplate(
 			expectedDisplayPageTemplate,
@@ -1201,7 +1201,7 @@ public class DisplayPageTemplateResourceTest
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		randomDisplayPageTemplate.setThumbnailURLReference(
-			() -> ThumbnailUtil.thumbnailURLReference(fileEntry));
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry, null));
 
 		DisplayPageTemplate postDisplayPageTemplate =
 			testPostSiteDisplayPageTemplate_addDisplayPageTemplate(
@@ -1427,13 +1427,8 @@ public class DisplayPageTemplateResourceTest
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		displayPageTemplate1.setThumbnailURLReference(
-			() -> new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						fileEntry.getExternalReferenceCode());
-					setUrl(RandomTestUtil.randomString());
-				}
-			});
+			() -> ThumbnailUtil.thumbnailURLReference(
+				fileEntry, RandomTestUtil.randomString()));
 
 		DisplayPageTemplateResource displayPageTemplateResource =
 			_getDisplayPageTemplateResource("thumbnail");
@@ -1453,13 +1448,8 @@ public class DisplayPageTemplateResourceTest
 			repository.getDlFolderId());
 
 		displayPageTemplate1.setThumbnailURLReference(
-			() -> new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						newFileEntry.getExternalReferenceCode());
-					setUrl(RandomTestUtil.randomString());
-				}
-			});
+			() -> ThumbnailUtil.thumbnailURLReference(
+				newFileEntry, RandomTestUtil.randomString()));
 
 		displayPageTemplateResource.patchSiteDisplayPageTemplate(
 			testGroup.getExternalReferenceCode(),
@@ -1800,7 +1790,7 @@ public class DisplayPageTemplateResourceTest
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		displayPageTemplate.setThumbnailURLReference(
-			() -> ThumbnailUtil.thumbnailURLReference(fileEntry));
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry, null));
 
 		DisplayPageTemplate postDisplayPageTemplate =
 			displayPageTemplateResource.postSiteDisplayPageTemplate(
@@ -2213,7 +2203,7 @@ public class DisplayPageTemplateResourceTest
 		FileEntry fileEntry1 = _addPortletFileEntry(repository.getDlFolderId());
 
 		displayPageTemplate.setThumbnailURLReference(
-			() -> ThumbnailUtil.thumbnailURLReference(fileEntry1));
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry1, null));
 
 		DisplayPageTemplate putDisplayPageTemplate =
 			displayPageTemplateResource.putSiteDisplayPageTemplate(
@@ -2228,7 +2218,7 @@ public class DisplayPageTemplateResourceTest
 		FileEntry fileEntry2 = _addPortletFileEntry(repository.getDlFolderId());
 
 		putDisplayPageTemplate.setThumbnailURLReference(
-			() -> ThumbnailUtil.thumbnailURLReference(fileEntry2));
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry2, null));
 
 		putDisplayPageTemplate =
 			displayPageTemplateResource.putSiteDisplayPageTemplate(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateResourceTest.java
@@ -35,6 +35,7 @@ import com.liferay.headless.admin.site.resource.v1_0.test.util.PageElementsTestU
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageExperiencesTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageSpecificationsTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.SettingsTestUtil;
+import com.liferay.headless.admin.site.resource.v1_0.test.util.ThumbnailUtil;
 import com.liferay.info.constants.InfoDisplayWebKeys;
 import com.liferay.info.item.ERCInfoItemIdentifier;
 import com.liferay.info.item.InfoItemClassDetails;
@@ -1482,15 +1483,7 @@ public class DisplayPageTemplateResourceTest
 		DisplayPageTemplate displayPageTemplate2 = randomDisplayPageTemplate();
 
 		ThumbnailURLReference thumbnailURLReference =
-			new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(RandomTestUtil.randomString());
-					setUrl(
-						() ->
-							"http://invalid.example.test/" +
-								RandomTestUtil.randomString());
-				}
-			};
+			ThumbnailUtil.randomThumbnailURLReference();
 
 		displayPageTemplate2.setThumbnailURLReference(thumbnailURLReference);
 
@@ -1835,15 +1828,7 @@ public class DisplayPageTemplateResourceTest
 		displayPageTemplate = randomDisplayPageTemplate();
 
 		ThumbnailURLReference thumbnailURLReference =
-			new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(RandomTestUtil.randomString());
-					setUrl(
-						() ->
-							"http://invalid.example.test/" +
-								RandomTestUtil.randomString());
-				}
-			};
+			ThumbnailUtil.randomThumbnailURLReference();
 
 		displayPageTemplate.setThumbnailURLReference(thumbnailURLReference);
 
@@ -2294,15 +2279,7 @@ public class DisplayPageTemplateResourceTest
 		displayPageTemplate = randomDisplayPageTemplate();
 
 		ThumbnailURLReference thumbnailURLReference =
-			new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(RandomTestUtil.randomString());
-					setUrl(
-						() ->
-							"http://invalid.example.test/" +
-								RandomTestUtil.randomString());
-				}
-			};
+			ThumbnailUtil.randomThumbnailURLReference();
 
 		displayPageTemplate.setThumbnailURLReference(thumbnailURLReference);
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
@@ -184,7 +184,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		randomMasterPage.setThumbnailURLReference(
-			() -> ThumbnailUtil.thumbnailURLReference(fileEntry));
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry, null));
 
 		MasterPage postMasterPage = testPostSiteMasterPage_addMasterPage(
 			randomMasterPage);
@@ -1014,7 +1014,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		masterPage1.setThumbnailURLReference(
-			() -> ThumbnailUtil.thumbnailURLReference(fileEntry));
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry, null));
 
 		MasterPageResource masterPageResource = _getMasterPageResource();
 
@@ -1031,7 +1031,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 			repository.getDlFolderId());
 
 		masterPage1.setThumbnailURLReference(
-			() -> ThumbnailUtil.thumbnailURLReference(newFileEntry));
+			() -> ThumbnailUtil.thumbnailURLReference(newFileEntry, null));
 
 		masterPageResource.patchSiteMasterPage(
 			testGroup.getExternalReferenceCode(),
@@ -1214,7 +1214,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		masterPage.setThumbnailURLReference(
-			() -> ThumbnailUtil.thumbnailURLReference(fileEntry));
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry, null));
 
 		MasterPage postMasterPage = masterPageResource.postSiteMasterPage(
 			testGroup.getExternalReferenceCode(), masterPage);
@@ -1422,7 +1422,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 		FileEntry fileEntry1 = _addPortletFileEntry(repository.getDlFolderId());
 
 		masterPage.setThumbnailURLReference(
-			() -> ThumbnailUtil.thumbnailURLReference(fileEntry1));
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry1, null));
 
 		MasterPage putMasterPage = masterPageResource.putSiteMasterPage(
 			testGroup.getExternalReferenceCode(),
@@ -1435,7 +1435,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 		FileEntry fileEntry2 = _addPortletFileEntry(repository.getDlFolderId());
 
 		putMasterPage.setThumbnailURLReference(
-			() -> ThumbnailUtil.thumbnailURLReference(fileEntry2));
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry2, null));
 
 		putMasterPage = masterPageResource.putSiteMasterPage(
 			testGroup.getExternalReferenceCode(),

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
@@ -27,6 +27,7 @@ import com.liferay.headless.admin.site.resource.v1_0.test.util.LayoutPageTemplat
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageElementsTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageExperiencesTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageSpecificationsTestUtil;
+import com.liferay.headless.admin.site.resource.v1_0.test.util.ThumbnailUtil;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
@@ -1058,15 +1059,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 		MasterPage masterPage2 = randomMasterPage();
 
 		ThumbnailURLReference thumbnailURLReference =
-			new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(RandomTestUtil.randomString());
-					setUrl(
-						() ->
-							"http://invalid.example.test/" +
-								RandomTestUtil.randomString());
-				}
-			};
+			ThumbnailUtil.randomThumbnailURLReference();
 
 		masterPage2.setThumbnailURLReference(thumbnailURLReference);
 
@@ -1255,15 +1248,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 		masterPage = randomMasterPage();
 
 		ThumbnailURLReference thumbnailURLReference =
-			new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(RandomTestUtil.randomString());
-					setUrl(
-						() ->
-							"http://invalid.example.test/" +
-								RandomTestUtil.randomString());
-				}
-			};
+			ThumbnailUtil.randomThumbnailURLReference();
 
 		masterPage.setThumbnailURLReference(thumbnailURLReference);
 
@@ -1502,15 +1487,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 		masterPage = randomMasterPage();
 
 		ThumbnailURLReference thumbnailURLReference =
-			new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(RandomTestUtil.randomString());
-					setUrl(
-						() ->
-							"http://invalid.example.test/" +
-								RandomTestUtil.randomString());
-				}
-			};
+			ThumbnailUtil.randomThumbnailURLReference();
 
 		masterPage.setThumbnailURLReference(thumbnailURLReference);
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
@@ -1063,7 +1063,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 					setExternalReferenceCode(RandomTestUtil.randomString());
 					setUrl(
 						() ->
-							"http://localhost:8080/" +
+							"http://invalid.example.test/" +
 								RandomTestUtil.randomString());
 				}
 			};
@@ -1260,7 +1260,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 					setExternalReferenceCode(RandomTestUtil.randomString());
 					setUrl(
 						() ->
-							"http://localhost:8080/" +
+							"http://invalid.example.test/" +
 								RandomTestUtil.randomString());
 				}
 			};
@@ -1507,7 +1507,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 					setExternalReferenceCode(RandomTestUtil.randomString());
 					setUrl(
 						() ->
-							"http://localhost:8080/" +
+							"http://invalid.example.test/" +
 								RandomTestUtil.randomString());
 				}
 			};

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
@@ -184,12 +184,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		randomMasterPage.setThumbnailURLReference(
-			() -> new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						fileEntry.getExternalReferenceCode());
-				}
-			});
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry));
 
 		MasterPage postMasterPage = testPostSiteMasterPage_addMasterPage(
 			randomMasterPage);
@@ -1019,12 +1014,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		masterPage1.setThumbnailURLReference(
-			() -> new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						fileEntry.getExternalReferenceCode());
-				}
-			});
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry));
 
 		MasterPageResource masterPageResource = _getMasterPageResource();
 
@@ -1041,12 +1031,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 			repository.getDlFolderId());
 
 		masterPage1.setThumbnailURLReference(
-			() -> new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						newFileEntry.getExternalReferenceCode());
-				}
-			});
+			() -> ThumbnailUtil.thumbnailURLReference(newFileEntry));
 
 		masterPageResource.patchSiteMasterPage(
 			testGroup.getExternalReferenceCode(),
@@ -1229,12 +1214,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		masterPage.setThumbnailURLReference(
-			() -> new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						fileEntry.getExternalReferenceCode());
-				}
-			});
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry));
 
 		MasterPage postMasterPage = masterPageResource.postSiteMasterPage(
 			testGroup.getExternalReferenceCode(), masterPage);
@@ -1442,12 +1422,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 		FileEntry fileEntry1 = _addPortletFileEntry(repository.getDlFolderId());
 
 		masterPage.setThumbnailURLReference(
-			() -> new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						fileEntry1.getExternalReferenceCode());
-				}
-			});
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry1));
 
 		MasterPage putMasterPage = masterPageResource.putSiteMasterPage(
 			testGroup.getExternalReferenceCode(),
@@ -1460,12 +1435,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 		FileEntry fileEntry2 = _addPortletFileEntry(repository.getDlFolderId());
 
 		putMasterPage.setThumbnailURLReference(
-			() -> new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						fileEntry2.getExternalReferenceCode());
-				}
-			});
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry2));
 
 		putMasterPage = masterPageResource.putSiteMasterPage(
 			testGroup.getExternalReferenceCode(),

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
@@ -1131,7 +1131,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		randomPageTemplate.setThumbnailURLReference(
-			() -> ThumbnailUtil.thumbnailURLReference(fileEntry));
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry, null));
 
 		PageTemplate postPageTemplate =
 			testPostSitePageTemplate_addPageTemplate(randomPageTemplate);
@@ -1449,7 +1449,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		pageTemplate.setThumbnailURLReference(
-			() -> ThumbnailUtil.thumbnailURLReference(fileEntry));
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry, null));
 
 		PageTemplateResource pageTemplateResource = _getPageTemplateResource();
 
@@ -1464,13 +1464,8 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 			repository.getDlFolderId());
 
 		pageTemplate.setThumbnailURLReference(
-			() -> new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						newFileEntry.getExternalReferenceCode());
-					setUrl(RandomTestUtil.randomString());
-				}
-			});
+			() -> ThumbnailUtil.thumbnailURLReference(
+				newFileEntry, RandomTestUtil.randomString()));
 
 		pageTemplateResource.patchSitePageTemplate(
 			testGroup.getExternalReferenceCode(),
@@ -1690,7 +1685,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		pageTemplate.setThumbnailURLReference(
-			() -> ThumbnailUtil.thumbnailURLReference(fileEntry));
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry, null));
 
 		PageTemplate postPageTemplate =
 			pageTemplateResource.postSitePageTemplate(
@@ -1923,7 +1918,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 		FileEntry fileEntry1 = _addPortletFileEntry(repository.getDlFolderId());
 
 		pageTemplate.setThumbnailURLReference(
-			() -> ThumbnailUtil.thumbnailURLReference(fileEntry1));
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry1, null));
 
 		PageTemplate putPageTemplate = pageTemplateResource.putSitePageTemplate(
 			testGroup.getExternalReferenceCode(),
@@ -1936,7 +1931,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 		FileEntry fileEntry2 = _addPortletFileEntry(repository.getDlFolderId());
 
 		putPageTemplate.setThumbnailURLReference(
-			() -> ThumbnailUtil.thumbnailURLReference(fileEntry2));
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry2, null));
 
 		putPageTemplate = pageTemplateResource.putSitePageTemplate(
 			testGroup.getExternalReferenceCode(),

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
@@ -1495,7 +1495,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 					setExternalReferenceCode(RandomTestUtil.randomString());
 					setUrl(
 						() ->
-							"http://localhost:8080/" +
+							"http://invalid.example.test/" +
 								RandomTestUtil.randomString());
 				}
 			};
@@ -1730,7 +1730,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 					setExternalReferenceCode(RandomTestUtil.randomString());
 					setUrl(
 						() ->
-							"http://localhost:8080/" +
+							"http://invalid.example.test/" +
 								RandomTestUtil.randomString());
 				}
 			};
@@ -2001,7 +2001,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 					setExternalReferenceCode(RandomTestUtil.randomString());
 					setUrl(
 						() ->
-							"http://localhost:8080/" +
+							"http://invalid.example.test/" +
 								RandomTestUtil.randomString());
 				}
 			};

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
@@ -1131,12 +1131,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		randomPageTemplate.setThumbnailURLReference(
-			() -> new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						fileEntry.getExternalReferenceCode());
-				}
-			});
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry));
 
 		PageTemplate postPageTemplate =
 			testPostSitePageTemplate_addPageTemplate(randomPageTemplate);
@@ -1454,12 +1449,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		pageTemplate.setThumbnailURLReference(
-			() -> new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						fileEntry.getExternalReferenceCode());
-				}
-			});
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry));
 
 		PageTemplateResource pageTemplateResource = _getPageTemplateResource();
 
@@ -1700,12 +1690,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		pageTemplate.setThumbnailURLReference(
-			() -> new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						fileEntry.getExternalReferenceCode());
-				}
-			});
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry));
 
 		PageTemplate postPageTemplate =
 			pageTemplateResource.postSitePageTemplate(
@@ -1938,12 +1923,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 		FileEntry fileEntry1 = _addPortletFileEntry(repository.getDlFolderId());
 
 		pageTemplate.setThumbnailURLReference(
-			() -> new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						fileEntry1.getExternalReferenceCode());
-				}
-			});
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry1));
 
 		PageTemplate putPageTemplate = pageTemplateResource.putSitePageTemplate(
 			testGroup.getExternalReferenceCode(),
@@ -1956,12 +1936,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 		FileEntry fileEntry2 = _addPortletFileEntry(repository.getDlFolderId());
 
 		putPageTemplate.setThumbnailURLReference(
-			() -> new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						fileEntry2.getExternalReferenceCode());
-				}
-			});
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry2));
 
 		putPageTemplate = pageTemplateResource.putSitePageTemplate(
 			testGroup.getExternalReferenceCode(),

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
@@ -31,6 +31,7 @@ import com.liferay.headless.admin.site.resource.v1_0.test.util.AssetTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.LayoutPageTemplateEntryTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageSpecificationsTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.SettingsTestUtil;
+import com.liferay.headless.admin.site.resource.v1_0.test.util.ThumbnailUtil;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateCollectionTypeConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
@@ -1490,15 +1491,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 			newFileEntry.getExternalReferenceCode());
 
 		ThumbnailURLReference thumbnailURLReference =
-			new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(RandomTestUtil.randomString());
-					setUrl(
-						() ->
-							"http://invalid.example.test/" +
-								RandomTestUtil.randomString());
-				}
-			};
+			ThumbnailUtil.randomThumbnailURLReference();
 
 		pageTemplate.setThumbnailURLReference(thumbnailURLReference);
 
@@ -1725,15 +1718,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 		pageTemplate = randomPageTemplate();
 
 		ThumbnailURLReference thumbnailURLReference =
-			new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(RandomTestUtil.randomString());
-					setUrl(
-						() ->
-							"http://invalid.example.test/" +
-								RandomTestUtil.randomString());
-				}
-			};
+			ThumbnailUtil.randomThumbnailURLReference();
 
 		pageTemplate.setThumbnailURLReference(thumbnailURLReference);
 
@@ -1996,15 +1981,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 			true, putPageTemplate.getExternalReferenceCode(), null);
 
 		ThumbnailURLReference thumbnailURLReference =
-			new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(RandomTestUtil.randomString());
-					setUrl(
-						() ->
-							"http://invalid.example.test/" +
-								RandomTestUtil.randomString());
-				}
-			};
+			ThumbnailUtil.randomThumbnailURLReference();
 
 		putPageTemplate.setThumbnailURLReference(thumbnailURLReference);
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
@@ -311,7 +311,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		ThumbnailURLReference thumbnailURLReference =
-			ThumbnailUtil.thumbnailURLReference(fileEntry);
+			ThumbnailUtil.thumbnailURLReference(fileEntry, null);
 
 		utilityPage.setThumbnailURLReference(thumbnailURLReference);
 
@@ -741,7 +741,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		randomUtilityPage.setThumbnailURLReference(
-			() -> ThumbnailUtil.thumbnailURLReference(fileEntry));
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry, null));
 
 		UtilityPage postUtilityPage = testPostSiteUtilityPage_addUtilityPage(
 			randomUtilityPage);
@@ -914,7 +914,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		utilityPage1.setThumbnailURLReference(
-			() -> ThumbnailUtil.thumbnailURLReference(fileEntry));
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry, null));
 
 		UtilityPageResource utilityPageResource = _getUtilityPageResource();
 
@@ -933,7 +933,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 			repository.getDlFolderId());
 
 		utilityPage1.setThumbnailURLReference(
-			() -> ThumbnailUtil.thumbnailURLReference(newFileEntry));
+			() -> ThumbnailUtil.thumbnailURLReference(newFileEntry, null));
 
 		utilityPageResource.patchSiteUtilityPage(
 			testGroup.getExternalReferenceCode(),
@@ -1179,7 +1179,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 		FileEntry fileEntry1 = _addPortletFileEntry(repository.getDlFolderId());
 
 		utilityPage.setThumbnailURLReference(
-			() -> ThumbnailUtil.thumbnailURLReference(fileEntry1));
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry1, null));
 
 		UtilityPage putUtilityPage = utilityPageResource.putSiteUtilityPage(
 			testGroup.getExternalReferenceCode(),
@@ -1192,7 +1192,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 		FileEntry fileEntry2 = _addPortletFileEntry(repository.getDlFolderId());
 
 		putUtilityPage.setThumbnailURLReference(
-			() -> ThumbnailUtil.thumbnailURLReference(fileEntry2));
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry2, null));
 
 		putUtilityPage = utilityPageResource.putSiteUtilityPage(
 			testGroup.getExternalReferenceCode(),

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
@@ -336,7 +336,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 				setExternalReferenceCode(RandomTestUtil.randomString());
 				setUrl(
 					() ->
-						"http://localhost:8080/" +
+						"http://invalid.example.test/" +
 							RandomTestUtil.randomString());
 			}
 		};
@@ -978,7 +978,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 					setExternalReferenceCode(RandomTestUtil.randomString());
 					setUrl(
 						() ->
-							"http://localhost:8080/" +
+							"http://invalid.example.test/" +
 								RandomTestUtil.randomString());
 				}
 			};
@@ -1264,7 +1264,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 					setExternalReferenceCode(RandomTestUtil.randomString());
 					setUrl(
 						() ->
-							"http://localhost:8080/" +
+							"http://invalid.example.test/" +
 								RandomTestUtil.randomString());
 				}
 			};

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
@@ -18,6 +18,7 @@ import com.liferay.headless.admin.site.client.problem.Problem;
 import com.liferay.headless.admin.site.client.resource.v1_0.UtilityPageResource;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.LayoutUtilityPageEntryTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageSpecificationsTestUtil;
+import com.liferay.headless.admin.site.resource.v1_0.test.util.ThumbnailUtil;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
@@ -331,15 +332,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 
 		utilityPage = randomUtilityPage();
 
-		thumbnailURLReference = new ThumbnailURLReference() {
-			{
-				setExternalReferenceCode(RandomTestUtil.randomString());
-				setUrl(
-					() ->
-						"http://invalid.example.test/" +
-							RandomTestUtil.randomString());
-			}
-		};
+		thumbnailURLReference = ThumbnailUtil.randomThumbnailURLReference();
 
 		utilityPage.setThumbnailURLReference(thumbnailURLReference);
 
@@ -973,15 +966,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 		UtilityPage utilityPage2 = randomUtilityPage();
 
 		ThumbnailURLReference thumbnailURLReference =
-			new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(RandomTestUtil.randomString());
-					setUrl(
-						() ->
-							"http://invalid.example.test/" +
-								RandomTestUtil.randomString());
-				}
-			};
+			ThumbnailUtil.randomThumbnailURLReference();
 
 		utilityPage2.setThumbnailURLReference(thumbnailURLReference);
 
@@ -1259,15 +1244,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 		utilityPage = randomUtilityPage();
 
 		ThumbnailURLReference thumbnailURLReference =
-			new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(RandomTestUtil.randomString());
-					setUrl(
-						() ->
-							"http://invalid.example.test/" +
-								RandomTestUtil.randomString());
-				}
-			};
+			ThumbnailUtil.randomThumbnailURLReference();
 
 		utilityPage.setThumbnailURLReference(thumbnailURLReference);
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
@@ -311,12 +311,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		ThumbnailURLReference thumbnailURLReference =
-			new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						fileEntry.getExternalReferenceCode());
-				}
-			};
+			ThumbnailUtil.thumbnailURLReference(fileEntry);
 
 		utilityPage.setThumbnailURLReference(thumbnailURLReference);
 
@@ -746,12 +741,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		randomUtilityPage.setThumbnailURLReference(
-			() -> new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						fileEntry.getExternalReferenceCode());
-				}
-			});
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry));
 
 		UtilityPage postUtilityPage = testPostSiteUtilityPage_addUtilityPage(
 			randomUtilityPage);
@@ -924,12 +914,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
 
 		utilityPage1.setThumbnailURLReference(
-			() -> new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						fileEntry.getExternalReferenceCode());
-				}
-			});
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry));
 
 		UtilityPageResource utilityPageResource = _getUtilityPageResource();
 
@@ -948,12 +933,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 			repository.getDlFolderId());
 
 		utilityPage1.setThumbnailURLReference(
-			() -> new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						newFileEntry.getExternalReferenceCode());
-				}
-			});
+			() -> ThumbnailUtil.thumbnailURLReference(newFileEntry));
 
 		utilityPageResource.patchSiteUtilityPage(
 			testGroup.getExternalReferenceCode(),
@@ -1199,12 +1179,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 		FileEntry fileEntry1 = _addPortletFileEntry(repository.getDlFolderId());
 
 		utilityPage.setThumbnailURLReference(
-			() -> new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						fileEntry1.getExternalReferenceCode());
-				}
-			});
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry1));
 
 		UtilityPage putUtilityPage = utilityPageResource.putSiteUtilityPage(
 			testGroup.getExternalReferenceCode(),
@@ -1217,12 +1192,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 		FileEntry fileEntry2 = _addPortletFileEntry(repository.getDlFolderId());
 
 		putUtilityPage.setThumbnailURLReference(
-			() -> new ThumbnailURLReference() {
-				{
-					setExternalReferenceCode(
-						fileEntry2.getExternalReferenceCode());
-				}
-			});
+			() -> ThumbnailUtil.thumbnailURLReference(fileEntry2));
 
 		putUtilityPage = utilityPageResource.putSiteUtilityPage(
 			testGroup.getExternalReferenceCode(),

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/ThumbnailUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/ThumbnailUtil.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.admin.site.resource.v1_0.test.util;
 
 import com.liferay.headless.admin.site.client.dto.v1_0.ThumbnailURLReference;
+import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 
 /**
@@ -22,6 +23,18 @@ public class ThumbnailUtil {
 		thumbnailURLReference.setUrl(
 			() ->
 				"http://invalid.example.test/" + RandomTestUtil.randomString());
+
+		return thumbnailURLReference;
+	}
+
+	public static ThumbnailURLReference thumbnailURLReference(
+		FileEntry fileEntry) {
+
+		ThumbnailURLReference thumbnailURLReference =
+			new ThumbnailURLReference();
+
+		thumbnailURLReference.setExternalReferenceCode(
+			fileEntry::getExternalReferenceCode);
 
 		return thumbnailURLReference;
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/ThumbnailUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/ThumbnailUtil.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.resource.v1_0.test.util;
+
+import com.liferay.headless.admin.site.client.dto.v1_0.ThumbnailURLReference;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public class ThumbnailUtil {
+
+	public static ThumbnailURLReference randomThumbnailURLReference() {
+		ThumbnailURLReference thumbnailURLReference =
+			new ThumbnailURLReference();
+
+		thumbnailURLReference.setExternalReferenceCode(
+			RandomTestUtil::randomString);
+		thumbnailURLReference.setUrl(
+			() ->
+				"http://invalid.example.test/" + RandomTestUtil.randomString());
+
+		return thumbnailURLReference;
+	}
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/ThumbnailUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/ThumbnailUtil.java
@@ -28,13 +28,14 @@ public class ThumbnailUtil {
 	}
 
 	public static ThumbnailURLReference thumbnailURLReference(
-		FileEntry fileEntry) {
+		FileEntry fileEntry, String url) {
 
 		ThumbnailURLReference thumbnailURLReference =
 			new ThumbnailURLReference();
 
 		thumbnailURLReference.setExternalReferenceCode(
 			fileEntry::getExternalReferenceCode);
+		thumbnailURLReference.setUrl(() -> url);
 
 		return thumbnailURLReference;
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89069

**What is being fixed:** `DisplayPageTemplateResourceTest`, `MasterPageResourceTest`, `PageTemplateResourceTest`, and `UtilityPageResourceTest` build random `ThumbnailURLReference` payloads with URLs of the form `http://localhost:8080/<random>`. Server-side, `URLUtil.getByteArray` issues an HTTP GET that loops back to the local Tomcat, which routes the missing path through `errors/code.jsp` and logs a 404 WARN, polluting the test logs.

**How it is being fixed:** The random URLs now point at the RFC-2606 reserved test domain `http://invalid.example.test/`, so the fetch fails at connect time without ever reaching Tomcat — the `BAD_REQUEST` problem the negative tests assert is unaffected. The inline `new ThumbnailURLReference() {{ ... }}` blocks scattered across the four test classes are also extracted into a single `ThumbnailUtil` helper with two methods, `randomThumbnailURLReference()` and `thumbnailURLReference(FileEntry, String url)`, removing 130+ lines of duplication.