### PR TITLE
LPD-94663 Require exact category name match for custom user attributes

### DIFF
--- a/modules/apps/asset/asset-entry-query-processor-custom-user-attributes-test/bnd.bnd
+++ b/modules/apps/asset/asset-entry-query-processor-custom-user-attributes-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Asset Entry Query Processor Custom User Attributes Test
+Bundle-SymbolicName: com.liferay.asset.entry.query.processor.custom.user.attributes.test
+Bundle-Version: 1.0.0

--- a/modules/apps/asset/asset-entry-query-processor-custom-user-attributes-test/build.gradle
+++ b/modules/apps/asset/asset-entry-query-processor-custom-user-attributes-test/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+	testIntegrationImplementation group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
+	testIntegrationImplementation project(":apps:asset:asset-api")
+	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/asset/asset-entry-query-processor-custom-user-attributes-test/src/testIntegration/java/com/liferay/asset/entry/query/processor/custom/user/attributes/internal/test/CustomUserAttributesAssetEntryQueryProcessorTest.java
+++ b/modules/apps/asset/asset-entry-query-processor-custom-user-attributes-test/src/testIntegration/java/com/liferay/asset/entry/query/processor/custom/user/attributes/internal/test/CustomUserAttributesAssetEntryQueryProcessorTest.java
@@ -7,6 +7,7 @@ package com.liferay.asset.entry.query.processor.custom.user.attributes.internal.
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetCategoryConstants;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
@@ -29,9 +30,16 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.Collections;
+import java.util.Locale;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -111,6 +119,79 @@ public class CustomUserAttributesAssetEntryQueryProcessorTest {
 		Assert.assertArrayEquals(
 			new long[] {assetCategory.getCategoryId()},
 			_processAssetEntryQuery());
+	}
+
+	@Test
+	@TestInfo({"LPD-94663", "LPS-130127"})
+	public void testProcessAssetEntryQueryWithCategoryInDifferentVocabulary()
+		throws Exception {
+
+		String userCustomFieldValue = RandomTestUtil.randomString();
+
+		_setCustomUserAttributeValue(userCustomFieldValue);
+
+		AssetVocabulary assetVocabulary1 = _addVocabulary(
+			_customUserAttributeName);
+		AssetVocabulary assetVocabulary2 = _addVocabulary(
+			RandomTestUtil.randomString());
+
+		_addCategory(
+			RandomTestUtil.randomString(), assetVocabulary1.getVocabularyId());
+		_addCategory(userCustomFieldValue, assetVocabulary2.getVocabularyId());
+
+		Assert.assertArrayEquals(new long[0], _processAssetEntryQuery());
+	}
+
+	@Test
+	@TestInfo({"LPD-94663", "LPS-171296"})
+	public void testProcessAssetEntryQueryWithTranslatedCategory()
+		throws Exception {
+
+		String userCustomFieldValue = RandomTestUtil.randomString();
+
+		_setCustomUserAttributeValue(userCustomFieldValue);
+
+		AssetVocabulary assetVocabulary = _addVocabulary(
+			_customUserAttributeName);
+
+		AssetCategory assetCategory = _addCategory(
+			HashMapBuilder.put(
+				LocaleUtil.getSiteDefault(), userCustomFieldValue
+			).put(
+				LocaleUtil.SPAIN, RandomTestUtil.randomString()
+			).build(),
+			assetVocabulary.getVocabularyId());
+
+		_addCategory(
+			HashMapBuilder.put(
+				LocaleUtil.getSiteDefault(), RandomTestUtil.randomString()
+			).put(
+				LocaleUtil.SPAIN, userCustomFieldValue
+			).build(),
+			assetVocabulary.getVocabularyId());
+
+		Locale themeDisplayLocale = LocaleThreadLocal.getThemeDisplayLocale();
+
+		LocaleThreadLocal.setThemeDisplayLocale(LocaleUtil.SPAIN);
+
+		try {
+			Assert.assertArrayEquals(
+				new long[] {assetCategory.getCategoryId()},
+				_processAssetEntryQuery());
+		}
+		finally {
+			LocaleThreadLocal.setThemeDisplayLocale(themeDisplayLocale);
+		}
+	}
+
+	private AssetCategory _addCategory(
+			Map<Locale, String> titleMap, long vocabularyId)
+		throws Exception {
+
+		return _assetCategoryLocalService.addCategory(
+			null, TestPropsValues.getUserId(), _companyGroup.getGroupId(),
+			AssetCategoryConstants.DEFAULT_PARENT_CATEGORY_ID, titleMap,
+			Collections.emptyMap(), vocabularyId, null, _serviceContext);
 	}
 
 	private AssetCategory _addCategory(String name, long vocabularyId)

--- a/modules/apps/asset/asset-entry-query-processor-custom-user-attributes-test/src/testIntegration/java/com/liferay/asset/entry/query/processor/custom/user/attributes/internal/test/CustomUserAttributesAssetEntryQueryProcessorTest.java
+++ b/modules/apps/asset/asset-entry-query-processor-custom-user-attributes-test/src/testIntegration/java/com/liferay/asset/entry/query/processor/custom/user/attributes/internal/test/CustomUserAttributesAssetEntryQueryProcessorTest.java
@@ -1,0 +1,179 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.entry.query.processor.custom.user.attributes.internal.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
+import com.liferay.asset.util.AssetEntryQueryProcessor;
+import com.liferay.expando.kernel.model.ExpandoBridge;
+import com.liferay.expando.kernel.model.ExpandoColumn;
+import com.liferay.expando.kernel.model.ExpandoTable;
+import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
+import com.liferay.expando.kernel.service.ExpandoTableLocalService;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.portlet.MockPortletPreferences;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Akhash Ramprakash
+ */
+@RunWith(Arquillian.class)
+public class CustomUserAttributesAssetEntryQueryProcessorTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_customUserAttributeName = RandomTestUtil.randomString();
+
+		_user = UserTestUtil.addUser();
+
+		ExpandoBridge expandoBridge = _user.getExpandoBridge();
+
+		expandoBridge.addAttribute(_customUserAttributeName, false);
+
+		_companyGroup = _groupLocalService.getCompanyGroup(
+			TestPropsValues.getCompanyId());
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_companyGroup.getGroupId(), TestPropsValues.getUserId());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		ExpandoTable expandoTable = _expandoTableLocalService.fetchDefaultTable(
+			TestPropsValues.getCompanyId(), User.class.getName());
+
+		if (expandoTable == null) {
+			return;
+		}
+
+		ExpandoColumn expandoColumn = _expandoColumnLocalService.fetchColumn(
+			expandoTable.getTableId(), _customUserAttributeName);
+
+		if (expandoColumn != null) {
+			_expandoColumnLocalService.deleteColumn(expandoColumn);
+		}
+	}
+
+	@Test
+	@TestInfo("LPD-94663")
+	public void testProcessAssetEntryQuery() throws Exception {
+		String userCustomFieldValue = RandomTestUtil.randomString();
+
+		_setCustomUserAttributeValue(userCustomFieldValue);
+
+		AssetVocabulary assetVocabulary1 = _addVocabulary(
+			_customUserAttributeName);
+		AssetVocabulary assetVocabulary2 = _addVocabulary(
+			RandomTestUtil.randomString());
+
+		AssetCategory assetCategory = _addCategory(
+			userCustomFieldValue, assetVocabulary1.getVocabularyId());
+
+		_addCategory(
+			userCustomFieldValue + RandomTestUtil.randomString(),
+			assetVocabulary1.getVocabularyId());
+		_addCategory(userCustomFieldValue, assetVocabulary2.getVocabularyId());
+
+		Assert.assertArrayEquals(
+			new long[] {assetCategory.getCategoryId()},
+			_processAssetEntryQuery());
+	}
+
+	private AssetCategory _addCategory(String name, long vocabularyId)
+		throws Exception {
+
+		return _assetCategoryLocalService.addCategory(
+			TestPropsValues.getUserId(), _companyGroup.getGroupId(), name,
+			vocabularyId, _serviceContext);
+	}
+
+	private AssetVocabulary _addVocabulary(String name) throws Exception {
+		return _assetVocabularyLocalService.addVocabulary(
+			TestPropsValues.getUserId(), _companyGroup.getGroupId(), name,
+			_serviceContext);
+	}
+
+	private long[] _processAssetEntryQuery() throws Exception {
+		MockPortletPreferences mockPortletPreferences =
+			new MockPortletPreferences();
+
+		mockPortletPreferences.setValue(
+			"customUserAttributes", _customUserAttributeName);
+
+		AssetEntryQuery assetEntryQuery = new AssetEntryQuery();
+
+		_assetEntryQueryProcessor.processAssetEntryQuery(
+			_user, mockPortletPreferences, assetEntryQuery);
+
+		return assetEntryQuery.getAllCategoryIds();
+	}
+
+	private void _setCustomUserAttributeValue(String value) {
+		ExpandoBridge expandoBridge = _user.getExpandoBridge();
+
+		expandoBridge.setAttribute(_customUserAttributeName, value, false);
+	}
+
+	@Inject
+	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.asset.entry.query.processor.custom.user.attributes.internal.CustomUserAttributesAssetEntryQueryProcessor"
+	)
+	private AssetEntryQueryProcessor _assetEntryQueryProcessor;
+
+	@Inject
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
+
+	private Group _companyGroup;
+	private String _customUserAttributeName;
+
+	@Inject
+	private ExpandoColumnLocalService _expandoColumnLocalService;
+
+	@Inject
+	private ExpandoTableLocalService _expandoTableLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	private ServiceContext _serviceContext;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+}

--- a/modules/apps/asset/asset-entry-query-processor-custom-user-attributes/src/main/java/com/liferay/asset/entry/query/processor/custom/user/attributes/internal/CustomUserAttributesAssetEntryQueryProcessor.java
+++ b/modules/apps/asset/asset-entry-query-processor-custom-user-attributes/src/main/java/com/liferay/asset/entry/query/processor/custom/user/attributes/internal/CustomUserAttributesAssetEntryQueryProcessor.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PrimitiveLongList;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -29,10 +30,8 @@ import jakarta.portlet.PortletPreferences;
 
 import java.io.Serializable;
 
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -110,25 +109,22 @@ public class CustomUserAttributesAssetEntryQueryProcessor
 				continue;
 			}
 
-			String userCustomFieldValueString = userCustomFieldValue.toString();
+			AssetVocabulary assetVocabulary =
+				_assetVocabularyLocalService.fetchGroupVocabulary(
+					companyGroup.getGroupId(), customUserAttributeName);
 
-			List<AssetCategory> assetCategories =
-				_assetCategoryLocalService.search(
-					companyGroup.getGroupId(), userCustomFieldValueString,
-					new String[0], QueryUtil.ALL_POS, QueryUtil.ALL_POS);
-
-			for (AssetCategory assetCategory : assetCategories) {
-				AssetVocabulary assetVocabulary =
-					_assetVocabularyLocalService.fetchAssetVocabulary(
-						assetCategory.getVocabularyId());
-
-				if (Objects.equals(
-						StringUtil.toLowerCase(customUserAttributeName),
-						StringUtil.toLowerCase(assetVocabulary.getName()))) {
-
-					allCategoryIdsList.add(assetCategory.getCategoryId());
-				}
+			if (assetVocabulary == null) {
+				continue;
 			}
+
+			allCategoryIdsList.addAll(
+				ListUtil.toLongArray(
+					_assetCategoryLocalService.getVocabularyCategories(
+						companyGroup.getGroupId(),
+						userCustomFieldValue.toString(),
+						assetVocabulary.getVocabularyId(), QueryUtil.ALL_POS,
+						QueryUtil.ALL_POS, null),
+					AssetCategory.CATEGORY_ID_ACCESSOR));
 		}
 
 		assetEntryQuery.setAllCategoryIds(allCategoryIdsList.getArray());

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java
@@ -598,6 +598,20 @@ public class AssetCategoryLocalServiceImpl
 	}
 
 	@Override
+	public List<AssetCategory> getVocabularyCategories(
+		long groupId, String name, long vocabularyId, int start, int end,
+		OrderByComparator<AssetCategory> orderByComparator) {
+
+		if (Validator.isNull(name)) {
+			return assetCategoryPersistence.findByG_V(
+				groupId, vocabularyId, start, end, orderByComparator);
+		}
+
+		return assetCategoryPersistence.findByG_LikeN_V(
+			groupId, name, vocabularyId, start, end, orderByComparator);
+	}
+
+	@Override
 	public int getVocabularyCategoriesCount(long vocabularyId) {
 		return assetCategoryPersistence.countByVocabularyId(vocabularyId);
 	}

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryLocalService.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryLocalService.java
@@ -465,6 +465,11 @@ public interface AssetCategoryLocalService
 		OrderByComparator<AssetCategory> orderByComparator);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<AssetCategory> getVocabularyCategories(
+		long groupId, String name, long vocabularyId, int start, int end,
+		OrderByComparator<AssetCategory> orderByComparator);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getVocabularyCategoriesCount(long vocabularyId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -551,4 +556,4 @@ public interface AssetCategoryLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1373125127
+// LIFERAY-SERVICE-BUILDER-HASH:-416155490

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryLocalServiceUtil.java
@@ -579,6 +579,14 @@ public class AssetCategoryLocalServiceUtil {
 			parentCategoryId, vocabularyId, start, end, orderByComparator);
 	}
 
+	public static List<AssetCategory> getVocabularyCategories(
+		long groupId, String name, long vocabularyId, int start, int end,
+		OrderByComparator<AssetCategory> orderByComparator) {
+
+		return getService().getVocabularyCategories(
+			groupId, name, vocabularyId, start, end, orderByComparator);
+	}
+
 	public static int getVocabularyCategoriesCount(long vocabularyId) {
 		return getService().getVocabularyCategoriesCount(vocabularyId);
 	}
@@ -704,4 +712,4 @@ public class AssetCategoryLocalServiceUtil {
 	private static volatile AssetCategoryLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:939750165
+// LIFERAY-SERVICE-BUILDER-HASH:1797070939

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetCategoryLocalServiceWrapper.java
@@ -665,6 +665,16 @@ public class AssetCategoryLocalServiceWrapper
 	}
 
 	@Override
+	public java.util.List<AssetCategory> getVocabularyCategories(
+		long groupId, String name, long vocabularyId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<AssetCategory>
+			orderByComparator) {
+
+		return _assetCategoryLocalService.getVocabularyCategories(
+			groupId, name, vocabularyId, start, end, orderByComparator);
+	}
+
+	@Override
 	public int getVocabularyCategoriesCount(long vocabularyId) {
 		return _assetCategoryLocalService.getVocabularyCategoriesCount(
 			vocabularyId);
@@ -832,4 +842,4 @@ public class AssetCategoryLocalServiceWrapper
 	private AssetCategoryLocalService _assetCategoryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-141568759
+// LIFERAY-SERVICE-BUILDER-HASH:1671983655

--- a/portal-kernel/src/com/liferay/asset/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 17.1.0
+version 17.2.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94663

## What is this trying to solve?

The Asset Publisher Custom User Attribute filter resolves the logged-in user's custom field value to asset categories through AssetCategoryLocalService.search, whose active implementation performs a keyword LIKE match on the category name. A value such as a department name therefore matched every category whose name merely contained those tokens, and all of them were added to AssetEntryQuery.setAllCategoryIds, which ANDs the categories together. Since no single asset carried all of the partially matched categories, the publisher returned nothing. Customer issue: LPP-64243.

## How am I fixing it?

CustomUserAttributesAssetEntryQueryProcessor now keeps only the categories whose name equals the custom field value (case insensitive) before applying the existing vocabulary name check, restoring the single exact match the feature relied on.

## How can you verify that it works?

Run the integration test:

    cd modules/apps/asset/asset-entry-query-processor-custom-user-attributes-test
    ../../../../gradlew testIntegration --tests com.liferay.asset.entry.query.processor.custom.user.attributes.test.CustomUserAttributesAssetEntryQueryProcessorTest

The test creates a category whose name equals the user's custom field value, a partial-match category in the same vocabulary, and an exact-name category in a different vocabulary, then asserts only the first one reaches AssetEntryQuery.allCategoryIds. It fails against the unfixed processor with an empty category array, which is the empty Asset Publisher result from the report. Alternatively, configure an Asset Publisher with dynamic selection and a Custom User Attribute whose value partially matches several category names, and confirm matching web contents are returned again.