### PR TITLE
LPD-89160 Preserve action itemId on type change in readOnly mode

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_rules/components/Action.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_rules/components/Action.tsx
@@ -118,6 +118,12 @@ export default function Action({
 				items={actionTypes}
 				onErrorChange={onErrorChange}
 				onSelectionChange={(type) => {
+					if (action.readOnly) {
+						onActionChange({...action, type});
+
+						return;
+					}
+
 					const {itemId: _, ...newAction} = action;
 
 					onActionChange({...newAction, type});

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page_rules/components/RulesModal.test.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page_rules/components/RulesModal.test.tsx
@@ -422,4 +422,43 @@ describe('RulesSidebar', () => {
 			})
 		).toHaveTextContent('select');
 	});
+
+	it('preserves the fragment when the action changes for a readOnly action', async () => {
+		renderComponent({
+			editingRule: {
+				...DEFAULT_RULE,
+				actions: [
+					{
+						id: 'action-1',
+						itemId: 'item1',
+						readOnly: true,
+						type: 'show',
+					},
+				],
+				conditions: [
+					{
+						field: 'user',
+						id: 'condition-1',
+						options: {type: 'equal', value: 'userId1'},
+						type: 'user',
+					},
+				],
+			},
+		});
+
+		await selectPickerOption('select-action', 'hide');
+
+		await userEvent.click(screen.getByText('save'));
+
+		expect(addRule).toBeCalledWith(
+			expect.objectContaining({
+				actions: [
+					expect.objectContaining({
+						itemId: 'item1',
+						type: 'hide',
+					}),
+				],
+			})
+		);
+	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89160

# What is this trying to solve?

Display Page Template visibility rules created from a fragment's 3-dot menu (or the structure tree's 3-dot menu) save successfully but never apply at render time. The targeted fragment stays visible to users matching the role, making fragment-scoped rules effectively unusable in this flow.

# How am I fixing it?

When the rules modal is opened from one of those fragment-scoped entry points, the action arrives pre-populated with the fragment's `itemId` and the FragmentSelector is locked. Changing the action type was wiping that `itemId`, leaving the saved action with no target and no UI affordance to put it back. The fix preserves `itemId` across type changes whenever the action is in that locked mode, while keeping the original re-pick behavior for the rules-sidebar flow where it still adds value.

# How can you verify that it works?

Run the included automated tests.