### PR TITLE
LPD-92334 Allow the previous creation of Widget Page Templates in the global site using the LayoutTestUtil and use it from LayoutSetPrototypePropagationTest

### DIFF
--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -1378,7 +1378,7 @@ public class LayoutSetPrototypePropagationTest
 		MergeLayoutPrototypesThreadLocal.clearMergeComplete();
 
 		_layoutSetPrototypeLayout = LayoutTestUtil.addTypePortletLayout(
-			_layoutSetPrototypeGroup, true, layoutPrototype,
+			_layoutSetPrototypeGroup, true, globalGroupId, layoutPrototype,
 			layoutSetLayoutLinkEnabled);
 
 		_layoutSetPrototypeLayout = propagateChanges(_layoutSetPrototypeLayout);

--- a/modules/apps/layout/layout-test-util/bnd.bnd
+++ b/modules/apps/layout/layout-test-util/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Layout Test Utilities
 Bundle-SymbolicName: com.liferay.layout.test.util
-Bundle-Version: 14.1.2
+Bundle-Version: 14.2.0
 Export-Package: com.liferay.layout.test.util

--- a/modules/apps/layout/layout-test-util/src/main/java/com/liferay/layout/test/util/LayoutTestUtil.java
+++ b/modules/apps/layout/layout-test-util/src/main/java/com/liferay/layout/test/util/LayoutTestUtil.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ScopeUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 
 import jakarta.portlet.PortletPreferences;
@@ -404,6 +405,22 @@ public class LayoutTestUtil {
 	}
 
 	public static Layout addTypePortletLayout(
+			Group group, boolean privateLayout,
+			long layoutPageTemplateEntryGroupId,
+			LayoutPrototype layoutPrototype, boolean linkEnabled)
+		throws Exception {
+
+		return addTypePortletLayout(
+			group.getGroupId(),
+			RandomTestUtil.randomString(
+				LayoutFriendlyURLRandomizerBumper.INSTANCE,
+				NumericStringRandomizerBumper.INSTANCE,
+				UniqueStringRandomizerBumper.INSTANCE),
+			privateLayout, layoutPageTemplateEntryGroupId, layoutPrototype,
+			linkEnabled, false);
+	}
+
+	public static Layout addTypePortletLayout(
 			Group group, long parentLayoutPlid)
 		throws Exception {
 
@@ -521,6 +538,18 @@ public class LayoutTestUtil {
 			boolean hidden)
 		throws Exception {
 
+		return addTypePortletLayout(
+			groupId, name, privateLayout, groupId, layoutPrototype, linkEnabled,
+			hidden);
+	}
+
+	public static Layout addTypePortletLayout(
+			long groupId, String name, boolean privateLayout,
+			long layoutPageTemplateEntryGroupId,
+			LayoutPrototype layoutPrototype, boolean linkEnabled,
+			boolean hidden)
+		throws Exception {
+
 		String friendlyURL =
 			StringPool.SLASH + FriendlyURLNormalizerUtil.normalize(name);
 
@@ -549,7 +578,7 @@ public class LayoutTestUtil {
 					getFirstLayoutPageTemplateEntry(
 						layoutPrototype.getLayoutPrototypeId());
 
-			layoutPageTemplateEntry.setGroupId(group.getGroupId());
+			layoutPageTemplateEntry.setGroupId(layoutPageTemplateEntryGroupId);
 
 			layoutPageTemplateEntry =
 				LayoutPageTemplateEntryLocalServiceUtil.
@@ -558,6 +587,11 @@ public class LayoutTestUtil {
 			serviceContext.setAttribute(
 				"portletLayoutPageTemplateEntryERC",
 				layoutPageTemplateEntry.getExternalReferenceCode());
+
+			serviceContext.setAttribute(
+				"portletLayoutPageTemplateEntryScopeERC",
+				ScopeUtil.getItemScopeExternalReferenceCode(
+					layoutPageTemplateEntryGroupId, groupId));
 
 			serviceContext.setAttribute(
 				"portletLayoutPageTemplateEntryLinkEnabled", linkEnabled);

--- a/modules/apps/layout/layout-test-util/src/main/resources/com/liferay/layout/test/util/packageinfo
+++ b/modules/apps/layout/layout-test-util/src/main/resources/com/liferay/layout/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 9.1.0
+version 9.2.0


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-92334