### PR TITLE
LPD-89304 Stop testDeleteSiteMasterPage flaking on the irrelevantGroup post

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
@@ -139,7 +139,8 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 
 		MasterPage liveGroupMasterPage =
 			testGetSiteMasterPagesPage_addMasterPage(
-				irrelevantGroup.getExternalReferenceCode(), randomMasterPage());
+				irrelevantGroup.getExternalReferenceCode(),
+				_randomMasterPage(irrelevantGroup));
 
 		_enableLocalStaging(irrelevantGroup);
 
@@ -451,20 +452,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 
 	@Override
 	protected MasterPage randomMasterPage() throws Exception {
-		MasterPage masterPage = super.randomMasterPage();
-
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(
-				testGroup, TestPropsValues.getUserId());
-
-		masterPage.setKeywords(AssetTestUtil.randomKeywords(serviceContext));
-
-		masterPage.setMarkedAsDefault(Boolean.FALSE);
-		masterPage.setTaxonomyCategoryBriefs(
-			AssetTestUtil.randomTaxonomyCategoryBriefs(
-				testCompany.getGroupId(), serviceContext));
-
-		return masterPage;
+		return _randomMasterPage(testGroup);
 	}
 
 	@Override
@@ -780,6 +768,23 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 			testGroup.getGroupId(), postMasterPage.getPageSpecifications());
 
 		return postMasterPage;
+	}
+
+	private MasterPage _randomMasterPage(Group group) throws Exception {
+		MasterPage masterPage = super.randomMasterPage();
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				group, TestPropsValues.getUserId());
+
+		masterPage.setKeywords(AssetTestUtil.randomKeywords(serviceContext));
+
+		masterPage.setMarkedAsDefault(Boolean.FALSE);
+		masterPage.setTaxonomyCategoryBriefs(
+			AssetTestUtil.randomTaxonomyCategoryBriefs(
+				testCompany.getGroupId(), serviceContext));
+
+		return masterPage;
 	}
 
 	private void _testGetSiteMasterPage(MasterPage masterPage)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89304

**What is being fixed:** `MasterPageResourceTest.testDeleteSiteMasterPage` was flaking on the `postSiteMasterPage` call against `irrelevantGroup`. The master page payload carries `taxonomyCategoryBriefs` referencing categories that `AssetTestUtil.randomTaxonomyCategoryBriefs` creates in two places: the company group (briefs carry `scope = L_GLOBAL`) and the `serviceContext`'s scope group (briefs carry no scope). Because the helper was always built with `testGroup`'s `serviceContext`, the no-scope briefs pointed to categories that lived in `testGroup` and could not be resolved when the master page was posted to `irrelevantGroup`, producing a `NoSuchCategoryException` that Vulcan rendered as an empty `404`.

**How it is being fixed:** Extract a private `_randomMasterPage(Group group)` that builds the master page against the given group's `serviceContext`, and use it at the `irrelevantGroup` post site so the categories created by `AssetTestUtil` land in `irrelevantGroup` and the no-scope briefs resolve correctly. `randomMasterPage()` now delegates to the helper with `testGroup`.