### PR TITLE
LPD-93856 Prevent phone number prefix dropdown from being clipped

### DIFF
--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.css
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.css
@@ -15,6 +15,7 @@
 	max-height: 18rem;
 	min-width: 16rem;
 	overflow-y: auto;
+	position: fixed;
 }
 
 .phone-number-input-prefix-menu.show {

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.js
@@ -126,14 +126,45 @@ async function main() {
 		}
 	}
 
-	function togglePrefixMenu(open) {
-		const next =
-			typeof open === 'boolean'
-				? open
+	function togglePrefixMenu(forceOpen) {
+		const open =
+			typeof forceOpen === 'boolean'
+				? forceOpen
 				: !prefixMenu.classList.contains('show');
 
-		prefixMenu.classList.toggle('show', next);
-		prefixTrigger.setAttribute('aria-expanded', next);
+		prefixMenu.classList.toggle('show', open);
+		prefixTrigger.setAttribute('aria-expanded', open);
+
+		if (open) {
+			positionPrefixMenu();
+		}
+	}
+
+	function positionPrefixMenu() {
+		if (!document.body.contains(fragmentElement)) {
+			window.removeEventListener('resize', positionPrefixMenu);
+			window.removeEventListener('scroll', positionPrefixMenu, {
+				capture: true,
+			});
+
+			return;
+		}
+
+		if (!prefixMenu.classList.contains('show')) {
+			return;
+		}
+
+		const triggerRect = prefixTrigger.getBoundingClientRect();
+		const menuHeight = prefixMenu.offsetHeight;
+		const spaceBelow = window.innerHeight - triggerRect.bottom;
+
+		const top =
+			spaceBelow < menuHeight && triggerRect.top > menuHeight
+				? triggerRect.top - menuHeight
+				: triggerRect.bottom;
+
+		prefixMenu.style.top = `${top}px`;
+		prefixMenu.style.left = `${triggerRect.left}px`;
 	}
 
 	function syncFromValue(value) {
@@ -233,6 +264,11 @@ async function main() {
 		prefixMenu.addEventListener('click', handleMenuClick);
 
 		document.addEventListener('click', handleDocumentClick);
+
+		window.addEventListener('resize', positionPrefixMenu);
+		window.addEventListener('scroll', positionPrefixMenu, {
+			capture: true,
+		});
 	}
 
 	// Register input

--- a/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/phoneNumberField.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/phoneNumberField.spec.ts
@@ -12,6 +12,7 @@ import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import {getRandomInt} from '../../../utils/getRandomInt';
 import getRandomString from '../../../utils/getRandomString';
+import {waitForAlert} from '../../../utils/waitForAlert';
 import {cmsPagesTest} from '../main/fixtures/cmsPagesTest';
 import {structureBuilderPagesTest} from './fixtures/structureBuilderPagesTest';
 import {FieldType} from './pages/StructureBuilderPage';
@@ -185,5 +186,116 @@ test(
 		await contentsPage.goto();
 
 		await contentsPage.deleteContent(contentTitle);
+	}
+);
+
+test(
+	'Phone prefix dropdown is not clipped when the form is nested in a grid',
+	{tag: '@LPD-93856'},
+	async ({contentsPage, page, pageEditorPage, structureBuilderPage}) => {
+		const structureLabel = `Structure${getRandomInt()}`;
+
+		// Create a structure with a Phone Number field
+
+		await structureBuilderPage.createStructureFromData({
+			label: structureLabel,
+			name: structureLabel,
+			page: structureBuilderPage,
+		});
+
+		await structureBuilderPage.addField('Phone Number' as FieldType);
+
+		const structureId = await structureBuilderPage.publishStructure();
+
+		// Customize the editor, add a grid and move the Form Container into one
+		// of its modules
+
+		await structureBuilderPage.editStructure(structureId);
+
+		await structureBuilderPage.customizeEditor();
+
+		await pageEditorPage.addFragment('Layout Elements', 'Grid');
+
+		// Move the Form Container into the first grid module
+
+		await pageEditorPage.dragAndDropFragment({
+			dragTarget: page.locator(
+				'.page-editor__topper[data-name="Form Container"]'
+			),
+			dropTarget: page
+				.locator(
+					'.page-editor__topper[data-name="Grid"] .page-editor__col'
+				)
+				.first(),
+			page,
+		});
+
+		await pageEditorPage.waitForChangesSaved();
+
+		await expect(
+			page
+				.locator('.page-editor__topper[data-name="Grid"]')
+				.locator('.page-editor__topper[data-name="Form Container"]')
+		).toBeVisible();
+
+		// Publish, confirming the form errors dialog raised by the unmapped
+		// metadata fields of the default form
+
+		await clickAndExpectToBeVisible({
+			target: page.locator('.modal-footer', {hasText: 'Publish'}),
+			timeout: 3000,
+			trigger: pageEditorPage.publishButton,
+		});
+
+		await page.locator('.modal-footer').getByText('Publish').click();
+
+		await waitForAlert(
+			page,
+			'Success:The editor was updated successfully.'
+		);
+
+		// Create content and open the country prefix dropdown
+
+		await contentsPage.goto();
+
+		await contentsPage.createContent(structureLabel);
+
+		const prefixMenu = page.locator('.phone-number-input-prefix-menu');
+
+		await expect(async () => {
+			await page.getByLabel('Country Code').click({timeout: 3000});
+
+			await expect(prefixMenu).toHaveClass(/show/, {timeout: 3000});
+		}).toPass();
+
+		// The dropdown must escape the grid's overflow clipping: every corner of
+		// its bounding box has to resolve to the menu itself. Sampling only the
+		// center would miss a menu clipped at its edges, which is exactly how the
+		// overflow cut it off
+
+		await expect(async () => {
+			const fullyVisible = await prefixMenu.evaluate((menu) => {
+				const rect = menu.getBoundingClientRect();
+				const inset = 4;
+
+				const corners = [
+					[rect.left + inset, rect.top + inset],
+					[rect.right - inset, rect.top + inset],
+					[rect.left + inset, rect.bottom - inset],
+					[rect.right - inset, rect.bottom - inset],
+				];
+
+				return corners.every(([x, y]) => {
+					const point = document.elementFromPoint(
+						Math.round(x),
+						Math.round(y)
+					);
+
+					return Boolean(point) && menu.contains(point);
+				});
+			});
+
+			expect(fullyVisible).toBe(true);
+		}).toPass();
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93856

## What Is Being Fixed

When a Phone Number field's form container is nested inside a grid, the
country code prefix dropdown was clipped by the grid's overflow, so part of
the country list was cut off and unreachable.

## How It Is Being Fixed

The prefix menu is now positioned with `position: fixed` and placed relative
to its trigger in JavaScript, so it escapes any ancestor's overflow clipping.
A `positionPrefixMenu` routine recomputes the menu's top/left whenever it
opens, flipping above the trigger when there is not enough space below, and
listens for scroll and resize events to keep it anchored while open. The
listeners detach once the fragment leaves the DOM. A Playwright test
reproduces the grid-nested layout and asserts every corner of the open
dropdown resolves to the menu itself, which fails without the fix.

## PR Check

**pr-check: PASS** — tested on `a04085a784de61c17e48a4ce0542fee0cab39724`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |

<!-- pr-check {"result": "success", "sha": "a04085a784de61c17e48a4ce0542fee0cab39724"} -->
