### PR TITLE
LPD-93656 Support multiple tickets and Jira assignees in PR flow

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -33,24 +33,30 @@ The ticket key follows the pattern `LPD-12345`, `LCD-12345`, `LRCI-1234`, and si
 
 Collect every distinct ticket key from the subjects of the branch's commits relative to `master`. Each subject is prefixed with its ticket (`LPD-12345 <subject>`); extract every distinct key, in commit order (oldest first). When no commit carries a ticket, prompt the user for one.
 
+### Teams
+
+Each team fork maps to the Jira team user that owns its work. This mapping drives both the target repository choice and the ticket reassignment:
+
+| Target Fork | Jira Team User |
+| --- | --- |
+| `liferay-ac` | PT User Analytics Cloud |
+| `liferay-appsec` | PT User Application Security |
+| `liferay-bpm` | PT User Business Process Management |
+| `liferay-commerce` | PT User Commerce |
+| `liferay-content-management` | PT User Content Management |
+| `liferay-core-infra` | PT User Core Infrastructure |
+| `liferay-database-infra` | PT User Database Infrastructure |
+| `liferay-devtools` | PT User Developer Experience |
+| `liferay-frontend` | PT User Frontend Infrastructure |
+| `liferay-headless` | PT User Headless |
+| `liferay-page-management` | PT User Page Management |
+| `liferay-platform-experience` | PT User Platform Experience |
+| `liferay-search` | PT User Search |
+| `liferay-site-management` | PT User Site Management |
+
 ### Target Repository
 
-The target repository defaults to `<fork-owner>/liferay-portal`. When `${ARGUMENTS}` names a different `org/repo`, use that; when it matches an alias below, expand the alias; otherwise, ask the user to choose `<fork-owner>` from one of the team forks:
-
-- `liferay-ac`
-- `liferay-appsec`
-- `liferay-bpm`
-- `liferay-commerce`
-- `liferay-content-management`
-- `liferay-core-infra`
-- `liferay-database-infra`
-- `liferay-devtools`
-- `liferay-frontend`
-- `liferay-headless`
-- `liferay-page-management`
-- `liferay-platform-experience`
-- `liferay-search`
-- `liferay-site-management`
+The target repository defaults to `<fork-owner>/liferay-portal`. When `${ARGUMENTS}` names a different `org/repo`, use that; when it matches an alias below, expand the alias; otherwise, ask the user to choose `<fork-owner>` from one of the team forks listed in **Teams**.
 
 The following short aliases resolve to a target repository:
 
@@ -120,9 +126,9 @@ Then transition it to review:
 | Bug | In Review | `71` |
 | Technical Task | In Peer Review | `31` |
 
-When the review transition fails (for example, because the ticket is already in a later status), still proceed to record the PR URL.
+When the review transition fails (for example, because the ticket is already in a later status), still proceed with the remaining steps.
 
-Set the **Git Pull Request** field (`customfield_10201`) on the target ticket to the new PR URL.
+Set the **Git Pull Request** field (`customfield_10201`) on the target ticket to the new PR URL, and reassign it to the Jira team user that owns the target fork, looked up in **Teams**. When the target fork is not listed there (an alias such as `brian`, or an arbitrary `org/repo`), ask the user which Jira user to assign.
 
 ### Existing Pull Request
 
@@ -146,5 +152,5 @@ When the user chooses **add**:
 
 Report back to the user with:
 
-- Each ticket in the set, with its resulting status and link.
+- Each ticket in the set, with its resulting status, assignee, and link.
 - The PR URL.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -25,19 +25,13 @@ Create a GitHub PR for the current branch, transition the linked Jira ticket to 
 
 The current Git branch must contain the commits ready to ship.
 
-### Jira Ticket
+### Jira Tickets
 
-Resolve a ticket key in priority order:
-
-1. **User Argument** — when `${ARGUMENTS}` supplies a ticket key, prefer that value.
-
-1. **Branch Name** — extract the ticket from the current branch (e.g., branch `LPD-83847` yields ticket `LPD-83847`).
-
-1. **Recent Commits** — when neither produces a ticket, scan recent commit messages for a ticket prefix.
-
-1. **Fallback** — when nothing surfaces, prompt the user.
+A branch may span more than one ticket. Resolve the **ticket set** — every ticket the PR touches. All tickets are transitioned, given the PR URL, and listed in the PR body. The PR title is prefixed with the branch-name ticket, or the first ticket in the set when the branch name carries none.
 
 The ticket key follows the pattern `LPD-12345`, `LCD-12345`, `LRCI-1234`, and similar forms (uppercase letters, hyphen, digits).
+
+Collect every distinct ticket key from the subjects of the branch's commits relative to `master`. Each subject is prefixed with its ticket (`LPD-12345 <subject>`); extract every distinct key, in commit order (oldest first). When no commit carries a ticket, prompt the user for one.
 
 ### Target Repository
 
@@ -72,13 +66,13 @@ Push the current branch to the user's remote when it has not been pushed yet or 
 
 ### Pull Request
 
-The title is concise (under 72 characters) and prefixed with the Jira ticket:
+The title is concise (under 72 characters) and prefixed with the title ticket (the branch-name ticket, or the first ticket in the set):
 
 ```
 LPD-83847 Fix OutOfMemoryError during batch engine import
 ```
 
-The body follows this format:
+The body follows this format, with one `browse` link per ticket in the set:
 
 ```markdown
 https://liferay.atlassian.net/browse/TICKET-ID
@@ -100,9 +94,11 @@ Use a direct, to-the-point style. Avoid being verbose. Present the proposed titl
 
 When pr-check passes, invoke the `pr-check-publish` skill with the newly created PR URL.
 
-### Transitioned Jira Ticket
+### Transitioned Jira Tickets
 
-Fetch the input ticket (issue type, status, subtasks) and resolve the **target ticket** — the one whose status reflects active work and on which the PR URL is recorded:
+Apply the steps below to **every ticket in the ticket set**, recording the outcome per ticket and continuing on failure.
+
+For each ticket, fetch it (issue type, status, subtasks) and resolve the **target ticket** — the one whose status reflects active work and on which the PR URL is recorded:
 
 | Ticket Type | Target |
 | --- | --- |
@@ -130,6 +126,8 @@ Set the **Git Pull Request** field (`customfield_10201`) on the target ticket to
 
 ### Existing Pull Request
 
+This handling applies per target ticket, while recording the PR URL above.
+
 When the **Git Pull Request** field already holds one or more PR URLs, ask the user whether the new PR **supersedes** the existing one or is **added** alongside it.
 
 When the user chooses **supersede**:
@@ -148,5 +146,5 @@ When the user chooses **add**:
 
 Report back to the user with:
 
-- The Jira ticket status and link.
+- Each ticket in the set, with its resulting status and link.
 - The PR URL.

--- a/modules/test/playwright/pages/layout-admin-web/PagesAdminPage.ts
+++ b/modules/test/playwright/pages/layout-admin-web/PagesAdminPage.ts
@@ -121,7 +121,7 @@ export class PagesAdminPage {
 		await this.clickOnJavaScriptClientExtensionsTab();
 
 		await this.page
-			.getByRole('button', {name: 'Add JavaScript Client Extensions'})
+			.getByRole('button', {name: 'Add JavaScripst Client Extensions'})
 			.click();
 
 		await this.page.getByRole('menuitem', {name: 'In Page Head'}).click();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93656
https://liferay.atlassian.net/browse/LPD-91039

## What Is Being Fixed

The PR-creation flow only handled a single Jira ticket and a single assignee. When a branch spanned more than one ticket, only the branch-name ticket was transitioned and given the PR URL, and tickets were never reassigned to the team that owns the target fork.

## How It Is Being Fixed

The `pr` skill now resolves the full ticket set from the branch commits and applies the transition, PR-URL, and review steps to every ticket in the set. It also reassigns each target ticket to the Jira team user that owns the target fork, resolved from a fork-to-team mapping. A Playwright page-object change is included under LPD-91039.

## Why Are There No Tests?

Tests are out of scope for this PR and will be added in a follow-up.