### PR TITLE
LPD-89133 - Pin company locales in PortletConfigurationPortletTest via @LanguageIds

### DIFF
--- a/modules/apps/portlet-configuration/portlet-configuration-test/src/testIntegration/java/com/liferay/portlet/configuration/util/test/PortletConfigurationPortletTest.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-test/src/testIntegration/java/com/liferay/portlet/configuration/util/test/PortletConfigurationPortletTest.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LanguageIds;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portlet.configuration.kernel.util.PortletConfigurationUtil;
@@ -34,6 +35,9 @@ import org.junit.runner.RunWith;
 /**
  * @author Eudaldo Alonso
  */
+@LanguageIds(
+	availableLanguageIds = {"en_US", "ja_JP"}, defaultLanguageId = "en_US"
+)
 @RunWith(Arquillian.class)
 public class PortletConfigurationPortletTest {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89133

**What is being fixed:** `PortletConfigurationPortletTest.testGetPortletTitle` exercises localization by reading the portlet title under `en_US` and `ja_JP`. The test inherits whatever locale set the company has at runtime, so on companies whose available locales drift from `{en_US, ja_JP}` the assertions can pass with the wrong fallback or fail outright.

**How it is being fixed:** Annotate the test class with `@LanguageIds(availableLanguageIds = {"en_US", "ja_JP"}, defaultLanguageId = "en_US")` so the test rule pins the company's locale set for the duration of the run and restores it afterwards. The test logic itself is unchanged.