### PR TITLE
LPD-91575 Restrict phone number input to allowed characters

### DIFF
--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.js
@@ -214,6 +214,16 @@ async function main() {
 		focusInput(inputElement);
 	}
 
+	// Restrict typed characters to digits, spaces, dashes, parentheses and dots
+
+	inputElement.addEventListener('input', () => {
+		const filtered = inputElement.value.replace(/[^0-9\s\-().]/g, '');
+
+		if (filtered !== inputElement.value) {
+			inputElement.value = filtered;
+		}
+	});
+
 	// Add prefix picker listeners
 
 	if (!IS_FIXED && prefixTrigger && prefixMenu) {

--- a/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/phoneNumberField.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/phoneNumberField.spec.ts
@@ -69,6 +69,13 @@ test(
 
 		const phoneInput = page.locator('input[type="tel"]');
 
+		// Typing letters is rejected — only digits, spaces, dashes,
+		// parentheses and dots survive
+
+		await phoneInput.pressSequentially('abc212-555 (1234)def');
+
+		await expect(phoneInput).toHaveValue('212-555 (1234)');
+
 		await phoneInput.fill('2125551234');
 
 		await contentsPage.saveContent();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91575

## What Is Being Fixed

The phone number input fragment let users type any character. The field
carried an HTML `pattern` attribute, but that only validates on form submit —
it does not stop invalid characters (letters, symbols) from being typed.

## How It Is Being Fixed

An `input` event listener now strips any character outside the allowed set —
digits, spaces, dashes, parentheses and dots — as the user types, so the field
can only ever hold valid phone characters. This mirrors the existing
PhoneNumberInput React component in object-js-components-web, which filters with
the same regex. The Playwright test for the phone field was extended to assert
that typed letters are rejected.
