### PR TITLE
LPD-91575 Condition the show prefix toggle to fixed country fields

### DIFF
--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.html
@@ -131,8 +131,8 @@
 		</label>
 
 		<div class="input-group">
-			[#if showPrefixPicker]
-				[#if fixed]
+			[#if fixed]
+				[#if showPrefixPicker]
 					<div class="input-group-item input-group-item-shrink input-group-prepend">
 						<div class="input-group-text p-3">
 							[#assign selectedFlagSymbol = (FLAG_ICON_MAP[selectedCountry.a2!""])!"" /]
@@ -148,7 +148,8 @@
 							</span>
 						</div>
 					</div>
-				[#else]
+				[/#if]
+			[#else]
 				<div class="dropdown input-group-item input-group-item-shrink input-group-prepend phone-number-input-prefix-picker" id="${fragmentElementId}-prefix-picker">
 					<button aria-expanded="false" aria-haspopup="listbox" aria-label="${languageUtil.get(locale, "country-code")}" class="form-control form-control-select form-control-select-secondary" [#if disabled || input.readOnly]disabled[/#if] id="${fragmentElementId}-prefix-trigger" type="button">
 						[#assign selectedFlagSymbol = (FLAG_ICON_MAP[selectedCountry.a2!""])!"" /]
@@ -198,7 +199,6 @@
 						</div>
 					[/#if]
 				</div>
-				[/#if]
 			[/#if]
 
 			<div class="input-group-append input-group-item">

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/MappingContentUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/MappingContentUtil.java
@@ -11,6 +11,7 @@ import com.liferay.info.field.InfoFieldSetEntry;
 import com.liferay.info.field.type.InfoFieldType;
 import com.liferay.info.field.type.MultiselectInfoFieldType;
 import com.liferay.info.field.type.OptionInfoFieldType;
+import com.liferay.info.field.type.PhoneNumberInfoFieldType;
 import com.liferay.info.field.type.SelectInfoFieldType;
 import com.liferay.info.form.InfoForm;
 import com.liferay.info.item.InfoItemServiceRegistry;
@@ -47,17 +48,7 @@ public class MappingContentUtil {
 		InfoField<?> infoField, Locale locale) {
 
 		return JSONUtil.put(
-			"attributes",
-			() -> {
-				JSONArray optionsJSONArray = _getOptionsJSONArray(
-					infoField, locale);
-
-				if (optionsJSONArray == null) {
-					return null;
-				}
-
-				return JSONUtil.put("options", optionsJSONArray);
-			}
+			"attributes", () -> _getAttributesJSONObject(infoField, locale)
 		).put(
 			"externalKey", infoField.getExternalUniqueId()
 		).put(
@@ -107,6 +98,30 @@ public class MappingContentUtil {
 		return _getMappingFieldsJSONArray(
 			formVariationKey, groupId, false, infoItemServiceRegistry,
 			itemClassName, locale);
+	}
+
+	private static JSONObject _getAttributesJSONObject(
+		InfoField infoField, Locale locale) {
+
+		InfoFieldType infoFieldType = infoField.getInfoFieldType();
+
+		if (infoFieldType instanceof PhoneNumberInfoFieldType) {
+			return JSONUtil.put(
+				"country",
+				infoField.getAttribute(PhoneNumberInfoFieldType.COUNTRY)
+			).put(
+				"countrySource",
+				infoField.getAttribute(PhoneNumberInfoFieldType.COUNTRY_SOURCE)
+			);
+		}
+
+		JSONArray optionsJSONArray = _getOptionsJSONArray(infoField, locale);
+
+		if (optionsJSONArray == null) {
+			return null;
+		}
+
+		return JSONUtil.put("options", optionsJSONArray);
 	}
 
 	private static JSONObject _getInfoFieldSetJSONObject(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/FormInputGeneralPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/FormInputGeneralPanel.js
@@ -34,6 +34,7 @@ import InfoItemService from '../../../../../../app/services/InfoItemService';
 import updateFragmentConfiguration from '../../../../../../app/thunks/updateFragmentConfiguration';
 import {CACHE_KEYS} from '../../../../../../app/utils/cache';
 import getMappedRelationship from '../../../../../../app/utils/editable_value/getMappedRelationship';
+import getSelectedField from '../../../../../../app/utils/getSelectedField';
 import {hasLocalizableFields} from '../../../../../../app/utils/hasLocalizableFields';
 import {isRequiredFormField} from '../../../../../../app/utils/isRequiredFormField';
 import useCache from '../../../../../../app/utils/useCache';
@@ -49,6 +50,7 @@ const HELP_TEXT_CONFIGURATION_KEY = 'inputHelpText';
 const LABEL_CONFIGURATION_KEY = 'inputLabel';
 const REQUIRED_CONFIGURATION_KEY = 'inputRequired';
 const SHOW_HELP_TEXT_CONFIGURATION_KEY = 'inputShowHelpText';
+const SHOW_PREFIX_CONFIGURATION_KEY = 'showPrefix';
 
 const SOURCE_TYPES = {
 	mainObject: 'main-object',
@@ -345,7 +347,22 @@ export function FormInputGeneralPanel({item}) {
 			allowedInputTypes
 		);
 
-		return [...inputCommonFields, ...fieldSetsWithoutLabel];
+		const fields = [...inputCommonFields, ...fieldSetsWithoutLabel];
+
+		const mappedField = getSelectedField({
+			fields: formFields,
+			value: configurationValues[FIELD_ID_CONFIGURATION_KEY],
+		});
+
+		const countrySource = mappedField?.attributes?.countrySource;
+
+		if (countrySource !== 'fixed') {
+			return fields.filter(
+				(field) => field.name !== SHOW_PREFIX_CONFIGURATION_KEY
+			);
+		}
+
+		return fields;
 	}, [
 		allowedInputTypes,
 		configurationValues,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/types/MappingField.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/types/MappingField.ts
@@ -50,6 +50,7 @@ export type MappingField = {
 };
 
 export type MappingFieldAttributes = {
+	countrySource?: string;
 	options?: {label: string; value: string}[];
 };
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/phoneNumberField.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/phoneNumberField.spec.ts
@@ -31,7 +31,7 @@ const test = mergeTests(
 
 test(
 	'Phone field disambiguates +1 (US vs CA), supports fixed prefix, and respects customized fragment configuration',
-	{tag: '@LPD-91059'},
+	{tag: ['@LPD-91059', '@LPD-91575']},
 	async ({contentsPage, page, pageEditorPage, structureBuilderPage}) => {
 		const structureLabel = `Structure${getRandomInt()}`;
 		const contentTitle = getRandomString();
@@ -84,7 +84,34 @@ test(
 
 		await contentsPage.saveContent();
 
-		// Go back to the structure and switch the prefix to fixed +44 (UK)
+		// While the user picks the country, the editor does not offer the "Show
+		// Prefix" configuration because the prefix picker is mandatory
+
+		await structureBuilderPage.editStructure(structureId);
+
+		await structureBuilderPage.customizeEditor();
+
+		await pageEditorPage.selectFragment(
+			await pageEditorPage.getFragmentId('Phone Number')
+		);
+
+		await pageEditorPage.goToConfigurationTab('General');
+
+		await expect(
+			page
+				.getByRole('tabpanel', {name: 'General'})
+				.getByLabel('Show Country Flag', {exact: true})
+		).toBeVisible();
+
+		await expect(
+			page
+				.getByRole('tabpanel', {name: 'General'})
+				.getByLabel('Show Prefix', {exact: true})
+		).toBeHidden();
+
+		await pageEditorPage.publishPage();
+
+		// Switch the structure prefix to fixed +44 (UK)
 
 		await structureBuilderPage.editStructure(structureId);
 
@@ -115,7 +142,8 @@ test(
 
 		await expect(page.getByText('+44', {exact: true})).toBeVisible();
 
-		// Customize the editor and hide the prefix on the phone fragment
+		// Customize the editor — now that the prefix is fixed, the "Show Prefix"
+		// configuration is offered; turning it off hides the static prefix
 
 		await structureBuilderPage.editStructure(structureId);
 
@@ -132,8 +160,8 @@ test(
 
 		await pageEditorPage.publishPage();
 
-		// Edit content — the prefix picker should no longer be rendered, only
-		// the bare phone input remains
+		// Edit content — the prefix is no longer rendered, only the bare phone
+		// input remains
 
 		await contentsPage.goto();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91575

## What Is Being Fixed

The phone number input fragment always exposed a "Show Prefix" toggle in the
page editor, regardless of how the mapped field defined its country. The toggle
only makes sense when the country is fixed by the field: when the country is
defined by the user, the prefix picker is mandatory and the toggle has no effect.

## How It Is Being Fixed

The mapped field now carries its country source down to the editor.
MappingContentUtil injects the phone-number attributes (country, countrySource)
into the mapping field JSON, and the form input configuration panel reads
countrySource to expose the "Show Prefix" configuration only when the country is
fixed, hiding it otherwise. The fragment template mirrors this: a fixed country
renders the static prefix only when "Show Prefix" is on, while a user-defined
country always renders the prefix picker. The existing phone number Playwright
test was adapted to assert the toggle is hidden for user-defined countries and
present and effective for fixed ones.
