### PR TITLE
LPD-75909 Limit stored FragmentEntryVersion rows per fragment entry

### DIFF
--- a/modules/apps/fragment/fragment-api/bnd.bnd
+++ b/modules/apps/fragment/fragment-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Fragment API
 Bundle-SymbolicName: com.liferay.fragment.api
-Bundle-Version: 62.0.1
+Bundle-Version: 62.1.0
 Export-Package:\
 	com.liferay.fragment.cache,\
 	com.liferay.fragment.configuration,\

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalService.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalService.java
@@ -96,6 +96,8 @@ public interface FragmentEntryLocalService
 			FragmentEntry publishedFragmentEntry, int version)
 		throws PortalException;
 
+	public void cleanUpFragmentEntryVersions(long companyId);
+
 	public FragmentEntry copyFragmentEntry(
 			long userId, long groupId, long sourceFragmentEntryId,
 			long fragmentCollectionId, ServiceContext serviceContext)
@@ -505,4 +507,4 @@ public interface FragmentEntryLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1870565390
+// LIFERAY-SERVICE-BUILDER-HASH:2000710867

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalServiceUtil.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalServiceUtil.java
@@ -75,6 +75,10 @@ public class FragmentEntryLocalServiceUtil {
 		return getService().checkout(publishedFragmentEntry, version);
 	}
 
+	public static void cleanUpFragmentEntryVersions(long companyId) {
+		getService().cleanUpFragmentEntryVersions(companyId);
+	}
+
 	public static FragmentEntry copyFragmentEntry(
 			long userId, long groupId, long sourceFragmentEntryId,
 			long fragmentCollectionId,
@@ -632,4 +636,4 @@ public class FragmentEntryLocalServiceUtil {
 			FragmentEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1358558076
+// LIFERAY-SERVICE-BUILDER-HASH:2133405135

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalServiceWrapper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalServiceWrapper.java
@@ -75,6 +75,11 @@ public class FragmentEntryLocalServiceWrapper
 	}
 
 	@Override
+	public void cleanUpFragmentEntryVersions(long companyId) {
+		_fragmentEntryLocalService.cleanUpFragmentEntryVersions(companyId);
+	}
+
+	@Override
 	public FragmentEntry copyFragmentEntry(
 			long userId, long groupId, long sourceFragmentEntryId,
 			long fragmentCollectionId,
@@ -760,4 +765,4 @@ public class FragmentEntryLocalServiceWrapper
 	private FragmentEntryLocalService _fragmentEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1282295569
+// LIFERAY-SERVICE-BUILDER-HASH:-641285732

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
@@ -1,1 +1,1 @@
-version 17.0.0
+version 17.1.0

--- a/modules/apps/fragment/fragment-service/bnd.bnd
+++ b/modules/apps/fragment/fragment-service/bnd.bnd
@@ -5,6 +5,6 @@ Import-Package:\
 	com.liferay.fragment.util.comparator,\
 	\
 	*
-Liferay-Require-SchemaVersion: 3.0.2
+Liferay-Require-SchemaVersion: 3.0.3
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/scheduler/CleanUpFragmentEntryVersionsSchedulerJobConfiguration.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/scheduler/CleanUpFragmentEntryVersionsSchedulerJobConfiguration.java
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.scheduler;
+
+import com.liferay.fragment.service.FragmentEntryLocalService;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.portal.kernel.scheduler.SchedulerJobConfiguration;
+import com.liferay.portal.kernel.scheduler.TimeUnit;
+import com.liferay.portal.kernel.scheduler.TriggerConfiguration;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Georgel Pop
+ */
+@Component(service = SchedulerJobConfiguration.class)
+public class CleanUpFragmentEntryVersionsSchedulerJobConfiguration
+	implements SchedulerJobConfiguration {
+
+	@Override
+	public UnsafeConsumer<Long, Exception>
+		getCompanyJobExecutorUnsafeConsumer() {
+
+		return _fragmentEntryLocalService::cleanUpFragmentEntryVersions;
+	}
+
+	@Override
+	public UnsafeRunnable<Exception> getJobExecutorUnsafeRunnable() {
+		return () -> _companyLocalService.forEachCompanyId(
+			_fragmentEntryLocalService::cleanUpFragmentEntryVersions);
+	}
+
+	@Override
+	public TriggerConfiguration getTriggerConfiguration() {
+		return TriggerConfiguration.createTriggerConfiguration(1, TimeUnit.DAY);
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private FragmentEntryLocalService _fragmentEntryLocalService;
+
+}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/registry/FragmentServiceUpgradeStepRegistrator.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/registry/FragmentServiceUpgradeStepRegistrator.java
@@ -14,6 +14,7 @@ import com.liferay.fragment.internal.upgrade.v2_1_0.SchemaUpgradeProcess;
 import com.liferay.fragment.internal.upgrade.v2_4_0.FragmentEntryLinkUpgradeProcess;
 import com.liferay.fragment.internal.upgrade.v3_0_1.BrowserSnifferFragmentEntryTemplateUpgradeProcess;
 import com.liferay.fragment.internal.upgrade.v3_0_2.FragmentEntryHTMLUpgradeProcess;
+import com.liferay.fragment.internal.util.FragmentEntryVersionCleanupUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
@@ -276,6 +277,11 @@ public class FragmentServiceUpgradeStepRegistrator
 
 		registry.register(
 			"3.0.1", "3.0.2", new FragmentEntryHTMLUpgradeProcess());
+
+		registry.register(
+			"3.0.2", "3.0.3",
+			UpgradeProcessFactory.runSQL(
+				FragmentEntryVersionCleanupUtil.getCleanupSQL()));
 	}
 
 	@Reference

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/util/FragmentEntryVersionCleanupUtil.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/util/FragmentEntryVersionCleanupUtil.java
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.util;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+
+/**
+ * @author Georgel Pop
+ */
+public class FragmentEntryVersionCleanupUtil {
+
+	public static String getCleanupSQL() {
+		return _getCleanupSQL(StringPool.BLANK);
+	}
+
+	public static String getCleanupSQL(long companyId) {
+		return _getCleanupSQL(" where companyId = " + companyId);
+	}
+
+	private static String _getCleanupSQL(String whereClause) {
+		return StringBundler.concat(
+			"delete from FragmentEntryVersion where fragmentEntryVersionId in ",
+			"(select fragmentEntryVersionId from (select ",
+			"fragmentEntryVersionId, row_number() over (partition by ",
+			"ctCollectionId, fragmentEntryId order by version desc) ",
+			"versionRowNumber from FragmentEntryVersion", whereClause,
+			") tempFragmentEntryVersion where ",
+			"tempFragmentEntryVersion.versionRowNumber > ",
+			_FRAGMENT_ENTRY_VERSIONS_COUNT_MAX, ")");
+	}
+
+	private static final int _FRAGMENT_ENTRY_VERSIONS_COUNT_MAX = 10;
+
+}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
@@ -13,6 +13,7 @@ import com.liferay.fragment.exception.DuplicateFragmentEntryKeyException;
 import com.liferay.fragment.exception.FragmentEntryNameException;
 import com.liferay.fragment.exception.NoSuchEntryException;
 import com.liferay.fragment.exception.RequiredFragmentEntryException;
+import com.liferay.fragment.internal.util.FragmentEntryVersionCleanupUtil;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.model.FragmentEntryLink;
@@ -164,6 +165,21 @@ public class FragmentEntryLocalServiceImpl
 		}
 
 		return updatedDraftFragmentEntry;
+	}
+
+	@Override
+	public void cleanUpFragmentEntryVersions(long companyId) {
+		try {
+			runSQL(FragmentEntryVersionCleanupUtil.getCleanupSQL(companyId));
+
+			fragmentEntryVersionPersistence.clearCache();
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to clean up fragment entry versions", exception);
+			}
+		}
 	}
 
 	@Override

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/scheduler/test/CleanUpFragmentEntryVersionsSchedulerJobConfigurationTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/scheduler/test/CleanUpFragmentEntryVersionsSchedulerJobConfigurationTest.java
@@ -1,0 +1,103 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.scheduler.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.change.tracking.constants.CTConstants;
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.test.util.FragmentEntryVersionTestUtil;
+import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.scheduler.SchedulerJobConfiguration;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Georgel Pop
+ */
+@RunWith(Arquillian.class)
+public class CleanUpFragmentEntryVersionsSchedulerJobConfigurationTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testCleanUpFragmentEntryVersions() throws Throwable {
+		FragmentEntry fragmentEntry1 =
+			FragmentEntryVersionTestUtil.addFragmentEntry(_group.getGroupId());
+		FragmentEntry fragmentEntry2 =
+			FragmentEntryVersionTestUtil.addFragmentEntry(_group.getGroupId());
+
+		long ctCollectionId = RandomTestUtil.randomLong();
+
+		FragmentEntryVersionTestUtil.insertFragmentEntryVersions(
+			FragmentEntryVersionTestUtil.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX + 5,
+			CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry1);
+		FragmentEntryVersionTestUtil.insertFragmentEntryVersions(
+			FragmentEntryVersionTestUtil.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX + 3,
+			ctCollectionId, fragmentEntry1);
+		FragmentEntryVersionTestUtil.insertFragmentEntryVersions(
+			FragmentEntryVersionTestUtil.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX - 1,
+			CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry2);
+
+		List<Integer> versions = FragmentEntryVersionTestUtil.getVersions(
+			fragmentEntry1);
+
+		UnsafeRunnable<Exception> jobExecutorUnsafeRunnable =
+			_schedulerJobConfiguration.getJobExecutorUnsafeRunnable();
+
+		jobExecutorUnsafeRunnable.run();
+
+		Assert.assertEquals(
+			FragmentEntryVersionTestUtil.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
+			FragmentEntryVersionTestUtil.countVersions(
+				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry1));
+		Assert.assertEquals(
+			FragmentEntryVersionTestUtil.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
+			FragmentEntryVersionTestUtil.countVersions(
+				ctCollectionId, fragmentEntry1));
+		Assert.assertEquals(
+			versions.subList(
+				versions.size() -
+					FragmentEntryVersionTestUtil.
+						FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
+				versions.size()),
+			FragmentEntryVersionTestUtil.getVersions(fragmentEntry1));
+		Assert.assertEquals(
+			FragmentEntryVersionTestUtil.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX,
+			FragmentEntryVersionTestUtil.countVersions(
+				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry2));
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject(
+		filter = "component.name=com.liferay.fragment.internal.scheduler.CleanUpFragmentEntryVersionsSchedulerJobConfiguration"
+	)
+	private SchedulerJobConfiguration _schedulerJobConfiguration;
+
+}

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v3_0_3/test/FragmentEntryVersionUpgradeProcessTest.java
@@ -1,0 +1,139 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.upgrade.v3_0_3.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.change.tracking.constants.CTConstants;
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.test.util.FragmentEntryVersionTestUtil;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.version.Version;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Georgel Pop
+ */
+@RunWith(Arquillian.class)
+public class FragmentEntryVersionUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		for (int count : new int[] {1, 10, 11, 20}) {
+			_testUpgrade(0, count);
+			_testUpgrade(count, 1);
+		}
+	}
+
+	private void _runUpgrade() throws Exception {
+		_entityCache.clearCache();
+		_multiVMPool.clear();
+
+		for (UpgradeProcess upgradeProcess :
+				UpgradeTestUtil.getUpgradeSteps(
+					_upgradeStepRegistrator, new Version(3, 0, 3))) {
+
+			upgradeProcess.upgrade();
+		}
+
+		_entityCache.clearCache();
+		_multiVMPool.clear();
+	}
+
+	private void _testUpgrade(
+			int ctCollectionVersionsCount, int productionVersionsCount)
+		throws Exception {
+
+		FragmentEntry fragmentEntry =
+			FragmentEntryVersionTestUtil.addFragmentEntry(_group.getGroupId());
+
+		List<Integer> productionVersions = new ArrayList<>(
+			FragmentEntryVersionTestUtil.getVersions(
+				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry));
+
+		long ctCollectionId = RandomTestUtil.randomLong();
+		List<Integer> ctCollectionVersions = new ArrayList<>();
+
+		if (ctCollectionVersionsCount > 0) {
+			ctCollectionVersions =
+				FragmentEntryVersionTestUtil.insertFragmentEntryVersions(
+					ctCollectionVersionsCount, ctCollectionId, fragmentEntry);
+		}
+
+		productionVersions.addAll(
+			FragmentEntryVersionTestUtil.insertFragmentEntryVersions(
+				productionVersionsCount - 1,
+				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry));
+
+		_runUpgrade();
+
+		int max =
+			FragmentEntryVersionTestUtil.FRAGMENT_ENTRY_VERSIONS_COUNT_MAX;
+
+		Assert.assertEquals(
+			productionVersions.subList(
+				Math.max(0, productionVersions.size() - max),
+				productionVersions.size()),
+			FragmentEntryVersionTestUtil.getVersions(
+				CTConstants.CT_COLLECTION_ID_PRODUCTION, fragmentEntry));
+
+		if (ctCollectionVersionsCount > 0) {
+			Assert.assertEquals(
+				ctCollectionVersions.subList(
+					Math.max(0, ctCollectionVersions.size() - max),
+					ctCollectionVersions.size()),
+				FragmentEntryVersionTestUtil.getVersions(
+					ctCollectionId, fragmentEntry));
+		}
+	}
+
+	@Inject
+	private EntityCache _entityCache;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.fragment.internal.upgrade.registry.FragmentServiceUpgradeStepRegistrator))"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/test/util/FragmentEntryVersionTestUtil.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/test/util/FragmentEntryVersionTestUtil.java
@@ -1,0 +1,203 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.test.util;
+
+import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
+import com.liferay.fragment.constants.FragmentConstants;
+import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.model.FragmentEntryVersion;
+import com.liferay.fragment.service.FragmentEntryLocalServiceUtil;
+import com.liferay.fragment.service.persistence.FragmentEntryVersionUtil;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
+import com.liferay.portal.kernel.util.OrderByComparatorFactoryUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Rubén Pulido
+ */
+public class FragmentEntryVersionTestUtil {
+
+	public static final int FRAGMENT_ENTRY_VERSIONS_COUNT_MAX = 10;
+
+	public static FragmentEntry addFragmentEntry(long groupId)
+		throws Exception {
+
+		FragmentCollection fragmentCollection =
+			FragmentTestUtil.addFragmentCollection(groupId);
+
+		return FragmentEntryLocalServiceUtil.addFragmentEntry(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(), groupId,
+			fragmentCollection.getFragmentCollectionId(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), false, StringPool.BLANK, null, 0,
+			false, false, FragmentConstants.TYPE_COMPONENT, null,
+			WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext(
+				groupId, TestPropsValues.getUserId()));
+	}
+
+	public static int countVersions(
+			long ctCollectionId, FragmentEntry fragmentEntry)
+		throws Exception {
+
+		try (Connection connection = DataAccess.getConnection();
+
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select count(*) as count from FragmentEntryVersion where " +
+					"ctCollectionId = ? and fragmentEntryId = ?")) {
+
+			preparedStatement.setLong(1, ctCollectionId);
+			preparedStatement.setLong(2, fragmentEntry.getFragmentEntryId());
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				if (resultSet.next()) {
+					return (int)resultSet.getLong("count");
+				}
+
+				return 0;
+			}
+		}
+	}
+
+	public static List<Integer> getVersions(FragmentEntry fragmentEntry)
+		throws Throwable {
+
+		return TransactionInvokerUtil.invoke(
+			_transactionConfig,
+			() -> TransformUtil.transform(
+				FragmentEntryVersionUtil.findByFragmentEntryId(
+					fragmentEntry.getFragmentEntryId(), QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS,
+					OrderByComparatorFactoryUtil.create(
+						"FragmentEntryVersion", "version", true)),
+				FragmentEntryVersion::getVersion));
+	}
+
+	public static List<Integer> getVersions(
+			long ctCollectionId, FragmentEntry fragmentEntry)
+		throws Exception {
+
+		List<Integer> versions = new ArrayList<>();
+
+		try (Connection connection = DataAccess.getConnection();
+
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select version from FragmentEntryVersion where " +
+					"ctCollectionId = ? and fragmentEntryId = ? order by " +
+						"version")) {
+
+			preparedStatement.setLong(1, ctCollectionId);
+			preparedStatement.setLong(2, fragmentEntry.getFragmentEntryId());
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					versions.add(resultSet.getInt("version"));
+				}
+			}
+		}
+
+		return versions;
+	}
+
+	public static List<Integer> insertFragmentEntryVersions(
+			int count, long ctCollectionId, FragmentEntry fragmentEntry)
+		throws Exception {
+
+		List<Integer> versions = new ArrayList<>(count);
+
+		long now = System.currentTimeMillis();
+
+		Timestamp createDateTimestamp = new Timestamp(now);
+
+		try (Connection connection = DataAccess.getConnection();
+
+			PreparedStatement preparedStatement =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					StringBundler.concat(
+						"insert into FragmentEntryVersion (mvccVersion, ",
+						"ctCollectionId, fragmentEntryVersionId, version, ",
+						"fragmentEntryId, groupId, companyId, userId, ",
+						"createDate, modifiedDate, name, status) values (0, ",
+						"?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"))) {
+
+			String className = FragmentEntryVersion.class.getName();
+			int startVersion = _getStartVersion(connection, fragmentEntry);
+
+			for (int i = 0; i < count; i++) {
+				int version = startVersion + i;
+
+				versions.add(version);
+
+				preparedStatement.setLong(1, ctCollectionId);
+				preparedStatement.setLong(
+					2, CounterLocalServiceUtil.increment(className));
+				preparedStatement.setInt(3, version);
+				preparedStatement.setLong(
+					4, fragmentEntry.getFragmentEntryId());
+				preparedStatement.setLong(5, fragmentEntry.getGroupId());
+				preparedStatement.setLong(6, fragmentEntry.getCompanyId());
+				preparedStatement.setLong(7, fragmentEntry.getUserId());
+				preparedStatement.setTimestamp(8, createDateTimestamp);
+				preparedStatement.setTimestamp(9, new Timestamp(now + i));
+				preparedStatement.setString(10, RandomTestUtil.randomString());
+				preparedStatement.setInt(11, WorkflowConstants.STATUS_APPROVED);
+
+				preparedStatement.addBatch();
+			}
+
+			preparedStatement.executeBatch();
+		}
+
+		FragmentEntryVersionUtil.clearCache();
+
+		return versions;
+	}
+
+	private static int _getStartVersion(
+			Connection connection, FragmentEntry fragmentEntry)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select max(version) as maxVersion from FragmentEntryVersion " +
+					"where fragmentEntryId = ?")) {
+
+			preparedStatement.setLong(1, fragmentEntry.getFragmentEntryId());
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				resultSet.next();
+
+				return resultSet.getInt("maxVersion") + 1;
+			}
+		}
+	}
+
+	private static final TransactionConfig _transactionConfig =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRED, new Class<?>[] {Exception.class});
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-75909

## What Is Being Fixed

The FragmentEntryVersion table grows without bound: every fragment edit appends a new version row and nothing ever removes the old ones. Frequently edited fragments accumulate a large number of stale version rows over time, bloating the table.

## How It Is Being Fixed

A cap of ten versions per fragment entry, per change-tracking collection, is enforced. A new FragmentEntryLocalService.cleanUpFragmentEntryVersions(long companyId) method deletes, for every (ctCollectionId, fragmentEntryId) group whose version count exceeds the cap, all but the ten most recent rows. The trim is run as raw SQL (held in FragmentEntryVersionCleanupUtil) rather than a change-tracking-aware query: the scheduled job runs in the production change-tracking context (ctCollectionId 0), so a CT-aware query would only ever see production's rows. Raw SQL trims every change-tracking collection in a single pass, so a publication's versions are counted and trimmed independently of production.

A daily scheduled job, CleanUpFragmentEntryVersionsSchedulerJobConfiguration, invokes the method once per company so the table stays within the cap going forward, and an upgrade step applies the same limit once to existing data. The job takes a company ID because it iterates companies itself via CompanyLocalService.forEachCompanyId and scopes the delete to each, which keeps it correct under database partitioning and avoids redundant full-table passes on a shared schema. The upgrade needs no company ID because the upgrade framework already runs each step once per partition.

## PR Check

**pr-check: PASS** — tested on `6445d49b2d8a4e6d7c991199d82658e52e1c18bb`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "6445d49b2d8a4e6d7c991199d82658e52e1c18bb"} -->
