### PR TITLE
LPD-60983 Fully hide the left sidebar when sidebars are toggled

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_Sidebar.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_Sidebar.scss
@@ -181,7 +181,7 @@ html#{$cadmin-selector} .cadmin .page-editor__sidebar {
 		);
 		left: $sidebarButtonWidth;
 		position: fixed;
-		transform: translateX(-100%);
+		transform: translateX(calc(-100% - $sidebarButtonWidth));
 		transition:
 			transform ease $defaultTransitionDuration,
 			left ease $defaultTransitionDuration;

--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -1949,6 +1949,10 @@ export class PageEditorPage {
 		}
 	}
 
+	async toggleSidebars({timeout}: {timeout?: number} = {}) {
+		await this.page.getByLabel('Toggle Sidebars').click({timeout});
+	}
+
 	async undoAction() {
 		await this.undoButton.click();
 

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/sidebar.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/sidebar.spec.ts
@@ -276,15 +276,11 @@ test(
 		const configurationPanel = page.getByLabel('Configuration Panel', {
 			exact: true,
 		});
-
 		const sidebarButtons = page.locator('.page-editor__sidebar__buttons');
-
 		const sidebarContent = page.locator('.page-editor__sidebar__content');
 
 		await expect(configurationPanel).toBeInViewport();
-
 		await expect(sidebarButtons).toBeInViewport();
-
 		await expect(sidebarContent).toBeInViewport();
 
 		// Toggle the Toggle Sidebars button
@@ -294,9 +290,7 @@ test(
 		// Check that sidebars are fully out of view
 
 		await expect(configurationPanel).not.toBeInViewport();
-
 		await expect(sidebarButtons).not.toBeInViewport();
-
 		await expect(sidebarContent).not.toBeInViewport();
 	}
 );

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/sidebar.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/sidebar.spec.ts
@@ -250,6 +250,57 @@ test('Checks sidebar accessibility', async ({
 	});
 });
 
+test(
+	'Check that the sidebars are fully closed when toggling the Toggle Sidebars button',
+	{
+		tag: ['@LPD-60893'],
+	},
+	async ({apiHelpers, page, pageEditorPage, site}) => {
+		await page.goto('/');
+
+		// Create content page and go to edit mode
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		// Click on the Browser panel
+
+		await pageEditorPage.goToSidebarTab('Browser');
+
+		// Check panels are visible
+
+		const configurationPanel = page.getByLabel('Configuration Panel', {
+			exact: true,
+		});
+
+		const sidebarButtons = page.locator('.page-editor__sidebar__buttons');
+
+		const sidebarContent = page.locator('.page-editor__sidebar__content');
+
+		await expect(configurationPanel).toBeInViewport();
+
+		await expect(sidebarButtons).toBeInViewport();
+
+		await expect(sidebarContent).toBeInViewport();
+
+		// Toggle the Toggle Sidebars button
+
+		await pageEditorPage.toggleSidebars();
+
+		// Check that sidebars are fully out of view
+
+		await expect(configurationPanel).not.toBeInViewport();
+
+		await expect(sidebarButtons).not.toBeInViewport();
+
+		await expect(sidebarContent).not.toBeInViewport();
+	}
+);
+
 test.describe('Browser Panel', () => {
 	test('Deleting a fragment while its editable is selected', async ({
 		apiHelpers,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-60983

## What Is Being Fixed

Toggling the sidebars did not fully hide the left sidebar — a strip the width of the button sidebar stayed visible.

## How It Is Being Fixed

Updated _Sidebar.scss to account for the button sidebar width when collapsing so the left sidebar is hidden completely. Added a Playwright test and a page object helper covering the toggle behavior.
