### PR TITLE
LPD-90085 LPD-90747 Structure Builder fixes

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/structure_builder/StructureBuilder.scss
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/css/structure_builder/StructureBuilder.scss
@@ -65,8 +65,8 @@ $structureFieldsWidthMobile: 320px;
 	&__help-button {
 		background-color: $cadmin-dark;
 		border-color: $cadmin-dark;
-		bottom: 1rem;
-		right: 1rem;
+		bottom: 2.5rem;
+		right: 2.5rem;
 		z-index: 100;
 
 		&:hover,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/contexts/StateContext.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/contexts/StateContext.tsx
@@ -30,7 +30,6 @@ import findAvailableFieldName from '../utils/findAvailableFieldName';
 import findChild from '../utils/findChild';
 import {getChildrenUuids} from '../utils/getChildrenUuids';
 import getRandomId from '../utils/getRandomId';
-import getRandomName from '../utils/getRandomName';
 import getUuid from '../utils/getUuid';
 import normalizeString from '../utils/normalizeString';
 import addChild from '../utils/state/addChild';
@@ -507,27 +506,12 @@ function reducer(state: State, action: Action): State {
 					uuid: child.parent,
 				}) || nextStructure) as Structure | RepeatableGroup;
 
-				const copyUuid = getUuid();
-
-				const copy = {...child, uuid: copyUuid};
-
-				if (copy.type === 'referenced-structure') {
-					copy.relationshipName = getRandomName();
-				}
-				else if (copy.type === 'repeatable-group') {
-					copy.erc = getRandomId();
-					copy.name = getRandomName({capitalize: true});
-					copy.relationshipERC = getRandomId();
-					copy.relationshipName = getRandomName();
-				}
-				else {
-					copy.erc = getRandomId();
-					copy.name = findAvailableFieldName(
-						parent.children,
-						state.history.deletedChildren,
-						child.name
-					);
-				}
+				const copy = cloneChild({
+					child,
+					deletedChildren: state.history.deletedChildren,
+					parent: parent.uuid,
+					siblings: parent.children,
+				});
 
 				const updatedChildren = addChild({
 					child: copy,
@@ -536,7 +520,7 @@ function reducer(state: State, action: Action): State {
 
 				nextStructure = {...nextStructure, children: updatedChildren};
 
-				newSelection.push(copyUuid);
+				newSelection.push(copy.uuid);
 			}
 
 			return {

--- a/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/contexts/StateContext.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/contexts/StateContext.test.tsx
@@ -11,6 +11,10 @@ import StateContextProvider, {
 	useSelector,
 	useStateDispatch,
 } from '../../../../src/main/resources/META-INF/resources/js/structure_builder/contexts/StateContext';
+import {
+	RepeatableGroup,
+	StructureChild,
+} from '../../../../src/main/resources/META-INF/resources/js/structure_builder/types/Structure';
 import {Field} from '../../../../src/main/resources/META-INF/resources/js/structure_builder/utils/field';
 import getUuid from '../../../../src/main/resources/META-INF/resources/js/structure_builder/utils/getUuid';
 
@@ -42,10 +46,10 @@ function buildField(overrides: Partial<Field> = {}): Field {
 	};
 }
 
-function buildInitialState(field: Field): State {
+function buildInitialState(child: StructureChild): State {
 	const children = new Map();
 
-	children.set(field.uuid, field);
+	children.set(child.uuid, child);
 
 	return {
 		clipboard: null,
@@ -76,9 +80,9 @@ function buildInitialState(field: Field): State {
 	};
 }
 
-function renderReducerHook(field: Field) {
+function renderReducerHook<T extends StructureChild>(child: T) {
 	const wrapper = ({children}: {children: ReactNode}) => (
-		<StateContextProvider initialState={buildInitialState(field)}>
+		<StateContextProvider initialState={buildInitialState(child)}>
 			{children}
 		</StateContextProvider>
 	);
@@ -87,8 +91,9 @@ function renderReducerHook(field: Field) {
 		() => ({
 			dispatch: useStateDispatch(),
 			field: useSelector(
-				(state) => state.structure.children.get(field.uuid) as Field
+				(state) => state.structure.children.get(child.uuid) as T
 			),
+			structure: useSelector((state) => state.structure),
 		}),
 		{wrapper}
 	);
@@ -132,5 +137,41 @@ describe('StateContext reducer', () => {
 			expect(result.current.field.label).toEqual({en_US: 'Headline'});
 			expect(result.current.field.name).toBe('headline');
 		});
+	});
+
+	it('reparents nested children when a repeatable group is duplicated', () => {
+		const group: RepeatableGroup = {
+			children: new Map(),
+			erc: 'group-erc',
+			label: {en_US: 'Group'},
+			name: 'group',
+			parent: STRUCTURE_UUID,
+			relationshipERC: 'group-relationship-erc',
+			relationshipName: 'groupRelationship',
+			type: 'repeatable-group',
+			uuid: getUuid(),
+		};
+
+		const nestedField = buildField({parent: group.uuid});
+
+		group.children.set(nestedField.uuid, nestedField);
+
+		const {result} = renderReducerHook(group);
+
+		act(() => {
+			result.current.dispatch({
+				type: 'duplicate-children',
+				uuids: [group.uuid],
+			});
+		});
+
+		const [, duplicate] = Array.from(
+			result.current.structure.children.values()
+		) as RepeatableGroup[];
+
+		const [duplicateNested] = Array.from(duplicate.children.values());
+
+		expect(duplicate.uuid).not.toBe(group.uuid);
+		expect(duplicateNested.parent).toBe(duplicate.uuid);
 	});
 });


### PR DESCRIPTION
**Ticket**: [LPD-90085](https://liferay.atlassian.net/browse/LPD-90085)

## Summary

- Reparent nested children when duplicating a repeatable group so that subsequent duplicates inside the new group land in the correct parent.
- Increase the help button offset from the viewport edges (LPD-90747).

## Tests

- New unit test in `StateContext.test.tsx` asserts that nested children of a duplicated repeatable group are reparented to the duplicate.

[LPD-90085]: https://liferay.atlassian.net/browse/LPD-90085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ