### PR TITLE
LPD-77431 LPD-82679 Adjust tests to friendly URL collision behavior

### DIFF
--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutExportImportTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutExportImportTest.java
@@ -699,7 +699,8 @@ public class LayoutExportImportTest extends BaseExportImportTestCase {
 
 			List<LogEntry> logEntries = logCapture.getLogEntries();
 
-			Assert.assertEquals(logEntries.toString(), 2, logEntries.size());
+			Assert.assertEquals(
+				logEntries.toString(), layoutIds.length, logEntries.size());
 
 			for (LogEntry logEntry : logEntries) {
 				Throwable throwable = logEntry.getThrowable();

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutExportImportTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutExportImportTest.java
@@ -27,6 +27,7 @@ import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
 import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.LayoutFriendlyURLsException;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -56,6 +57,9 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -686,10 +690,28 @@ public class LayoutExportImportTest extends BaseExportImportTestCase {
 		_layoutLocalService.updateFriendlyURL(
 			layoutA.getUserId(), layoutA.getPlid(), friendlyURLB + "-de", "de");
 
-		exportImportLayouts(layoutIds, getImportParameterMap());
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.batch.engine.internal." +
+					"BatchEngineImportTaskExecutorImpl",
+				LoggerTestUtil.ERROR)) {
 
-		_assertNewFriendlyURL(layoutA, friendlyURLB);
-		_assertNewFriendlyURL(layoutB, friendlyURLA);
+			exportImportLayouts(layoutIds, getImportParameterMap());
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 2, logEntries.size());
+
+			for (LogEntry logEntry : logEntries) {
+				Throwable throwable = logEntry.getThrowable();
+
+				Assert.assertTrue(
+					String.valueOf(throwable),
+					throwable instanceof LayoutFriendlyURLsException);
+			}
+		}
+
+		_assertFriendlyURL(layoutA, friendlyURLA);
+		_assertFriendlyURL(layoutB, friendlyURLB);
 	}
 
 	@FeatureFlag("LPD-34594")
@@ -776,12 +798,16 @@ public class LayoutExportImportTest extends BaseExportImportTestCase {
 		}
 	}
 
-	private void _assertNewFriendlyURL(Layout layout, String friendlyURL)
+	private void _assertFriendlyURL(Layout layout, String friendlyURL)
 		throws Exception {
 
 		Layout importedLayout = _layoutLocalService.getLayoutByUuidAndGroupId(
 			layout.getUuid(), importedGroup.getGroupId(),
 			layout.isPrivateLayout());
+
+		Assert.assertEquals(
+			friendlyURL,
+			importedLayout.getFriendlyURL(LocaleUtil.getDefault()));
 
 		FriendlyURLEntry friendlyURLEntry =
 			_friendlyURLEntryLocalService.fetchFriendlyURLEntry(
@@ -790,7 +816,7 @@ public class LayoutExportImportTest extends BaseExportImportTestCase {
 					importedLayout.isPrivateLayout()),
 				FriendlyURLEntryConstants.
 					FRIENDLY_URL_ENTRY_PARENT_CLASS_PK_DEFAULT,
-				friendlyURL + "-1");
+				friendlyURL);
 
 		Assert.assertEquals(
 			importedLayout.getPlid(), friendlyURLEntry.getClassPK());

--- a/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingLayoutFriendlyURLTest.java
+++ b/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingLayoutFriendlyURLTest.java
@@ -142,6 +142,10 @@ public class StagingLayoutFriendlyURLTest extends BaseLocalStagingTestCase {
 					FRIENDLY_URL_ENTRY_PARENT_CLASS_PK_DEFAULT,
 				"en_US", originalFriendlyURL);
 
+		Assert.assertEquals(
+			liveLayout.getPlid(),
+			liveFriendlyURLEntryLocalization2.getClassPK());
+
 		FriendlyURLEntryLocalization liveFriendlyURLEntryLocalization3 =
 			_friendlyURLEntryLocalService.fetchFriendlyURLEntryLocalization(
 				liveGroup.getGroupId(), layoutClassNameId,
@@ -149,9 +153,6 @@ public class StagingLayoutFriendlyURLTest extends BaseLocalStagingTestCase {
 					FRIENDLY_URL_ENTRY_PARENT_CLASS_PK_DEFAULT,
 				"en_US", testFriendlyURL);
 
-		Assert.assertEquals(
-			liveLayout.getPlid(),
-			liveFriendlyURLEntryLocalization2.getClassPK());
 		Assert.assertEquals(
 			liveLayout2.getPlid(),
 			liveFriendlyURLEntryLocalization3.getClassPK());

--- a/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingLayoutFriendlyURLTest.java
+++ b/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingLayoutFriendlyURLTest.java
@@ -89,7 +89,7 @@ public class StagingLayoutFriendlyURLTest extends BaseLocalStagingTestCase {
 				LocaleUtil.US, testFriendlyURL
 			).build());
 
-		_publishLayoutsExpectLayoutFriendlyURLsException(stagingLayout2);
+		_publishLayoutsWithLayoutFriendlyURLsException(stagingLayout2);
 
 		Layout liveLayout2 = _layoutLocalService.getLayoutByUuidAndGroupId(
 			stagingLayout2.getUuid(), liveGroup.getGroupId(),
@@ -99,7 +99,7 @@ public class StagingLayoutFriendlyURLTest extends BaseLocalStagingTestCase {
 			originalLayout2FriendlyURL,
 			liveLayout2.getFriendlyURL(LocaleUtil.US));
 
-		_publishLayoutsExpectLayoutFriendlyURLsException(stagingLayout2);
+		_publishLayoutsWithLayoutFriendlyURLsException(stagingLayout2);
 
 		List<BackgroundTask> failedBackgroundTasks =
 			_backgroundTaskLocalService.getBackgroundTasks(
@@ -158,7 +158,7 @@ public class StagingLayoutFriendlyURLTest extends BaseLocalStagingTestCase {
 			liveFriendlyURLEntryLocalization3.getClassPK());
 	}
 
-	private void _publishLayoutsExpectLayoutFriendlyURLsException(Layout layout)
+	private void _publishLayoutsWithLayoutFriendlyURLsException(Layout layout)
 		throws Exception {
 
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(

--- a/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingLayoutFriendlyURLTest.java
+++ b/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingLayoutFriendlyURLTest.java
@@ -14,10 +14,14 @@ import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.portal.background.task.model.BackgroundTask;
 import com.liferay.portal.background.task.service.BackgroundTaskLocalService;
 import com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstants;
+import com.liferay.portal.kernel.exception.LayoutFriendlyURLsException;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -55,6 +59,8 @@ public class StagingLayoutFriendlyURLTest extends BaseLocalStagingTestCase {
 		Layout stagingLayout2 = LayoutTestUtil.addTypePortletLayout(
 			stagingGroup);
 
+		String stagingLayout2FriendlyURL = stagingLayout2.getFriendlyURL();
+
 		publishLayouts();
 
 		stagingLayout = LayoutTestUtil.updateFriendlyURL(
@@ -83,16 +89,17 @@ public class StagingLayoutFriendlyURLTest extends BaseLocalStagingTestCase {
 				LocaleUtil.US, testFriendlyURL
 			).build());
 
-		publishLayouts(new long[] {stagingLayout2.getLayoutId()});
+		_publishLayoutsExpectLayoutFriendlyURLsException(stagingLayout2);
 
 		Layout liveLayout2 = _layoutLocalService.getLayoutByUuidAndGroupId(
 			stagingLayout2.getUuid(), liveGroup.getGroupId(),
 			stagingLayout2.isPrivateLayout());
 
 		Assert.assertEquals(
-			testFriendlyURL + "1", liveLayout2.getFriendlyURL(LocaleUtil.US));
+			stagingLayout2FriendlyURL,
+			liveLayout2.getFriendlyURL(LocaleUtil.US));
 
-		publishLayouts(new long[] {stagingLayout2.getLayoutId()});
+		_publishLayoutsExpectLayoutFriendlyURLsException(stagingLayout2);
 
 		List<BackgroundTask> failedBackgroundTasks =
 			_backgroundTaskLocalService.getBackgroundTasks(
@@ -105,6 +112,22 @@ public class StagingLayoutFriendlyURLTest extends BaseLocalStagingTestCase {
 			"There should not be a failed staging publication",
 			failedBackgroundTasks.isEmpty());
 
+		publishLayouts(new long[] {stagingLayout.getLayoutId()});
+
+		Assert.assertEquals(
+			originalFriendlyURL, liveLayout.getFriendlyURL(LocaleUtil.US));
+
+		FriendlyURLEntryLocalization liveFriendlyURLEntryLocalization1 =
+			_friendlyURLEntryLocalService.fetchFriendlyURLEntryLocalization(
+				liveGroup.getGroupId(), layoutClassNameId,
+				FriendlyURLEntryConstants.
+					FRIENDLY_URL_ENTRY_PARENT_CLASS_PK_DEFAULT,
+				testFriendlyURL);
+
+		_friendlyURLEntryLocalService.deleteFriendlyURLLocalizationEntry(
+			liveFriendlyURLEntryLocalization1.getFriendlyURLEntryId(),
+			liveFriendlyURLEntryLocalization1.getLanguageId());
+
 		publishLayouts();
 
 		Assert.assertEquals(
@@ -112,14 +135,14 @@ public class StagingLayoutFriendlyURLTest extends BaseLocalStagingTestCase {
 		Assert.assertEquals(
 			testFriendlyURL, liveLayout2.getFriendlyURL(LocaleUtil.US));
 
-		FriendlyURLEntryLocalization liveFriendlyURLEntryLocalization1 =
+		FriendlyURLEntryLocalization liveFriendlyURLEntryLocalization2 =
 			_friendlyURLEntryLocalService.fetchFriendlyURLEntryLocalization(
 				liveGroup.getGroupId(), layoutClassNameId,
 				FriendlyURLEntryConstants.
 					FRIENDLY_URL_ENTRY_PARENT_CLASS_PK_DEFAULT,
 				"en_US", originalFriendlyURL);
 
-		FriendlyURLEntryLocalization liveFriendlyURLEntryLocalization2 =
+		FriendlyURLEntryLocalization liveFriendlyURLEntryLocalization3 =
 			_friendlyURLEntryLocalService.fetchFriendlyURLEntryLocalization(
 				liveGroup.getGroupId(), layoutClassNameId,
 				FriendlyURLEntryConstants.
@@ -128,10 +151,34 @@ public class StagingLayoutFriendlyURLTest extends BaseLocalStagingTestCase {
 
 		Assert.assertEquals(
 			liveLayout.getPlid(),
-			liveFriendlyURLEntryLocalization1.getClassPK());
+			liveFriendlyURLEntryLocalization2.getClassPK());
 		Assert.assertEquals(
 			liveLayout2.getPlid(),
-			liveFriendlyURLEntryLocalization2.getClassPK());
+			liveFriendlyURLEntryLocalization3.getClassPK());
+	}
+
+	private void _publishLayoutsExpectLayoutFriendlyURLsException(Layout layout)
+		throws Exception {
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.batch.engine.internal." +
+					"BatchEngineImportTaskExecutorImpl",
+				LoggerTestUtil.ERROR)) {
+
+			publishLayouts(new long[] {layout.getLayoutId()});
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Throwable throwable = logEntry.getThrowable();
+
+			Assert.assertTrue(
+				String.valueOf(throwable),
+				throwable instanceof LayoutFriendlyURLsException);
+		}
 	}
 
 	@Inject

--- a/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingLayoutFriendlyURLTest.java
+++ b/modules/apps/staging/staging-test/src/testIntegration/java/com/liferay/staging/test/StagingLayoutFriendlyURLTest.java
@@ -59,7 +59,7 @@ public class StagingLayoutFriendlyURLTest extends BaseLocalStagingTestCase {
 		Layout stagingLayout2 = LayoutTestUtil.addTypePortletLayout(
 			stagingGroup);
 
-		String stagingLayout2FriendlyURL = stagingLayout2.getFriendlyURL();
+		String originalLayout2FriendlyURL = stagingLayout2.getFriendlyURL();
 
 		publishLayouts();
 
@@ -96,7 +96,7 @@ public class StagingLayoutFriendlyURLTest extends BaseLocalStagingTestCase {
 			stagingLayout2.isPrivateLayout());
 
 		Assert.assertEquals(
-			stagingLayout2FriendlyURL,
+			originalLayout2FriendlyURL,
 			liveLayout2.getFriendlyURL(LocaleUtil.US));
 
 		_publishLayoutsExpectLayoutFriendlyURLsException(stagingLayout2);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-77431
https://liferay.atlassian.net/browse/LPD-82679

## What Is Being Fixed

`StagingLayoutFriendlyURLTest.testLayoutFriendlyURL` and `LayoutExportImportTest.testFriendlyURLCollision` fail because they still assert the legacy collision behavior, where a layout imported with an already-taken friendly URL was silently renamed with a numeric suffix (`/test` → `/test1`). With batch-engine-based publishing (the promote content feature flag was removed from the code in LPD-79715, so this path is always active), a collision now fails the import item with a `LayoutFriendlyURLsException` instead, the error is logged, and the target layout keeps its previous friendly URL.

## How It Is Being Fixed

Both tests are adjusted to the new expected behavior. The colliding publish/import operations are wrapped in a `LogCapture` on the batch engine import task executor that asserts the logged `LayoutFriendlyURLsException`, and the assertions now verify the target layout's friendly URL stays unchanged instead of expecting a renamed one. Since friendly URL history is no longer propagated by the publish process, the staging test also releases the colliding friendly URL on the live group the same way it already does on the staging group before the final publication.