### PR TITLE
LPD-94135 Render the headless rendered-page in the requested locale

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
@@ -762,7 +762,14 @@ public class SitePageResourceImpl
 
 			ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
 
+			themeDisplay.setLanguageId(
+				LocaleUtil.toLanguageId(
+					contextAcceptLanguage.getPreferredLocale()));
+			themeDisplay.setLocale(contextAcceptLanguage.getPreferredLocale());
 			themeDisplay.setRequest(httpServletRequest);
+
+			httpServletRequest.setAttribute(
+				WebKeys.LOCALE, contextAcceptLanguage.getPreferredLocale());
 
 			SegmentsExperience segmentsExperience = _getSegmentsExperience(
 				httpServletRequest, layout, segmentsExperienceKey);

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/SitePageResourceTest.java
@@ -291,35 +291,10 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 	@Override
 	@Test
-	@TestInfo("LPD-56213")
+	@TestInfo({"LPD-56213", "LPD-94135"})
 	public void testGetSiteSitePageRenderedPage() throws Exception {
-		Layout layout = LayoutTestUtil.addTypeContentLayout(testGroup);
-
-		Layout draftLayout = layout.fetchDraftLayout();
-
-		ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
-			"{}", layout.fetchDraftLayout(),
-			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
-				draftLayout.getPlid()));
-
-		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
-
-		String friendlyURL = layout.getFriendlyURL();
-
-		String pageHTML = sitePageResource.getSiteSitePageRenderedPage(
-			testGroup.getGroupId(), friendlyURL.substring(1));
-
-		Assert.assertNotNull(pageHTML, pageHTML);
-		Assert.assertTrue(pageHTML, pageHTML.contains("<html"));
-		Assert.assertTrue(pageHTML, pageHTML.contains("<head>"));
-		Assert.assertTrue(pageHTML, pageHTML.contains("<title>"));
-		Assert.assertTrue(pageHTML, pageHTML.contains("</title>"));
-		Assert.assertTrue(
-			pageHTML, pageHTML.contains("<script type=\"importmap\">"));
-		Assert.assertTrue(pageHTML, pageHTML.contains("</head>"));
-		Assert.assertTrue(pageHTML, pageHTML.contains("<body"));
-		Assert.assertTrue(pageHTML, pageHTML.contains("</body>"));
-		Assert.assertTrue(pageHTML, pageHTML.contains("</html>"));
+		_testGetSiteSitePageRenderedPage();
+		_testGetSiteSitePageRenderedPageInRequestedLocale();
 	}
 
 	@Test
@@ -664,6 +639,27 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		}
 	}
 
+	private void _assertRenderedPage(
+			String expectedTitle, String friendlyURL, Locale locale)
+		throws Exception {
+
+		SitePageResource sitePageResource = SitePageResource.builder(
+		).authentication(
+			"test@liferay.com", PropsValues.DEFAULT_ADMIN_PASSWORD
+		).locale(
+			locale
+		).build();
+
+		String pageHTML = sitePageResource.getSiteSitePageRenderedPage(
+			testGroup.getGroupId(), friendlyURL);
+
+		Assert.assertTrue(
+			pageHTML,
+			pageHTML.contains(
+				" lang=\"" + LocaleUtil.toW3cLanguageId(locale) + "\""));
+		Assert.assertTrue(pageHTML, pageHTML.contains(expectedTitle));
+	}
+
 	private String _getRandomFriendlyURL() {
 		String urlTitle = StringUtil.toLowerCase(
 			RandomTestUtil.randomString(
@@ -841,6 +837,56 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		).user(
 			UserTestUtil.getAdminUser(testCompany.getCompanyId())
 		).build();
+	}
+
+	private void _testGetSiteSitePageRenderedPage() throws Exception {
+		Layout layout = LayoutTestUtil.addTypeContentLayout(testGroup);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+			"{}", layout.fetchDraftLayout(),
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				draftLayout.getPlid()));
+
+		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
+
+		String friendlyURL = layout.getFriendlyURL();
+
+		String pageHTML = sitePageResource.getSiteSitePageRenderedPage(
+			testGroup.getGroupId(), friendlyURL.substring(1));
+
+		Assert.assertNotNull(pageHTML, pageHTML);
+		Assert.assertTrue(pageHTML, pageHTML.contains("<html"));
+		Assert.assertTrue(pageHTML, pageHTML.contains("<head>"));
+		Assert.assertTrue(pageHTML, pageHTML.contains("<title>"));
+		Assert.assertTrue(pageHTML, pageHTML.contains("</title>"));
+		Assert.assertTrue(
+			pageHTML, pageHTML.contains("<script type=\"importmap\">"));
+		Assert.assertTrue(pageHTML, pageHTML.contains("</head>"));
+		Assert.assertTrue(pageHTML, pageHTML.contains("<body"));
+		Assert.assertTrue(pageHTML, pageHTML.contains("</body>"));
+		Assert.assertTrue(pageHTML, pageHTML.contains("</html>"));
+	}
+
+	private void _testGetSiteSitePageRenderedPageInRequestedLocale()
+		throws Exception {
+
+		String esName = RandomTestUtil.randomString();
+		String usName = RandomTestUtil.randomString();
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(
+			testGroup,
+			HashMapBuilder.put(
+				LocaleUtil.SPAIN, esName
+			).put(
+				LocaleUtil.US, usName
+			).build());
+
+		String friendlyURL = layout.getFriendlyURL();
+
+		_assertRenderedPage(esName, friendlyURL.substring(1), LocaleUtil.SPAIN);
+		_assertRenderedPage(usName, friendlyURL.substring(1), LocaleUtil.US);
 	}
 
 	private void _testGetSiteSitePagesPagePageSet() throws Exception {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94135

## What Is Being Fixed

The headless delivery rendered-page endpoint
(/o/headless-delivery/v1.0/sites/{siteId}/site-pages/{friendlyUrlPath}/rendered-page)
returned `<html lang="en-US">` regardless of the `Accept-Language` header, so
clients always received the page in the default locale instead of the requested
one.

## How It Is Being Fixed

In `SitePageResourceImpl._toHTML`, once the `ThemeDisplay` is resolved, the
language id and locale are set from `contextAcceptLanguage.getPreferredLocale()`
and placed on the request as `WebKeys.LOCALE` before `layout.includeLayoutContent`
runs. The rendered full document then reflects the requested locale, including the
`<html lang>` attribute.

The integration test creates a content page with distinct localized names and
asserts the rendered HTML carries the requested locale's `<html lang>` and title.
The locale check lives in a dedicated private `_testGetSiteSitePageRenderedPageInRequestedLocale`
helper, and the original rendered-page assertions were extracted into a sibling
`_testGetSiteSitePageRenderedPage` helper so the public test method is a clean
delegator.

ref https://github.com/brianchandotcom/liferay-portal/pull/176514#issuecomment-4682291878