### PR TITLE
LPD-93663 Add the page experience key to the page view event context

### DIFF
--- a/modules/apps/analytics/analytics-client-js/src/middlewares/meta.ts
+++ b/modules/apps/analytics/analytics-client-js/src/middlewares/meta.ts
@@ -27,6 +27,10 @@ function meta(request: {context: Analytics.Context}) {
 		description: getAttribute('meta[name="description"]', 'content'),
 		keywords: getAttribute('meta[name="keywords"]', 'content'),
 		languageId: navigator.language,
+		pageExperienceKey: getAttribute(
+			'meta[name="page-experience-key"]',
+			'content'
+		),
 		referrer: document.referrer,
 		timezoneOffset: getTimezoneOffsetHour(),
 		title: getAttribute('title', 'textContent'),

--- a/modules/apps/analytics/analytics-client-js/test/middleware.ts
+++ b/modules/apps/analytics/analytics-client-js/test/middleware.ts
@@ -79,5 +79,32 @@ describe('Analytics MiddleWare Integration', () => {
 				})
 			);
 		});
+
+		it('includes an empty page experience key when the meta tag is absent', () => {
+			const req = {context: {channelId: '', dataSourceId: ''}};
+
+			expect(meta(req).context).toEqual(
+				expect.objectContaining({pageExperienceKey: ''})
+			);
+		});
+
+		it('includes the page experience key when the meta tag is present', () => {
+			const metaElement = document.createElement('meta');
+
+			metaElement.setAttribute('content', 'TEST_EXPERIENCE_KEY');
+			metaElement.setAttribute('name', 'page-experience-key');
+
+			document.head.appendChild(metaElement);
+
+			const req = {context: {channelId: '', dataSourceId: ''}};
+
+			expect(meta(req).context).toEqual(
+				expect.objectContaining({
+					pageExperienceKey: 'TEST_EXPERIENCE_KEY',
+				})
+			);
+
+			document.head.removeChild(metaElement);
+		});
 	});
 });

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/servlet/taglib/SegmentsExperienceTopHeadDynamicInclude.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/servlet/taglib/SegmentsExperienceTopHeadDynamicInclude.java
@@ -1,0 +1,136 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.segments.web.internal.servlet.taglib;
+
+import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.servlet.taglib.BaseDynamicInclude;
+import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.segments.constants.SegmentsExperienceConstants;
+import com.liferay.segments.manager.SegmentsExperienceManager;
+import com.liferay.segments.model.SegmentsExperience;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Georgel Pop
+ */
+@Component(service = DynamicInclude.class)
+public class SegmentsExperienceTopHeadDynamicInclude
+	extends BaseDynamicInclude {
+
+	@Override
+	public void include(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, String key)
+		throws IOException {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		if ((themeDisplay == null) || !themeDisplay.isLifecycleRender() ||
+			!FeatureFlagManagerUtil.isEnabled(
+				themeDisplay.getCompanyId(), "LPD-81914")) {
+
+			return;
+		}
+
+		Layout layout = themeDisplay.getLayout();
+
+		if ((layout == null) || layout.isTypeControlPanel() ||
+			(!layout.isTypeAssetDisplay() && !layout.isTypeContent())) {
+
+			return;
+		}
+
+		if (!_isAnalyticsEnabled(themeDisplay.getCompanyId())) {
+			return;
+		}
+
+		PrintWriter printWriter = httpServletResponse.getWriter();
+
+		printWriter.print("<meta content=\"");
+		printWriter.print(
+			HtmlUtil.escapeAttribute(
+				_getSegmentsExperienceKey(httpServletRequest)));
+		printWriter.print("\" name=\"page-experience-key\" />");
+	}
+
+	@Override
+	public void register(DynamicIncludeRegistry dynamicIncludeRegistry) {
+		dynamicIncludeRegistry.register("/html/common/themes/top_head.jsp#pre");
+	}
+
+	private String _getSegmentsExperienceKey(
+		HttpServletRequest httpServletRequest) {
+
+		try {
+			SegmentsExperienceManager segmentsExperienceManager =
+				new SegmentsExperienceManager(_segmentsExperienceLocalService);
+
+			long segmentsExperienceId =
+				segmentsExperienceManager.getSegmentsExperienceId(
+					httpServletRequest);
+
+			if (segmentsExperienceId !=
+					SegmentsExperienceConstants.ID_DEFAULT) {
+
+				SegmentsExperience segmentsExperience =
+					_segmentsExperienceLocalService.fetchSegmentsExperience(
+						segmentsExperienceId);
+
+				if (segmentsExperience != null) {
+					return segmentsExperience.getSegmentsExperienceKey();
+				}
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
+
+		return SegmentsExperienceConstants.KEY_DEFAULT;
+	}
+
+	private boolean _isAnalyticsEnabled(long companyId) {
+		try {
+			return _analyticsSettingsManager.isAnalyticsEnabled(companyId);
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			return false;
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SegmentsExperienceTopHeadDynamicInclude.class);
+
+	@Reference
+	private AnalyticsSettingsManager _analyticsSettingsManager;
+
+	@Reference
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
+
+}

--- a/modules/test/playwright/fixtures/analyticsCloudConnectionTest.ts
+++ b/modules/test/playwright/fixtures/analyticsCloudConnectionTest.ts
@@ -1,0 +1,79 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from './apiHelpersTest';
+import {featureFlagsTest} from './featureFlagsTest';
+import {loginTest} from './loginTest';
+
+const ANALYTICS_CONFIGURATION_PID =
+	'com.liferay.analytics.settings.configuration.AnalyticsConfiguration';
+
+const ANALYTICS_CONFIGURATION_URL = `/o/headless-admin-configuration/v1.0/instance-configurations/${ANALYTICS_CONFIGURATION_PID}`;
+
+const test = mergeTests(apiHelpersTest, featureFlagsTest({}), loginTest());
+
+/**
+ * Stubs the Analytics Cloud connection so the analytics client initializes and
+ * emits events without reaching a real backend, then restores the original
+ * configuration when the test finishes, whether it passed or failed.
+ */
+const analyticsCloudConnectionTest = test.extend<{
+	analyticsCloudConnection: void;
+}>({
+	analyticsCloudConnection: [
+		async ({apiHelpers, featureFlags, login}, use) => {
+
+			// Run after the feature flags and login are in place
+
+			void featureFlags;
+			void login;
+
+			const configuration = await apiHelpers.get(
+				ANALYTICS_CONFIGURATION_URL
+			);
+
+			const originalAnalyticsProperties = configuration?.properties ?? {};
+
+			try {
+				await apiHelpers.put(ANALYTICS_CONFIGURATION_URL, {
+					data: {
+						externalReferenceCode: ANALYTICS_CONFIGURATION_PID,
+						properties: {
+							liferayAnalyticsDataSourceId:
+								'playwright-stub-data-source',
+							liferayAnalyticsFaroBackendSecuritySignature:
+								'playwright-stub-signature',
+							liferayAnalyticsFaroBackendURL:
+								'http://playwright-stub.invalid',
+						},
+					},
+					failOnStatusCode: true,
+				});
+
+				await use();
+			}
+			finally {
+
+				// Restore only a prior configuration; the endpoint rejects an
+				// empty-properties restore
+
+				if (Object.keys(originalAnalyticsProperties).length) {
+					await apiHelpers.put(ANALYTICS_CONFIGURATION_URL, {
+						data: {
+							externalReferenceCode: ANALYTICS_CONFIGURATION_PID,
+							properties: originalAnalyticsProperties,
+						},
+						failOnStatusCode: true,
+					});
+				}
+			}
+		},
+		{auto: true},
+	],
+});
+
+export {analyticsCloudConnectionTest};

--- a/modules/test/playwright/tests/asset-publisher-web/main/assetPublisherAnalyticsAttributes.spec.ts
+++ b/modules/test/playwright/tests/asset-publisher-web/main/assetPublisherAnalyticsAttributes.spec.ts
@@ -5,6 +5,7 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
+import {analyticsCloudConnectionTest} from '../../../fixtures/analyticsCloudConnectionTest';
 import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
 import {assetPublisherPagesTest} from '../../../fixtures/assetPublisherPagesTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
@@ -17,12 +18,8 @@ import getPageDefinition from '../../layout-content-page-editor-web/main/utils/g
 import getWidgetDefinition from '../../layout-content-page-editor-web/main/utils/getWidgetDefinition';
 import {templatesPageTest} from '../../template-web/main/fixtures/templatesPageTest';
 
-const ANALYTICS_CONFIGURATION_PID =
-	'com.liferay.analytics.settings.configuration.AnalyticsConfiguration';
-
-const ANALYTICS_CONFIGURATION_URL = `/o/headless-admin-configuration/v1.0/instance-configurations/${ANALYTICS_CONFIGURATION_PID}`;
-
 const test = mergeTests(
+	analyticsCloudConnectionTest,
 	apiHelpersTest,
 	assetPublisherPagesTest,
 	featureFlagsTest({
@@ -35,38 +32,6 @@ const test = mergeTests(
 	pageEditorPagesTest,
 	templatesPageTest
 );
-
-let originalAnalyticsProperties: Record<string, unknown> = {};
-
-test.beforeEach(async ({apiHelpers}) => {
-	const configuration = await apiHelpers.get(ANALYTICS_CONFIGURATION_URL);
-
-	originalAnalyticsProperties = configuration?.properties ?? {};
-
-	await apiHelpers.put(ANALYTICS_CONFIGURATION_URL, {
-		data: {
-			externalReferenceCode: ANALYTICS_CONFIGURATION_PID,
-			properties: {
-				liferayAnalyticsDataSourceId: 'playwright-stub-data-source',
-				liferayAnalyticsFaroBackendSecuritySignature:
-					'playwright-stub-signature',
-				liferayAnalyticsFaroBackendURL:
-					'http://playwright-stub.invalid',
-			},
-		},
-		failOnStatusCode: true,
-	});
-});
-
-test.afterEach(async ({apiHelpers}) => {
-	await apiHelpers.put(ANALYTICS_CONFIGURATION_URL, {
-		data: {
-			externalReferenceCode: ANALYTICS_CONFIGURATION_PID,
-			properties: originalAnalyticsProperties,
-		},
-		failOnStatusCode: true,
-	});
-});
 
 test(
 	'Emits data-analytics-asset-* attributes for Asset Publisher display templates',

--- a/modules/test/playwright/tests/segments-web/main/pageExperienceKey.spec.ts
+++ b/modules/test/playwright/tests/segments-web/main/pageExperienceKey.spec.ts
@@ -1,0 +1,151 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {analyticsCloudConnectionTest} from '../../../fixtures/analyticsCloudConnectionTest';
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
+import getRandomString from '../../../utils/getRandomString';
+import {performUserSwitchViaApi, userData} from '../../../utils/performLogin';
+import {waitForAlert} from '../../../utils/waitForAlert';
+
+const SEGMENTS_EXPERIENCES_URL =
+	'/api/jsonws/segments.segmentsexperience/get-segments-experiences';
+
+const test = mergeTests(
+	analyticsCloudConnectionTest,
+	apiHelpersTest,
+	featureFlagsTest({
+		'LPD-65399': {enabled: true},
+		'LPD-78863': {enabled: true, system: true},
+		'LPD-81914': {enabled: true},
+		'LPS-155284': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+test(
+	'Emits the default and matched segment experience keys on a content page',
+	{
+		tag: '@LPD-93663',
+	},
+	async ({apiHelpers, page, pageEditorPage, site}) => {
+
+		// Create a user and a matching segment
+
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		userData[user.alternateName] = {
+			name: user.givenName,
+			password: 'test',
+			surname: user.familyName,
+		};
+
+		const segmentName = getRandomString();
+
+		await apiHelpers.jsonWebServicesSegmentsEntry.addSegmentsEntry({
+			criteria: {
+				criteria: {
+					user: {
+						conjunction: 'and',
+						filterString: `(emailAddress eq '${user.emailAddress}')`,
+						typeValue: 'model',
+					},
+				},
+				filterString: {
+					model: `(emailAddress eq '${user.emailAddress}')`,
+				},
+			},
+			groupId: site.id,
+			name: segmentName,
+		});
+
+		// Create a content page with a prioritized experience for the segment
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		const experienceName = getRandomString();
+
+		await pageEditorPage.createExperience(experienceName);
+
+		await pageEditorPage.editExperienceSegment(experienceName, segmentName);
+
+		await waitForAlert(
+			page,
+			'Success:The experience was updated successfully.'
+		);
+
+		await pageEditorPage.openExperienceSelector();
+
+		await page
+			.locator('.dropdown-menu__experience', {hasText: experienceName})
+			.getByLabel('Prioritize Experience', {exact: true})
+			.click();
+
+		await pageEditorPage.closeExperienceSelector();
+
+		await pageEditorPage.publishPage();
+
+		// The admin does not match the segment, so the default key is reported
+
+		await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`);
+
+		const metaLocator = page.locator('meta[name="page-experience-key"]');
+
+		await expect(metaLocator).toHaveCount(1);
+
+		await expect(metaLocator).toHaveAttribute('content', 'DEFAULT');
+
+		// Get the experience key
+
+		const urlSearchParams = new URLSearchParams();
+
+		urlSearchParams.append('active', 'true');
+		urlSearchParams.append('groupId', site.id);
+		urlSearchParams.append('plid', layout.id);
+
+		const segmentsExperiences = await apiHelpers.post(
+			SEGMENTS_EXPERIENCES_URL,
+			{
+				data: urlSearchParams.toString(),
+				failOnStatusCode: true,
+				headers: await apiHelpers.getJSONWebServicesHeaders(),
+			}
+		);
+
+		const segmentsExperience = segmentsExperiences.find(
+			(experience: {segmentsExperienceKey: string}) =>
+				experience.segmentsExperienceKey !== 'DEFAULT'
+		);
+
+		// View the page as the segment-matching user
+
+		await performUserSwitchViaApi(page, user.alternateName);
+
+		await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`);
+
+		await expect(metaLocator).toHaveCount(1);
+
+		await expect(metaLocator).toHaveAttribute(
+			'content',
+			segmentsExperience.segmentsExperienceKey
+		);
+
+		// Switch back to the admin so cleanup runs with the right permissions
+
+		await performUserSwitchViaApi(page, 'test');
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93663

Asked for a review from AC team: https://liferay.atlassian.net/browse/LPD-86280?focusedCommentId=5113178

## What Is Being Fixed

The Analytics Cloud page view event captured page metadata (title, description, keywords, language, ...) but had no way to know which segments experience a visitor was served. Without that key, page view data could not be attributed to the specific experience that produced the page.

## How It Is Being Fixed

A new `SegmentsExperienceTopHeadDynamicInclude` writes the active segments experience key into the page head as a `<meta name="page-experience-key">` tag, resolving the current experience for the layout (falling back to the default experience key). The analytics client's meta middleware then reads that tag and adds `pageExperienceKey` to the page view event context, so every page view event carries the experience it was rendered under.

## PR Check

**pr-check: FAIL** — tested on `0e9b2b18a8fadbec402c228504edbceabab1f3e7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | FAIL |
| JavaScript Unit Tests | PASS |

The Structural Smoke failure (`Log4jConfigUtilTest`, code coverage assertion on `Log4jConfigUtil`) is pre-existing on master from LPD-82616 — this branch touches no portal-kernel files. All branch-relevant validations pass; the new context property is covered by the analytics-client-js middleware Jest suite (202 passed).

<!-- pr-check {"result": "failure", "sha": "0e9b2b18a8fadbec402c228504edbceabab1f3e7"} -->
