### PR TITLE
LPD-60983 Toggle sidebars doesn't fully hide left sidebar

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_Sidebar.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_Sidebar.scss
@@ -181,7 +181,7 @@ html#{$cadmin-selector} .cadmin .page-editor__sidebar {
 		);
 		left: $sidebarButtonWidth;
 		position: fixed;
-		transform: translateX(-100%);
+		transform: translateX(calc(-100% - $sidebarButtonWidth));
 		transition:
 			transform ease $defaultTransitionDuration,
 			left ease $defaultTransitionDuration;

--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -1949,6 +1949,10 @@ export class PageEditorPage {
 		}
 	}
 
+	async toggleSidebars({timeout}: {timeout?: number} = {}) {
+		await this.page.getByLabel('Toggle Sidebars').click({timeout});
+	}
+
 	async undoAction() {
 		await this.undoButton.click();
 

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/sidebar.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/sidebar.spec.ts
@@ -250,6 +250,57 @@ test('Checks sidebar accessibility', async ({
 	});
 });
 
+test(
+	'Check that the sidebars are fully closed when toggling the Toggle Sidebars button',
+	{
+		tag: ['@LPD-60893'],
+	},
+	async ({apiHelpers, page, pageEditorPage, site}) => {
+		await page.goto('/');
+
+		// Create content page and go to edit mode
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		// Click on the Browser panel
+
+		await pageEditorPage.goToSidebarTab('Browser');
+
+		// Check panels are visible
+
+		const configurationPanel = page.getByLabel('Configuration Panel', {
+			exact: true,
+		});
+
+		const sidebarButtons = page.locator('.page-editor__sidebar__buttons');
+
+		const sidebarContent = page.locator('.page-editor__sidebar__content');
+
+		await expect(configurationPanel).toBeInViewport();
+
+		await expect(sidebarButtons).toBeInViewport();
+
+		await expect(sidebarContent).toBeInViewport();
+
+		// Toggle the Toggle Sidebars button
+
+		await pageEditorPage.toggleSidebars();
+
+		// Check that sidebars are fully out of view
+
+		await expect(configurationPanel).not.toBeInViewport();
+
+		await expect(sidebarButtons).not.toBeInViewport();
+
+		await expect(sidebarContent).not.toBeInViewport();
+	}
+);
+
 test.describe('Browser Panel', () => {
 	test('Deleting a fragment while its editable is selected', async ({
 		apiHelpers,


### PR DESCRIPTION
# Summary of Changes

[LPD-60983](https://liferay.atlassian.net/browse/LPD-60983)

The content sidebar when editing a content page is not fully hidden when toggling the button Toggle Sidebars because the size of the buttons sidebar is not taken into account.

# Technical Approach

The sidebar is hidden by translating in the horizontal direction by the full width of the panel but it's not taking into account the width of the buttons sidebar that's also being hidden. The fix just considers that width too.

# Validation Performed

**Automated Tests**

- [ ] Unit tests
- [x] Integration tests
- [ ] Functional / end-to-end tests
- [ ] Not applicable (explain why)

**Manual Testing**

- Steps:
  1. Create a Content Page.
  2. In the edit view, switch to a different left side panel section (for example, “Browser”).
  3. Toggle the button Toggle Sidebars (button with the eye icon) to hide both sidebars left and right.
- Expected result: The sidebar on the left is fully hidden.
- Actual result: A bit of the left sidebar is still shown.

# UI / UX Changes

- [ ] No UI changes
- [x] UI changes included (screenshots/media below)

**Screenshots / Media (Before & After)**

| Before | After |
| ------ | ----- |
|![before](https://github.com/user-attachments/assets/a9a225ba-75c2-464b-94a6-e837bf4a7e7c) |![after](https://github.com/user-attachments/assets/4db0ffc6-ccd6-4cd2-b1fa-b767b0fa97d2) |

# Checklist for Author

- [x] Linked to the correct Jira / LPD / related ticket.
- [ ] Relevant unit tests updated/added and passed locally.
- [x] Relevant integration / functional / Playwright tests updated/added and passed locally (if applicable).
- [ ] ci:test:sf has been run and is green.
- [ ] ci:test:relevant has been run and is green.
- [ ] Any domain‑specific suites (ci:test:security, ci:test:ldap, ci:test:oauth2, ci:test:saml, …) have been run if the change touches those areas.
- [ ] No unique CI failures remain (anything unique is investigated and fixed).
- [x] Self-reviewed the code (style, naming, dead code, logs, etc.).
- [ ] Updated documentation / comments where needed.
- [x] `../gradlew -b util.gradle validateBranch`


[LPD-60983]: https://liferay.atlassian.net/browse/LPD-60983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ