### PR TITLE
LPD-91226 Preserve resource file entries on ZIP import when propagation is enabled

### DIFF
--- a/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
+++ b/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
@@ -9,6 +9,7 @@ import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.exception.NoSuchFolderException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLTrashLocalService;
 import com.liferay.document.library.kernel.util.DLAppHelperThreadLocal;
 import com.liferay.petra.function.UnsafeSupplier;
@@ -796,6 +797,63 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 			_repositoryProvider.getRepository(repositoryId);
 
 		return repository.search(searchContext);
+	}
+
+	@Override
+	public FileEntry updatePortletFileEntry(
+			long userId, long fileEntryId, File file, String fileName,
+			String mimeType, ServiceContext serviceContext)
+		throws PortalException {
+
+		FileEntry fileEntry = getPortletFileEntry(fileEntryId);
+
+		if (Validator.isNull(mimeType) ||
+			mimeType.equals(ContentTypes.APPLICATION_OCTET_STREAM)) {
+
+			mimeType = MimeTypesUtil.getContentType(file, fileName);
+		}
+
+		String finalMimeType = mimeType;
+
+		return _run(
+			() -> {
+				LocalRepository localRepository =
+					_repositoryProvider.getLocalRepository(
+						fileEntry.getRepositoryId());
+
+				return localRepository.updateFileEntry(
+					userId, fileEntryId, fileName, finalMimeType,
+					fileEntry.getTitle(), null, fileEntry.getDescription(),
+					null, DLVersionNumberIncrease.NONE, file, null, null, null,
+					serviceContext);
+			});
+	}
+
+	@Override
+	public FileEntry updatePortletFileEntry(
+			long userId, long fileEntryId, InputStream inputStream,
+			String fileName, String mimeType, ServiceContext serviceContext)
+		throws PortalException {
+
+		if (inputStream == null) {
+			return null;
+		}
+
+		File file = null;
+
+		try {
+			file = FileUtil.createTempFile(inputStream);
+
+			return updatePortletFileEntry(
+				userId, fileEntryId, file, fileName, mimeType, serviceContext);
+		}
+		catch (IOException ioException) {
+			throw new SystemException(
+				"Unable to write temporary file", ioException);
+		}
+		finally {
+			FileUtil.delete(file);
+		}
 	}
 
 	private boolean _isAttachment(FileEntry fileEntry) {

--- a/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
+++ b/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
@@ -145,14 +145,6 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 			return null;
 		}
 
-		if (Validator.isNull(mimeType) ||
-			mimeType.equals(ContentTypes.APPLICATION_OCTET_STREAM)) {
-
-			mimeType = MimeTypesUtil.getContentType(file, sourceFileName);
-		}
-
-		String finalMimeType = mimeType;
-
 		return _run(
 			() -> {
 				ServiceContext serviceContext = new ServiceContext();
@@ -177,8 +169,9 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 
 				return localRepository.addFileEntry(
 					externalReferenceCode, userId, folderId, sourceFileName,
-					finalMimeType, title, title, StringPool.BLANK,
-					StringPool.BLANK, file, null, null, null, serviceContext);
+					_getMimeType(file, sourceFileName, mimeType), title, title,
+					StringPool.BLANK, StringPool.BLANK, file, null, null, null,
+					serviceContext);
 			});
 	}
 
@@ -807,14 +800,6 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 
 		FileEntry fileEntry = getPortletFileEntry(fileEntryId);
 
-		if (Validator.isNull(mimeType) ||
-			mimeType.equals(ContentTypes.APPLICATION_OCTET_STREAM)) {
-
-			mimeType = MimeTypesUtil.getContentType(file, fileName);
-		}
-
-		String finalMimeType = mimeType;
-
 		return _run(
 			() -> {
 				LocalRepository localRepository =
@@ -822,7 +807,8 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 						fileEntry.getRepositoryId());
 
 				return localRepository.updateFileEntry(
-					userId, fileEntryId, fileName, finalMimeType,
+					userId, fileEntryId, fileName,
+					_getMimeType(file, fileName, mimeType),
 					fileEntry.getTitle(), null, fileEntry.getDescription(),
 					null, DLVersionNumberIncrease.NONE, file, null, null, null,
 					serviceContext);
@@ -854,6 +840,16 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 		finally {
 			FileUtil.delete(file);
 		}
+	}
+
+	private String _getMimeType(File file, String fileName, String mimeType) {
+		if (Validator.isNull(mimeType) ||
+			mimeType.equals(ContentTypes.APPLICATION_OCTET_STREAM)) {
+
+			return MimeTypesUtil.getContentType(file, fileName);
+		}
+
+		return mimeType;
 	}
 
 	private boolean _isAttachment(FileEntry fileEntry) {

--- a/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
+++ b/modules/apps/document-library/document-library-repository-portlet-file-repository-impl/src/main/java/com/liferay/document/library/repository/portlet/file/repository/internal/PortletFileRepositoryImpl.java
@@ -843,13 +843,13 @@ public class PortletFileRepositoryImpl implements PortletFileRepository {
 	}
 
 	private String _getMimeType(File file, String fileName, String mimeType) {
-		if (Validator.isNull(mimeType) ||
-			mimeType.equals(ContentTypes.APPLICATION_OCTET_STREAM)) {
+		if (Validator.isNotNull(mimeType) &&
+			!mimeType.equals(ContentTypes.APPLICATION_OCTET_STREAM)) {
 
-			return MimeTypesUtil.getContentType(file, fileName);
+			return mimeType;
 		}
 
-		return mimeType;
+		return MimeTypesUtil.getContentType(file, fileName);
 	}
 
 	private boolean _isAttachment(FileEntry fileEntry) {

--- a/modules/apps/document-library/document-library-repository-portlet-file-repository-test/src/testIntegration/java/com/liferay/document/library/repository/portlet/file/repository/test/PortletFileRepositoryTest.java
+++ b/modules/apps/document-library/document-library-repository-portlet-file-repository-test/src/testIntegration/java/com/liferay/document/library/repository/portlet/file/repository/test/PortletFileRepositoryTest.java
@@ -307,9 +307,7 @@ public class PortletFileRepositoryTest {
 		FileEntry fileEntry = _addPortletFileEntry(
 			RandomTestUtil.randomString());
 
-		String randomString = RandomTestUtil.randomString();
-
-		byte[] bytes = randomString.getBytes();
+		byte[] bytes = RandomTestUtil.randomBytes();
 
 		FileEntry updatedFileEntry;
 
@@ -322,9 +320,7 @@ public class PortletFileRepositoryTest {
 
 		_assertUpdatedFileEntry(bytes, fileEntry, updatedFileEntry);
 
-		randomString = RandomTestUtil.randomString();
-
-		bytes = randomString.getBytes();
+		bytes = RandomTestUtil.randomBytes();
 
 		File file = FileUtil.createTempFile(bytes);
 

--- a/modules/apps/document-library/document-library-repository-portlet-file-repository-test/src/testIntegration/java/com/liferay/document/library/repository/portlet/file/repository/test/PortletFileRepositoryTest.java
+++ b/modules/apps/document-library/document-library-repository-portlet-file-repository-test/src/testIntegration/java/com/liferay/document/library/repository/portlet/file/repository/test/PortletFileRepositoryTest.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil
 import com.liferay.portal.kernel.repository.capabilities.WorkflowCapability;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.constants.TestDataConstants;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -36,6 +37,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
+import java.io.File;
 import java.io.InputStream;
 
 import org.junit.Assert;
@@ -299,6 +301,46 @@ public class PortletFileRepositoryTest {
 				null, fileEntry, StringPool.AMPERSAND + queryString));
 	}
 
+	@Test
+	@TestInfo("LPD-91226")
+	public void testUpdatePortletFileEntry() throws Exception {
+		FileEntry fileEntry = _addPortletFileEntry(
+			RandomTestUtil.randomString());
+
+		String randomString = RandomTestUtil.randomString();
+
+		byte[] bytes = randomString.getBytes();
+
+		FileEntry updatedFileEntry;
+
+		try (InputStream inputStream = new UnsyncByteArrayInputStream(bytes)) {
+			updatedFileEntry = PortletFileRepositoryUtil.updatePortletFileEntry(
+				TestPropsValues.getUserId(), fileEntry.getFileEntryId(),
+				inputStream, fileEntry.getFileName(), fileEntry.getMimeType(),
+				ServiceContextTestUtil.getServiceContext());
+		}
+
+		_assertUpdatedFileEntry(bytes, fileEntry, updatedFileEntry);
+
+		randomString = RandomTestUtil.randomString();
+
+		bytes = randomString.getBytes();
+
+		File file = FileUtil.createTempFile(bytes);
+
+		try {
+			updatedFileEntry = PortletFileRepositoryUtil.updatePortletFileEntry(
+				TestPropsValues.getUserId(), fileEntry.getFileEntryId(), file,
+				fileEntry.getFileName(), fileEntry.getMimeType(),
+				ServiceContextTestUtil.getServiceContext());
+		}
+		finally {
+			FileUtil.delete(file);
+		}
+
+		_assertUpdatedFileEntry(bytes, fileEntry, updatedFileEntry);
+	}
+
 	private FileEntry _addPortletFileEntry(String name) throws Exception {
 		try (InputStream inputStream = new UnsyncByteArrayInputStream(
 				TestDataConstants.TEST_BYTE_ARRAY)) {
@@ -316,6 +358,26 @@ public class PortletFileRepositoryTest {
 			_group.getGroupId(), TestPropsValues.getUserId(), _portletId,
 			_folder.getFolderId(), name,
 			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private void _assertUpdatedFileEntry(
+			byte[] expectedBytes, FileEntry fileEntry,
+			FileEntry updatedFileEntry)
+		throws Exception {
+
+		Assert.assertEquals(fileEntry.getUuid(), updatedFileEntry.getUuid());
+		Assert.assertEquals(
+			fileEntry.getExternalReferenceCode(),
+			updatedFileEntry.getExternalReferenceCode());
+		Assert.assertEquals(
+			fileEntry.getFileEntryId(), updatedFileEntry.getFileEntryId());
+		Assert.assertEquals(
+			fileEntry.getFolderId(), updatedFileEntry.getFolderId());
+
+		try (InputStream inputStream = updatedFileEntry.getContentStream()) {
+			Assert.assertArrayEquals(
+				expectedBytes, FileUtil.getBytes(inputStream));
+		}
 	}
 
 	@Inject

--- a/modules/apps/document-library/document-library-repository-portlet-file-repository-test/src/testIntegration/java/com/liferay/document/library/repository/portlet/file/repository/test/PortletFileRepositoryTest.java
+++ b/modules/apps/document-library/document-library-repository-portlet-file-repository-test/src/testIntegration/java/com/liferay/document/library/repository/portlet/file/repository/test/PortletFileRepositoryTest.java
@@ -373,6 +373,8 @@ public class PortletFileRepositoryTest {
 			fileEntry.getFileEntryId(), updatedFileEntry.getFileEntryId());
 		Assert.assertEquals(
 			fileEntry.getFolderId(), updatedFileEntry.getFolderId());
+		Assert.assertEquals(
+			fileEntry.getVersion(), updatedFileEntry.getVersion());
 
 		try (InputStream inputStream = updatedFileEntry.getContentStream()) {
 			Assert.assertArrayEquals(

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
@@ -474,14 +474,9 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 					FileEntry fileEntry = entry.getValue();
 
 					if (fragmentServiceConfiguration.propagateChanges()) {
-						PortletFileRepositoryUtil.deletePortletFileEntry(
-							fileEntry.getFileEntryId());
-
-						_addFileEntry(
-							folderIdsMap,
-							fragmentCollection.getFragmentCollectionId(),
-							groupId, fileEntryPath, repository, userId,
-							zipEntryNames.get(fileEntryPath), zipFile);
+						_updateFileEntry(
+							fileEntry, userId, zipEntryNames.get(fileEntryPath),
+							zipFile);
 
 						zipEntryNames.remove(fileEntryPath);
 					}
@@ -1192,6 +1187,32 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 		}
 
 		return input;
+	}
+
+	private void _updateFileEntry(
+			FileEntry fileEntry, long userId, String zipEntryName,
+			ZipFile zipFile)
+		throws Exception {
+
+		ZipEntry zipEntry = zipFile.getEntry(zipEntryName);
+
+		if (zipEntry == null) {
+			return;
+		}
+
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext == null) {
+			serviceContext = new ServiceContext();
+		}
+
+		try (InputStream inputStream = zipFile.getInputStream(zipEntry)) {
+			PortletFileRepositoryUtil.updatePortletFileEntry(
+				userId, fileEntry.getFileEntryId(), inputStream,
+				fileEntry.getFileName(), fileEntry.getMimeType(),
+				serviceContext);
+		}
 	}
 
 	private boolean _validateFragmentCompositions(

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
@@ -565,6 +565,57 @@ public class FragmentsImporterTest {
 	}
 
 	@Test
+	@TestInfo("LPD-91226")
+	public void testImportFragmentResourcesPreservesIdentifiersWithPropagation()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						_group.getCompanyId(),
+						FragmentServiceConfiguration.class.getName(),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"propagateChanges", true
+						).build())) {
+
+			_fragmentsImporter.importFragmentEntries(
+				_user.getUserId(), _group.getGroupId(), 0, _resourcesFile,
+				FragmentsImportStrategy.OVERWRITE, false);
+
+			List<FragmentCollection> fragmentCollections =
+				_fragmentCollectionLocalService.getFragmentCollections(
+					_group.getGroupId(), 0, 1);
+
+			FragmentCollection fragmentCollection = fragmentCollections.get(0);
+
+			List<FileEntry> resources = fragmentCollection.getResources();
+
+			Assert.assertEquals(resources.toString(), 1, resources.size());
+
+			FileEntry originalFileEntry = resources.get(0);
+
+			_fragmentsImporter.importFragmentEntries(
+				_user.getUserId(), _group.getGroupId(), 0, _resourcesFile,
+				FragmentsImportStrategy.OVERWRITE, false);
+
+			resources = fragmentCollection.getResources();
+
+			Assert.assertEquals(resources.toString(), 1, resources.size());
+
+			FileEntry reimportedFileEntry = resources.get(0);
+
+			Assert.assertEquals(
+				originalFileEntry.getUuid(), reimportedFileEntry.getUuid());
+			Assert.assertEquals(
+				originalFileEntry.getExternalReferenceCode(),
+				reimportedFileEntry.getExternalReferenceCode());
+			Assert.assertEquals(
+				originalFileEntry.getFileEntryId(),
+				reimportedFileEntry.getFileEntryId());
+		}
+	}
+
+	@Test
 	public void testImportInputFragmentEntriesWithTypeOptions()
 		throws Exception {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/PortletFileRepository.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/PortletFileRepository.java
@@ -199,4 +199,14 @@ public interface PortletFileRepository {
 			long repositoryId, SearchContext searchContext)
 		throws PortalException;
 
+	public FileEntry updatePortletFileEntry(
+			long userId, long fileEntryId, File file, String fileName,
+			String mimeType, ServiceContext serviceContext)
+		throws PortalException;
+
+	public FileEntry updatePortletFileEntry(
+			long userId, long fileEntryId, InputStream inputStream,
+			String fileName, String mimeType, ServiceContext serviceContext)
+		throws PortalException;
+
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/PortletFileRepositoryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/PortletFileRepositoryUtil.java
@@ -494,6 +494,31 @@ public class PortletFileRepositoryUtil {
 			repositoryId, searchContext);
 	}
 
+	public static FileEntry updatePortletFileEntry(
+			long userId, long fileEntryId, File file, String fileName,
+			String mimeType, ServiceContext serviceContext)
+		throws PortalException {
+
+		PortletFileRepository portletFileRepository =
+			_portletFileRepositorySnapshot.get();
+
+		return portletFileRepository.updatePortletFileEntry(
+			userId, fileEntryId, file, fileName, mimeType, serviceContext);
+	}
+
+	public static FileEntry updatePortletFileEntry(
+			long userId, long fileEntryId, InputStream inputStream,
+			String fileName, String mimeType, ServiceContext serviceContext)
+		throws PortalException {
+
+		PortletFileRepository portletFileRepository =
+			_portletFileRepositorySnapshot.get();
+
+		return portletFileRepository.updatePortletFileEntry(
+			userId, fileEntryId, inputStream, fileName, mimeType,
+			serviceContext);
+	}
+
 	private static final Snapshot<PortletFileRepository>
 		_portletFileRepositorySnapshot = new Snapshot<>(
 			PortletFileRepositoryUtil.class, PortletFileRepository.class);

--- a/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/portletfilerepository/packageinfo
@@ -1,1 +1,1 @@
-version 5.2.0
+version 5.3.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91226

Re-send of https://github.com/liferay-page-management/liferay-portal/pull/18492 (authored by @lfbesada) with one follow-up commit on top.

## What is being fixed

When fragments propagation is enabled, re-importing a fragments ZIP whose collection already exists in the target site deletes each matching resource `FileEntry` and re-adds a fresh one, so the entry's `uuid` and `externalReferenceCode` are regenerated. A subsequent LAR import of the same site (which carries the source `uuid`) then fails with `PortletDataException: A file entry already exists with file name <name>` because the `uuid` is gone from the target while the file name is still taken by the regenerated entry.

## How it is being fixed

Adds `PortletFileRepository.updatePortletFileEntry(...)` (covered by a new unit test in `PortletFileRepositoryTest`) so callers can refresh the binary content of an existing `FileEntry` while preserving `fileEntryId`, `uuid`, `externalReferenceCode` and `folderId`. Routes the propagation branch of `FragmentsImporterImpl._addPortletFileEntriesWithFolders` through the new method instead of delete-then-add, and adds a regression test that re-imports the same ZIP twice with propagation enabled and asserts those identifiers stay stable across the re-import.

The single follow-up commit on top simplifies `PortletFileRepositoryTest.testUpdatePortletFileEntry` to call `RandomTestUtil.randomBytes()` directly, dropping two unused intermediate locals.