### PR TITLE
LPD-91119 Preserve fragmentCollectionKey when adding a FragmentCollection via LAR import

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/staged/model/repository/FragmentCollectionStagedModelRepository.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/staged/model/repository/FragmentCollectionStagedModelRepository.java
@@ -49,8 +49,10 @@ public class FragmentCollectionStagedModelRepository
 
 		return _fragmentCollectionLocalService.addFragmentCollection(
 			fragmentCollection.getExternalReferenceCode(), userId,
-			fragmentCollection.getGroupId(), fragmentCollection.getName(),
-			fragmentCollection.getDescription(), serviceContext);
+			fragmentCollection.getGroupId(),
+			fragmentCollection.getFragmentCollectionKey(),
+			fragmentCollection.getName(), fragmentCollection.getDescription(),
+			fragmentCollection.isMarketplace(), serviceContext);
 	}
 
 	@Override

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/exportimport/data/handler/test/FragmentCollectionStagedModelDataHandlerTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/exportimport/data/handler/test/FragmentCollectionStagedModelDataHandlerTest.java
@@ -84,6 +84,9 @@ public class FragmentCollectionStagedModelDataHandlerTest
 
 		Assert.assertEquals(
 			importedFragmentCollection.getName(), fragmentCollection.getName());
+		Assert.assertEquals(
+			fragmentCollection.getFragmentCollectionKey(),
+			importedFragmentCollection.getFragmentCollectionKey());
 	}
 
 	@Inject

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/exportimport/data/handler/test/FragmentCollectionStagedModelDataHandlerTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/exportimport/data/handler/test/FragmentCollectionStagedModelDataHandlerTest.java
@@ -119,7 +119,7 @@ public class FragmentCollectionStagedModelDataHandlerTest
 			(FragmentCollection)importedStagedModel;
 
 		Assert.assertEquals(
-			importedFragmentCollection.getName(), fragmentCollection.getName());
+			fragmentCollection.getName(), importedFragmentCollection.getName());
 		Assert.assertEquals(
 			fragmentCollection.getFragmentCollectionKey(),
 			importedFragmentCollection.getFragmentCollectionKey());

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/exportimport/data/handler/test/FragmentCollectionStagedModelDataHandlerTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/exportimport/data/handler/test/FragmentCollectionStagedModelDataHandlerTest.java
@@ -6,15 +6,19 @@
 package com.liferay.fragment.internal.exportimport.data.handler.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.test.util.lar.BaseStagedModelDataHandlerTestCase;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.service.FragmentCollectionLocalService;
 import com.liferay.fragment.test.util.FragmentTestUtil;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.StagedModel;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.DateTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -25,6 +29,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
@@ -43,6 +48,37 @@ public class FragmentCollectionStagedModelDataHandlerTest
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
+	}
+
+	@Test
+	@TestInfo("LPD-91119")
+	public void testImportPreservesFragmentCollectionKey() throws Exception {
+		initExport();
+
+		FragmentCollection fragmentCollection =
+			FragmentTestUtil.addFragmentCollection(
+				stagingGroup.getGroupId(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString());
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, fragmentCollection);
+
+		try (SafeCloseable safeCloseable = initImportWithSafeCloseable()) {
+			StagedModel exportedStagedModel = readExportedStagedModel(
+				fragmentCollection);
+
+			StagedModelDataHandlerUtil.importStagedModel(
+				portletDataContext, exportedStagedModel);
+
+			FragmentCollection importedFragmentCollection =
+				_fragmentCollectionLocalService.
+					getFragmentCollectionByUuidAndGroupId(
+						fragmentCollection.getUuid(), liveGroup.getGroupId());
+
+			Assert.assertEquals(
+				fragmentCollection.getFragmentCollectionKey(),
+				importedFragmentCollection.getFragmentCollectionKey());
+		}
 	}
 
 	@Override


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91119

**What is being fixed:** When a site LAR is imported, `FragmentCollectionStagedModelRepository#addStagedModel` called the `FragmentCollectionLocalService.addFragmentCollection` overload that does not accept a `fragmentCollectionKey`, so the key was regenerated from the collection name. Because `FragmentCollectionImpl#getResourcesFolderId` resolves the Documents and Media folder by `fragmentCollectionKey`, the imported collection pointed at a different folder than the one the LAR-imported resources were deposited under, orphaning them in the Fragment Administration UI.

**How it is being fixed:** Switch `FragmentCollectionStagedModelRepository#addStagedModel` to the overload that takes the source `fragmentCollectionKey`, so the imported collection keeps the same key as the source and its resources folder resolves consistently. A regression test asserts the key survives a LAR export/import roundtrip.

//cc @lfbesada