### PR TITLE
LPD-93600 Scope Number field locator to the configuration tab

### DIFF
--- a/modules/test/playwright/tests/layout-content-page-editor-web/fragments/fragmentConfiguration.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/fragments/fragmentConfiguration.spec.ts
@@ -1174,13 +1174,17 @@ test.describe('General Configuration', () => {
 
 			await pageEditorPage.goToConfigurationTab('General');
 
-			await page.getByLabel('Number').fill('0');
+			const numberInput = page
+				.getByRole('tabpanel', {name: 'General'})
+				.getByLabel('Number', {exact: true});
+
+			await numberInput.fill('0');
 
 			await expect(
 				page.getByText('You have entered invalid data.')
 			).toBeVisible();
 
-			await page.getByLabel('Number').fill('11');
+			await numberInput.fill('11');
 
 			await expect(
 				page.getByText('You have entered invalid data.')


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93600

## What Is Being Fixed

The Playwright test "Text configuration allows setting a max and min value" in `fragmentConfiguration.spec.ts` fails with a Playwright strict-mode violation. Its `page.getByLabel('Number')` call resolves to three elements: the configuration number input plus the "Add Phone Number" and "Mark Phone Number as Favorite" buttons in the Fragments and Widgets panel. Those buttons started matching after LPD-91059 added the Phone Number input fragment, whose name contains "Number".

## How It Is Being Fixed

The locator is scoped to the General configuration tabpanel — `getByRole('tabpanel', {name: 'General'}).getByLabel('Number', {exact: true})` — mirroring the existing `changeConfiguration` page-object helper. This confines the match to the configuration field, so unrelated entries in the Fragments and Widgets panel (including any future fragment named "Number") cannot collide. The locator is extracted into a local since both fills reuse it.

## Why Are There No Tests?

This change only adjusts a locator in an existing Playwright test; it touches no product code, so no new test is warranted. The fix was verified by running the spec locally (3 passed).