### PR TITLE
LPD-92001 Render fragments for translation export with proper context

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/helper/LayoutInfoItemFieldValuesProviderHelper.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/helper/LayoutInfoItemFieldValuesProviderHelper.java
@@ -15,12 +15,22 @@ import com.liferay.layout.admin.web.internal.info.item.LayoutInfoItemFields;
 import com.liferay.layout.util.InfoFieldUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.events.ServicePreAction;
+import com.liferay.portal.events.ThemeServicePreAction;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.servlet.DummyHttpServletResponse;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.service.SegmentsExperienceLocalServiceUtil;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -42,12 +52,34 @@ public class LayoutInfoItemFieldValuesProviderHelper {
 	public InfoItemFieldValues getInfoItemFieldValues(
 		Layout layout, long segmentsExperienceId) {
 
-		long defaultSegmentsExperienceId =
-			SegmentsExperienceLocalServiceUtil.fetchDefaultSegmentsExperienceId(
-				layout.getPlid());
+		HttpServletRequest httpServletRequest = _setUpThemeDisplay(layout);
 
-		if (segmentsExperienceId != defaultSegmentsExperienceId) {
+		try {
+			long defaultSegmentsExperienceId =
+				SegmentsExperienceLocalServiceUtil.
+					fetchDefaultSegmentsExperienceId(layout.getPlid());
+
+			if (segmentsExperienceId != defaultSegmentsExperienceId) {
+				return InfoItemFieldValues.builder(
+				).infoFieldValues(
+					_getLayoutInfoFieldValues(layout, segmentsExperienceId)
+				).infoItemReference(
+					_getInfoItemReference(
+						defaultSegmentsExperienceId, layout,
+						segmentsExperienceId)
+				).build();
+			}
+
 			return InfoItemFieldValues.builder(
+			).infoFieldValue(
+				new InfoFieldValue<>(
+					LayoutInfoItemFields.nameInfoField,
+					InfoLocalizedValue.<String>builder(
+					).defaultLocale(
+						LocaleUtil.fromLanguageId(layout.getDefaultLanguageId())
+					).values(
+						layout.getNameMap()
+					).build())
 			).infoFieldValues(
 				_getLayoutInfoFieldValues(layout, segmentsExperienceId)
 			).infoItemReference(
@@ -55,23 +87,11 @@ public class LayoutInfoItemFieldValuesProviderHelper {
 					defaultSegmentsExperienceId, layout, segmentsExperienceId)
 			).build();
 		}
-
-		return InfoItemFieldValues.builder(
-		).infoFieldValue(
-			new InfoFieldValue<>(
-				LayoutInfoItemFields.nameInfoField,
-				InfoLocalizedValue.<String>builder(
-				).defaultLocale(
-					LocaleUtil.fromLanguageId(layout.getDefaultLanguageId())
-				).values(
-					layout.getNameMap()
-				).build())
-		).infoFieldValues(
-			_getLayoutInfoFieldValues(layout, segmentsExperienceId)
-		).infoItemReference(
-			_getInfoItemReference(
-				defaultSegmentsExperienceId, layout, segmentsExperienceId)
-		).build();
+		finally {
+			if (httpServletRequest != null) {
+				httpServletRequest.removeAttribute(WebKeys.THEME_DISPLAY);
+			}
+		}
 	}
 
 	private InfoItemReference _getInfoItemReference(
@@ -159,6 +179,51 @@ public class LayoutInfoItemFieldValuesProviderHelper {
 		}
 		catch (JSONException jsonException) {
 			return ReflectionUtil.throwException(jsonException);
+		}
+	}
+
+	private HttpServletRequest _setUpThemeDisplay(Layout layout) {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext == null) {
+			return null;
+		}
+
+		HttpServletRequest httpServletRequest = serviceContext.getRequest();
+
+		if ((httpServletRequest == null) ||
+			(httpServletRequest.getAttribute(WebKeys.THEME_DISPLAY) != null)) {
+
+			return null;
+		}
+
+		try {
+			HttpServletResponse httpServletResponse =
+				new DummyHttpServletResponse();
+
+			ServicePreAction servicePreAction = new ServicePreAction();
+
+			servicePreAction.servicePre(
+				httpServletRequest, httpServletResponse, false);
+
+			ThemeServicePreAction themeServicePreAction =
+				new ThemeServicePreAction();
+
+			themeServicePreAction.run(httpServletRequest, httpServletResponse);
+
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)httpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			themeDisplay.setLayout(layout);
+			themeDisplay.setScopeGroupId(layout.getGroupId());
+			themeDisplay.setSiteGroupId(layout.getGroupId());
+
+			return httpServletRequest;
+		}
+		catch (Exception exception) {
+			return ReflectionUtil.throwException(exception);
 		}
 	}
 

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/InfoFieldUtil.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/InfoFieldUtil.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.servlet.DummyHttpServletResponse;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -112,10 +113,15 @@ public class InfoFieldUtil {
 		}
 
 		HttpServletRequest httpServletRequest = serviceContext.getRequest();
+
+		if (httpServletRequest == null) {
+			return _renderHtml(fragmentEntryLink, defaultElementName);
+		}
+
 		HttpServletResponse httpServletResponse = serviceContext.getResponse();
 
-		if ((httpServletRequest == null) || (httpServletResponse == null)) {
-			return _renderHtml(fragmentEntryLink, defaultElementName);
+		if (httpServletResponse == null) {
+			httpServletResponse = new DummyHttpServletResponse();
 		}
 
 		ThemeDisplay themeDisplay =

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/web/internal/servlet/test/ExportTranslationServletTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/web/internal/servlet/test/ExportTranslationServletTest.java
@@ -11,11 +11,22 @@ import com.liferay.change.tracking.model.CTCollection;
 import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.change.tracking.service.CTPreferencesService;
 import com.liferay.dynamic.data.mapping.io.DDMFormDeserializer;
+import com.liferay.fragment.constants.FragmentConstants;
+import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.service.FragmentCollectionService;
+import com.liferay.fragment.service.FragmentEntryService;
 import com.liferay.journal.model.JournalArticle;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.TestInfo;
@@ -23,18 +34,27 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.segments.service.SegmentsExperienceLocalServiceUtil;
 import com.liferay.translation.test.util.TranslationTestUtil;
 
 import jakarta.servlet.Servlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.ByteArrayInputStream;
+
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -99,26 +119,99 @@ public class ExportTranslationServletTest {
 			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
 			_ctCollection.getCtCollectionId());
 
-		User user = _userLocalService.getUser(TestPropsValues.getUserId());
+		String xliff = _exportTranslation(
+			JournalArticle.class, journalArticle.getResourcePrimKey(),
+			_MIMETYPE_XLIFF_1_2);
+
+		Assert.assertFalse(xliff.isEmpty());
+	}
+
+	@Test
+	@TestInfo("LPD-92001")
+	public void testDoGetExportsIteratedFragmentEditable() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				TestPropsValues.getGroupId(), TestPropsValues.getUserId());
+
+		FragmentCollection fragmentCollection =
+			_fragmentCollectionService.addFragmentCollection(
+				null, _group.getGroupId(), RandomTestUtil.randomString(),
+				StringPool.BLANK, serviceContext);
+
+		FragmentEntry fragmentEntry = _fragmentEntryService.addFragmentEntry(
+			null, _group.getGroupId(),
+			fragmentCollection.getFragmentCollectionId(), null,
+			RandomTestUtil.randomString(), null, _read("index.html"), null,
+			false, _read("configuration.json"), null, 0, false, false,
+			FragmentConstants.TYPE_COMPONENT, null,
+			WorkflowConstants.STATUS_APPROVED, serviceContext);
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		long segmentsExperienceId =
+			SegmentsExperienceLocalServiceUtil.fetchDefaultSegmentsExperienceId(
+				draftLayout.getPlid());
+
+		FragmentEntryLink fragmentEntryLink =
+			ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+				JSONUtil.put(
+					"com.liferay.fragment.entry.processor.editable." +
+						"EditableFragmentEntryProcessor",
+					JSONUtil.put(
+						"title-1", JSONUtil.put("defaultValue", "Title One")
+					).put(
+						"title-2", JSONUtil.put("defaultValue", "Title Two")
+					)
+				).put(
+					"com.liferay.fragment.entry.processor.freemarker." +
+						"FreeMarkerFragmentEntryProcessor",
+					JSONUtil.put("itemCount", "2")
+				).toString(),
+				fragmentEntry.getCss(), fragmentEntry.getConfiguration(),
+				fragmentEntry.getExternalReferenceCode(), null,
+				fragmentEntry.getHtml(), fragmentEntry.getJs(), draftLayout,
+				null, FragmentConstants.TYPE_COMPONENT, null, 0,
+				segmentsExperienceId);
+
+		String xliff = _exportTranslation(
+			Layout.class, layout.getPlid(), _MIMETYPE_XLIFF_2_0);
+
+		String fragmentEntryLinkPrefix =
+			"FragmentEntryLink_" + fragmentEntryLink.getFragmentEntryLinkId() +
+				":";
+
+		Assert.assertTrue(xliff.contains(fragmentEntryLinkPrefix + "title-1"));
+		Assert.assertTrue(xliff.contains(fragmentEntryLinkPrefix + "title-2"));
+
+		Assert.assertTrue(xliff.contains("Title One"));
+		Assert.assertTrue(xliff.contains("Title Two"));
+	}
+
+	private String _exportTranslation(
+			Class<?> clazz, long classPK, String xliffMimeType)
+		throws Exception {
 
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();
 
-		mockHttpServletRequest.setAttribute(WebKeys.USER, user);
+		mockHttpServletRequest.setAttribute(
+			WebKeys.CURRENT_URL, "/translation/export_translation");
+		mockHttpServletRequest.setAttribute(
+			WebKeys.USER,
+			_userLocalService.getUser(TestPropsValues.getUserId()));
 		mockHttpServletRequest.setMethod("GET");
 		mockHttpServletRequest.setParameter(
-			"classNameId",
-			String.valueOf(_portal.getClassNameId(JournalArticle.class)));
-		mockHttpServletRequest.setParameter(
-			"classPK", String.valueOf(journalArticle.getResourcePrimKey()));
+			"classNameId", String.valueOf(_portal.getClassNameId(clazz)));
+		mockHttpServletRequest.setParameter("classPK", String.valueOf(classPK));
 		mockHttpServletRequest.setParameter(
 			"groupId", String.valueOf(_group.getGroupId()));
 		mockHttpServletRequest.setParameter(
 			"sourceLanguageId", LocaleUtil.toLanguageId(LocaleUtil.US));
 		mockHttpServletRequest.setParameter(
 			"targetLanguageIds", LocaleUtil.toLanguageId(LocaleUtil.SPAIN));
-		mockHttpServletRequest.setParameter(
-			"xliffMimeType", _MIMETYPE_XLIFF_1_2);
+		mockHttpServletRequest.setParameter("xliffMimeType", xliffMimeType);
 
 		MockHttpServletResponse mockHttpServletResponse =
 			new MockHttpServletResponse();
@@ -133,12 +226,37 @@ public class ExportTranslationServletTest {
 		Assert.assertEquals(
 			HttpServletResponse.SC_OK, mockHttpServletResponse.getStatus());
 
-		byte[] bytes = mockHttpServletResponse.getContentAsByteArray();
+		return _readXLIFFEntry(mockHttpServletResponse.getContentAsByteArray());
+	}
 
-		Assert.assertTrue(bytes.length > 0);
+	private String _read(String fileName) throws Exception {
+		Class<?> clazz = getClass();
+
+		return StringUtil.read(
+			clazz.getResourceAsStream("dependencies/" + fileName));
+	}
+
+	private String _readXLIFFEntry(byte[] zipBytes) throws Exception {
+		try (ZipInputStream zipInputStream = new ZipInputStream(
+				new ByteArrayInputStream(zipBytes))) {
+
+			ZipEntry zipEntry;
+
+			while ((zipEntry = zipInputStream.getNextEntry()) != null) {
+				String name = zipEntry.getName();
+
+				if (name.endsWith(".xlf") || name.endsWith(".xliff")) {
+					return StringUtil.read(zipInputStream);
+				}
+			}
+
+			throw new AssertionError("Export ZIP contains no XLIFF entry");
+		}
 	}
 
 	private static final String _MIMETYPE_XLIFF_1_2 = "application/x-xliff+xml";
+
+	private static final String _MIMETYPE_XLIFF_2_0 = "application/xliff+xml";
 
 	private CTCollection _ctCollection;
 
@@ -150,6 +268,12 @@ public class ExportTranslationServletTest {
 
 	@Inject(filter = "ddm.form.deserializer.type=json")
 	private DDMFormDeserializer _ddmFormDeserializer;
+
+	@Inject
+	private FragmentCollectionService _fragmentCollectionService;
+
+	@Inject
+	private FragmentEntryService _fragmentEntryService;
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/web/internal/servlet/test/dependencies/configuration.json
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/web/internal/servlet/test/dependencies/configuration.json
@@ -1,0 +1,15 @@
+{
+	"fieldSets": [
+		{
+			"fields": [
+				{
+					"dataType": "int",
+					"defaultValue": "2",
+					"label": "Item Count",
+					"name": "itemCount",
+					"type": "text"
+				}
+			]
+		}
+	]
+}

--- a/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/web/internal/servlet/test/dependencies/index.html
+++ b/modules/apps/translation/translation-test/src/testIntegration/resources/com/liferay/translation/web/internal/servlet/test/dependencies/index.html
@@ -1,0 +1,6 @@
+[#assign itemCount = (configuration.itemCount!2)?number]
+[#list 1..itemCount as i]
+	<h4 data-lfr-editable-id="title-${i}" data-lfr-editable-type="text">
+		Title ${i}
+	</h4>
+[/#list]

--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/servlet/ExportTranslationServlet.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/servlet/ExportTranslationServlet.java
@@ -23,6 +23,8 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
@@ -125,15 +127,29 @@ public class ExportTranslationServlet extends HttpServlet {
 				String xliffMimeType = ParamUtil.getString(
 					httpServletRequest, "xliffMimeType");
 
-				File file = _translationManager.getXLIFFZipFile(
-					className, ArrayUtil.toLongArray(classPKs), xliffMimeType,
-					_portal.getLocale(httpServletRequest), sourceLanguageId,
-					targetLanguageIds);
+				ServiceContext serviceContext = new ServiceContext();
 
-				try (InputStream inputStream = new FileInputStream(file)) {
-					ServletResponseUtil.sendFile(
-						httpServletRequest, httpServletResponse, file.getName(),
-						inputStream, ContentTypes.APPLICATION_ZIP);
+				serviceContext.setCompanyId(user.getCompanyId());
+				serviceContext.setRequest(httpServletRequest);
+				serviceContext.setUserId(user.getUserId());
+
+				ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+				try {
+					File file = _translationManager.getXLIFFZipFile(
+						className, ArrayUtil.toLongArray(classPKs),
+						xliffMimeType, _portal.getLocale(httpServletRequest),
+						sourceLanguageId, targetLanguageIds);
+
+					try (InputStream inputStream = new FileInputStream(file)) {
+						ServletResponseUtil.sendFile(
+							httpServletRequest, httpServletResponse,
+							file.getName(), inputStream,
+							ContentTypes.APPLICATION_ZIP);
+					}
+				}
+				finally {
+					ServiceContextThreadLocal.popServiceContext();
 				}
 			}
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92001

## What is this trying to solve?

Exporting a content page for translation (Site Admin → Pages → Actions → Export for Translation) emits an XLIFF whose fragment editables come back with empty CDATA when those editables' ids are generated by FreeMarker iteration (`data-lfr-editable-id="title-${i}"` inside `[#list]`). `ExportTranslationServlet` runs as a plain `HttpServlet` (not a portlet), so `InfoFieldUtil._getHtml` had no `ServiceContext` or `ThemeDisplay` on the thread, fell back to regex-substituting every `${...}` with one random sentinel, the discovered editable ids never matched the keys persisted in `editableValues`, and every iterated editable lost its content. Reported via LPP-64113 (customer case LRHC-149512).

## How am I fixing it?

`ExportTranslationServlet` pushes a minimal `ServiceContext` carrying the request so downstream code can find it. `LayoutInfoItemFieldValuesProviderHelper`, when the request has no `ThemeDisplay` yet, runs `ServicePreAction` + `ThemeServicePreAction` — the same idiom used in `headless-delivery-impl` — to populate one, then layers the layout's scope on top; the attribute is restored on exit so portlet callers stay unaffected. `InfoFieldUtil._getHtml` no longer bails to the regex fallback when `ServiceContext.getResponse()` returns null — it substitutes a `DummyHttpServletResponse`, since the fragment renderer wraps the response in a `PipingServletResponse` and routes output to its own buffer. The proper FreeMarker render path then runs from the export servlet too, `${i}` is evaluated, and the editable ids match what is persisted.

## How can you verify that it works?

Run the included automated tests.