### PR TITLE
LPD-93265 Tolerate embedded portlet rendering in test mock request

### DIFF
--- a/modules/apps/layout/layout-test-util/src/main/java/com/liferay/layout/test/util/ContentLayoutTestUtil.java
+++ b/modules/apps/layout/layout-test-util/src/main/java/com/liferay/layout/test/util/ContentLayoutTestUtil.java
@@ -61,6 +61,9 @@ import com.liferay.segments.service.SegmentsExperienceLocalServiceUtil;
 import jakarta.portlet.ActionRequest;
 import jakarta.portlet.ActionResponse;
 
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.Collection;
@@ -522,7 +525,7 @@ public class ContentLayoutTestUtil {
 			new MockLiferayPortletActionResponse());
 
 		MockHttpServletRequest mockHttpServletRequest =
-			new MockHttpServletRequest();
+			_createMockHttpServletRequest();
 
 		mockHttpServletRequest.setAttribute(WebKeys.LAYOUT, layout);
 
@@ -711,6 +714,31 @@ public class ContentLayoutTestUtil {
 		finally {
 			ServiceContextThreadLocal.popServiceContext();
 		}
+	}
+
+	private static MockHttpServletRequest _createMockHttpServletRequest() {
+		return new MockHttpServletRequest() {
+
+			@Override
+			public RequestDispatcher getRequestDispatcher(String path) {
+				return new RequestDispatcher() {
+
+					@Override
+					public void forward(
+						ServletRequest servletRequest,
+						ServletResponse servletResponse) {
+					}
+
+					@Override
+					public void include(
+						ServletRequest servletRequest,
+						ServletResponse servletResponse) {
+					}
+
+				};
+			}
+
+		};
 	}
 
 	private static final String _INPUT_HTML = StringBundler.concat(

--- a/modules/apps/layout/layout-test-util/src/main/java/com/liferay/layout/test/util/ContentLayoutTestUtil.java
+++ b/modules/apps/layout/layout-test-util/src/main/java/com/liferay/layout/test/util/ContentLayoutTestUtil.java
@@ -525,7 +525,7 @@ public class ContentLayoutTestUtil {
 			new MockLiferayPortletActionResponse());
 
 		MockHttpServletRequest mockHttpServletRequest =
-			_createMockHttpServletRequest();
+			_getMockHttpServletRequest();
 
 		mockHttpServletRequest.setAttribute(WebKeys.LAYOUT, layout);
 
@@ -716,7 +716,7 @@ public class ContentLayoutTestUtil {
 		}
 	}
 
-	private static MockHttpServletRequest _createMockHttpServletRequest() {
+	private static MockHttpServletRequest _getMockHttpServletRequest() {
 		return new MockHttpServletRequest() {
 
 			@Override


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93265

## What Is Being Fixed

AddFragmentEntryLinkMVCActionCommandTest fails at runtime with `IllegalArgumentException: MockRequestDispatcher requires MockHttpServletResponse`. LPD-92001 changed InfoFieldUtil to fully render a fragment entry link's HTML against a DummyHttpServletResponse during editable field discovery, which now runs on every fragment entry link creation. When the fragment embeds a portlet through a FreeMarker runtime tag, the render reaches the portlet container, which dispatches through the request. The Spring MockHttpServletRequest built for content page editor action tests returns a MockRequestDispatcher that rejects the non mock response, so the render fails before the test reaches its assertions.

## How It Is Being Fixed

ContentLayoutTestUtil.getMockLiferayPortletActionRequest now builds a MockHttpServletRequest whose getRequestDispatcher returns a no-op dispatcher, so the editable field discovery render completes in the mock environment, mirroring how a real request dispatcher tolerates the response in production. There is no production code change.

@JavierMoral 