### PR TITLE
LPD-92505 Update the Inherit Changes script to the renamed input id

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/layout.jsp
@@ -69,51 +69,54 @@ Layout selLayout = layoutsAdminDisplayContext.getSelLayout();
 
 <aui:script sandbox="<%= true %>">
 	Liferay.Util.toggleBoxes(
-		'<portlet:namespace />layoutPrototypeLinkEnabled',
+		'<portlet:namespace />portletLayoutPageTemplateEntryLinkEnabled',
 		'<portlet:namespace />layoutPrototypeMergeAlert'
 	);
 	Liferay.Util.toggleBoxes(
-		'<portlet:namespace />layoutPrototypeLinkEnabled',
+		'<portlet:namespace />portletLayoutPageTemplateEntryLinkEnabled',
 		'<portlet:namespace />typeOptions',
 		true
 	);
 
-	var layoutPrototypeLinkEnabled = document.getElementById(
-		'<portlet:namespace />layoutPrototypeLinkEnabled'
+	var portletLayoutPageTemplateEntryLinkEnabled = document.getElementById(
+		'<portlet:namespace />portletLayoutPageTemplateEntryLinkEnabled'
 	);
 
-	if (layoutPrototypeLinkEnabled) {
-		layoutPrototypeLinkEnabled.addEventListener('change', (event) => {
-			var layoutPrototypeLinkChecked = event.currentTarget.checked;
+	if (portletLayoutPageTemplateEntryLinkEnabled) {
+		portletLayoutPageTemplateEntryLinkEnabled.addEventListener(
+			'change',
+			(event) => {
+				var layoutPrototypeLinkChecked = event.currentTarget.checked;
 
-			var layoutPrototypeInfoMessage = document.querySelector(
-				'.layout-prototype-info-message'
-			);
+				var layoutPrototypeInfoMessage = document.querySelector(
+					'.layout-prototype-info-message'
+				);
 
-			var applyLayoutPrototype = document.getElementById(
-				'<portlet:namespace />applyLayoutPrototype'
-			);
+				var applyLayoutPrototype = document.getElementById(
+					'<portlet:namespace />applyLayoutPrototype'
+				);
 
-			if (layoutPrototypeInfoMessage) {
-				if (layoutPrototypeLinkChecked) {
-					layoutPrototypeInfoMessage.classList.remove('hide');
+				if (layoutPrototypeInfoMessage) {
+					if (layoutPrototypeLinkChecked) {
+						layoutPrototypeInfoMessage.classList.remove('hide');
 
-					applyLayoutPrototype.value = '<%= true %>';
+						applyLayoutPrototype.value = '<%= true %>';
+					}
+					else {
+						layoutPrototypeInfoMessage.classList.add('hide');
+
+						applyLayoutPrototype.value = '<%= false %>';
+					}
 				}
-				else {
-					layoutPrototypeInfoMessage.classList.add('hide');
 
-					applyLayoutPrototype.value = '<%= false %>';
-				}
+				var propagatableFields = document.querySelectorAll(
+					'#<portlet:namespace />editLayoutFm .propagatable-field'
+				);
+
+				Array.prototype.forEach.call(propagatableFields, (field, index) => {
+					Liferay.Util.toggleDisabled(field, layoutPrototypeLinkChecked);
+				});
 			}
-
-			var propagatableFields = document.querySelectorAll(
-				'#<portlet:namespace />editLayoutFm .propagatable-field'
-			);
-
-			Array.prototype.forEach.call(propagatableFields, (field, index) => {
-				Liferay.Util.toggleDisabled(field, layoutPrototypeLinkChecked);
-			});
-		});
+		);
 	}
 </aui:script>

--- a/modules/test/playwright/tests/layout-page-template-admin-web/main/widgetPageTemplatesAdmin.spec.ts
+++ b/modules/test/playwright/tests/layout-page-template-admin-web/main/widgetPageTemplatesAdmin.spec.ts
@@ -115,7 +115,7 @@ test('Add an active page template in global site and deactivate it', async ({
 test(
 	'Disable inherit changes and check it works',
 	{
-		tag: ['@LPS-54099', '@LPS-145264', '@LPS-154130'],
+		tag: ['@LPS-54099', '@LPS-145264', '@LPS-154130', '@LPD-92505'],
 	},
 	async ({
 		page,
@@ -159,6 +159,8 @@ test(
 		// Disable inherit changes
 
 		await page.getByLabel('Inherit Changes').uncheck();
+
+		await expect(page.locator('[id$="typeOptions"]')).toBeVisible();
 
 		await pagesAdminPage.saveConfiguration();
 
@@ -220,6 +222,8 @@ test(
 		await pagesAdminPage.clickOnAction('Configure', layoutTitle);
 
 		await page.getByLabel('Inherit Changes').check();
+
+		await expect(page.locator('[id$="typeOptions"]')).toBeHidden();
 
 		await pagesAdminPage.saveConfiguration();
 


### PR DESCRIPTION
## Summary

- Fixes [LPD-92505](https://liferay.atlassian.net/browse/LPD-92505): the "Inherit Changes" toggle in a Widget Page's Page Settings did not hide the layout-template options when checked, did not show the "Some page settings are unavailable" warning, did not disable the propagatable fields, and did not switch the hidden `applyLayoutPrototype` field to `true`.
- Root cause: LPD-74302 (`f81d3b262d120`) renamed the checkbox name from `layoutPrototypeLinkEnabled` to `portletLayoutPageTemplateEntryLinkEnabled` but left the inline `<aui:script>` referencing the old id, so the two `Liferay.Util.toggleBoxes` calls and the `document.getElementById` lookup all returned null.
- Updates the existing Playwright test `Disable inherit changes and check it works` to assert the immediate DOM effect (typeOptions visibility) after `uncheck()` / `check()`, with tag `@LPD-92505`.

Related ticket: https://liferay.atlassian.net/browse/LPD-92505

[LPD-92505]: https://liferay.atlassian.net/browse/LPD-92505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ