### PR TITLE
LPD-94368 Fetch all picklists instead of only the first page

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/PicklistService.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/services/PicklistService.ts
@@ -28,15 +28,9 @@ async function createPicklist({
 }
 
 async function getPicklists(): Promise<Picklist[]> {
-	const {data, error} = await ApiHelper.get<{items: Picklist[]}>(
-		'/o/headless-admin-list-type/v1.0/list-type-definitions'
-	);
-
-	if (data) {
-		return data.items;
-	}
-
-	throw new Error(error);
+	return ApiHelper.getAll<Picklist>({
+		url: '/o/headless-admin-list-type/v1.0/list-type-definitions',
+	});
 }
 
 async function updatePicklist({

--- a/modules/apps/site/site-cms-site-initializer/test/js/common/services/PicklistService.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/common/services/PicklistService.test.ts
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import PicklistService from '../../../../src/main/resources/META-INF/resources/js/common/services/PicklistService';
+import {mockFetch} from '../../__mocks__/frontend-js-web';
+
+describe('PicklistService.getPicklists', () => {
+	afterEach(() => {
+		mockFetch.mockReset();
+	});
+
+	it('requests pageSize=-1 and returns every picklist across all pages, not just the first page of 20', async () => {
+		const maxId = 21;
+		const page1 = Array.from({length: 20}, (_, i) => ({id: i + 1}));
+		const page2 = [{id: maxId}];
+
+		const getMockResponse = (page: {id: number}[]) => {
+			return {
+				json: async () => ({items: page, lastPage: 2}),
+				ok: true,
+				status: 200,
+			} as Response;
+		};
+
+		mockFetch
+			.mockResolvedValueOnce(getMockResponse(page1))
+			.mockResolvedValueOnce(getMockResponse(page2));
+
+		const result = await PicklistService.getPicklists();
+
+		expect(mockFetch).toHaveBeenCalledWith(
+			expect.stringContaining(
+				'/o/headless-admin-list-type/v1.0/list-type-definitions?pageSize=-1'
+			),
+			expect.anything()
+		);
+		expect(result).toHaveLength(maxId);
+		expect(result).toContainEqual({id: maxId});
+	});
+
+	it('rejects when a page request returns an error', async () => {
+		mockFetch.mockResolvedValue({
+			json: async () => ({title: 'an-unexpected-error-occurred'}),
+			ok: false,
+			status: 500,
+		} as Response);
+
+		await expect(PicklistService.getPicklists()).rejects.toBe(
+			'an-unexpected-error-occurred'
+		);
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94368

## What Is Being Fixed

When configuring a "Select From List" field in the CMS structure builder, the picklist selector only listed the first 20 picklists. `getPicklists` issued a single unpaginated request to the list type definitions endpoint, whose default page size is 20, so any picklist beyond the twentieth was silently dropped and could not be selected.

## How It Is Being Fixed

`PicklistService.getPicklists` now delegates to `ApiHelper.getAll`, which requests `pageSize=-1` and walks every page, accumulating all items before returning. This aligns it with the sibling fetchers (`getObjectDefinitions`, `getSpaces`) that already use `getAll`, including their error contract — the rejection propagates as before. A unit test covers both that the uncapped page is requested and that items across all pages are returned, plus the error-rejection path.

## PR Check

**pr-check: PASS** — tested on `4032e52856f38030e81bcc145bcc59e1a58d45fb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "4032e52856f38030e81bcc145bcc59e1a58d45fb"} -->
