### PR TITLE
LPD-93487 Expose the publish date as an asset entry information field

### DIFF
--- a/modules/apps/asset/asset-info-impl/src/main/java/com/liferay/asset/info/internal/item/AssetEntryInfoItemFields.java
+++ b/modules/apps/asset/asset-info-impl/src/main/java/com/liferay/asset/info/internal/item/AssetEntryInfoItemFields.java
@@ -62,6 +62,15 @@ public class AssetEntryInfoItemFields {
 			InfoLocalizedValue.localize(
 				AssetEntryInfoItemFields.class, "modified-date")
 		).build();
+	public static final InfoField<DateInfoFieldType> publishDateInfoField =
+		BuilderHolder._builder.infoFieldType(
+			DateInfoFieldType.INSTANCE
+		).name(
+			"publishDate"
+		).labelInfoLocalizedValue(
+			InfoLocalizedValue.localize(
+				AssetEntryInfoItemFields.class, "publish-date")
+		).build();
 	public static final InfoField<TextInfoFieldType> summaryInfoField =
 		BuilderHolder._builder.infoFieldType(
 			TextInfoFieldType.INSTANCE

--- a/modules/apps/asset/asset-info-impl/src/main/java/com/liferay/asset/info/internal/item/provider/AssetEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/asset/asset-info-impl/src/main/java/com/liferay/asset/info/internal/item/provider/AssetEntryInfoItemFieldValuesProvider.java
@@ -81,6 +81,9 @@ public class AssetEntryInfoItemFieldValuesProvider
 				AssetEntryInfoItemFields.modifiedDateInfoField,
 				assetEntry.getModifiedDate()),
 			new InfoFieldValue<>(
+				AssetEntryInfoItemFields.publishDateInfoField,
+				assetEntry.getPublishDate()),
+			new InfoFieldValue<>(
 				AssetEntryInfoItemFields.expirationDateInfoField,
 				assetEntry.getExpirationDate()),
 			new InfoFieldValue<>(

--- a/modules/apps/asset/asset-info-impl/src/main/java/com/liferay/asset/info/internal/item/provider/AssetEntryInfoItemFormProvider.java
+++ b/modules/apps/asset/asset-info-impl/src/main/java/com/liferay/asset/info/internal/item/provider/AssetEntryInfoItemFormProvider.java
@@ -43,6 +43,8 @@ public class AssetEntryInfoItemFormProvider
 			).infoFieldSetEntry(
 				AssetEntryInfoItemFields.modifiedDateInfoField
 			).infoFieldSetEntry(
+				AssetEntryInfoItemFields.publishDateInfoField
+			).infoFieldSetEntry(
 				AssetEntryInfoItemFields.expirationDateInfoField
 			).infoFieldSetEntry(
 				AssetEntryInfoItemFields.viewCountInfoField

--- a/modules/apps/asset/asset-info-test/src/testIntegration/java/com/liferay/asset/info/internal/item/provider/test/AssetEntryInfoItemFieldValuesProviderTest.java
+++ b/modules/apps/asset/asset-info-test/src/testIntegration/java/com/liferay/asset/info/internal/item/provider/test/AssetEntryInfoItemFieldValuesProviderTest.java
@@ -96,6 +96,8 @@ public class AssetEntryInfoItemFieldValuesProviderTest {
 			"expirationDate");
 		_assertDateFieldValue(
 			assetEntry.getModifiedDate(), infoItemFieldValues, "modifiedDate");
+		_assertDateFieldValue(
+			assetEntry.getPublishDate(), infoItemFieldValues, "publishDate");
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93487

## What Is Being Fixed

On a Display Page Template for Web Content Articles, a "Date" fragment placed inside a "Collection Display" fragment did not offer the "Publication Date" mapping option. Only "Creation Date", "Modification Date", and "Expiration Date" were available, because the asset entry information form did not expose a publish date field. This is the fix for LPP-64270.

## How It Is Being Fixed

Added a publishDate field to the asset entry information item, backed by AssetEntry.getPublishDate(). The field is declared in AssetEntryInfoItemFields, surfaced through AssetEntryInfoItemFormProvider so it appears in the field mapping picker, and populated by AssetEntryInfoItemFieldValuesProvider. As a result, the "Date" fragment now offers "Publication Date" when mapping asset entry collection items. The existing AssetEntryInfoItemFieldValuesProviderTest was extended to assert that the new field returns the asset entry's publish date.
