### PR TITLE
LPD-88958 Persist impersonated user language without affecting impersonator

### DIFF
--- a/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/UpdateLanguageActionTest.java
+++ b/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/UpdateLanguageActionTest.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.VirtualLayoutConstants;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolverRegistryUtil;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
@@ -25,12 +26,15 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
@@ -45,6 +49,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LanguageIds;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import jakarta.servlet.http.HttpSession;
 
@@ -76,8 +81,10 @@ public class UpdateLanguageActionTest {
 
 	@ClassRule
 	@Rule
-	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
-		new LiferayIntegrationTestRule();
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {
@@ -276,6 +283,16 @@ public class UpdateLanguageActionTest {
 	private void _testExecuteWithImpersonationPreservesSessionLocale()
 		throws Exception {
 
+		User impersonatedUser = UserTestUtil.addUser(_group.getGroupId());
+
+		impersonatedUser.setLanguageId(LocaleUtil.toLanguageId(_sourceLocale));
+
+		impersonatedUser = _userLocalService.updateUser(impersonatedUser);
+
+		User user = TestPropsValues.getUser();
+
+		String userLanguageId = user.getLanguageId();
+
 		UpdateLanguageAction updateLanguageAction = new UpdateLanguageAction();
 
 		MockHttpServletRequest mockHttpServletRequest =
@@ -287,7 +304,6 @@ public class UpdateLanguageActionTest {
 
 		mockHttpServletRequest.setParameter("languageId", languageId);
 
-		mockHttpServletRequest.setParameter("persistState", "false");
 		mockHttpServletRequest.setParameter(
 			"redirect",
 			PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING +
@@ -301,10 +317,13 @@ public class UpdateLanguageActionTest {
 
 		themeDisplay.setCompany(
 			_companyLocalService.getCompany(_group.getCompanyId()));
-		themeDisplay.setDoAsUserId(RandomTestUtil.randomString());
+		themeDisplay.setDoAsUserId(
+			String.valueOf(impersonatedUser.getUserId()));
 		themeDisplay.setLayout(_layout);
 		themeDisplay.setLayoutSet(_group.getPublicLayoutSet());
+		themeDisplay.setSignedIn(true);
 		themeDisplay.setSiteGroupId(_group.getGroupId());
+		themeDisplay.setUser(impersonatedUser);
 
 		mockHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);
@@ -320,6 +339,17 @@ public class UpdateLanguageActionTest {
 
 		Assert.assertEquals(
 			_sourceLocale, httpSession.getAttribute(WebKeys.LOCALE));
+
+		impersonatedUser = _userLocalService.getUser(
+			impersonatedUser.getUserId());
+
+		Assert.assertEquals(languageId, impersonatedUser.getLanguageId());
+
+		user = _userLocalService.getUser(user.getUserId());
+
+		Assert.assertEquals(userLanguageId, user.getLanguageId());
+
+		_userLocalService.deleteUser(impersonatedUser);
 	}
 
 	private void _testGetRedirect(
@@ -717,5 +747,8 @@ public class UpdateLanguageActionTest {
 	private final Locale _sourceLocale = LocaleUtil.FRANCE;
 	private final Locale _sourceUKLocale = LocaleUtil.UK;
 	private final Locale _targetLocale = LocaleUtil.GERMANY;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/UpdateLanguageActionTest.java
+++ b/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/UpdateLanguageActionTest.java
@@ -131,7 +131,7 @@ public class UpdateLanguageActionTest {
 	@Test
 	@TestInfo("LPD-88958")
 	public void testExecute() throws Exception {
-		_testExecuteWithImpersonationPreservesSessionLocale();
+		_testExecuteWithImpersonation();
 	}
 
 	@Test
@@ -280,9 +280,7 @@ public class UpdateLanguageActionTest {
 		return separator + friendlyURLMap.get(locale);
 	}
 
-	private void _testExecuteWithImpersonationPreservesSessionLocale()
-		throws Exception {
-
+	private void _testExecuteWithImpersonation() throws Exception {
 		User impersonatedUser = UserTestUtil.addUser(_group.getGroupId());
 
 		impersonatedUser.setLanguageId(LocaleUtil.toLanguageId(_sourceLocale));

--- a/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/UpdateLanguageActionTest.java
+++ b/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/UpdateLanguageActionTest.java
@@ -62,6 +62,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 /**
  * @author Ricardo Couso
@@ -118,6 +119,12 @@ public class UpdateLanguageActionTest {
 			_layout.getUuid(), LocaleUtil.getSiteDefault(), null, false, true,
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	@Test
+	@TestInfo("LPD-88958")
+	public void testExecute() throws Exception {
+		_testExecuteWithImpersonationPreservesSessionLocale();
 	}
 
 	@Test
@@ -264,6 +271,55 @@ public class UpdateLanguageActionTest {
 			_journalArticle.getFriendlyURLMap();
 
 		return separator + friendlyURLMap.get(locale);
+	}
+
+	private void _testExecuteWithImpersonationPreservesSessionLocale()
+		throws Exception {
+
+		UpdateLanguageAction updateLanguageAction = new UpdateLanguageAction();
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		String languageId = LocaleUtil.toLanguageId(_targetLocale);
+
+		mockHttpServletRequest.setParameter("languageId", languageId);
+
+		mockHttpServletRequest.setParameter("persistState", "false");
+		mockHttpServletRequest.setParameter(
+			"redirect",
+			PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING +
+				_group.getFriendlyURL() + StringPool.SLASH);
+
+		HttpSession httpSession = mockHttpServletRequest.getSession();
+
+		httpSession.setAttribute(WebKeys.LOCALE, _sourceLocale);
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(_group.getCompanyId()));
+		themeDisplay.setDoAsUserId(RandomTestUtil.randomString());
+		themeDisplay.setLayout(_layout);
+		themeDisplay.setLayoutSet(_group.getPublicLayoutSet());
+		themeDisplay.setSiteGroupId(_group.getGroupId());
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		updateLanguageAction.execute(
+			null, mockHttpServletRequest, mockHttpServletResponse);
+
+		String redirectedUrl = mockHttpServletResponse.getRedirectedUrl();
+
+		Assert.assertNotNull(redirectedUrl);
+		Assert.assertTrue(
+			redirectedUrl.contains("doAsUserLanguageId=" + languageId));
+
+		Assert.assertEquals(
+			_sourceLocale, httpSession.getAttribute(WebKeys.LOCALE));
 	}
 
 	private void _testGetRedirect(

--- a/modules/apps/portal/portal-i18n-filter/src/main/java/com/liferay/portal/i18n/filter/internal/I18nFilter.java
+++ b/modules/apps/portal/portal-i18n-filter/src/main/java/com/liferay/portal/i18n/filter/internal/I18nFilter.java
@@ -230,6 +230,13 @@ public class I18nFilter extends BasePortalFilter {
 	protected String getRequestedLanguageId(
 		HttpServletRequest httpServletRequest, String userLanguageId) {
 
+		String doAsUserLanguageId = httpServletRequest.getParameter(
+			"doAsUserLanguageId");
+
+		if (Validator.isNotNull(doAsUserLanguageId)) {
+			return doAsUserLanguageId;
+		}
+
 		String requestedLanguageId = null;
 
 		HttpSession httpSession = httpServletRequest.getSession();

--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/i18n/test/I18nFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/i18n/test/I18nFilterTest.java
@@ -182,6 +182,11 @@ public class I18nFilterTest {
 	}
 
 	@Test
+	public void testGetRequestedLanguageId() throws Exception {
+		_testGetRequestedLanguageIdWithImpersonation();
+	}
+
+	@Test
 	public void testGuestEnglishPreferredWithoutSessionCookieVirtualHostAlgorithm3()
 		throws Exception {
 
@@ -414,6 +419,34 @@ public class I18nFilterTest {
 		Assert.assertEquals(
 			i18nLanguageId,
 			mockHttpServletRequest.getAttribute(WebKeys.I18N_LANGUAGE_ID));
+	}
+
+	private void _testGetRequestedLanguageIdWithImpersonation()
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setParameter(
+			"doAsUserLanguageId", LocaleUtil.toLanguageId(LocaleUtil.SPAIN));
+
+		HttpSession httpSession = mockHttpServletRequest.getSession();
+
+		httpSession.setAttribute(WebKeys.LOCALE, LocaleUtil.US);
+
+		_user = UserTestUtil.addUser(
+			null, LocaleUtil.US, RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), new long[] {_group.getGroupId()});
+
+		mockHttpServletRequest.setAttribute(WebKeys.USER, _user);
+
+		Assert.assertEquals(
+			LocaleUtil.toLanguageId(LocaleUtil.SPAIN),
+			ReflectionTestUtil.invoke(
+				_i18nFilter, "getRequestedLanguageId",
+				new Class<?>[] {HttpServletRequest.class, String.class},
+				mockHttpServletRequest,
+				LocaleUtil.toLanguageId(LocaleUtil.US)));
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/site-navigation/site-navigation-taglib/build.gradle
+++ b/modules/apps/site-navigation/site-navigation-taglib/build.gradle
@@ -17,4 +17,6 @@ dependencies {
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
+	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	testImplementation project(":core:petra:petra-reflect")
 }

--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/LanguageTag.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/LanguageTag.java
@@ -236,8 +236,17 @@ public class LanguageTag extends IncludeTag {
 		formAction = HttpComponentsUtil.setParameter(
 			formAction, "privateLayout", layout.isPrivateLayout());
 
-		return HttpComponentsUtil.setParameter(
+		formAction = HttpComponentsUtil.setParameter(
 			formAction, "layoutId", layout.getLayoutId());
+
+		String doAsUserId = themeDisplay.getDoAsUserId();
+
+		if (Validator.isNotNull(doAsUserId)) {
+			formAction = HttpComponentsUtil.setParameter(
+				formAction, "doAsUserId", doAsUserId);
+		}
+
+		return formAction;
 	}
 
 	private List<LanguageEntry> _getLanguageEntries(

--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/LanguageTag.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/LanguageTag.java
@@ -239,14 +239,8 @@ public class LanguageTag extends IncludeTag {
 		formAction = HttpComponentsUtil.setParameter(
 			formAction, "layoutId", layout.getLayoutId());
 
-		String doAsUserId = themeDisplay.getDoAsUserId();
-
-		if (Validator.isNotNull(doAsUserId)) {
-			formAction = HttpComponentsUtil.setParameter(
-				formAction, "doAsUserId", doAsUserId);
-		}
-
-		return formAction;
+		return PortalUtil.addPreservedParameters(
+			themeDisplay, layout, formAction, true);
 	}
 
 	private List<LanguageEntry> _getLanguageEntries(

--- a/modules/apps/site-navigation/site-navigation-taglib/src/test/java/com/liferay/site/navigation/taglib/servlet/taglib/LanguageTagTest.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/test/java/com/liferay/site/navigation/taglib/servlet/taglib/LanguageTagTest.java
@@ -46,7 +46,7 @@ public class LanguageTagTest {
 	@Test
 	public void testGetFormAction() throws Exception {
 		String formAction = ReflectionTestUtil.invoke(
-			_createLanguageTag(StringPool.BLANK), "_getFormAction",
+			_getLanguageTag(StringPool.BLANK), "_getFormAction",
 			new Class<?>[0]);
 
 		Assert.assertFalse(formAction.contains("doAsUserId="));
@@ -54,12 +54,12 @@ public class LanguageTagTest {
 		String doAsUserId = RandomTestUtil.randomString();
 
 		formAction = ReflectionTestUtil.invoke(
-			_createLanguageTag(doAsUserId), "_getFormAction", new Class<?>[0]);
+			_getLanguageTag(doAsUserId), "_getFormAction", new Class<?>[0]);
 
 		Assert.assertTrue(formAction.contains("doAsUserId=" + doAsUserId));
 	}
 
-	private LanguageTag _createLanguageTag(String doAsUserId) {
+	private LanguageTag _getLanguageTag(String doAsUserId) {
 		LanguageTag languageTag = new LanguageTag();
 
 		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);

--- a/modules/apps/site-navigation/site-navigation-taglib/src/test/java/com/liferay/site/navigation/taglib/servlet/taglib/LanguageTagTest.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/test/java/com/liferay/site/navigation/taglib/servlet/taglib/LanguageTagTest.java
@@ -72,7 +72,7 @@ public class LanguageTagTest {
 			new MockHttpServletRequest();
 
 		mockHttpServletRequest.setAttribute(
-			WebKeys.CURRENT_URL, "/web/guest/home");
+			WebKeys.CURRENT_URL, RandomTestUtil.randomString());
 		mockHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);
 

--- a/modules/apps/site-navigation/site-navigation-taglib/src/test/java/com/liferay/site/navigation/taglib/servlet/taglib/LanguageTagTest.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/test/java/com/liferay/site/navigation/taglib/servlet/taglib/LanguageTagTest.java
@@ -5,7 +5,6 @@
 
 package com.liferay.site.navigation.taglib.servlet.taglib;
 
-import com.liferay.petra.lang.ClassLoaderPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
@@ -39,9 +38,6 @@ public class LanguageTagTest {
 
 	@BeforeClass
 	public static void setUpClass() {
-		ClassLoaderPool.register(
-			"ShieldedContainerClassLoader", PortalImpl.class.getClassLoader());
-
 		PortalUtil portalUtil = new PortalUtil();
 
 		portalUtil.setPortal(new PortalImpl());
@@ -56,11 +52,25 @@ public class LanguageTagTest {
 	private LanguageTag _createLanguageTag(String doAsUserId) {
 		LanguageTag languageTag = new LanguageTag();
 
-		ThemeDisplay themeDisplay = new ThemeDisplay();
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
 
-		themeDisplay.setDoAsUserId(doAsUserId);
-		themeDisplay.setPathMain("/c");
-		themeDisplay.setScopeGroupId(RandomTestUtil.randomLong());
+		Mockito.when(
+			themeDisplay.getDoAsUserId()
+		).thenReturn(
+			doAsUserId
+		);
+
+		Mockito.when(
+			themeDisplay.getPathMain()
+		).thenReturn(
+			"/c"
+		);
+
+		Mockito.when(
+			themeDisplay.getScopeGroupId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
 
 		Layout layout = Mockito.mock(Layout.class);
 
@@ -76,7 +86,11 @@ public class LanguageTagTest {
 			RandomTestUtil.randomLong()
 		);
 
-		themeDisplay.setLayout(layout);
+		Mockito.when(
+			themeDisplay.getLayout()
+		).thenReturn(
+			layout
+		);
 
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();

--- a/modules/apps/site-navigation/site-navigation-taglib/src/test/java/com/liferay/site/navigation/taglib/servlet/taglib/LanguageTagTest.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/test/java/com/liferay/site/navigation/taglib/servlet/taglib/LanguageTagTest.java
@@ -1,0 +1,116 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.navigation.taglib.servlet.taglib;
+
+import com.liferay.petra.lang.ClassLoaderPool;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.util.PortalImpl;
+
+import jakarta.servlet.ServletContext;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockPageContext;
+
+/**
+ * @author Georgel Pop
+ */
+public class LanguageTagTest {
+
+	@ClassRule
+	public static LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		ClassLoaderPool.register(
+			"ShieldedContainerClassLoader", PortalImpl.class.getClassLoader());
+
+		PortalUtil portalUtil = new PortalUtil();
+
+		portalUtil.setPortal(new PortalImpl());
+	}
+
+	@Test
+	public void testGetFormAction() throws Exception {
+		_testGetFormActionOmitsDoAsUserId();
+		_testGetFormActionPropagatesDoAsUserId();
+	}
+
+	private LanguageTag _createLanguageTag(String doAsUserId) {
+		LanguageTag languageTag = new LanguageTag();
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setDoAsUserId(doAsUserId);
+		themeDisplay.setPathMain("/c");
+		themeDisplay.setScopeGroupId(RandomTestUtil.randomLong());
+
+		Layout layout = Mockito.mock(Layout.class);
+
+		Mockito.when(
+			layout.isPrivateLayout()
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
+			layout.getLayoutId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		themeDisplay.setLayout(layout);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.CURRENT_URL, "/web/guest/home");
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		languageTag.setPageContext(
+			new MockPageContext(
+				Mockito.mock(ServletContext.class), mockHttpServletRequest));
+
+		return languageTag;
+	}
+
+	private void _testGetFormActionOmitsDoAsUserId() throws Exception {
+		LanguageTag languageTag = _createLanguageTag(StringPool.BLANK);
+
+		String formAction = ReflectionTestUtil.invoke(
+			languageTag, "_getFormAction", new Class<?>[0]);
+
+		Assert.assertFalse(formAction.contains("doAsUserId="));
+	}
+
+	private void _testGetFormActionPropagatesDoAsUserId() throws Exception {
+		String doAsUserId = RandomTestUtil.randomString();
+
+		LanguageTag languageTag = _createLanguageTag(doAsUserId);
+
+		String formAction = ReflectionTestUtil.invoke(
+			languageTag, "_getFormAction", new Class<?>[0]);
+
+		Assert.assertTrue(formAction.contains("doAsUserId=" + doAsUserId));
+	}
+
+}

--- a/modules/apps/site-navigation/site-navigation-taglib/src/test/java/com/liferay/site/navigation/taglib/servlet/taglib/LanguageTagTest.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/test/java/com/liferay/site/navigation/taglib/servlet/taglib/LanguageTagTest.java
@@ -45,8 +45,18 @@ public class LanguageTagTest {
 
 	@Test
 	public void testGetFormAction() throws Exception {
-		_testGetFormActionOmitsDoAsUserId();
-		_testGetFormActionPropagatesDoAsUserId();
+		String formAction = ReflectionTestUtil.invoke(
+			_createLanguageTag(StringPool.BLANK), "_getFormAction",
+			new Class<?>[0]);
+
+		Assert.assertFalse(formAction.contains("doAsUserId="));
+
+		String doAsUserId = RandomTestUtil.randomString();
+
+		formAction = ReflectionTestUtil.invoke(
+			_createLanguageTag(doAsUserId), "_getFormAction", new Class<?>[0]);
+
+		Assert.assertTrue(formAction.contains("doAsUserId=" + doAsUserId));
 	}
 
 	private LanguageTag _createLanguageTag(String doAsUserId) {
@@ -81,26 +91,6 @@ public class LanguageTagTest {
 				Mockito.mock(ServletContext.class), mockHttpServletRequest));
 
 		return languageTag;
-	}
-
-	private void _testGetFormActionOmitsDoAsUserId() throws Exception {
-		LanguageTag languageTag = _createLanguageTag(StringPool.BLANK);
-
-		String formAction = ReflectionTestUtil.invoke(
-			languageTag, "_getFormAction", new Class<?>[0]);
-
-		Assert.assertFalse(formAction.contains("doAsUserId="));
-	}
-
-	private void _testGetFormActionPropagatesDoAsUserId() throws Exception {
-		String doAsUserId = RandomTestUtil.randomString();
-
-		LanguageTag languageTag = _createLanguageTag(doAsUserId);
-
-		String formAction = ReflectionTestUtil.invoke(
-			languageTag, "_getFormAction", new Class<?>[0]);
-
-		Assert.assertTrue(formAction.contains("doAsUserId=" + doAsUserId));
 	}
 
 }

--- a/modules/apps/site-navigation/site-navigation-taglib/src/test/java/com/liferay/site/navigation/taglib/servlet/taglib/LanguageTagTest.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/test/java/com/liferay/site/navigation/taglib/servlet/taglib/LanguageTagTest.java
@@ -60,31 +60,7 @@ public class LanguageTagTest {
 			doAsUserId
 		);
 
-		Mockito.when(
-			themeDisplay.getPathMain()
-		).thenReturn(
-			"/c"
-		);
-
-		Mockito.when(
-			themeDisplay.getScopeGroupId()
-		).thenReturn(
-			RandomTestUtil.randomLong()
-		);
-
 		Layout layout = Mockito.mock(Layout.class);
-
-		Mockito.when(
-			layout.isPrivateLayout()
-		).thenReturn(
-			false
-		);
-
-		Mockito.when(
-			layout.getLayoutId()
-		).thenReturn(
-			RandomTestUtil.randomLong()
-		);
 
 		Mockito.when(
 			themeDisplay.getLayout()

--- a/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
+++ b/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
@@ -312,9 +312,10 @@ public class UpdateLanguageAction implements Action {
 		}
 
 		if (Validator.isNotNull(themeDisplay.getDoAsUserId())) {
-			redirect = HttpComponentsUtil.setParameter(
-				redirect, "doAsUserLanguageId",
-				LocaleUtil.toLanguageId(locale));
+			return HttpComponentsUtil.setParameter(
+				PortalUtil.addPreservedParameters(
+					themeDisplay, layout, redirect, true),
+				"doAsUserLanguageId", LocaleUtil.toLanguageId(locale));
 		}
 
 		return redirect;

--- a/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
+++ b/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
@@ -87,15 +87,8 @@ public class UpdateLanguageAction implements Action {
 		// Send redirect
 
 		try {
-			String redirect = getRedirect(
-				httpServletRequest, themeDisplay, locale);
-
-			if (Validator.isNotNull(themeDisplay.getDoAsUserId())) {
-				redirect = HttpComponentsUtil.setParameter(
-					redirect, "doAsUserLanguageId", languageId);
-			}
-
-			httpServletResponse.sendRedirect(redirect);
+			httpServletResponse.sendRedirect(
+				getRedirect(httpServletRequest, themeDisplay, locale));
 		}
 		catch (IllegalArgumentException | NoSuchLayoutException exception) {
 			if (_log.isDebugEnabled()) {
@@ -316,6 +309,12 @@ public class UpdateLanguageAction implements Action {
 
 		if (Validator.isNotNull(queryString)) {
 			redirect = redirect + queryString;
+		}
+
+		if (Validator.isNotNull(themeDisplay.getDoAsUserId())) {
+			redirect = HttpComponentsUtil.setParameter(
+				redirect, "doAsUserLanguageId",
+				LocaleUtil.toLanguageId(locale));
 		}
 
 		return redirect;

--- a/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
+++ b/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -73,19 +74,28 @@ public class UpdateLanguageAction implements Action {
 					themeDisplay.getUserId(), languageId);
 			}
 
-			HttpSession httpSession = httpServletRequest.getSession();
+			if (Validator.isNull(themeDisplay.getDoAsUserId())) {
+				HttpSession httpSession = httpServletRequest.getSession();
 
-			httpSession.setAttribute(WebKeys.LOCALE, locale);
+				httpSession.setAttribute(WebKeys.LOCALE, locale);
 
-			LanguageUtil.updateCookie(
-				httpServletRequest, httpServletResponse, locale);
+				LanguageUtil.updateCookie(
+					httpServletRequest, httpServletResponse, locale);
+			}
 		}
 
 		// Send redirect
 
 		try {
-			httpServletResponse.sendRedirect(
-				getRedirect(httpServletRequest, themeDisplay, locale));
+			String redirect = getRedirect(
+				httpServletRequest, themeDisplay, locale);
+
+			if (Validator.isNotNull(themeDisplay.getDoAsUserId())) {
+				redirect = HttpComponentsUtil.setParameter(
+					redirect, "doAsUserLanguageId", languageId);
+			}
+
+			httpServletResponse.sendRedirect(redirect);
 		}
 		catch (IllegalArgumentException | NoSuchLayoutException exception) {
 			if (_log.isDebugEnabled()) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88958

**What is being fixed:** When an administrator impersonates another user and changes the language via the language picker, the change was persisted against the impersonator and polluted the impersonator's session.

**How it is being fixed:** Propagate doAsUserId through the language form action so UpdateLanguageAction sees the impersonation context, skip the session locale / cookie update during impersonation, and inject doAsUserLanguageId into the redirect so the I18nFilter prepends the correct locale prefix on the next request. The fix leverages PortalUtil.addPreservedParameters for both the form action (in LanguageTag) and the redirect URL (in UpdateLanguageAction.getRedirect), and is covered by integration tests for the action and the filter plus a unit test for the taglib.