### PR TITLE
LPD-89085 Fix broken test

### DIFF
--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -290,7 +290,9 @@ export class PageEditorPage {
 			await this.page.keyboard.press('Enter');
 
 			await expect(
-				this.page.locator('#content').getByText(name, {exact: true})
+				this.page
+					.locator('.page-editor__keyboard-movement-preview')
+					.getByText(name, {exact: true})
 			).toBeVisible();
 
 			await this.page.keyboard.press('Enter');


### PR DESCRIPTION
Hi,

In [LPD-87827](https://liferay.atlassian.net/browse/LPD-87827) we [introduce](https://github.com/liferay-page-management/liferay-portal/pull/18414) this assertion and that locator is working fine... as long as the widget is not instanceable. If you already have one instance of a widget deployed, and try to drop a second one, that locator will resolve to two elements making the test to fail, as it is happening right now with [Custom Element can be instanceable](https://github.com/liferay/liferay-portal/blob/master/modules/test/playwright/tests/client-extension-web/main/customElement.spec.ts#L566) test.

This change is narrowing down the are where we need to look for the locator to avoid finding previously instances of the same widget.

Thanks.

[LPD-87827]: https://liferay.atlassian.net/browse/LPD-87827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ