### PR TITLE
LPD-94235 Fix the Widget Pages deprecation badge and panel visibility

### DIFF
--- a/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/js/ScopeDropdown.tsx
+++ b/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/js/ScopeDropdown.tsx
@@ -51,7 +51,7 @@ export default function ScopeDropdown({
 						<ClayBadge
 							className="c-ml-2 text-uppercase"
 							displayType="warning"
-							label="deprecated"
+							label={Liferay.Language.get('deprecated')}
 							translucent
 						/>
 					)}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
@@ -29,6 +29,7 @@ const Item = ({item, onClick}) => {
 					{unescapeHTML(item.label)}
 
 					<ClayBadge
+						className="text-uppercase"
 						displayType="warning"
 						label={Liferay.Language.get('deprecated')}
 						translucent

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -1593,8 +1593,9 @@ public class LayoutsAdminDisplayContext {
 					verticalNavItem.setLabel(name);
 				}
 			).add(
-				() -> FeatureFlagManagerUtil.isEnabled(
-					themeDisplay.getCompanyId(), "LPD-76864"),
+				() ->
+					selectLayoutPageTemplateEntryDisplayContext.
+						isShowGlobalTemplates(),
 				verticalNavItem -> {
 					verticalNavItem.setActive(
 						selectLayoutPageTemplateEntryDisplayContext.

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/SelectLayoutPageTemplateEntryDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/SelectLayoutPageTemplateEntryDisplayContext.java
@@ -278,6 +278,12 @@ public class SelectLayoutPageTemplateEntryDisplayContext {
 		_selectedTab = ParamUtil.getString(
 			_httpServletRequest, "selectedTab", "basic-templates");
 
+		if (Objects.equals(_selectedTab, "global-templates") &&
+			!isShowGlobalTemplates()) {
+
+			_selectedTab = "basic-templates";
+		}
+
 		return _selectedTab;
 	}
 
@@ -362,6 +368,16 @@ public class SelectLayoutPageTemplateEntryDisplayContext {
 		}
 
 		return true;
+	}
+
+	public boolean isShowGlobalTemplates() {
+		if (_isWidgetPageFeatureFlagEnabled() &&
+			(getGlobalLayoutPageTemplateEntriesCount() > 0)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private String _getLayoutPageTemplateEntryAddLayoutURL(

--- a/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContextTest.java
+++ b/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContextTest.java
@@ -233,33 +233,50 @@ public class LayoutsAdminDisplayContextTest {
 				1
 			);
 
-			for (boolean featureFlagEnabled : new boolean[] {false, true}) {
-				try (MockedStatic<FeatureFlagManagerUtil>
-						featureFlagManagerUtilMockedStatic = Mockito.mockStatic(
-							FeatureFlagManagerUtil.class)) {
+			SelectLayoutPageTemplateEntryDisplayContext
+				selectLayoutPageTemplateEntryDisplayContext = Mockito.mock(
+					SelectLayoutPageTemplateEntryDisplayContext.class);
 
-					featureFlagManagerUtilMockedStatic.when(
-						() -> FeatureFlagManagerUtil.isEnabled(
-							Mockito.anyLong(), Mockito.eq("LPD-76864"))
-					).thenReturn(
-						featureFlagEnabled
-					);
+			for (boolean showGlobalTemplates : new boolean[] {false, true}) {
+				Mockito.when(
+					selectLayoutPageTemplateEntryDisplayContext.
+						isShowGlobalTemplates()
+				).thenReturn(
+					showGlobalTemplates
+				);
 
-					VerticalNavItemList verticalNavItemList =
-						layoutsAdminDisplayContext.getVerticalNavItemList(
-							Mockito.mock(
-								SelectLayoutPageTemplateEntryDisplayContext.
-									class));
+				for (boolean featureFlagEnabled : new boolean[] {false, true}) {
+					try (MockedStatic<FeatureFlagManagerUtil>
+							featureFlagManagerUtilMockedStatic =
+								Mockito.mockStatic(
+									FeatureFlagManagerUtil.class)) {
 
-					if (featureFlagEnabled) {
+						featureFlagManagerUtilMockedStatic.when(
+							() -> FeatureFlagManagerUtil.isEnabled(
+								Mockito.anyLong(), Mockito.eq("LPD-76864"))
+						).thenReturn(
+							featureFlagEnabled
+						);
+
+						VerticalNavItemList verticalNavItemList =
+							layoutsAdminDisplayContext.getVerticalNavItemList(
+								selectLayoutPageTemplateEntryDisplayContext);
+
+						int expectedNavItemsCount = 1;
+
+						if (showGlobalTemplates) {
+							expectedNavItemsCount++;
+						}
+
+						expectedNavItemsCount++;
+
+						if (featureFlagEnabled) {
+							expectedNavItemsCount++;
+						}
+
 						Assert.assertEquals(
-							verticalNavItemList.toString(), 4,
-							verticalNavItemList.size());
-					}
-					else {
-						Assert.assertEquals(
-							verticalNavItemList.toString(), 2,
-							verticalNavItemList.size());
+							verticalNavItemList.toString(),
+							expectedNavItemsCount, verticalNavItemList.size());
 					}
 				}
 			}

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/LayoutPageTemplatesAdminDisplayContext.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/LayoutPageTemplatesAdminDisplayContext.java
@@ -8,6 +8,9 @@ package com.liferay.layout.page.template.admin.web.internal.display.context;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemListBuilder;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryServiceUtil;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
@@ -121,6 +124,23 @@ public class LayoutPageTemplatesAdminDisplayContext {
 			_liferayPortletRequest, "tabs1", "master-layouts");
 
 		return _tabs1;
+	}
+
+	public boolean isShowWidgetPageTemplates() {
+		int widgetPageTemplateEntriesCount =
+			LayoutPageTemplateEntryServiceUtil.
+				getLayoutPageTemplateEntriesCountByType(
+					_themeDisplay.getScopeGroupId(), 0,
+					LayoutPageTemplateEntryTypeConstants.WIDGET_PAGE);
+
+		if (FeatureFlagManagerUtil.isEnabled(
+				_themeDisplay.getCompanyId(), "LPD-76864") ||
+			(widgetPageTemplateEntriesCount > 0)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private final HttpServletRequest _httpServletRequest;

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -18,7 +18,7 @@ Group scopeGroup = themeDisplay.getScopeGroup();
 	<c:when test='<%= Objects.equals(layoutPageTemplatesAdminDisplayContext.getTabs1(), "master-layouts") %>'>
 		<liferay-util:include page="/view_master_layouts.jsp" servletContext="<%= application %>" />
 	</c:when>
-	<c:when test='<%= Objects.equals(layoutPageTemplatesAdminDisplayContext.getTabs1(), "page-templates") && scopeGroup.isCompany() %>'>
+	<c:when test='<%= Objects.equals(layoutPageTemplatesAdminDisplayContext.getTabs1(), "page-templates") && scopeGroup.isCompany() && layoutPageTemplatesAdminDisplayContext.isShowWidgetPageTemplates() %>'>
 		<liferay-util:include page="/view_layout_prototypes.jsp" servletContext="<%= application %>" />
 	</c:when>
 	<c:when test='<%= Objects.equals(layoutPageTemplatesAdminDisplayContext.getTabs1(), "page-templates") && !scopeGroup.isCompany() %>'>

--- a/modules/apps/layout/layout-page-template-admin-web/src/test/java/com/liferay/layout/page/template/admin/web/internal/display/context/LayoutPageTemplatesAdminDisplayContextTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/test/java/com/liferay/layout/page/template/admin/web/internal/display/context/LayoutPageTemplatesAdminDisplayContextTest.java
@@ -6,6 +6,9 @@
 package com.liferay.layout.page.template.admin.web.internal.display.context;
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryServiceUtil;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -137,6 +140,53 @@ public class LayoutPageTemplatesAdminDisplayContextTest {
 
 		Assert.assertEquals(
 			navigationItems.toString(), 0, navigationItems.size());
+	}
+
+	@Test
+	public void testIsShowWidgetPageTemplates() {
+		for (boolean featureFlagEnabled : new boolean[] {false, true}) {
+			try (MockedStatic<FeatureFlagManagerUtil>
+					featureFlagManagerUtilMockedStatic = Mockito.mockStatic(
+						FeatureFlagManagerUtil.class);
+				MockedStatic<LayoutPageTemplateEntryServiceUtil>
+					layoutPageTemplateEntryServiceUtilMockedStatic =
+						Mockito.mockStatic(
+							LayoutPageTemplateEntryServiceUtil.class)) {
+
+				featureFlagManagerUtilMockedStatic.when(
+					() -> FeatureFlagManagerUtil.isEnabled(
+						Mockito.anyLong(), Mockito.eq("LPD-76864"))
+				).thenReturn(
+					featureFlagEnabled
+				);
+
+				for (int widgetPageTemplateEntriesCount : new int[] {0, 1}) {
+					layoutPageTemplateEntryServiceUtilMockedStatic.when(
+						() ->
+							LayoutPageTemplateEntryServiceUtil.
+								getLayoutPageTemplateEntriesCountByType(
+									Mockito.anyLong(), Mockito.eq(0L),
+									Mockito.eq(
+										LayoutPageTemplateEntryTypeConstants.
+											WIDGET_PAGE))
+					).thenReturn(
+						widgetPageTemplateEntriesCount
+					);
+
+					LayoutPageTemplatesAdminDisplayContext
+						layoutPageTemplatesAdminDisplayContext =
+							new LayoutPageTemplatesAdminDisplayContext(
+								_liferayPortletRequest,
+								_liferayPortletResponse);
+
+					Assert.assertEquals(
+						featureFlagEnabled ||
+						(widgetPageTemplateEntriesCount > 0),
+						layoutPageTemplatesAdminDisplayContext.
+							isShowWidgetPageTemplates());
+				}
+			}
+		}
 	}
 
 	private void _setUpGroup(boolean company) {


### PR DESCRIPTION
## What

Part of LPD-85701 (Deprecation of Widget Pages). Fixes the deprecation badge styling and the Widget Page Template panel visibility:

- **Panel visibility** — the page-creation "Global Templates" panel shows only when the `LPD-76864` flag is on **and** global templates exist (`isShowGlobalTemplates`); the Global Site "Widget Page Templates" panel hides only when the flag is off **and** no templates exist (`isShowWidgetPageTemplates`), so existing templates stay editable.
- **Deprecation badge** — the creation-menu badge now renders uppercase ("DEPRECATED"); the scope-dropdown badge label is localized via the `deprecated` language key.

## Related

The deprecation badge's translucent **background** depends on **LPD-94260** (Clay fix) — liferay-platform-experience/liferay-portal#2017. Merge that first for the complete visual; this PR works independently otherwise.

**pr-check: PASS** — tested on `c4c396f64b4906744defdee30a1b6e6897d0a401`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| JSP Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c4c396f64b4906744defdee30a1b6e6897d0a401"} -->
