### PR TITLE
LPD-94135 Render the headless rendered-page in the requested locale

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
@@ -764,6 +764,14 @@ public class SitePageResourceImpl
 
 			themeDisplay.setRequest(httpServletRequest);
 
+			Locale preferredLocale = contextAcceptLanguage.getPreferredLocale();
+
+			themeDisplay.setLanguageId(
+				LocaleUtil.toLanguageId(preferredLocale));
+			themeDisplay.setLocale(preferredLocale);
+
+			httpServletRequest.setAttribute(WebKeys.LOCALE, preferredLocale);
+
 			SegmentsExperience segmentsExperience = _getSegmentsExperience(
 				httpServletRequest, layout, segmentsExperienceKey);
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/SitePageResourceTest.java
@@ -291,7 +291,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 	@Override
 	@Test
-	@TestInfo("LPD-56213")
+	@TestInfo({"LPD-56213", "LPD-94135"})
 	public void testGetSiteSitePageRenderedPage() throws Exception {
 		Layout layout = LayoutTestUtil.addTypeContentLayout(testGroup);
 
@@ -320,6 +320,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		Assert.assertTrue(pageHTML, pageHTML.contains("<body"));
 		Assert.assertTrue(pageHTML, pageHTML.contains("</body>"));
 		Assert.assertTrue(pageHTML, pageHTML.contains("</html>"));
+
+		_testGetSiteSitePageRenderedPageInRequestedLocale();
 	}
 
 	@Test
@@ -664,6 +666,27 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		}
 	}
 
+	private void _assertRenderedPage(
+			String expectedTitle, String friendlyURL, Locale locale)
+		throws Exception {
+
+		SitePageResource sitePageResource = SitePageResource.builder(
+		).authentication(
+			"test@liferay.com", PropsValues.DEFAULT_ADMIN_PASSWORD
+		).locale(
+			locale
+		).build();
+
+		String pageHTML = sitePageResource.getSiteSitePageRenderedPage(
+			testGroup.getGroupId(), friendlyURL);
+
+		Assert.assertTrue(
+			pageHTML,
+			pageHTML.contains(
+				" lang=\"" + LocaleUtil.toW3cLanguageId(locale) + "\""));
+		Assert.assertTrue(pageHTML, pageHTML.contains(expectedTitle));
+	}
+
 	private String _getRandomFriendlyURL() {
 		String urlTitle = StringUtil.toLowerCase(
 			RandomTestUtil.randomString(
@@ -841,6 +864,28 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		).user(
 			UserTestUtil.getAdminUser(testCompany.getCompanyId())
 		).build();
+	}
+
+	private void _testGetSiteSitePageRenderedPageInRequestedLocale()
+		throws Exception {
+
+		String esName = RandomTestUtil.randomString();
+		String usName = RandomTestUtil.randomString();
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(
+			testGroup,
+			HashMapBuilder.put(
+				LocaleUtil.SPAIN, esName
+			).put(
+				LocaleUtil.US, usName
+			).build());
+
+		String friendlyURL = layout.getFriendlyURL();
+
+		friendlyURL = friendlyURL.substring(1);
+
+		_assertRenderedPage(esName, friendlyURL, LocaleUtil.SPAIN);
+		_assertRenderedPage(usName, friendlyURL, LocaleUtil.US);
 	}
 
 	private void _testGetSiteSitePagesPagePageSet() throws Exception {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94135

## What Is Being Fixed

The `/o/headless-delivery/v1.0/sites/{siteId}/site-pages/{friendlyUrlPath}/rendered-page` endpoint always rendered the page in the default locale, ignoring the `Accept-Language` header. Consumers requesting another language still received the page in the default language.

## How It Is Being Fixed

`SitePageResourceImpl._toHTML` now applies the locale from `contextAcceptLanguage.getPreferredLocale()` to the `ThemeDisplay` and the request before the page is rendered, so the returned document reflects the requested locale.