### PR TITLE
LPD-94755 Search page titles the same way as Web Content

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/query/contributor/LayoutHighlightFieldNamesQueryConfigContributor.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/query/contributor/LayoutHighlightFieldNamesQueryConfigContributor.java
@@ -8,11 +8,10 @@ package com.liferay.layout.internal.search.spi.model.query.contributor;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.search.localization.SearchLocalizationHelper;
 import com.liferay.portal.search.spi.model.query.contributor.HighlightFieldNamesQueryConfigContributor;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
@@ -30,8 +29,7 @@ public class LayoutHighlightFieldNamesQueryConfigContributor
 
 	@Override
 	public String[] getHighlightFieldNames(SearchContext searchContext) {
-		List<String> prefixes = new ArrayList<>(
-			Arrays.asList(Field.NAME, Field.TITLE));
+		List<String> prefixes = ListUtil.fromArray(Field.TITLE);
 
 		if (!GetterUtil.getBoolean(
 				searchContext.getAttribute("searchOnlyByTitle"))) {

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/query/contributor/LayoutKeywordQueryContributor.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/query/contributor/LayoutKeywordQueryContributor.java
@@ -41,8 +41,6 @@ public class LayoutKeywordQueryContributor implements KeywordQueryContributor {
 				booleanQuery, searchContext, Field.CONTENT, false);
 		}
 
-		_queryHelper.addSearchTerm(
-			booleanQuery, searchContext, Field.NAME, false);
 		_queryHelper.addSearchLocalizedTerm(
 			booleanQuery, searchContext, Field.TITLE, false);
 

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutMultiLanguageSearchTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutMultiLanguageSearchTest.java
@@ -10,15 +10,22 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.settings.LocalizedValuesMap;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
+import com.liferay.portal.search.test.util.HitsAssert;
 import com.liferay.portal.search.test.util.IndexerFixture;
+import com.liferay.portal.search.test.util.SearchContextTestUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.users.admin.test.util.search.UserSearchFixture;
@@ -81,8 +88,11 @@ public class LayoutMultiLanguageSearchTest {
 	}
 
 	@Test
+	@TestInfo("LPD-94755")
 	public void testJapaneseTitle() throws Exception {
 		_testLocaleKeywords(LocaleUtil.JAPAN, _JAPANESE_KEYWORD, _TITLE);
+
+		_testJapaneseTitleWhitespaceSeparatedWord();
 	}
 
 	@Test
@@ -173,6 +183,24 @@ public class LayoutMultiLanguageSearchTest {
 		).put(
 			prefix + "_ja_JP", _JAPANESE_KEYWORD
 		).build();
+	}
+
+	private void _testJapaneseTitleWhitespaceSeparatedWord() throws Exception {
+		setTestLocale(LocaleUtil.JAPAN);
+
+		layoutFixture.createLayout("公式");
+		layoutFixture.createLayout("公　式");
+
+		Indexer<Layout> indexer = IndexerRegistryUtil.getIndexer(Layout.class);
+
+		Hits hits = indexer.search(
+			SearchContextTestUtil.getSearchContext(
+				TestPropsValues.getUserId(), new long[] {_group.getGroupId()},
+				"公式", LocaleUtil.JAPAN));
+
+		Document document = HitsAssert.assertOnlyOne("公式", hits);
+
+		Assert.assertEquals("公式", document.get("title_ja_JP"));
 	}
 
 	private void _testLocaleKeywords(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94755

## What Is Being Fixed

Page search returned different results than Web Content for the same title. Both index their titles in localized fields with the proper per-language analyzer, but Pages additionally indexed and queried the default-language page title through a non-localized field analyzed with the standard analyzer (added by LPS-193898 to enable partial keyword matching). The standard analyzer is not language aware: for languages without word delimiters such as Japanese it splits the title into per-character unigrams and ignores spaces, so page search over-matched. For example, with Japanese as the default language, searching "公式" matched a page titled "日本版公　式20260601" (where 公 and 式 are separated by a full-width space), a hit Web Content never returns for the same title.

## How It Is Being Fixed

Revert LPS-193898 so the page title is searched only through the localized title field, with each language's own analyzer (kuromoji for Japanese), exactly like Web Content. In LayoutKeywordQueryContributor the non-localized Field.NAME term is removed, and in LayoutHighlightFieldNamesQueryConfigContributor Field.NAME is dropped from the highlighted fields. The page name remains indexed; only the query side changes, so no reindex is required.

LayoutMultiLanguageSearchTest gains a case asserting that, with Japanese as the default language, a search for a whole word matches a title containing that word but not a title where the word is split by a full-width space.

This trade-off reintroduces the limitation LPS-193898 addressed: a partial English keyword such as "employ" no longer matches a page titled "Employees" (it now matches only whole, analyzer-segmented words, as Web Content does). The behavior is the same stemming limitation across every language, so aligning Pages with Web Content is consistent rather than English-specific.

## PR Check

**pr-check: PASS** — tested on `c3aacbfa4007fb49943b5bd7eea28abf8591b762`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "c3aacbfa4007fb49943b5bd7eea28abf8591b762"} -->
