### PR TITLE
LPD-94743 Keep service build.number from decreasing on regen

### DIFF
--- a/modules/apps/layout/layout-page-template-service/src/main/resources/service.properties
+++ b/modules/apps/layout/layout-page-template-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.layout.page.template.service
-    build.number=1
-    build.date=1781143842931
+    build.number=6
+    build.date=1781102513277

--- a/modules/apps/segments/segments-service/src/main/resources/service.properties
+++ b/modules/apps/segments/segments-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.segments.service
-    build.number=12
+    build.number=13
     build.date=1781102517793


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94743

## What Is Being Fixed

The PortalContinuousUpgrade AutoUpgradeFromLatest7413Update test fails because the ServiceComponent for com.liferay.layout.page.template.service is reported as outdated. A previous regeneration (LPD-93973) lowered build.number in the layout-page-template-service service.properties, so the build number persisted by an already-upgraded instance was higher than the one shipped in the module. The upgrade framework treats the lower shipped number as out of date and the upgrade fails.

## How It Is Being Fixed

Partially revert the LPD-93973 regeneration of the two affected service.properties files so build.number does not regress: layout-page-template-service is restored to its earlier higher value (6) along with its matching build.date, and segments-service is advanced to 13. Because build.number must only ever increase, keeping it from going downwards keeps the deployed ServiceComponent current.

## Why Are There No Tests?

This change only adjusts generated Service Builder build metadata (build.number / build.date) in two service.properties files; there is no code behavior to unit- or integration-test. The fix is verified by the existing PortalContinuousUpgrade upgrade test that was failing.

## PR Check

**pr-check: PASS** — tested on `8acff3b6296e913cb2de7800200a547abb3244ab`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "8acff3b6296e913cb2de7800200a547abb3244ab"} -->