### PR TITLE
LPD-94627 Enable LPD-70672 so email and phone number fields render

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/structureBuilder.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/structureBuilder.spec.ts
@@ -23,6 +23,7 @@ const test = mergeTests(
 	cmsPagesTest,
 	featureFlagsTest({
 		'LPD-17564': {enabled: true},
+		'LPD-70672': {enabled: true},
 		'LPD-83570': {enabled: true},
 	}),
 	loginTest(),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94627

## What Is Being Fixed

The Playwright test `structureBuilder.spec.ts > Structures can be saved with all type of fields without labels` fails because it iterates every structure builder field type, but the email and phone number field types are gated behind the `LPD-70672` feature flag, which the spec never enables — so those two types are missing from the field type menu when the test runs.

## How It Is Being Fixed

The spec declares `LPD-70672` in its `featureFlagsTest` fixture, alongside the flags it already enables, so the gated field types render during the test and are restored to their previous state afterwards.

## PR Check

**pr-check: PASS** — tested on `f8cd5de61ac3719810f598467424f4039d34ca41`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "f8cd5de61ac3719810f598467424f4039d34ca41"} -->