### PR TITLE
LPD-93224 Stabilize the pages admin copy and translation tests

### DIFF
--- a/modules/test/playwright/pages/layout-admin-web/PagesAdminPage.ts
+++ b/modules/test/playwright/pages/layout-admin-web/PagesAdminPage.ts
@@ -8,6 +8,7 @@ import {Locator, Page, expect} from '@playwright/test';
 import {clickAndExpectToBeHidden} from '../../utils/clickAndExpectToBeHidden';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import fillAndClickOutside from '../../utils/fillAndClickOutside';
+import {hoverAndExpectToBeVisible} from '../../utils/hoverAndExpectToBeVisible';
 import {PORTLET_URLS} from '../../utils/portletUrls';
 import {waitForAlert} from '../../utils/waitForAlert';
 import {waitForAllPortletsReady} from '../../utils/waitForAllPortletsReady';
@@ -355,6 +356,57 @@ export class PagesAdminPage {
 				.locator('li', {has: this.page.getByText(title)})
 				.getByRole('button', {name: 'Open Page Options Menu'}),
 		});
+	}
+
+	async makeCopy({
+		name,
+		newName,
+		type = 'page',
+	}: {
+		name: string;
+		newName: string;
+		type?: 'page' | 'page-with-permissions';
+	}) {
+		const iframeTitle =
+			type === 'page-with-permissions'
+				? 'Copy Page With Permissions'
+				: 'Copy Page';
+		const label =
+			type === 'page-with-permissions' ? 'Page With Permissions' : 'Page';
+
+		// Open the page options menu
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {
+				exact: true,
+				name: 'Make a Copy',
+			}),
+			trigger: this.page
+				.locator('li', {has: this.page.getByText(name)})
+				.getByRole('button', {name: 'Open Page Options Menu'}),
+		});
+
+		// Click desired option
+
+		await hoverAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {exact: true, name: label}),
+			timeout: 5000,
+			trigger: this.page.getByRole('menuitem', {name: 'Make a Copy'}),
+		});
+
+		// Fill the copy name and confirm
+
+		const copyPageFrame = this.page.frameLocator(
+			`iframe[title="${iframeTitle}"]`
+		);
+
+		await copyPageFrame.getByPlaceholder('Add Page Name').fill(newName);
+
+		await copyPageFrame.getByRole('button', {name: 'Add'}).click();
+
+		await waitForAlert(this.page);
 	}
 
 	async clickNewButtonAndWaitForBlankTemplate() {

--- a/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
+++ b/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
@@ -57,7 +57,10 @@ export class DisplayPageTemplatesPage {
 
 		await hoverAndExpectToBeVisible({
 			autoClick: true,
-			target: this.page.getByText('Display Page', {exact: true}).nth(1),
+			target: this.page
+				.getByText('Display Page', {exact: true})
+				.filter({visible: true}),
+			timeout: 5000,
 			trigger: this.page.getByRole('menuitem', {name: 'Make a Copy'}),
 		});
 

--- a/modules/test/playwright/pages/layout-page-template-admin-web/MasterPagesPage.ts
+++ b/modules/test/playwright/pages/layout-page-template-admin-web/MasterPagesPage.ts
@@ -6,6 +6,7 @@
 import {Locator, Page, expect} from '@playwright/test';
 
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
+import {hoverAndExpectToBeVisible} from '../../utils/hoverAndExpectToBeVisible';
 import {PORTLET_URLS} from '../../utils/portletUrls';
 import {waitForAlert} from '../../utils/waitForAlert';
 import {zipFolder} from '../../utils/zip';
@@ -201,6 +202,37 @@ export class MasterPagesPage {
 		).toBeVisible();
 
 		await this.page.getByRole('button', {name: 'Import'}).click();
+	}
+
+	async makeCopy(
+		name: string,
+		type: 'master-page' | 'master-page-with-permissions' = 'master-page'
+	) {
+		const label =
+			type === 'master-page-with-permissions'
+				? 'Master Page With Permissions'
+				: 'Master Page';
+
+		// Open the actions menu
+
+		await clickAndExpectToBeVisible({
+			autoClick: false,
+			target: this.page.getByRole('menuitem', {name: 'Make a Copy'}),
+			trigger: this.getMasterCard(name).getByLabel('More actions'),
+		});
+
+		// Click desired option
+
+		await hoverAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page
+				.getByText(label, {exact: true})
+				.filter({visible: true}),
+			timeout: 5000,
+			trigger: this.page.getByRole('menuitem', {name: 'Make a Copy'}),
+		});
+
+		await waitForAlert(this.page);
 	}
 
 	async openMasterActionsMenu(name: string) {

--- a/modules/test/playwright/tests/layout-admin-web/main/pages/ContentPageTranslationPage.ts
+++ b/modules/test/playwright/tests/layout-admin-web/main/pages/ContentPageTranslationPage.ts
@@ -251,32 +251,41 @@ export class ContentPageTranslationPage {
 	}
 
 	async switchLanguage({from, to}: {from?: string; to?: string}) {
-		if (from) {
+		const selectLanguage = async (
+			language: string,
+			toggleIndex: number
+		) => {
+			const toggle = this.page
+				.locator('.management-bar .dropdown-toggle')
+				.nth(toggleIndex);
+
+			const option = this.page.getByRole('menuitem', {name: language});
+
 			await clickAndExpectToBeVisible({
-				autoClick: true,
-				target: this.page.getByRole('menuitem', {
-					name: from,
-				}),
-				trigger: this.page
-					.locator('.management-bar .dropdown-toggle')
-					.nth(0),
+				target: option,
+				trigger: toggle,
 			});
 
-			await this.page.locator('.col-md-6').getByText(from).waitFor();
+			// The already-selected language renders as an active,
+			// non-clickable item, so only click it when it is not the active
+			// one and close the dropdown otherwise.
+
+			if ((await option.getAttribute('aria-selected')) === 'true') {
+				await toggle.click();
+			}
+			else {
+				await option.click();
+			}
+
+			await this.page.locator('.col-md-6').getByText(language).waitFor();
+		};
+
+		if (from) {
+			await selectLanguage(from, 0);
 		}
 
 		if (to) {
-			await clickAndExpectToBeVisible({
-				autoClick: true,
-				target: this.page.getByRole('menuitem', {
-					name: to,
-				}),
-				trigger: this.page
-					.locator('.management-bar .dropdown-toggle')
-					.nth(1),
-			});
-
-			await this.page.locator('.col-md-6').getByText(to).waitFor();
+			await selectLanguage(to, 1);
 		}
 	}
 

--- a/modules/test/playwright/tests/layout-admin-web/main/pagesAdmin.spec.ts
+++ b/modules/test/playwright/tests/layout-admin-web/main/pagesAdmin.spec.ts
@@ -15,7 +15,6 @@ import {pageViewModePagesTest} from '../../../fixtures/pageViewModePagesTest';
 import {pagesAdminPagesTest} from '../../../fixtures/pagesAdminPagesTest';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../../utils/getRandomString';
-import {hoverAndExpectToBeVisible} from '../../../utils/hoverAndExpectToBeVisible';
 import {waitForAlert} from '../../../utils/waitForAlert';
 import getFragmentDefinition from '../../layout-content-page-editor-web/main/utils/getFragmentDefinition';
 import getPageDefinition from '../../layout-content-page-editor-web/main/utils/getPageDefinition';
@@ -987,38 +986,13 @@ test(
 
 		await pagesAdminPage.goto(site.friendlyUrlPath);
 
-		await clickAndExpectToBeVisible({
-			autoClick: true,
-			target: page.getByRole('menuitem', {
-				exact: true,
-				name: 'Make a Copy',
-			}),
-			trigger: page
-				.locator('li', {has: page.getByText(layoutTitle)})
-				.getByRole('button', {name: 'Open Page Options Menu'}),
-		});
-
-		await hoverAndExpectToBeVisible({
-			autoClick: true,
-			target: page.getByRole('menuitem', {name: 'Page With Permissions'}),
-			trigger: page.getByRole('menuitem', {name: 'Make a Copy'}),
-		});
-
-		const copyPageWithPermissionsFrame = page.frameLocator(
-			'iframe[title="Copy Page With Permissions"]'
-		);
-
 		const copyPageName = getRandomString();
 
-		await copyPageWithPermissionsFrame
-			.getByPlaceholder('Add Page Name')
-			.fill(copyPageName);
-
-		await copyPageWithPermissionsFrame
-			.getByRole('button', {name: 'Add'})
-			.click();
-
-		await waitForAlert(page);
+		await pagesAdminPage.makeCopy({
+			name: layoutTitle,
+			newName: copyPageName,
+			type: 'page-with-permissions',
+		});
 
 		// Assert copied permissions
 
@@ -1079,38 +1053,17 @@ test(
 			]
 		);
 
-		// Copy page with permissions
+		// Copy page without permissions
 
 		await pagesAdminPage.goto(site.friendlyUrlPath);
 
-		await clickAndExpectToBeVisible({
-			autoClick: true,
-			target: page.getByRole('menuitem', {
-				exact: true,
-				name: 'Make a Copy',
-			}),
-			trigger: page
-				.locator('li', {has: page.getByText(layoutTitle)})
-				.getByRole('button', {name: 'Open Page Options Menu'}),
-		});
-
-		await hoverAndExpectToBeVisible({
-			autoClick: true,
-			target: page.getByRole('menuitem', {exact: true, name: 'Page'}),
-			trigger: page.getByRole('menuitem', {name: 'Make a Copy'}),
-		});
-
-		const copyPageFrame = page.frameLocator('iframe[title="Copy Page"]');
-
 		const copyPageName = getRandomString();
 
-		await copyPageFrame
-			.getByPlaceholder('Add Page Name')
-			.fill(copyPageName);
-
-		await copyPageFrame.getByRole('button', {name: 'Add'}).click();
-
-		await waitForAlert(page);
+		await pagesAdminPage.makeCopy({
+			name: layoutTitle,
+			newName: copyPageName,
+			type: 'page',
+		});
 
 		// Assert copied permissions
 

--- a/modules/test/playwright/tests/layout-page-template-admin-web/main/masterPagesAdmin.spec.ts
+++ b/modules/test/playwright/tests/layout-page-template-admin-web/main/masterPagesAdmin.spec.ts
@@ -18,8 +18,6 @@ import {PageEditorPage} from '../../../pages/layout-content-page-editor-web/Page
 import {MasterPagesPage} from '../../../pages/layout-page-template-admin-web/MasterPagesPage';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../../utils/getRandomString';
-import {hoverAndExpectToBeVisible} from '../../../utils/hoverAndExpectToBeVisible';
-import {waitForAlert} from '../../../utils/waitForAlert';
 
 export const test = mergeTests(
 	apiHelpersTest,
@@ -309,22 +307,7 @@ test(
 
 		await masterPagesPage.goto(site.friendlyUrlPath);
 
-		await clickAndExpectToBeVisible({
-			autoClick: false,
-			target: page.getByRole('menuitem', {name: 'Make a Copy'}),
-			trigger: page
-				.locator('.card-page-item')
-				.filter({hasText: masterName})
-				.getByLabel('More actions'),
-		});
-
-		await hoverAndExpectToBeVisible({
-			autoClick: true,
-			target: page.getByText('Master Page', {exact: true}).nth(1),
-			trigger: page.getByRole('menuitem', {name: 'Make a Copy'}),
-		});
-
-		await waitForAlert(page);
+		await masterPagesPage.makeCopy(masterName, 'master-page');
 
 		// Assert master page template is duplicated
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93224

## What Is Being Fixed

Several Playwright tests under layout-admin-web and
layout-page-template-admin-web broke after UI changes to the "Make a Copy"
submenu and the translation language selector. The copy submenu now renders its
options twice (a collapsed, non-clickable copy and the expanded one), and the
language selector no longer lets you click the already-selected language. Both
made the existing clicks fail.

## How It Is Being Fixed

The "Make a Copy" flow is extracted into reusable makeCopy methods on
PagesAdminPage and MasterPagesPage, and the existing copyTemplate on
DisplayPageTemplatesPage now targets the visible submenu item instead of relying
on a positional nth() locator. The pages admin and master pages specs are
adapted to use these methods. For translations (LPD-93219), switchLanguage now
clicks a language only when it is not already the active one, closing the
dropdown otherwise, so the source and target selection works whether or not the
language is already selected.

## Why Are There No Tests?

This PR only repairs and refactors existing Playwright tests to match current UI
behavior; it introduces no product code, so no new tests are added.