### PR TITLE
LPD-94560 Add layout-content-web module base for the frontend team

### DIFF
--- a/modules/apps/layout/layout-content-web/bnd.bnd
+++ b/modules/apps/layout/layout-content-web/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Layout Content Web
+Bundle-SymbolicName: com.liferay.layout.content.web
+Bundle-Version: 1.0.0
+Web-ContextPath: /layout-content-web

--- a/modules/apps/layout/layout-content-web/build.gradle
+++ b/modules/apps/layout/layout-content-web/build.gradle
@@ -1,0 +1,11 @@
+dependencies {
+	compileOnly group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
+	compileOnly group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
+	compileOnly group: "jakarta.servlet.jsp", name: "jakarta.servlet.jsp-api", version: "3.1.1"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:layout:layout-api")
+}

--- a/modules/apps/layout/layout-content-web/src/main/java/com/liferay/layout/content/web/internal/constants/LayoutContentVersionPortletKeys.java
+++ b/modules/apps/layout/layout-content-web/src/main/java/com/liferay/layout/content/web/internal/constants/LayoutContentVersionPortletKeys.java
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.web.internal.constants;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public class LayoutContentVersionPortletKeys {
+
+	public static final String LAYOUT_CONTENT_VERSION =
+		"com_liferay_layout_content_web_internal_portlet_" +
+			"LayoutContentVersionPortlet";
+
+}

--- a/modules/apps/layout/layout-content-web/src/main/java/com/liferay/layout/content/web/internal/constants/LayoutContentVersionWebKeys.java
+++ b/modules/apps/layout/layout-content-web/src/main/java/com/liferay/layout/content/web/internal/constants/LayoutContentVersionWebKeys.java
@@ -1,0 +1,16 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.web.internal.constants;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public class LayoutContentVersionWebKeys {
+
+	public static final String LAYOUT_CONTENT_VERSION_DISPLAY_CONTEXT =
+		"LAYOUT_CONTENT_VERSION_DISPLAY_CONTEXT";
+
+}

--- a/modules/apps/layout/layout-content-web/src/main/java/com/liferay/layout/content/web/internal/display/context/LayoutContentVersionDisplayContext.java
+++ b/modules/apps/layout/layout-content-web/src/main/java/com/liferay/layout/content/web/internal/display/context/LayoutContentVersionDisplayContext.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.web.internal.display.context;
+
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public class LayoutContentVersionDisplayContext {
+
+	public LayoutContentVersionDisplayContext(
+		HttpServletRequest httpServletRequest,
+		LayoutLocalService layoutLocalService) {
+
+		_layoutLocalService = layoutLocalService;
+
+		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+	}
+
+	public Map<String, Object> getContext() {
+		return Collections.emptyMap();
+	}
+
+	private final LayoutLocalService _layoutLocalService;
+	private final ThemeDisplay _themeDisplay;
+
+}

--- a/modules/apps/layout/layout-content-web/src/main/java/com/liferay/layout/content/web/internal/portlet/LayoutContentVersionPortlet.java
+++ b/modules/apps/layout/layout-content-web/src/main/java/com/liferay/layout/content/web/internal/portlet/LayoutContentVersionPortlet.java
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.web.internal.portlet;
+
+import com.liferay.layout.content.web.internal.constants.LayoutContentVersionPortletKeys;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+
+import jakarta.portlet.Portlet;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+@Component(
+	property = {
+		"com.liferay.portlet.add-default-resource=true",
+		"com.liferay.portlet.preferences-owned-by-group=true",
+		"com.liferay.portlet.private-request-attributes=false",
+		"com.liferay.portlet.private-session-attributes=false",
+		"com.liferay.portlet.render-weight=50",
+		"com.liferay.portlet.system=true",
+		"com.liferay.portlet.use-default-template=false",
+		"jakarta.portlet.display-name=Layout Content Version",
+		"jakarta.portlet.expiration-cache=0",
+		"jakarta.portlet.init-param.template-path=/META-INF/resources/",
+		"jakarta.portlet.init-param.view-template=/view.jsp",
+		"jakarta.portlet.name=" + LayoutContentVersionPortletKeys.LAYOUT_CONTENT_VERSION,
+		"jakarta.portlet.resource-bundle=content.Language",
+		"jakarta.portlet.version=4.0"
+	},
+	service = Portlet.class
+)
+public class LayoutContentVersionPortlet extends MVCPortlet {
+}

--- a/modules/apps/layout/layout-content-web/src/main/java/com/liferay/layout/content/web/internal/portlet/LayoutContentVersionPortlet.java
+++ b/modules/apps/layout/layout-content-web/src/main/java/com/liferay/layout/content/web/internal/portlet/LayoutContentVersionPortlet.java
@@ -6,11 +6,23 @@
 package com.liferay.layout.content.web.internal.portlet;
 
 import com.liferay.layout.content.web.internal.constants.LayoutContentVersionPortletKeys;
+import com.liferay.layout.content.web.internal.constants.LayoutContentVersionWebKeys;
+import com.liferay.layout.content.web.internal.display.context.LayoutContentVersionDisplayContext;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.util.Portal;
 
 import jakarta.portlet.Portlet;
+import jakarta.portlet.PortletException;
+import jakarta.portlet.RenderRequest;
+import jakarta.portlet.RenderResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.io.IOException;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Lourdes Fernández Besada
@@ -35,4 +47,38 @@ import org.osgi.service.component.annotations.Component;
 	service = Portlet.class
 )
 public class LayoutContentVersionPortlet extends MVCPortlet {
+
+	@Override
+	protected void doDispatch(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws IOException, PortletException {
+
+		HttpServletRequest httpServletRequest = _portal.getHttpServletRequest(
+			renderRequest);
+
+		LayoutContentVersionDisplayContext layoutContentVersionDisplayContext =
+			(LayoutContentVersionDisplayContext)httpServletRequest.getAttribute(
+				LayoutContentVersionWebKeys.
+					LAYOUT_CONTENT_VERSION_DISPLAY_CONTEXT);
+
+		if (layoutContentVersionDisplayContext == null) {
+			layoutContentVersionDisplayContext =
+				new LayoutContentVersionDisplayContext(
+					httpServletRequest, _layoutLocalService);
+
+			httpServletRequest.setAttribute(
+				LayoutContentVersionWebKeys.
+					LAYOUT_CONTENT_VERSION_DISPLAY_CONTEXT,
+				layoutContentVersionDisplayContext);
+		}
+
+		super.doDispatch(renderRequest, renderResponse);
+	}
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private Portal _portal;
+
 }

--- a/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/init.jsp
@@ -1,0 +1,14 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
+<%@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
+
+<liferay-theme:defineObjects />
+
+<portlet:defineObjects />

--- a/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/view.jsp
@@ -1,0 +1,8 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/init.jsp" %>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94560

## What Is Being Fixed

The frontend team needs a runtime base to start wiring the page-versioning view: an OSGi web module bundle with a registered portlet, JSPs to host their component, and a DisplayContext to inject server-side state. Without that base they cannot start the UI work in parallel with PR2/PR4 (which still carry the rest of the backend).

## How It Is Being Fixed

Adds a new `layout-content-web` OSGi module under `modules/apps/layout` with the minimum surface front needs:

- `LayoutContentVersionPortlet` (MVCPortlet) registered as a system portlet, with `init.jsp`/`view.jsp` scaffolds.
- `LayoutContentVersionPortletKeys` and `LayoutContentVersionWebKeys` for portlet name and request attribute key respectively.
- `LayoutContentVersionDisplayContext` exposed via the standard request attribute; its `getContext()` returns `Collections.emptyMap()` so the frontend can wire the call site immediately and the team will populate the keys in follow-up PRs as the REST endpoints land (PR2).

## Why Are There No Tests?

This PR adds a portlet shell intended as a base for the frontend team: a module skeleton (`bnd.bnd`, `build.gradle`), an `MVCPortlet` that wires up an empty DisplayContext, and JSPs that only include `init.jsp`. The `getContext()` method on the DisplayContext returns an empty map by design — the frontend team will populate it and add their component tests in follow-up PRs once the corresponding REST endpoints land. There is no behavior to assert at this stage.

## PR Check

**pr-check: PASS** — tested on `f2d7c64cc54570641c38f9836d515a96a8ea9979`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Module Registration | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| JSP Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f2d7c64cc54570641c38f9836d515a96a8ea9979"} -->
