### PR TITLE
LPD-91701 Avoid applying cadmin to Widget configuration modal on Content Pages to make it consistent with Widget Pages

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/topper/TopperItemActions.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/topper/TopperItemActions.js
@@ -361,6 +361,7 @@ function addPortletAction(items, action, portletId) {
 	items.push({
 		action: () => {
 			openModal({
+				iframeBodyCssClass: '',
 				onClose: () => Liferay.Portlet.refresh(`#p_p_id_${portletId}_`),
 				title: action.title,
 				url: action.url,


### PR DESCRIPTION
Information from [LPD-91701](https://liferay.atlassian.net/browse/LPD-91701)

As of today, we are applying cadmin to Widget Configuration's Modal Window when it's opened from a Content Page but not when it is opened from a Widget Page, causing some visual differences.

Since it is explicitly removed from Widget Pages in render_portlet.jsp, I'm removing it as well from Content Pages, so it is more consistent and it does not cause visual issues with other components, such as CKEditor.

Thanks.

[LPD-91701]: https://liferay.atlassian.net/browse/LPD-91701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ