### PR TITLE
LPD-85513 Map FragmentCollectionNameException to HTTP 400

### DIFF
--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/vulcan/problem/FragmentCollectionNameExceptionProblemMapper.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/vulcan/problem/FragmentCollectionNameExceptionProblemMapper.java
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.fragment.internal.vulcan.problem;
+
+import com.liferay.fragment.exception.FragmentCollectionNameException;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.vulcan.problem.Problem;
+import com.liferay.portal.vulcan.problem.ProblemMapper;
+
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Rubén Pulido
+ */
+@Component(service = ProblemMapper.class)
+public class FragmentCollectionNameExceptionProblemMapper
+	implements ProblemMapper<FragmentCollectionNameException> {
+
+	@Override
+	public Problem getProblem(
+		FragmentCollectionNameException fragmentCollectionNameException) {
+
+		return new Problem() {
+
+			@Override
+			public String getDetail(Locale locale) {
+				return _language.get(locale, "name-is-invalid");
+			}
+
+			@Override
+			public Status getStatus() {
+				return Status.BAD_REQUEST;
+			}
+
+			@Override
+			public String getTitle(Locale locale) {
+				return _language.get(locale, "name-is-invalid");
+			}
+
+			@Override
+			public String getType() {
+				return FragmentCollectionNameException.class.getName();
+			}
+
+		};
+	}
+
+	@Reference
+	private Language _language;
+
+}

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -147,6 +147,15 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 				testGroup.getExternalReferenceCode(), duplicateKeyFragmentSet),
 			duplicateKeyFragmentSet.getKey());
 
+		FragmentSet invalidNameFragmentSet = randomFragmentSet();
+
+		invalidNameFragmentSet.setName("bad.name");
+
+		_assertProblemException(
+			"BAD_REQUEST", "name-is-invalid",
+			() -> fragmentSetResource.postSiteFragmentSet(
+				testGroup.getExternalReferenceCode(), invalidNameFragmentSet));
+
 		_testPostSiteFragmentSetBatch();
 	}
 

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -231,6 +231,23 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 				nullNameFragmentSet.getExternalReferenceCode(),
 				nullNameFragmentSet));
 
+		FragmentSet nullDescriptionFragmentSet =
+			testPutSiteFragmentSet_addFragmentSet();
+
+		nullDescriptionFragmentSet.setDescription((String)null);
+		nullDescriptionFragmentSet.setName(RandomTestUtil.randomString());
+
+		FragmentSet nullDescriptionPutFragmentSet =
+			fragmentSetResource.putSiteFragmentSet(
+				testGroup.getExternalReferenceCode(),
+				nullDescriptionFragmentSet.getExternalReferenceCode(),
+				nullDescriptionFragmentSet);
+
+		Assert.assertEquals("", nullDescriptionPutFragmentSet.getDescription());
+		Assert.assertEquals(
+			nullDescriptionFragmentSet.getName(),
+			nullDescriptionPutFragmentSet.getName());
+
 		_testPutSiteFragmentSetBatch();
 	}
 

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -219,6 +219,18 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 				duplicateKeyFragmentSet),
 			duplicateKeyFragmentSet.getKey());
 
+		FragmentSet nullNameFragmentSet =
+			testPutSiteFragmentSet_addFragmentSet();
+
+		nullNameFragmentSet.setName((String)null);
+
+		_assertProblemException(
+			"BAD_REQUEST", "name-is-invalid",
+			() -> fragmentSetResource.putSiteFragmentSet(
+				testGroup.getExternalReferenceCode(),
+				nullNameFragmentSet.getExternalReferenceCode(),
+				nullNameFragmentSet));
+
 		_testPutSiteFragmentSetBatch();
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85513

## What is being fixed

`POST /sites/{siteExternalReferenceCode}/fragment-sets` and `PUT /sites/{siteExternalReferenceCode}/fragment-sets/{externalReferenceCode}` returned HTTP 500 when the request body had a null name or a name containing slashes or periods. The underlying `FragmentCollectionNameException` was unhandled by the headless layer, so it surfaced as a server error instead of a client error.

## How it is being fixed

A new `FragmentCollectionNameExceptionProblemMapper` translates `FragmentCollectionNameException` into an HTTP 400 Problem with the `name-is-invalid` language key, matching the existing mapper pattern for `DuplicateFragmentCollectionKeyException`. Integration tests cover both the null-name path on PUT and the invalid-character path on POST. The PUT test also pins the current behavior that a null description is persisted as an empty string.