### PR TITLE
LPD-93244 Clear unselected checkbox and multiselect fields on submit

### DIFF
--- a/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/request/helper/InfoRequestFieldValuesProviderHelper.java
+++ b/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/request/helper/InfoRequestFieldValuesProviderHelper.java
@@ -132,7 +132,7 @@ public class InfoRequestFieldValuesProviderHelper {
 				infoField, LocaleUtil.toLanguageIds(availableLocales),
 				multipartParameterMap, regularParameterMap);
 
-			if (inputNames.isEmpty() && !infoField.isLocalizable()) {
+			if (inputNames.isEmpty()) {
 				if ((infoField.getInfoFieldType() instanceof
 						BooleanInfoFieldType) &&
 					ArrayUtil.contains(

--- a/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/request/helper/InfoRequestFieldValuesProviderHelper.java
+++ b/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/request/helper/InfoRequestFieldValuesProviderHelper.java
@@ -128,11 +128,40 @@ public class InfoRequestFieldValuesProviderHelper {
 			Set<Locale> availableLocales = LanguageUtil.getAvailableLocales(
 				themeDisplay.getSiteGroupId());
 
-			for (String inputName :
-					_getInputNames(
-						infoField, LocaleUtil.toLanguageIds(availableLocales),
-						multipartParameterMap, regularParameterMap)) {
+			Set<String> inputNames = _getInputNames(
+				infoField, LocaleUtil.toLanguageIds(availableLocales),
+				multipartParameterMap, regularParameterMap);
 
+			if (inputNames.isEmpty() && !infoField.isLocalizable()) {
+				if ((infoField.getInfoFieldType() instanceof
+						BooleanInfoFieldType) &&
+					ArrayUtil.contains(
+						checkboxNames, infoField.getUniqueId())) {
+
+					infoFieldValues.put(
+						infoField.getUniqueId(),
+						_getInfoFieldValue(
+							true, infoField, themeDisplay.getLocale(), false));
+
+					continue;
+				}
+
+				if ((infoField.getInfoFieldType() instanceof
+						MultiselectInfoFieldType) &&
+					ArrayUtil.contains(
+						checkboxNames, infoField.getUniqueId())) {
+
+					infoFieldValues.put(
+						infoField.getUniqueId(),
+						_getInfoFieldValue(
+							true, infoField, themeDisplay.getLocale(),
+							Collections.emptyList()));
+
+					continue;
+				}
+			}
+
+			for (String inputName : inputNames) {
 				if (infoField.isLocalizable()) {
 					infoFieldValues.put(
 						inputName,
@@ -171,36 +200,6 @@ public class InfoRequestFieldValuesProviderHelper {
 
 				List<String> regularParameters = regularParameterMap.get(
 					inputName);
-
-				if (regularParameters == null) {
-					if ((infoField.getInfoFieldType() instanceof
-							BooleanInfoFieldType) &&
-						ArrayUtil.contains(
-							checkboxNames, infoField.getUniqueId())) {
-
-						infoFieldValues.put(
-							infoField.getUniqueId(),
-							_getInfoFieldValue(
-								true, infoField, themeDisplay.getLocale(),
-								false));
-
-						continue;
-					}
-
-					if ((infoField.getInfoFieldType() instanceof
-							MultiselectInfoFieldType) &&
-						ArrayUtil.contains(
-							checkboxNames, infoField.getUniqueId())) {
-
-						infoFieldValues.put(
-							infoField.getUniqueId(),
-							_getInfoFieldValue(
-								true, infoField, themeDisplay.getLocale(),
-								Collections.emptyList()));
-
-						continue;
-					}
-				}
 
 				Object value = _parseValue(
 					groupId, infoField, themeDisplay.getLocale(),

--- a/modules/apps/info/info-test/src/testIntegration/java/com/liferay/info/request/struts/test/EditInfoItemStrutsActionTest.java
+++ b/modules/apps/info/info-test/src/testIntegration/java/com/liferay/info/request/struts/test/EditInfoItemStrutsActionTest.java
@@ -737,11 +737,9 @@ public class EditInfoItemStrutsActionTest {
 			"classPK",
 			Collections.singletonList(
 				String.valueOf(objectEntry.getObjectEntryId())));
-		regularParameters.put(
-			"ObjectField_myLocalizedMultiselectPicklist_en_US",
-			Collections.emptyList());
-
 		regularParameters.remove("ObjectField_myBoolean");
+		regularParameters.remove(
+			"ObjectField_myLocalizedMultiselectPicklist_en_US");
 		regularParameters.remove("ObjectField_myMultiselectPicklist");
 
 		mockHttpServletResponse = new MockHttpServletResponse();
@@ -765,12 +763,12 @@ public class EditInfoItemStrutsActionTest {
 
 		Assert.assertEquals(
 			Boolean.FALSE.toString(), String.valueOf(values.get("myBoolean")));
-		Assert.assertTrue(
-			Validator.isNull(
-				String.valueOf(values.get("myLocalizedMultiselectPicklist"))));
-		Assert.assertTrue(
-			Validator.isNull(
-				String.valueOf(values.get("myMultiselectPicklist"))));
+		Assert.assertEquals(
+			StringPool.BLANK,
+			String.valueOf(values.get("myLocalizedMultiselectPicklist")));
+		Assert.assertEquals(
+			StringPool.BLANK,
+			String.valueOf(values.get("myMultiselectPicklist")));
 	}
 
 	@Test

--- a/modules/apps/info/info-test/src/testIntegration/java/com/liferay/info/request/struts/test/EditInfoItemStrutsActionTest.java
+++ b/modules/apps/info/info-test/src/testIntegration/java/com/liferay/info/request/struts/test/EditInfoItemStrutsActionTest.java
@@ -668,6 +668,9 @@ public class EditInfoItemStrutsActionTest {
 		mockMultipartHttpServletRequest.setContentType(
 			"multipart/form-data;boundary=" + System.currentTimeMillis());
 
+		ListTypeEntry listTypeEntry1 = _listTypeEntries.get(0);
+		ListTypeEntry listTypeEntry2 = _listTypeEntries.get(1);
+
 		Map<String, List<String>> regularParameters =
 			HashMapBuilder.<String, List<String>>put(
 				"classNameId", Collections.singletonList(_classNameId)
@@ -677,7 +680,14 @@ public class EditInfoItemStrutsActionTest {
 				"groupId",
 				Collections.singletonList(String.valueOf(_group.getGroupId()))
 			).put(
-				"myBoolean", Collections.singletonList(Boolean.TRUE.toString())
+				"ObjectField_myBoolean",
+				Collections.singletonList(Boolean.TRUE.toString())
+			).put(
+				"ObjectField_myLocalizedMultiselectPicklist_en_US",
+				Arrays.asList(listTypeEntry1.getKey(), listTypeEntry2.getKey())
+			).put(
+				"ObjectField_myMultiselectPicklist",
+				Arrays.asList(listTypeEntry1.getKey(), listTypeEntry2.getKey())
 			).put(
 				"p_l_id",
 				Collections.singletonList(String.valueOf(_layout.getPlid()))
@@ -717,14 +727,22 @@ public class EditInfoItemStrutsActionTest {
 
 		regularParameters.put(
 			"checkboxNames",
-			Collections.singletonList("ObjectField_myBoolean"));
+			Arrays.asList(
+				"ObjectField_myBoolean",
+				"ObjectField_myLocalizedMultiselectPicklist",
+				"ObjectField_myMultiselectPicklist"));
 		regularParameters.put(
 			"classNameId", Collections.singletonList(_classNameId));
 		regularParameters.put(
 			"classPK",
 			Collections.singletonList(
 				String.valueOf(objectEntry.getObjectEntryId())));
-		regularParameters.remove("myBoolean");
+		regularParameters.put(
+			"ObjectField_myLocalizedMultiselectPicklist_en_US",
+			Collections.emptyList());
+
+		regularParameters.remove("ObjectField_myBoolean");
+		regularParameters.remove("ObjectField_myMultiselectPicklist");
 
 		mockHttpServletResponse = new MockHttpServletResponse();
 
@@ -747,6 +765,12 @@ public class EditInfoItemStrutsActionTest {
 
 		Assert.assertEquals(
 			Boolean.FALSE.toString(), String.valueOf(values.get("myBoolean")));
+		Assert.assertTrue(
+			Validator.isNull(
+				String.valueOf(values.get("myLocalizedMultiselectPicklist"))));
+		Assert.assertTrue(
+			Validator.isNull(
+				String.valueOf(values.get("myMultiselectPicklist"))));
 	}
 
 	@Test
@@ -990,6 +1014,16 @@ public class EditInfoItemStrutsActionTest {
 				_listTypeDefinition.getListTypeDefinitionId()
 			).name(
 				"myMultiselectPicklist"
+			).build(),
+			new MultiselectPicklistObjectFieldBuilder(
+			).labelMap(
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+			).listTypeDefinitionId(
+				_listTypeDefinition.getListTypeDefinitionId()
+			).localized(
+				true
+			).name(
+				"myLocalizedMultiselectPicklist"
 			).build(),
 			ObjectFieldUtil.createObjectField(
 				ObjectFieldConstants.BUSINESS_TYPE_DATE,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93244

Previous pull: https://github.com/liferay-page-management/liferay-portal/pull/18562

## What Is Being Fixed

Unchecking a boolean checkbox or deselecting a multiselect in a Form Container and submitting did not persist the change — the field kept its previous value. A browser omits an unchecked checkbox (and an empty multiselect) from the request entirely, so the server received no value for that field and never cleared the stored one. The same gap applied to localizable multiselect fields.

## How It Is Being Fixed

The handler uses the hidden checkboxNames parameter to default an absent checkbox or multiselect field to false or empty. That logic ran inside the loop over the field's submitted parameters, so a field that submitted nothing — the unchecked case — was never reached. It now runs once per field before that loop, when the field has no submitted input names. Because the shared value builder already produces a localized value when the field is localizable, that same path also clears unselected localizable fields, so no separate handling is needed.

The integration test that covers this (testUpdateInfoItemWithCheckboxNames) is extended to genuinely exercise the unchecked case: the boolean, a non-localizable multiselect, and a localizable multiselect are each fully omitted from the update, and the assertions check the concrete cleared value rather than a null-tolerant predicate that passed even when nothing was cleared.

## PR Check

**pr-check: PASS** — tested SHA `a2967e76fd439d23a6a611666643a4b94634c98d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | SKIP — no unit counterpart (covered by integration test) |

<!-- pr-check {"result": "success", "sha": "a2967e76fd439d23a6a611666643a4b94634c98d"} -->