### PR TITLE
LPD-94764 Stabilize the page structure tree drag in Playwright tests

### DIFF
--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -873,7 +873,17 @@ export class PageEditorPage {
 
 		await sourceNode.hover();
 
+		const sourceBox = await sourceNode.boundingBox();
+
 		await this.page.mouse.down();
+
+		// Nudge the pointer so Chromium starts the native HTML5 drag
+
+		await this.page.mouse.move(
+			sourceBox.x + sourceBox.width / 2,
+			sourceBox.y + sourceBox.height / 2 + 8,
+			{steps: 5}
+		);
 
 		// Calculate drop data
 
@@ -893,15 +903,22 @@ export class PageEditorPage {
 					? /drag-over-bottom/
 					: /drag-over-top/;
 
-		// Check hover is correct
+		const jiggleY = position === 'top' ? y + 4 : y - 4;
+
+		// Move over the target until the drop indicator appears
 
 		await expect(async () => {
-			await targetNode.hover({
-				position: {
-					x: targetBox.width / 2,
-					y,
-				},
-			});
+			await this.page.mouse.move(
+				targetBox.x + targetBox.width / 2,
+				targetBox.y + jiggleY,
+				{steps: 5}
+			);
+
+			await this.page.mouse.move(
+				targetBox.x + targetBox.width / 2,
+				targetBox.y + y,
+				{steps: 5}
+			);
 
 			await expect(targetNode).toHaveClass(cssClass, {
 				timeout: 1000,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94764

## What Is Being Fixed

The Playwright test layout-content-page-editor-web/main/mapping.spec.ts > "Unmaps input fragment when moving it to another parent" was ~50% flaky locally, timing out at 90s waiting for the drag-over-middle drop indicator. The page editor's page-structure tree uses react-dnd's HTML5 backend, but the shared dragTreeNode helper drove it with a single synthetic mouse move after mouse.down; Chromium only intermittently starts a native HTML5 drag from that, so react-dnd's monitor.isOver() was often never true and the drop indicator never appeared.

## How It Is Being Fixed

Harden the dragTreeNode helper: nudge the pointer immediately after mouse.down() so Chromium fires dragstart, and replace the single hover with stepped mouse.move calls that re-enter the target on each retry so dragover keeps firing. This stabilizes every dragTreeNode-based test. Verified by running the affected test 8 times with zero failures (was ~50%).

## Why Are There No Tests?

This modifies a shared Playwright test helper (test infrastructure) - no production code, no new test. Validated by re-running the affected Playwright test repeatedly (8/8 passes, was ~50% flaky).

## PR Check

**pr-check: PASS** - tested on `b2824b5b34245aaff13969655a94747907ecfd02`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "b2824b5b34245aaff13969655a94747907ecfd02"} -->