### PR TITLE
LPD-93783 Resolve the portal server port at use time in LayoutSEOLinkManagerTest

### DIFF
--- a/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/test/LayoutSEOLinkManagerTest.java
+++ b/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/test/LayoutSEOLinkManagerTest.java
@@ -50,7 +50,6 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -469,7 +468,7 @@ public class LayoutSEOLinkManagerTest {
 		_themeDisplay.setResponse(new MockHttpServletResponse());
 		_themeDisplay.setScopeGroupId(_group.getGroupId());
 		_themeDisplay.setServerName("localhost");
-		_themeDisplay.setServerPort(PortalUtil.getPortalServerPort(false));
+		_themeDisplay.setServerPort(_portal.getPortalServerPort(false));
 		_themeDisplay.setSiteGroupId(_group.getGroupId());
 		_themeDisplay.setUser(TestPropsValues.getUser());
 

--- a/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/test/LayoutSEOLinkManagerTest.java
+++ b/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/test/LayoutSEOLinkManagerTest.java
@@ -425,7 +425,7 @@ public class LayoutSEOLinkManagerTest {
 		}
 
 		return StringBundler.concat(
-			_PORTAL_URL, expectedLanguagePath, _groupFriendlyURL, urlPrefix,
+			_getPortalURL(), expectedLanguagePath, _groupFriendlyURL, urlPrefix,
 			_expectedFriendlyURLs.get(locale));
 	}
 
@@ -479,6 +479,10 @@ public class LayoutSEOLinkManagerTest {
 		return mockHttpServletRequest;
 	}
 
+	private String _getPortalURL() {
+		return "http://localhost:" + _portal.getPortalServerPort(false);
+	}
+
 	private LayoutSEOLink _getXDefaultAlternateLayoutSEOLink(
 		List<LayoutSEOLink> layoutSEOLinks) {
 
@@ -502,7 +506,7 @@ public class LayoutSEOLinkManagerTest {
 			_group.getPublicLayoutSet(), _themeDisplay, false, false);
 
 		_canonicalURL = StringBundler.concat(
-			_PORTAL_URL, _groupFriendlyURL,
+			_getPortalURL(), _groupFriendlyURL,
 			FriendlyURLResolverConstants.URL_SEPARATOR_JOURNAL_ARTICLE,
 			_expectedFriendlyURLs.get(LocaleUtil.US));
 	}
@@ -531,7 +535,7 @@ public class LayoutSEOLinkManagerTest {
 			_group.getPublicLayoutSet(), _themeDisplay, false, false);
 
 		_canonicalURL = StringBundler.concat(
-			_PORTAL_URL, _groupFriendlyURL, StringPool.SLASH,
+			_getPortalURL(), _groupFriendlyURL, StringPool.SLASH,
 			_expectedFriendlyURLs.get(LocaleUtil.US));
 	}
 
@@ -625,9 +629,6 @@ public class LayoutSEOLinkManagerTest {
 	private static final String _LAYOUT_SEO_CONFIGURATION_PID =
 		"com.liferay.layout.seo.internal.configuration." +
 			"LayoutSEOCompanyConfiguration";
-
-	private static final String _PORTAL_URL =
-		"http://localhost:" + PortalUtil.getPortalServerPort(false);
 
 	@Inject
 	private AssetDisplayPageEntryLocalService


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93783

## What Is Being Fixed

`LayoutSEOLinkManagerTest` builds its expected URLs from a static `_PORTAL_URL` constant initialized via `PortalUtil.getPortalServerPort(false)` at class-load time, when the portal singleton has not yet been populated with the resolved server port. The resulting URLs miss the port segment and the assertions diverge from what `LayoutSEOLinkManagerImpl` produces.

## How It Is Being Fixed

Replace the static constant with a private `_getPortalURL()` helper that resolves the port lazily through the injected `Portal` instance at each call site, and switch the remaining static facade call in the theme display setup to the same injected dependency.

Supersedes #18547.