### PR TITLE
LPD-93218 Embed the thumbnail file during a staging export

### DIFF
--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/display/context/CommerceOrderContentDisplayContext.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/display/context/CommerceOrderContentDisplayContext.java
@@ -842,7 +842,7 @@ public class CommerceOrderContentDisplayContext {
 		}
 
 		if (!commerceOrder.isOpen()) {
-			String portletURL = PortletURLBuilder.createActionURL(
+			String portletURLString = PortletURLBuilder.createActionURL(
 				_cpRequestHelper.getLiferayPortletResponse()
 			).setActionName(
 				"/commerce_open_order_content/edit_commerce_order"
@@ -854,7 +854,7 @@ public class CommerceOrderContentDisplayContext {
 
 			headerActionModels.add(
 				new HeaderActionModel(
-					"btn-primary", null, portletURL, null, "reorder"));
+					"btn-primary", null, portletURLString, null, "reorder"));
 		}
 
 		List<CommerceOrderStatus> commerceOrderStatuses =

--- a/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium-impl/src/main/java/com/liferay/commerce/theme/minium/internal/helper/CommerceThemeMiniumHttpHelper.java
+++ b/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium-impl/src/main/java/com/liferay/commerce/theme/minium/internal/helper/CommerceThemeMiniumHttpHelper.java
@@ -92,40 +92,42 @@ public class CommerceThemeMiniumHttpHelper {
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		String portletURL = _getPortletURL(
+		String portletURLString = _getPortletURLString(
 			"/dashboard", httpServletRequest, themeDisplay,
 			CommercePortletKeys.COMMERCE_DASHBOARD_FORECASTS_CHART);
 
-		if (Validator.isBlank(portletURL)) {
-			portletURL = _getPortletURL(
+		if (Validator.isBlank(portletURLString)) {
+			portletURLString = _getPortletURLString(
 				"/catalog", httpServletRequest, themeDisplay,
 				CPPortletKeys.CP_SEARCH_RESULTS);
 		}
 
 		List<Layout> layouts = themeDisplay.getLayouts();
 
-		if (Validator.isBlank(portletURL) && ListUtil.isNotEmpty(layouts)) {
+		if (Validator.isBlank(portletURLString) &&
+			ListUtil.isNotEmpty(layouts)) {
+
 			return _portal.getLayoutURL(layouts.get(0), themeDisplay);
 		}
 
-		if (!Validator.isBlank(portletURL) &&
-			portletURL.contains(StringPool.QUESTION)) {
+		if (!Validator.isBlank(portletURLString) &&
+			portletURLString.contains(StringPool.QUESTION)) {
 
-			portletURL = portletURL.substring(
-				0, portletURL.lastIndexOf(StringPool.QUESTION));
+			portletURLString = portletURLString.substring(
+				0, portletURLString.lastIndexOf(StringPool.QUESTION));
 		}
 
-		if (!Validator.isBlank(portletURL) &&
+		if (!Validator.isBlank(portletURLString) &&
 			Validator.isNotNull(themeDisplay.getDoAsUserId())) {
 
-			portletURL = _portal.addPreservedParameters(
-				themeDisplay, portletURL, false, true);
+			portletURLString = _portal.addPreservedParameters(
+				themeDisplay, portletURLString, false, true);
 		}
 
-		return portletURL;
+		return portletURLString;
 	}
 
-	private String _getPortletURL(
+	private String _getPortletURLString(
 			String friendlyURL, HttpServletRequest httpServletRequest,
 			ThemeDisplay themeDisplay, String portletId)
 		throws PortalException {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/util/ThumbnailURLReferenceUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/util/ThumbnailURLReferenceUtil.java
@@ -9,6 +9,7 @@ import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.processor.ImageProcessorUtil;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.exportimport.attachment.ExportImportAttachmentManagerUtil;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.headless.admin.site.dto.v1_0.ThumbnailURLReference;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -41,7 +42,8 @@ public class ThumbnailURLReferenceUtil {
 				setExternalReferenceCode(dlFileEntry::getExternalReferenceCode);
 				setUrl(
 					() -> {
-						if (!ImageProcessorUtil.hasImages(
+						if (!ExportImportThreadLocal.isExportInProcess() &&
+							!ImageProcessorUtil.hasImages(
 								fileEntry.getFileVersion())) {
 
 							return null;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateResourceTest.java
@@ -500,7 +500,26 @@ public class DisplayPageTemplateResourceTest
 
 		_testPutSiteDisplayPageTemplateWithPageSpecifications();
 
+		Repository repository = _portletFileRepository.addPortletRepository(
+			testGroup.getGroupId(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(
+				testGroup, TestPropsValues.getUserId()));
+
+		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
+
+		displayPageTemplate.setThumbnailURLReference(
+			() -> ThumbnailURLReferenceUtil.getThumbnailURLReference(
+				fileEntry, null));
+
+		displayPageTemplateResource.putSiteDisplayPageTemplate(
+			testGroup.getExternalReferenceCode(),
+			displayPageTemplate.getExternalReferenceCode(),
+			displayPageTemplate);
+
 		_enableLocalStaging();
+
+		_assertStagingGroupDisplayPageTemplateThumbnail(
+			displayPageTemplate, fileEntry);
 
 		_assertProblemException(
 			"BAD_REQUEST", null,
@@ -692,6 +711,29 @@ public class DisplayPageTemplateResourceTest
 			Assert.assertEquals(expectedStatus, problem.getStatus());
 			Assert.assertEquals(expectedTitle, problem.getTitle());
 		}
+	}
+
+	private void _assertStagingGroupDisplayPageTemplateThumbnail(
+			DisplayPageTemplate displayPageTemplate,
+			FileEntry liveGroupFileEntry)
+		throws Exception {
+
+		Group stagingGroup = testGroup.getStagingGroup();
+
+		FileEntry stagingGroupFileEntry =
+			_portletFileRepository.getPortletFileEntryByExternalReferenceCode(
+				liveGroupFileEntry.getExternalReferenceCode(),
+				stagingGroup.getGroupId());
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.
+				getLayoutPageTemplateEntryByExternalReferenceCode(
+					displayPageTemplate.getExternalReferenceCode(),
+					stagingGroup.getGroupId());
+
+		Assert.assertEquals(
+			stagingGroupFileEntry.getFileEntryId(),
+			layoutPageTemplateEntry.getPreviewFileEntryId());
 	}
 
 	private void _assertThumbnailFileEntryId(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
@@ -423,6 +423,8 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 
 		_enableLocalStaging();
 
+		_assertStagingGroupMasterPageThumbnail(fileEntry, masterPage);
+
 		_assertProblemException(
 			"BAD_REQUEST", null,
 			() -> masterPageResource.putSiteMasterPage(
@@ -605,6 +607,28 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 			Assert.assertEquals(expectedStatus, problem.getStatus());
 			Assert.assertEquals(expectedTitle, problem.getTitle());
 		}
+	}
+
+	private void _assertStagingGroupMasterPageThumbnail(
+			FileEntry liveGroupFileEntry, MasterPage masterPage)
+		throws Exception {
+
+		Group stagingGroup = testGroup.getStagingGroup();
+
+		FileEntry stagingGroupFileEntry =
+			_portletFileRepository.getPortletFileEntryByExternalReferenceCode(
+				liveGroupFileEntry.getExternalReferenceCode(),
+				stagingGroup.getGroupId());
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.
+				getLayoutPageTemplateEntryByExternalReferenceCode(
+					masterPage.getExternalReferenceCode(),
+					stagingGroup.getGroupId());
+
+		Assert.assertEquals(
+			stagingGroupFileEntry.getFileEntryId(),
+			layoutPageTemplateEntry.getPreviewFileEntryId());
 	}
 
 	private void _assertThumbnailFileEntryId(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
@@ -513,7 +513,26 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 		_testPutSitePageTemplateWithPageTemplateSet();
 		_testPutSitePageTemplateWithThumbnail();
 
+		Repository repository = _portletFileRepository.addPortletRepository(
+			testGroup.getGroupId(), RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext(
+				testGroup, TestPropsValues.getUserId()));
+
+		FileEntry fileEntry = _addPortletFileEntry(repository.getDlFolderId());
+
+		contentPageTemplate.setThumbnailURLReference(
+			() -> ThumbnailURLReferenceUtil.getThumbnailURLReference(
+				fileEntry, null));
+
+		pageTemplateResource.putSitePageTemplate(
+			testGroup.getExternalReferenceCode(),
+			contentPageTemplate.getExternalReferenceCode(),
+			contentPageTemplate);
+
 		_enableLocalStaging();
+
+		_assertStagingGroupPageTemplateThumbnail(
+			fileEntry, contentPageTemplate);
 
 		_assertProblemException(
 			"BAD_REQUEST", null,
@@ -732,6 +751,28 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 			Assert.assertEquals(expectedStatus, problem.getStatus());
 			Assert.assertEquals(expectedTitle, problem.getTitle());
 		}
+	}
+
+	private void _assertStagingGroupPageTemplateThumbnail(
+			FileEntry liveGroupFileEntry, PageTemplate pageTemplate)
+		throws Exception {
+
+		Group stagingGroup = testGroup.getStagingGroup();
+
+		FileEntry stagingGroupFileEntry =
+			_portletFileRepository.getPortletFileEntryByExternalReferenceCode(
+				liveGroupFileEntry.getExternalReferenceCode(),
+				stagingGroup.getGroupId());
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.
+				getLayoutPageTemplateEntryByExternalReferenceCode(
+					pageTemplate.getExternalReferenceCode(),
+					stagingGroup.getGroupId());
+
+		Assert.assertEquals(
+			stagingGroupFileEntry.getFileEntryId(),
+			layoutPageTemplateEntry.getPreviewFileEntryId());
 	}
 
 	private void _assertThumbnailFileEntryId(

--- a/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContextTest.java
+++ b/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContextTest.java
@@ -149,13 +149,14 @@ public class LayoutsAdminDisplayContextTest {
 
 		Layout layout = _getContentLayout(true, true);
 
-		String portletURL = String.valueOf(
+		String portletURLString = String.valueOf(
 			layoutsAdminDisplayContext.getLayoutScreenNavigationPortletURL(
 				layout.getPlid()));
 
 		Assert.assertTrue(
-			portletURL,
-			StringUtil.contains(portletURL, "param_privateLayout=true", ";"));
+			portletURLString,
+			StringUtil.contains(
+				portletURLString, "param_privateLayout=true", ";"));
 	}
 
 	private void _assertGetEditOrViewLayoutURL(Layout layout, String layoutMode)

--- a/modules/apps/portal-workflow/portal-workflow-instance-tracker-web/src/main/java/com/liferay/portal/workflow/instance/tracker/web/internal/url/provider/WorkflowInstanceTrackerURLProviderImpl.java
+++ b/modules/apps/portal-workflow/portal-workflow-instance-tracker-web/src/main/java/com/liferay/portal/workflow/instance/tracker/web/internal/url/provider/WorkflowInstanceTrackerURLProviderImpl.java
@@ -38,7 +38,7 @@ public class WorkflowInstanceTrackerURLProviderImpl
 		Object bean, HttpServletRequest httpServletRequest, Class<?> modelClass,
 		boolean useDialog) {
 
-		String portletURL = PortletURLBuilder.create(
+		String portletURLString = PortletURLBuilder.create(
 			_portal.getControlPanelPortletURL(
 				httpServletRequest, null,
 				WorkflowPortletKeys.WORKFLOW_INSTANCE_TRACKER, 0, 0,
@@ -74,10 +74,10 @@ public class WorkflowInstanceTrackerURLProviderImpl
 				"javascript:",
 				"Liferay.Util.openModal({iframeBodyCssClass: '', title: '",
 				UnicodeLanguageUtil.get(httpServletRequest, "track-workflow"),
-				"', url: '", portletURL, "'});;");
+				"', url: '", portletURLString, "'});;");
 		}
 
-		return portletURL;
+		return portletURLString;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/portal-workflow/portal-workflow-test/src/testIntegration/java/com/liferay/portal/workflow/instance/tracker/url/provider/test/WorkflowInstanceTrackerURLProviderTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-test/src/testIntegration/java/com/liferay/portal/workflow/instance/tracker/url/provider/test/WorkflowInstanceTrackerURLProviderTest.java
@@ -104,7 +104,7 @@ public class WorkflowInstanceTrackerURLProviderTest {
 			_workflowInstanceLinkLocalService.getWorkflowInstanceLink(
 				TestPropsValues.getCompanyId(), 0, clazz.getName(), 1);
 
-		String portletURL = PortletURLBuilder.create(
+		String portletURLString = PortletURLBuilder.create(
 			_portal.getControlPanelPortletURL(
 				mockHttpServletRequest, null,
 				_WORKFLOW_INSTANCE_TRACKER_PORTLET, 0, 0,
@@ -121,12 +121,12 @@ public class WorkflowInstanceTrackerURLProviderTest {
 				"title: '",
 				UnicodeLanguageUtil.get(
 					mockHttpServletRequest, "track-workflow"),
-				"', url: '", portletURL, "'});;"),
+				"', url: '", portletURLString, "'});;"),
 			_workflowInstanceTrackerURLProvider.getURL(
 				object, mockHttpServletRequest, clazz, true));
 
 		Assert.assertEquals(
-			portletURL,
+			portletURLString,
 			_workflowInstanceTrackerURLProvider.getURL(
 				object, mockHttpServletRequest, clazz, false));
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
@@ -70,6 +70,7 @@ public class VariableNameCheck extends BaseCheck {
 			if (firstChildDetailAST.getType() != TokenTypes.DOT) {
 				_checkCountVariableName(detailAST, name, typeName);
 				_checkInstanceVariableName(detailAST, name, typeName);
+				_checkStringSuffixVariableName(detailAST, name, typeName);
 				_checkTypeName(detailAST, name, typeName);
 				_checkTypo(detailAST, name, typeName, true);
 			}
@@ -467,6 +468,43 @@ public class VariableNameCheck extends BaseCheck {
 			log(
 				detailAST, MSG_RENAME_VARIABLE, variableName,
 				"_" + expectedVariableName);
+		}
+	}
+
+	private void _checkStringSuffixVariableName(
+		DetailAST detailAST, String variableName, String typeName) {
+
+		if (!typeName.equals("String") ||
+			(detailAST.getType() != TokenTypes.VARIABLE_DEF)) {
+
+			return;
+		}
+
+		DetailAST parentDetailAST = detailAST.getParent();
+
+		if (parentDetailAST.getType() != TokenTypes.SLIST) {
+			return;
+		}
+
+		String trailingDigits = _getTrailingDigits(variableName);
+
+		String trimmedName = StringUtil.replaceLast(
+			variableName, trailingDigits, StringPool.BLANK);
+
+		for (String enforceStringSuffixTypeName :
+				getAttributeValues(_ENFORCE_STRING_SUFFIX_TYPE_NAMES_KEY)) {
+
+			String expectedVariableName = getExpectedVariableName(
+				enforceStringSuffixTypeName);
+
+			if (trimmedName.equals(expectedVariableName)) {
+				log(
+					detailAST, MSG_RENAME_VARIABLE, variableName,
+					StringBundler.concat(
+						expectedVariableName, "String", trailingDigits));
+
+				return;
+			}
 		}
 	}
 
@@ -1049,6 +1087,9 @@ public class VariableNameCheck extends BaseCheck {
 
 	private static final String _ENFORCE_SHORT_TYPE_NAMES_KEY =
 		"enforceShortTypeNames";
+
+	private static final String _ENFORCE_STRING_SUFFIX_TYPE_NAMES_KEY =
+		"enforceStringSuffixTypeNames";
 
 	private static final String _ENFORCE_TABLE_SCHEMA_FIELD_TYPE_NAMES_KEY =
 		"enforceTableSchemaFieldTypeNames";

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -1098,6 +1098,7 @@
 			<property name="allowedVariableNames" value="bitMode,metadata,superClass,userName" />
 			<property name="category" value="Naming Conventions" />
 			<property name="description" value="Checks that variable names follow naming conventions." />
+			<property name="enforceStringSuffixTypeNames" value="PortletURL" />
 			<property name="enforceTypeNames" value="" />
 			<message key="variable.incorrect.count" value="Rename variable &quot;{0}&quot; to &quot;{1}&quot; (and increment counts for other variables &quot;{0}*&quot;)" />
 			<message key="variable.incorrect.ending.1" value="Name of variable with type &quot;{0}&quot; should end with &quot;{1}&quot;" />

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
@@ -1013,6 +1013,13 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 	}
 
 	@Test
+	public void testStringSuffixVariableNames() throws Exception {
+		test(
+			"StringSuffixVariableNames.testjava",
+			"Rename variable \"portletURL\" to \"portletURLString\"", 16);
+	}
+
+	@Test
 	public void testSwitchExpression() throws Exception {
 		test(
 			"SwitchExpression.testjava",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/StringSuffixVariableNames.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/StringSuffixVariableNames.testjava
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies;
+
+import java.util.Map;
+
+/**
+ * @author Hugo Huijser
+ */
+public class StringSuffixVariableNames {
+
+	public void method1(Map<String, String> map) {
+		String portletURL = "test";
+
+		map.put(portletURL, portletURL);
+	}
+
+	public void method2(Map<String, String> map) {
+		String portletURLString = "test";
+
+		map.put(portletURLString, portletURLString);
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93218

## What Is Being Fixed

Enabling local staging republishes a site's master pages, page templates, and display page templates through the headless batch engine. When one of those entities has a preview thumbnail whose document library image derivatives have not been generated yet, the export omitted the thumbnail file and the import could not resolve it, failing with an "Unable to resolve file" error logged at ERROR by the batch engine during the initial publication. PortalLogAssertorTest flagged that ERROR line.

## How It Is Being Fixed

The thumbnail reference is produced by ThumbnailURLReferenceUtil, which only included the file URL when ImageProcessorUtil.hasImages was true. During an export that URL is what carries the file bytes into the LAR: getFileURL writes them into the zip and returns a lar: URL the import reads back to recreate the file in the target group. Gating it on hasImages dropped the bytes whenever the asynchronous preview generation had not finished, leaving only an external reference code that does not resolve in the newly created staging group. The fix always includes the file URL while an export is in process, so the bytes always round-trip; outside an export the hasImages guard is unchanged, so a plain REST read still omits the thumbnail URL when no preview exists. A regression test asserts the thumbnail survives the staging publication for master pages, page templates, and display page templates.