### PR TITLE
LPD-94532 Add upgrade steps for the tables introduced by LPD-93973

### DIFF
--- a/modules/apps/layout/layout-page-template-service/bnd.bnd
+++ b/modules/apps/layout/layout-page-template-service/bnd.bnd
@@ -5,6 +5,6 @@ Import-Package:\
 	com.liferay.layout.page.template.util.comparator,\
 	\
 	*
-Liferay-Require-SchemaVersion: 6.0.0
+Liferay-Require-SchemaVersion: 6.1.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/registry/LayoutPageTemplateServiceUpgradeStepRegistrator.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/registry/LayoutPageTemplateServiceUpgradeStepRegistrator.java
@@ -17,6 +17,7 @@ import com.liferay.layout.page.template.internal.upgrade.v3_1_4.ResourcePermissi
 import com.liferay.layout.page.template.internal.upgrade.v3_3_0.LayoutPageTemplateStructureRelUpgradeProcess;
 import com.liferay.layout.page.template.internal.upgrade.v3_4_1.FragmentEntryLinkEditableValuesUpgradeProcess;
 import com.liferay.layout.page.template.internal.upgrade.v5_3_0.LayoutPageTemplateCollectionUpgradeProcess;
+import com.liferay.layout.page.template.internal.upgrade.v6_1_0.util.LayoutPageTemplateStructureRelElementVariationTable;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutPrototypeLocalService;
@@ -258,6 +259,10 @@ public class LayoutPageTemplateServiceUpgradeStepRegistrator
 			"5.8.0", "6.0.0",
 			new com.liferay.layout.page.template.internal.upgrade.v6_0_0.
 				LayoutPageTemplateStructureRelUpgradeProcess());
+
+		registry.register(
+			"6.0.0", "6.1.0",
+			LayoutPageTemplateStructureRelElementVariationTable.create());
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v6_1_0/util/LayoutPageTemplateStructureRelElementVariationTable.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v6_1_0/util/LayoutPageTemplateStructureRelElementVariationTable.java
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.internal.upgrade.v6_1_0.util;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+/**
+ * @author Victor Galan
+ * @generated
+ * @see com.liferay.portal.tools.upgrade.table.builder.UpgradeTableBuilder
+ */
+public class LayoutPageTemplateStructureRelElementVariationTable {
+
+	public static UpgradeProcess create() {
+		return new UpgradeProcess() {
+
+			@Override
+			protected void doUpgrade() throws Exception {
+				if (!hasTable(_TABLE_NAME)) {
+					runSQL(_TABLE_SQL_CREATE);
+				}
+			}
+
+		};
+	}
+
+	private static final String _TABLE_NAME = "LPTStructureElementVariation";
+
+	private static final String _TABLE_SQL_CREATE =
+		"create table LPTStructureElementVariation (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,lptStructureElementVariationId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,audienceEntryERC VARCHAR(75) null,hide STRING null,html STRING null,js STRING null,name VARCHAR(75) null,plid LONG,segmentsExperienceERC VARCHAR(75) null,targetElement VARCHAR(75) null,primary key (lptStructureElementVariationId, ctCollectionId))";
+
+}

--- a/modules/apps/segments/segments-service/bnd.bnd
+++ b/modules/apps/segments/segments-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Segments Service
 Bundle-SymbolicName: com.liferay.segments.service
 Bundle-Version: 3.0.136
-Liferay-Require-SchemaVersion: 4.0.0
+Liferay-Require-SchemaVersion: 4.1.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/upgrade/registry/SegmentsServiceUpgradeStepRegistrator.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/upgrade/registry/SegmentsServiceUpgradeStepRegistrator.java
@@ -17,6 +17,7 @@ import com.liferay.segments.internal.upgrade.v2_0_0.SchemaUpgradeProcess;
 import com.liferay.segments.internal.upgrade.v2_0_0.SegmentsExperienceUpgradeProcess;
 import com.liferay.segments.internal.upgrade.v2_8_1.SegmentsExperimentUpgradeProcess;
 import com.liferay.segments.internal.upgrade.v3_1_1.SegmentsEntryUpgradeProcess;
+import com.liferay.segments.internal.upgrade.v4_1_0.util.SegmentsExperienceAudienceEntryRelTable;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -131,6 +132,9 @@ public class SegmentsServiceUpgradeStepRegistrator
 			"3.3.0", "4.0.0",
 			new com.liferay.segments.internal.upgrade.v4_0_0.
 				SegmentsExperienceUpgradeProcess());
+
+		registry.register(
+			"4.0.0", "4.1.0", SegmentsExperienceAudienceEntryRelTable.create());
 	}
 
 	@Reference

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/upgrade/v4_1_0/util/SegmentsExperienceAudienceEntryRelTable.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/upgrade/v4_1_0/util/SegmentsExperienceAudienceEntryRelTable.java
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.segments.internal.upgrade.v4_1_0.util;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+/**
+ * @author Victor Galan
+ * @generated
+ * @see com.liferay.portal.tools.upgrade.table.builder.UpgradeTableBuilder
+ */
+public class SegmentsExperienceAudienceEntryRelTable {
+
+	public static UpgradeProcess create() {
+		return new UpgradeProcess() {
+
+			@Override
+			protected void doUpgrade() throws Exception {
+				if (!hasTable(_TABLE_NAME)) {
+					runSQL(_TABLE_SQL_CREATE);
+				}
+			}
+
+		};
+	}
+
+	private static final String _TABLE_NAME = "SExperienceAudienceEntryRel";
+
+	private static final String _TABLE_SQL_CREATE =
+		"create table SExperienceAudienceEntryRel (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,sExperienceAudienceEntryRelId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,audienceEntryERC VARCHAR(75) null,priority INTEGER,segmentsExperienceERC VARCHAR(75) null,primary key (sExperienceAudienceEntryRelId, ctCollectionId))";
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94532

## What Is Being Fixed

LPD-93973 added the  and  entities, creating their tables (, ) in each module's , but no upgrade step. The tables exist only on fresh installs; on databases upgraded from 7.4.13/7.3.10 they are missing and  fails at startup (), producing 7 failures across the upgrade testflow.

## How It Is Being Fixed

Each module registers a new upgrade step ( to  in segments-service,  to  in layout-page-template-service) that creates the table when absent, following the generated UpgradeTableBuilder pattern used across the codebase, and bumps  to match. Indexes need no explicit step:  creates them at startup once the table exists — its failure was caused solely by the missing table. Both steps were verified against a simulated upgraded database (table dropped,  at the previous schema version): the upgrade recreated each table, advanced the schema version, and  completed cleanly, creating all indexes.

## Why Are There No Tests?

Create-table upgrade steps of this shape ship untested across the codebase (the  precedents in commerce have no dedicated tests). Coverage comes from the upgrade testflow that caught the regression, which re-validates on its next run, and the fix was verified manually end-to-end as described above.

## PR Check

**pr-check: PASS** — tested on 

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {result: success, sha: 5312ab30aee3fdeb9250ed412b2df6cd86e871a7} -->