### PR TITLE
LPD-94654 Fix content titles truncating too early in the Add panel

### DIFF
--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/css/_TabItem.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/css/_TabItem.scss
@@ -21,7 +21,8 @@ html#{$cadmin-selector} {
 				.sidebar-body__add-panel__tab-item-add {
 					position: absolute;
 					right: 4px;
-					top: 0;
+					top: 50%;
+					transform: translateY(-50%);
 				}
 			}
 
@@ -128,6 +129,8 @@ html#{$cadmin-selector} {
 
 				.sidebar-body__add-panel__tab-item-add {
 					right: 0;
+					top: 0;
+					transform: none;
 				}
 			}
 		}

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/css/_TabItem.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/css/_TabItem.scss
@@ -82,11 +82,11 @@ html#{$cadmin-selector} {
 				.title {
 					font-size: 12px;
 					font-weight: 600;
+					min-width: 0;
 				}
 
 				.subtitle {
 					color: $cadmin-gray-600;
-					flex-basis: 100%;
 					font-size: 12px;
 				}
 			}

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/TabItem.js
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/TabItem.js
@@ -64,17 +64,19 @@ const TabItem = ({item}) => {
 					<ClayIcon symbol={item.icon} />
 				</div>
 
-				<div className="align-items-center d-flex text">
-					<div className="mr-1 text-truncate title">{item.label}</div>
+				<div className="text">
+					<div className="align-items-center d-flex">
+						<div className="text-truncate title">{item.label}</div>
 
-					{item.data.deprecated && (
-						<div className="flex-shrink-0 ml-1">
-							<FeatureIndicator type="deprecated" />
-						</div>
-					)}
+						{item.data.deprecated && (
+							<div className="flex-shrink-0 ml-1">
+								<FeatureIndicator type="deprecated" />
+							</div>
+						)}
+					</div>
 
 					{isContent && (
-						<div className="subtitle text-break">
+						<div className="subtitle text-truncate">
 							{item.category}
 						</div>
 					)}

--- a/modules/test/playwright/tests/layout-admin-web/main/widgetPage.spec.ts
+++ b/modules/test/playwright/tests/layout-admin-web/main/widgetPage.spec.ts
@@ -228,6 +228,101 @@ test.describe('Content tab add panel', () => {
 			page.locator('.portlet-journal-content').getByText(webContentTitle)
 		).toBeVisible();
 	});
+
+	test(
+		'Content item stacks the subtitle below the title and centers the add button on the right',
+		{
+			tag: '@LPD-94654',
+		},
+		async ({apiHelpers, page, site, widgetPagePage}) => {
+
+			// Add required web content
+
+			const webContentTitle = getRandomString();
+
+			const contentStructureId =
+				await getBasicWebContentStructureId(apiHelpers);
+
+			await addApprovedStructuredContent({
+				apiHelpers,
+				contentStructureId,
+				siteId: site.id,
+				title: webContentTitle,
+			});
+
+			// Create page, go to view mode and open the Content panel
+
+			const layout = await apiHelpers.jsonWebServicesLayout.addLayout({
+				groupId: site.id,
+				title: getRandomString(),
+			});
+
+			await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyURL}`);
+
+			await widgetPagePage.openAddPanel();
+
+			await widgetPagePage.contentTab.click();
+
+			// Wait for the content item to render
+
+			const item = page
+				.locator('.sidebar-body__add-panel__tab-item')
+				.filter({hasText: webContentTitle})
+				.first();
+
+			await expect(item).toBeVisible();
+
+			// Measure the content item layout, retrying until it settles
+
+			await expect(async () => {
+				await item.hover({timeout: 2000});
+
+				const itemBox = await item.boundingBox({timeout: 2000});
+				const titleBox = await item
+					.locator('.title')
+					.boundingBox({timeout: 2000});
+				const subtitleBox = await item
+					.locator('.subtitle')
+					.boundingBox({timeout: 2000});
+				const addButtonBox = await item
+					.getByRole('button', {name: 'Add Content'})
+					.boundingBox({timeout: 2000});
+
+				if (!itemBox || !titleBox || !subtitleBox || !addButtonBox) {
+					throw new Error(
+						'Expected the content item layout to be measurable'
+					);
+				}
+
+				// The subtitle sits below the title and is left-aligned with it
+
+				expect(subtitleBox.y).toBeGreaterThanOrEqual(
+					titleBox.y + titleBox.height - 2
+				);
+				expect(
+					Math.abs(subtitleBox.x - titleBox.x)
+				).toBeLessThanOrEqual(2);
+
+				// The add button is vertically centered within the row
+
+				expect(
+					Math.abs(
+						addButtonBox.y +
+							addButtonBox.height / 2 -
+							(itemBox.y + itemBox.height / 2)
+					)
+				).toBeLessThanOrEqual(3);
+
+				// The add button is anchored to the right edge of the row
+
+				expect(
+					itemBox.x +
+						itemBox.width -
+						(addButtonBox.x + addButtonBox.width)
+				).toBeLessThanOrEqual(12);
+			}).toPass({timeout: 10000});
+		}
+	);
 });
 
 test.describe('Customization settings', () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94654

## What Is Being Fixed

In the widget page "Add" sidebar, under the Content tab, item titles were truncated with an ellipsis far too early, leaving a large empty space on the right of each row. The subtitle (the content type, e.g. "Document") shared the same flex row as the title and competed for horizontal space, so even short titles were cut off. The add button was also anchored to the top of the row instead of being vertically centered.

## How It Is Being Fixed

The content row markup in TabItem.js now stacks the subtitle below the title instead of placing it as a sibling on the same flex row, so the title can use the full row width before truncating. The accompanying _TabItem.scss drops the flex-basis: 100% that forced the subtitle to compete for space, adds min-width: 0 so the title truncates correctly as a flex child, and vertically centers the add button on the right of the row (top: 50% + translateY(-50%)), while keeping it anchored to the top-right corner in the grid view.

## PR Check

**pr-check: PASS** — tested on `bdd67b7011617cedec117a3dbd69136c035a84c2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "bdd67b7011617cedec117a3dbd69136c035a84c2"} -->
