### PR TITLE
LPD-89564 Use the id to update structures so changing the ERC works

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
@@ -196,10 +196,14 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
+		JSONObject objectDefinitionJSONObject = _jsonFactory.createJSONObject(
+			objectDefinitionString);
+
 		Callable<Void> callable = new UpdateStructureCallable(
 			themeDisplay.getCompanyId(), deletedObjectRelationshipsJSONArray,
 			deletedRepeatableGroupsERCs,
 			ObjectDefinition.toDTO(objectDefinitionString),
+			objectDefinitionJSONObject.getLong("id"),
 			_getObjectRelationships(objectRelationshipsJSONArray),
 			_getObjectDefinitions(repeatableGroupObjectDefinitionsJSONArray),
 			themeDisplay.getUser());
@@ -308,9 +312,8 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 				}
 			}
 
-			objectDefinitionResource.putObjectDefinitionByExternalReferenceCode(
-				_objectDefinition.getExternalReferenceCode(),
-				_objectDefinition);
+			objectDefinitionResource.putObjectDefinition(
+				_objectDefinitionId, _objectDefinition);
 
 			com.liferay.object.model.ObjectDefinition
 				serviceBuilderObjectDefinition =
@@ -345,7 +348,7 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 		private UpdateStructureCallable(
 			long companyId, JSONArray deletedObjectRelationshipsJSONArray,
 			String[] deletedRepeatableGroupsERCs,
-			ObjectDefinition objectDefinition,
+			ObjectDefinition objectDefinition, long objectDefinitionId,
 			List<ObjectRelationship> objectRelationships,
 			List<ObjectDefinition> repeatableGroupObjectDefinitions,
 			User user) {
@@ -355,6 +358,7 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 				deletedObjectRelationshipsJSONArray;
 			_deletedRepeatableGroupsERCs = deletedRepeatableGroupsERCs;
 			_objectDefinition = objectDefinition;
+			_objectDefinitionId = objectDefinitionId;
 			_objectRelationships = objectRelationships;
 			_repeatableGroupObjectDefinitions =
 				repeatableGroupObjectDefinitions;
@@ -365,6 +369,7 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 		private final JSONArray _deletedObjectRelationshipsJSONArray;
 		private final String[] _deletedRepeatableGroupsERCs;
 		private final ObjectDefinition _objectDefinition;
+		private final long _objectDefinitionId;
 		private final List<ObjectRelationship> _objectRelationships;
 		private final List<ObjectDefinition> _repeatableGroupObjectDefinitions;
 		private final User _user;

--- a/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/structureBuilder.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/structureBuilder.spec.ts
@@ -675,3 +675,44 @@ test(
 		});
 	}
 );
+
+test(
+	'Can republish a structure after changing its ERC',
+	{tag: '@LPD-89564'},
+	async ({apiHelpers, structureBuilderPage}) => {
+
+		// Create and publish a structure with an initial ERC
+
+		const label = `Structure${getRandomInt()}`;
+		const initialERC = getRandomString();
+
+		const structureId = await structureBuilderPage.createStructureFromData({
+			erc: initialERC,
+			label,
+			name: label,
+			page: structureBuilderPage,
+		});
+
+		// Change the ERC and republish
+
+		const updatedERC = getRandomString();
+
+		await structureBuilderPage.changeStructureSettings({erc: updatedERC});
+
+		const republishedId = await structureBuilderPage.publishStructure();
+
+		// Republishing must update the existing structure, not create a new one
+
+		expect(republishedId).toBe(structureId);
+
+		// The persisted ERC should match the updated value
+
+		const objectDefinitionAPIClient =
+			await apiHelpers.buildRestClient(ObjectDefinitionAPI);
+
+		const {body: objectDefinition} =
+			await objectDefinitionAPIClient.getObjectDefinition(structureId);
+
+		expect(objectDefinition.externalReferenceCode).toBe(updatedERC);
+	}
+);


### PR DESCRIPTION
## Summary

Fixes the Name already exists failure when republishing a CMS structure after changing its ERC, and adds a Playwright regression test that reproduces it.

## Why

UpdateStructureStrutsAction looked the existing definition up by the new ERC, which did not match any row, so the resource fell through to postObjectDefinition and the create then failed because the original row name was still taken. The action now looks the row up by id, which is stable across ERC changes. The id has to be parsed from the raw JSON because the generated ObjectDefinition DTO marks the id field as JsonProperty.Access.READ_ONLY, so Jackson silently drops it on deserialize.

## Test plan

- [x] New Playwright test Can republish a structure after changing its ERC @LPD-89564 passes.
- [x] Existing Can configure a text field @LPD-49168 still passes.