### PR TITLE
LPD-94363 Fix false success toast and "null" phone field on error

### DIFF
--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.html
@@ -114,6 +114,10 @@
 
 [#assign displayValue = (input.value)!"" /]
 
+[#if displayValue == "null"]
+	[#assign displayValue = "" /]
+[/#if]
+
 [#if prefix?has_content && displayValue?starts_with(prefix)]
 	[#assign displayValue = displayValue?remove_beginning(prefix) /]
 [/#if]

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.js
@@ -237,7 +237,7 @@ async function main() {
 
 	// Initial sync of input value into local number + country
 
-	syncFromValue(input.value);
+	syncFromValue(input.value === 'null' ? '' : input.value);
 
 	// Autofocus on backend error
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorToolbar.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorToolbar.tsx
@@ -192,12 +192,18 @@ export default function ContentEditorToolbar({
 			sessionStorage.TYPES.NECESSARY
 		);
 
-		if (message) {
-			openToast({message, type: 'success'});
-
-			sessionStorage.removeItem(SUCCESS_MESSAGE_SESSION_KEY);
+		if (!message) {
+			return;
 		}
-	}, []);
+
+		sessionStorage.removeItem(SUCCESS_MESSAGE_SESSION_KEY);
+
+		if (getForm()?.querySelector('.form-group.has-error')) {
+			return;
+		}
+
+		openToast({message, type: 'success'});
+	}, [getForm]);
 
 	return (
 		<Toolbar

--- a/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/phoneNumberField.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/phoneNumberField.spec.ts
@@ -189,12 +189,12 @@ test(
 );
 
 test(
-	'Publishing a content with an invalid phone number shows a descriptive validation error',
+	'Publishing a content with an invalid phone number shows a descriptive error, keeps the untouched field empty, and raises no success toast',
 	{tag: '@LPD-94363'},
 	async ({contentsPage, page, structureBuilderPage}) => {
 		const structureLabel = `Structure${getRandomInt()}`;
 
-		// Create a structure with a Phone Number field
+		// Create a structure with two Phone Number fields
 
 		await structureBuilderPage.createStructureFromData({
 			label: structureLabel,
@@ -204,9 +204,12 @@ test(
 
 		await structureBuilderPage.addField('Phone Number');
 
+		await structureBuilderPage.addField('Phone Number');
+
 		await structureBuilderPage.publishStructure();
 
-		// Create a content and enter an invalid phone number
+		// Create a content, enter an invalid number in the first phone field and
+		// leave the second one untouched
 
 		await contentsPage.goto();
 
@@ -214,7 +217,9 @@ test(
 
 		await page.getByLabel('Title').fill(getRandomString());
 
-		await page.locator('input[type="tel"]').fill('1');
+		const phoneInputs = page.locator('input[type="tel"]');
+
+		await phoneInputs.first().fill('123');
 
 		// Publish and check the error is descriptive instead of generic
 
@@ -222,6 +227,14 @@ test(
 			target: page.getByText('Please enter a valid phone number.'),
 			trigger: contentsPage.publishButton,
 		});
+
+		// The failed publish must not raise the optimistic success toast
+
+		await expect(page.locator('.alert-success')).not.toBeVisible();
+
+		// The untouched second field must stay empty instead of rendering "null"
+
+		await expect(phoneInputs.nth(1)).toHaveValue('');
 	}
 );
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94363

## What Is Being Fixed

When publishing CMS content whose structure has a Phone Number field, an invalid
number correctly surfaces a server-side validation error, but two unrelated
regressions appear alongside it:

- A success toast (for example "X was updated successfully") is shown even though
  the publish failed.
- A second, untouched Phone Number field renders the literal string "null" in its
  input.

## How It Is Being Fixed

The success message is stored in session storage before the form is submitted,
gated only by the native HTML5 `checkValidity()`, which cannot see server-side
validation errors, so the optimistic toast is shown when that message is read
back on the next page load. The fix moves the guard to the read side: the editor
now clears the stored message and skips the toast when the form still shows
validation errors (`.form-group.has-error`). On a successful publish the editor
navigates away and the destination page shows the toast exactly as before.

The "null" originates from the input fragment rendering `input.value` when the
backend returns the literal string "null" for an empty localized value after a
failed publish. The phone number fragment now treats a "null" value as empty,
both in the FreeMarker template (the rendered `value` attribute) and in the
client-side `syncFromValue` call that re-populates the input after the server
render.

## PR Check

**pr-check: PASS** — tested on `e794d998012c5799ee4617d71f38f86dcbabf9cf`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "e794d998012c5799ee4617d71f38f86dcbabf9cf"} -->
