### PR TITLE
LPD-94563 Lower the widget page section test fallback to ten columns

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageSpecificationsTestUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageSpecificationsTestUtil.java
@@ -617,7 +617,7 @@ public class PageSpecificationsTestUtil {
 			columns.add("column-3");
 		}
 		else {
-			for (int i = 1; i <= 100; i++) {
+			for (int i = 1; i <= 10; i++) {
 				columns.add(LayoutTypePortletConstants.COLUMN_PREFIX + i);
 			}
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94563

## What Is Being Fixed

SitePageResourceTest#testPutSiteSitePage fails on master. Commit 3e065eca281ead reverted "LPD-78667 Increase default layout template to consider more complex layout templates" only on the production side, lowering the fallback in LayoutTypePortletImpl#getLayoutTemplate from one hundred to ten columns for unknown layout templates, but left the matching test helper generating one hundred widget page sections. When the test creates a widget page with a random, non-existent layout template, LayoutUtil now rejects column-11 with "The widget page section is missing, or the page is not customizable".

## How It Is Being Fixed

Complete the revert on the test side: PageSpecificationsTestUtil#getWidgetPageSections now generates ten widget page sections instead of one hundred for unknown layout templates, mirroring the production fallback again. This restores the existing test to green without touching production behavior.

## Why Are There No Tests?

The change is confined to test code — it lowers a test-helper fallback from one hundred to ten to match the production default that commit 3e065eca281ead already reverted. There is no production code change to cover; the fix restores the existing SitePageResourceTest#testPutSiteSitePage, which was verified green locally.

## PR Check

**pr-check: PASS** — tested on `d21f9be51685c6f88c3eea1249f30fcfea77040d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "d21f9be51685c6f88c3eea1249f30fcfea77040d"} -->