### PR TITLE
LPD-89494 Fix accessibility issue in collection filter label

### DIFF
--- a/modules/apps/fragment/fragment-collection-filter-category/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/fragment/fragment-collection-filter-category/src/main/resources/META-INF/resources/page.jsp
@@ -8,9 +8,9 @@
 <%@ include file="/init.jsp" %>
 
 <div class="form-group form-group-sm">
-	<label class="control-label <%= fragmentCollectionFilterCategoryDisplayContext.isShowLabel() ? "" : "sr-only" %>">
+	<span class="control-label <%= fragmentCollectionFilterCategoryDisplayContext.isShowLabel() ? "" : "sr-only" %>">
 		<%= fragmentCollectionFilterCategoryDisplayContext.getLabel() %>
-	</label>
+	</span>
 
 	<div>
 		<clay:button


### PR DESCRIPTION
# What is this trying to solve?
[LPD-89494](https://liferay.atlassian.net/browse/LPD-89494)

Fix accessibility issue in collection filter label

# How am I fixing it?

Replaced the `<label> `element with a `<span>` element to avoid rendering an unassociated label and to comply with accessibility standards.

# How can you verify that it works?

Follow the steps described in [LPD-89494](https://liferay.atlassian.net/browse/LPD-89494)



[LPD-89494]: https://liferay.atlassian.net/browse/LPD-89494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-89494]: https://liferay.atlassian.net/browse/LPD-89494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ