### PR TITLE
LPD-93309 Track CMS assets as object entries in analytics

### DIFF
--- a/modules/apps/analytics/analytics-asset-api/src/main/java/com/liferay/analytics/asset/AssetAnalyticsAttributesProvider.java
+++ b/modules/apps/analytics/analytics-asset-api/src/main/java/com/liferay/analytics/asset/AssetAnalyticsAttributesProvider.java
@@ -67,15 +67,7 @@ public class AssetAnalyticsAttributesProvider {
 	}
 
 	private String _getAnalyticsCMSVersion() {
-		String className = _assetEntry.getClassName();
-
-		if (!className.startsWith(_CLASS_NAME_OBJECT_DEFINITION)) {
-			return "1.0";
-		}
-
-		ObjectDefinition objectDefinition =
-			ObjectDefinitionLocalServiceUtil.fetchObjectDefinitionByClassName(
-				_assetEntry.getCompanyId(), className);
+		ObjectDefinition objectDefinition = _getObjectDefinition();
 
 		if ((objectDefinition != null) && objectDefinition.isCMS()) {
 			return "2.0";
@@ -98,6 +90,22 @@ public class AssetAnalyticsAttributesProvider {
 		return null;
 	}
 
+	private String _getAnalyticsObjectDefinitionName() {
+		ObjectDefinition objectDefinition = _getObjectDefinition();
+
+		if (objectDefinition == null) {
+			return null;
+		}
+
+		String name = objectDefinition.getName();
+
+		if (Validator.isNull(name)) {
+			return null;
+		}
+
+		return TextFormatter.format(name, TextFormatter.K);
+	}
+
 	private String _getAnalyticsSubtype() {
 		if (_assetRenderer == null) {
 			return null;
@@ -116,19 +124,6 @@ public class AssetAnalyticsAttributesProvider {
 		String className = _assetEntry.getClassName();
 
 		if (className.startsWith(_CLASS_NAME_OBJECT_DEFINITION)) {
-			ObjectDefinition objectDefinition =
-				ObjectDefinitionLocalServiceUtil.
-					fetchObjectDefinitionByClassName(
-						_assetEntry.getCompanyId(), className);
-
-			if (objectDefinition != null) {
-				String name = objectDefinition.getName();
-
-				if (Validator.isNotNull(name)) {
-					return TextFormatter.format(name, TextFormatter.K);
-				}
-			}
-
 			return "object-entry";
 		}
 
@@ -161,7 +156,28 @@ public class AssetAnalyticsAttributesProvider {
 		).put(
 			"analytics-external-reference-code",
 			() -> _getAnalyticsExternalReferenceCode()
+		).put(
+			"analytics-object-definition-name",
+			() -> _getAnalyticsObjectDefinitionName()
 		).build();
+	}
+
+	private ObjectDefinition _getObjectDefinition() {
+		if (_objectDefinition != null) {
+			return _objectDefinition;
+		}
+
+		String className = _assetEntry.getClassName();
+
+		if (!className.startsWith(_CLASS_NAME_OBJECT_DEFINITION)) {
+			return null;
+		}
+
+		_objectDefinition =
+			ObjectDefinitionLocalServiceUtil.fetchObjectDefinitionByClassName(
+				_assetEntry.getCompanyId(), className);
+
+		return _objectDefinition;
 	}
 
 	private boolean _isAnalyticsEnabled() {
@@ -206,5 +222,6 @@ public class AssetAnalyticsAttributesProvider {
 	private final AssetEntry _assetEntry;
 	private final AssetRenderer<?> _assetRenderer;
 	private final Locale _locale;
+	private ObjectDefinition _objectDefinition;
 
 }

--- a/modules/apps/analytics/analytics-asset-api/src/main/java/com/liferay/analytics/asset/AssetAnalyticsAttributesProvider.java
+++ b/modules/apps/analytics/analytics-asset-api/src/main/java/com/liferay/analytics/asset/AssetAnalyticsAttributesProvider.java
@@ -66,16 +66,6 @@ public class AssetAnalyticsAttributesProvider {
 		return HtmlUtil.buildData(_getAttributes(action, field));
 	}
 
-	private String _getAnalyticsCMSVersion() {
-		ObjectDefinition objectDefinition = _getObjectDefinition();
-
-		if ((objectDefinition != null) && objectDefinition.isCMS()) {
-			return "2.0";
-		}
-
-		return "1.0";
-	}
-
 	private String _getAnalyticsExternalReferenceCode() {
 		if (_assetRenderer == null) {
 			return null;
@@ -139,8 +129,6 @@ public class AssetAnalyticsAttributesProvider {
 	private Map<String, Object> _getAttributes(String action, String field) {
 		return TreeMapBuilder.<String, Object>put(
 			"analytics-asset-action", () -> action
-		).put(
-			"analytics-asset-cmsversion", () -> _getAnalyticsCMSVersion()
 		).put(
 			"analytics-asset-field", () -> field
 		).put(

--- a/modules/apps/analytics/analytics-asset-api/src/test/java/com/liferay/analytics/asset/AssetAnalyticsAttributesProviderTest.java
+++ b/modules/apps/analytics/analytics-asset-api/src/test/java/com/liferay/analytics/asset/AssetAnalyticsAttributesProviderTest.java
@@ -59,7 +59,6 @@ public class AssetAnalyticsAttributesProviderTest {
 	@Test
 	@TestInfo("LPD-83537")
 	public void testBuildAttributes() {
-		_testBuildAttributesCMSVersion();
 		_testBuildAttributesForBlogsEntry();
 		_testBuildAttributesForDLFileEntry();
 		_testBuildAttributesForJournalArticle();
@@ -68,19 +67,6 @@ public class AssetAnalyticsAttributesProviderTest {
 		_testBuildAttributesWithoutAssetRenderer();
 		_testBuildAttributesWithoutField();
 		_testBuildAttributesWithoutLocale();
-	}
-
-	private void _assertCMSVersion(
-		AssetAnalyticsAttributesProvider assetAnalyticsAttributesProvider,
-		String expectedVersion) {
-
-		String attributes = assetAnalyticsAttributesProvider.buildAttributes(
-			AssetAnalyticsAttributesProvider.ACTION_VIEW,
-			AssetAnalyticsAttributesProvider.FIELD_CONTENT);
-
-		Assert.assertTrue(
-			attributes.contains(
-				"analytics-asset-cmsversion=\"" + expectedVersion + "\""));
 	}
 
 	private void _assertObjectDefinitionName(
@@ -152,54 +138,6 @@ public class AssetAnalyticsAttributesProviderTest {
 		);
 
 		return assetRenderer;
-	}
-
-	private void _testBuildAttributesCMSVersion() {
-		String className = "com.liferay.object.model.ObjectDefinition#42";
-		long companyId = RandomTestUtil.randomLong();
-
-		AssetEntry assetEntry = _mockAssetEntry(
-			className, RandomTestUtil.randomLong(), companyId);
-
-		AssetAnalyticsAttributesProvider assetAnalyticsAttributesProvider =
-			new AssetAnalyticsAttributesProvider(assetEntry, null, null);
-
-		ObjectDefinition objectDefinition = Mockito.mock(
-			ObjectDefinition.class);
-
-		_objectDefinitionLocalServiceUtilMockedStatic.when(
-			() ->
-				ObjectDefinitionLocalServiceUtil.
-					fetchObjectDefinitionByClassName(companyId, className)
-		).thenReturn(
-			objectDefinition
-		);
-
-		Mockito.when(
-			objectDefinition.isCMS()
-		).thenReturn(
-			true
-		);
-
-		_assertCMSVersion(assetAnalyticsAttributesProvider, "2.0");
-
-		Mockito.when(
-			objectDefinition.isCMS()
-		).thenReturn(
-			false
-		);
-
-		_assertCMSVersion(assetAnalyticsAttributesProvider, "1.0");
-
-		_objectDefinitionLocalServiceUtilMockedStatic.when(
-			() ->
-				ObjectDefinitionLocalServiceUtil.
-					fetchObjectDefinitionByClassName(companyId, className)
-		).thenReturn(
-			null
-		);
-
-		_assertCMSVersion(assetAnalyticsAttributesProvider, "1.0");
 	}
 
 	private void _testBuildAttributesForBlogsEntry() {
@@ -279,8 +217,6 @@ public class AssetAnalyticsAttributesProviderTest {
 			attributes.contains(
 				"analytics-asset-action=\"" +
 					AssetAnalyticsAttributesProvider.ACTION_VIEW + "\""));
-		Assert.assertTrue(
-			attributes.contains("analytics-asset-cmsversion=\"1.0\""));
 		Assert.assertTrue(
 			attributes.contains(
 				"analytics-asset-field=\"" +

--- a/modules/apps/analytics/analytics-asset-api/src/test/java/com/liferay/analytics/asset/AssetAnalyticsAttributesProviderTest.java
+++ b/modules/apps/analytics/analytics-asset-api/src/test/java/com/liferay/analytics/asset/AssetAnalyticsAttributesProviderTest.java
@@ -63,7 +63,7 @@ public class AssetAnalyticsAttributesProviderTest {
 		_testBuildAttributesForBlogsEntry();
 		_testBuildAttributesForDLFileEntry();
 		_testBuildAttributesForJournalArticle();
-		_testBuildAttributesTypeForObjectEntry();
+		_testBuildAttributesForObjectEntry();
 		_testBuildAttributesWithoutAssetEntry();
 		_testBuildAttributesWithoutAssetRenderer();
 		_testBuildAttributesWithoutField();
@@ -81,6 +81,26 @@ public class AssetAnalyticsAttributesProviderTest {
 		Assert.assertTrue(
 			attributes.contains(
 				"analytics-asset-cmsversion=\"" + expectedVersion + "\""));
+	}
+
+	private void _assertObjectDefinitionName(
+		AssetAnalyticsAttributesProvider assetAnalyticsAttributesProvider,
+		String expectedObjectDefinitionName) {
+
+		String attributes = assetAnalyticsAttributesProvider.buildAttributes(
+			AssetAnalyticsAttributesProvider.ACTION_VIEW,
+			AssetAnalyticsAttributesProvider.FIELD_CONTENT);
+
+		if (expectedObjectDefinitionName == null) {
+			Assert.assertFalse(
+				attributes.contains("analytics-object-definition-name="));
+		}
+		else {
+			Assert.assertTrue(
+				attributes.contains(
+					"analytics-object-definition-name=\"" +
+						expectedObjectDefinitionName + "\""));
+		}
 	}
 
 	private void _assertType(
@@ -279,7 +299,7 @@ public class AssetAnalyticsAttributesProviderTest {
 			attributes.contains("analytics-asset-type=\"web-content\""));
 	}
 
-	private void _testBuildAttributesTypeForObjectEntry() {
+	private void _testBuildAttributesForObjectEntry() {
 		String className = "com.liferay.object.model.ObjectDefinition#42";
 		long companyId = RandomTestUtil.randomLong();
 
@@ -306,7 +326,9 @@ public class AssetAnalyticsAttributesProviderTest {
 			"MyCMSType"
 		);
 
-		_assertType(assetAnalyticsAttributesProvider, "my-cms-type");
+		_assertObjectDefinitionName(
+			assetAnalyticsAttributesProvider, "my-cms-type");
+		_assertType(assetAnalyticsAttributesProvider, "object-entry");
 
 		Mockito.when(
 			objectDefinition.getName()
@@ -314,6 +336,7 @@ public class AssetAnalyticsAttributesProviderTest {
 			null
 		);
 
+		_assertObjectDefinitionName(assetAnalyticsAttributesProvider, null);
 		_assertType(assetAnalyticsAttributesProvider, "object-entry");
 	}
 

--- a/modules/test/playwright/tests/asset-publisher-web/main/assetPublisherAnalyticsAttributes.spec.ts
+++ b/modules/test/playwright/tests/asset-publisher-web/main/assetPublisherAnalyticsAttributes.spec.ts
@@ -243,7 +243,7 @@ test(
 
 		await expect(
 			page.getByText(
-				'Builds the data-analytics-asset-* attributes for an asset entry.'
+				'Build the data-analytics-asset-* attributes for an asset entry.'
 			)
 		).toBeVisible();
 

--- a/modules/test/playwright/tests/asset-publisher-web/main/assetPublisherAnalyticsAttributes.spec.ts
+++ b/modules/test/playwright/tests/asset-publisher-web/main/assetPublisherAnalyticsAttributes.spec.ts
@@ -7,12 +7,14 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
 import {assetPublisherPagesTest} from '../../../fixtures/assetPublisherPagesTest';
+import {collectionsPagesTest} from '../../../fixtures/collectionsPagesTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
 import getRandomString from '../../../utils/getRandomString';
 import getBasicWebContentStructureId from '../../../utils/structured-content/getBasicWebContentStructureId';
+import {waitForAlert} from '../../../utils/waitForAlert';
 import getPageDefinition from '../../layout-content-page-editor-web/main/utils/getPageDefinition';
 import getWidgetDefinition from '../../layout-content-page-editor-web/main/utils/getWidgetDefinition';
 import {templatesPageTest} from '../../template-web/main/fixtures/templatesPageTest';
@@ -25,7 +27,9 @@ const ANALYTICS_CONFIGURATION_URL = `/o/headless-admin-configuration/v1.0/instan
 const test = mergeTests(
 	apiHelpersTest,
 	assetPublisherPagesTest,
+	collectionsPagesTest,
 	featureFlagsTest({
+		'LPD-17564': {enabled: true},
 		'LPD-65399': {enabled: true},
 		'LPD-81914': {enabled: true},
 		'LPS-155284': {enabled: true},
@@ -212,6 +216,145 @@ test(
 				`${name}: no analytics attributes in edit mode`
 			).toHaveCount(0);
 		}
+	}
+);
+
+test(
+	'Emits object entry analytics attributes for CMS basic web content',
+	{
+		tag: '@LPD-93309',
+	},
+	async ({
+		apiHelpers,
+		assetPublisherPage,
+		collectionsPage,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+		test.slow();
+
+		// Create a space and connect it to the site
+
+		const space = await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			externalReferenceCode: getRandomString(),
+			name: `Space ${getRandomString()}`,
+			settings: {},
+			type: 'Space',
+		});
+
+		await apiHelpers.headlessAssetLibrary.connectSite(
+			space.externalReferenceCode,
+			site.externalReferenceCode
+		);
+
+		// Add a CMS basic web content entry to the space
+
+		const title = getRandomString();
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{title},
+			'cms/basic-web-contents',
+			space.externalReferenceCode
+		);
+
+		// Create a dynamic collection on the site scoped to the space
+
+		const collectionName = getRandomString();
+
+		await collectionsPage.goto(site.friendlyUrlPath);
+
+		await collectionsPage.addNewDynamicCollection(collectionName);
+
+		await page
+			.getByLabel('Item Type')
+			.selectOption({label: 'Basic Web Content (CMS)'});
+
+		await page.getByRole('button', {name: 'Scope'}).click();
+
+		await page.getByRole('button', {name: 'Select Site'}).click();
+
+		await page
+			.getByRole('menuitem', {name: 'Other Site, Asset Library, or'})
+			.click();
+
+		const scopeIframe = page
+			.locator('iframe[title="Scope"]')
+			.contentFrame();
+
+		await scopeIframe.getByRole('link', {name: 'Spaces'}).click();
+
+		await scopeIframe
+			.getByRole('link', {exact: true, name: space.name})
+			.click();
+
+		await page.getByRole('button', {name: 'Save'}).click();
+
+		await waitForAlert(page, undefined, {autoClose: false, first: true});
+
+		// Add an Asset Publisher widget to a site page
+
+		const widgetId = getRandomString();
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				getWidgetDefinition({
+					id: widgetId,
+					widgetName:
+						'com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet',
+				}),
+			]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		// Configure the widget to display the dynamic collection
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.goToWidgetConfiguration(widgetId);
+
+		await assetPublisherPage.openAssetSelectionTab();
+
+		await assetPublisherPage.configurationIframe
+			.getByRole('button', {exact: true, name: 'Select Collection'})
+			.click();
+
+		await assetPublisherPage.configurationIframe
+			.frameLocator('iframe[title="Select Collection"]')
+			.getByRole('button', {name: `Select ${collectionName}`})
+			.click();
+
+		await assetPublisherPage.saveConfiguration();
+
+		await assetPublisherPage.closeConfiguration();
+
+		// Publish the page and assert the rendered analytics attributes
+
+		await page.getByLabel('Publish', {exact: true}).click();
+
+		await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`);
+
+		const titleLocator = page
+			.locator(`[data-analytics-asset-title="${title}"]`)
+			.first();
+
+		await expect(titleLocator).toBeVisible();
+
+		await expect(titleLocator).toHaveAttribute(
+			'data-analytics-asset-type',
+			'object-entry'
+		);
+
+		await expect(titleLocator).toHaveAttribute(
+			'data-analytics-external-reference-code',
+			/.+/
+		);
+
+		await expect(titleLocator).toHaveAttribute(
+			'data-analytics-object-definition-name',
+			'cms-basic-web-content'
+		);
 	}
 );
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93309

## What Is Being Fixed

CMS assets (such as CMS basic web content) are stored as object entries, but the Analytics SDK only recognizes its predefined asset types. These entries were reported under their kebab-cased object definition name (e.g. `cms-basic-web-content`), which the SDK does not know about, so CMS objects were not tracked correctly. The page also emitted an `analytics-asset-cmsversion` attribute that Analytics Cloud never consumed.

## How It Is Being Fixed

The `analytics-asset-type` attribute is hardcoded to `object-entry` for object entries, and the object definition name moves to a new `analytics-object-definition-name` attribute (as agreed on LPD-81915), so the SDK tracks the entry by a type it recognizes while still carrying the specific definition. The unused `analytics-asset-cmsversion` attribute is removed, since type, subtype, and object definition name already distinguish CMS from classic assets. Unit tests cover the object-definition-name and CMS basic web content cases, and the Asset Publisher Playwright spec exercises the rendered attributes end to end.

Validated by the AC team in https://github.com/interaminense/liferay-portal/pull/486.

## PR Check

**pr-check: FAIL** — tested on `92ab3041f23aaed9fc418ce69d0e734b60554411`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | FAIL |
| Java Unit Tests | PASS |

The Structural Smoke failure (`Log4jConfigUtilTest`, code coverage assertion on `Log4jConfigUtil`) is pre-existing on master from LPD-82616 — this branch touches no portal-kernel files. All branch-relevant validations pass.

<!-- pr-check {"result": "failure", "sha": "92ab3041f23aaed9fc418ce69d0e734b60554411"} -->
