### PR TITLE
LPD-89086 Format LayoutActionDropdownItemsProviderTest

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/servlet/taglib/util/LayoutActionDropdownItemsProviderTest.java
+++ b/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/servlet/taglib/util/LayoutActionDropdownItemsProviderTest.java
@@ -59,8 +59,7 @@ public class LayoutActionDropdownItemsProviderTest {
 			LayoutConstants.TYPE_FULL_PAGE_APPLICATION, true, true);
 		_testIsShowMakeACopyAction(LayoutConstants.TYPE_PANEL, false, false);
 		_testIsShowMakeACopyAction(LayoutConstants.TYPE_PANEL, true, true);
-		_testIsShowMakeACopyAction(
-			LayoutConstants.TYPE_PORTLET, false, false);
+		_testIsShowMakeACopyAction(LayoutConstants.TYPE_PORTLET, false, false);
 		_testIsShowMakeACopyAction(LayoutConstants.TYPE_PORTLET, true, true);
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89086

## What Is Being Fixed

A line in `LayoutActionDropdownItemsProviderTest` did not conform to the source formatter's wrapping rules.

## How It Is Being Fixed

Applies the source formatter, collapsing the `_testIsShowMakeACopyAction(LayoutConstants.TYPE_PORTLET, false, false)` call onto a single line. This is a formatting-only change with no behavioral impact.

## Why Are There No Tests?

This change only reformats an existing test; it introduces no behavioral change, so no new test coverage applies.

## PR Check

**pr-check: PASS** — tested on `42bf33990712098061cfec7e40bc031e4b9af531`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Java Unit Tests | PASS |
| Structural Smoke | PASS\* |

\* `Log4jConfigUtilTest` (whip code-coverage assertion) and `LibraryReferenceTest.testIntelliJLibPreModules` (`util-bridges.iml` missing IntelliJ orderEntry elements) fail due to pre-existing local-checkout/IDE-config baseline drift in areas this diff does not touch; they fail identically on `master`.

<!-- pr-check {"result": "success", "sha": "42bf33990712098061cfec7e40bc031e4b9af531"} -->
