### PR TITLE
LPD-93455 Allow repeated LAR imports of dynamic-data fragments

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker-test/src/testIntegration/java/com/liferay/fragment/entry/processor/freemarker/test/FreeMarkerFragmentEntryProcessorTest.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker-test/src/testIntegration/java/com/liferay/fragment/entry/processor/freemarker/test/FreeMarkerFragmentEntryProcessorTest.java
@@ -10,6 +10,7 @@ import com.liferay.asset.list.model.AssetListEntry;
 import com.liferay.asset.list.service.AssetListEntryLocalService;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.entry.processor.constants.FragmentEntryProcessorConstants;
 import com.liferay.fragment.exception.FragmentEntryContentException;
@@ -127,6 +128,22 @@ public class FreeMarkerFragmentEntryProcessorTest {
 	@After
 	public void tearDown() {
 		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	public void testAddFragmentEntryWithDynamicDataDuringImport()
+		throws Exception {
+
+		try {
+			ExportImportThreadLocal.setLayoutImportInProcess(true);
+
+			Assert.assertNotNull(
+				_addFragmentEntry(
+					"fragment_entry_with_rest_client_data.html", null));
+		}
+		finally {
+			ExportImportThreadLocal.setLayoutImportInProcess(false);
+		}
 	}
 
 	@Test

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker-test/src/testIntegration/resources/com/liferay/fragment/entry/processor/freemarker/test/dependencies/fragment_entry_with_rest_client_data.html
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker-test/src/testIntegration/resources/com/liferay/fragment/entry/processor/freemarker/test/dependencies/fragment_entry_with_rest_client_data.html
@@ -1,0 +1,9 @@
+[#assign
+	restGetSample = restClient.get("/o/headless-delivery/v1.0/sites/0/site-pages?fields=taxonomyCategoryBriefs")
+]
+
+[#if (restGetSample.taxonomyCategoryBriefs)??]
+	${restGetSample.taxonomyCategoryBriefs}
+[/#if]
+
+<h1>Sample</h1>

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker/src/main/java/com/liferay/fragment/entry/processor/freemarker/FreeMarkerFragmentEntryValidator.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker/src/main/java/com/liferay/fragment/entry/processor/freemarker/FreeMarkerFragmentEntryValidator.java
@@ -5,6 +5,7 @@
 
 package com.liferay.fragment.entry.processor.freemarker;
 
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.fragment.entry.processor.freemarker.internal.configuration.FreeMarkerFragmentEntryProcessorConfiguration;
 import com.liferay.fragment.exception.FragmentEntryContentException;
 import com.liferay.fragment.input.template.parser.InputTemplateNode;
@@ -62,7 +63,8 @@ public class FreeMarkerFragmentEntryValidator
 					CompanyThreadLocal.getCompanyId());
 
 		if (!freeMarkerFragmentEntryProcessorConfiguration.enable() ||
-			!_isFreeMarkerTemplate(html)) {
+			!_isFreeMarkerTemplate(html) ||
+			ExportImportThreadLocal.isImportInProcess()) {
 
 			return;
 		}


### PR DESCRIPTION
# What is this trying to solve?
Ticket: https://liferay.atlassian.net/browse/LPD-93455.

Importing a LAR a second time into the same site fails when a fragment's HTML reads live data (e.g. `restClient.get(...)`), aborting with `FragmentEntryContentException: FreeMarker syntax is invalid ... evaluated to a string: restGetSample`. The first LAR import, ZIP import, and importing with automatic propagation disabled all succeed, only the re-import breaks.

It's not really a syntax error: `restClient.get(...)` returns no live data during validation, so `restGetSample` resolves to a string. The fragment is valid and renders fine at runtime, so failing the import is a false positive. The second import is the lone outlier, so I'm making it succeed like the others.

# How am I fixing it?
The validator validates by *executing* the template against a dummy context, so templates that read live data throw and get reported as invalid syntax. The first import *creates* the fragment (no request on the thread → validation skipped); the second treats it as an *update*, which runs with a request present → validation executes and fails.

The fix: skip this validation while an import is in process (`ExportImportThreadLocal.isImportInProcess()`) in `FreeMarkerFragmentEntryValidator`. Normal authoring still validates.

# How can you verify that it works?
Run the included automated tests.

**pr-check: PASS** — tested on `0fbd0bc75e237c5e77b00d4f655aa29914332d2d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "0fbd0bc75e237c5e77b00d4f655aa29914332d2d"} -->
