### PR TITLE
LPD-88784 Collection filter label not shown if Single Selection is used

### DIFF
--- a/modules/apps/fragment/fragment-collection-filter-category/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/fragment/fragment-collection-filter-category/src/main/resources/META-INF/resources/js/index.js
@@ -78,7 +78,7 @@ export function SelectCategory({
 		? [
 				{
 					items: filteredCategories.map((category) => ({
-						label: category.label,
+						title: category.label,
 						type: 'radio',
 						value: category.id,
 					})),

--- a/modules/test/playwright/tests/layout-content-page-editor-web/fragments/collectionFilterFragment.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/fragments/collectionFilterFragment.spec.ts
@@ -215,6 +215,113 @@ test(
 	}
 );
 
+test(
+	'Filters a web content collection by category in single selection mode',
+	{
+		tag: '@LPD-88784',
+	},
+	async ({
+		apiHelpers,
+		collectionsPage,
+		page,
+		pageEditorPage,
+		pageManagementSite,
+	}) => {
+
+		// Create a content page with a Collection Filter and a collection
+		// mapped to the Animals collection
+
+		const collectionFilterId = getRandomString();
+
+		const animalsClassPK = await collectionsPage.getCollectionClassPK(
+			ANIMALS_COLLECTION_NAME,
+			pageManagementSite.friendlyUrlPath
+		);
+
+		const layout = await createPageWithCollectionAndFilterCollection({
+			apiHelpers,
+			classPK: animalsClassPK,
+			collectionFilterId,
+			siteId: pageManagementSite.id,
+		});
+
+		await pageEditorPage.goto(layout, pageManagementSite.friendlyUrlPath);
+
+		// Go to edit mode of the created page and select the Collection Filter fragment
+
+		await pageEditorPage.selectFragment(collectionFilterId);
+
+		// Set Filter configuration for categories with single selection
+
+		await configureFilter(page, 'category');
+
+		await page.getByLabel('Single Selection').check();
+
+		// Check the option to show the label with the selected vocabulary
+
+		await page.getByLabel('Show Label').check();
+
+		await pageEditorPage.publishPage();
+
+		// Go to view mode of the created page
+
+		await page.goto(
+			`/web${pageManagementSite.friendlyUrlPath}${layout.friendlyUrlPath}`
+		);
+
+		// Both should be visible initially
+
+		await expect(
+			page.getByText('Animal 01 - Dogs and Cats categories')
+		).toBeVisible();
+		await expect(page.getByText('Animal 02 - Dogs category')).toBeVisible();
+
+		await expect(
+			page.getByText(ANIMALS_COLLECTION_NAME, {exact: true})
+		).toBeVisible();
+
+		// Open the filter dropdown and assert radio labels are visible
+
+		await page.getByRole('button', {name: 'Select'}).click();
+
+		await expect(page.getByRole('radio', {name: 'cats'})).toBeVisible();
+		await expect(page.getByRole('radio', {name: 'dogs'})).toBeVisible();
+
+		// Select a single category: Cats
+
+		await page.getByRole('radio', {name: 'cats'}).click();
+
+		await page.waitForURL(/(.)filter_category(.)/);
+
+		await expect(
+			page.getByText('Animal 01 - Dogs and Cats categories')
+		).toBeVisible();
+
+		await expect(
+			page.getByText('Animal 02 - Dogs category')
+		).not.toBeVisible();
+
+		// Select a single category: Dogs
+
+		await page.goto(
+			`/web${pageManagementSite.friendlyUrlPath}${layout.friendlyUrlPath}`
+		);
+
+		await page.getByRole('button', {name: 'Select'}).click();
+
+		await page.getByRole('radio', {name: 'dogs'}).click();
+
+		await page.waitForURL(/(.)filter_category(.)/);
+
+		await expect(
+			page.getByText('Animal 01 - Dogs and Cats categories')
+		).toBeVisible();
+		await expect(page.getByText('Animal 02 - Dogs category')).toBeVisible();
+
+		await apiHelpers.jsonWebServicesLayout.deleteLayout(layout.id);
+	}
+);
+
 testWithIsolatedSite(
 	'Filters a web content collection by single and multiple tags',
 	async ({apiHelpers, collectionsPage, page, pageEditorPage, site}) => {


### PR DESCRIPTION
LPD-88784 Collection filter label not shown if Single Selection is

# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-88784

When a Collection Filter fragment is configured with Single Selection enabled, the drop-down renders radio items with no visible label text. Users see an unlabeled list of radio buttons and have no way to tell which category each option represents, making the filter unusable in that mode.

# How am I fixing it?

 In **SelectCategory**, the radiogroup branch was passing each item's display text under a label key, but **ClayDropDownWithItems** reads the visible text from title (which is what the multi-selection / checkbox branch right below already uses). Renaming the property to title aligns the two branches and lets the drop-down render the category name next to each radio.

# How can you verify that it works?

Follow the steps described in https://liferay.atlassian.net/browse/LPD-88784.