### PR TITLE
LPD-95001 Hide spaces collection from the page editor outside CMS sites

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/SpacesComponentSectionFragmentRenderer.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/SpacesComponentSectionFragmentRenderer.java
@@ -7,7 +7,10 @@ package com.liferay.site.cms.site.initializer.internal.fragment.renderer;
 
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.fragment.renderer.FragmentRendererContext;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.PortalRunMode;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSpaceConstants;
 import com.liferay.site.cms.site.initializer.internal.display.context.SpaceStickerDisplayContext;
 import com.liferay.site.cms.site.initializer.internal.util.InfoItemUtil;
@@ -32,7 +35,13 @@ public class SpacesComponentSectionFragmentRenderer
 
 	@Override
 	public boolean isSelectable(HttpServletRequest httpServletRequest) {
-		return true;
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		Group group = themeDisplay.getScopeGroup();
+
+		return group.isCMS();
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/SpacesComponentSectionFragmentRendererTest.java
+++ b/modules/apps/site/site-cms-site-initializer/src/test/java/com/liferay/site/cms/site/initializer/internal/fragment/renderer/SpacesComponentSectionFragmentRendererTest.java
@@ -1,0 +1,73 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.fragment.renderer;
+
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Víctor Galán
+ */
+public class SpacesComponentSectionFragmentRendererTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testIsSelectable() {
+		Assert.assertTrue(
+			_spacesComponentSectionFragmentRenderer.isSelectable(
+				_getMockHttpServletRequest(true)));
+
+		Assert.assertFalse(
+			_spacesComponentSectionFragmentRenderer.isSelectable(
+				_getMockHttpServletRequest(false)));
+	}
+
+	private MockHttpServletRequest _getMockHttpServletRequest(boolean cms) {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Group group = Mockito.mock(Group.class);
+
+		Mockito.when(
+			group.isCMS()
+		).thenReturn(
+			cms
+		);
+
+		Mockito.when(
+			themeDisplay.getScopeGroup()
+		).thenReturn(
+			group
+		);
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		return mockHttpServletRequest;
+	}
+
+	private final SpacesComponentSectionFragmentRenderer
+		_spacesComponentSectionFragmentRenderer =
+			new SpacesComponentSectionFragmentRenderer();
+
+}

--- a/modules/apps/site/site-dsr-site-initializer/src/main/java/com/liferay/site/dsr/site/initializer/internal/fragment/renderer/BaseSectionFragmentRenderer.java
+++ b/modules/apps/site/site-dsr-site-initializer/src/main/java/com/liferay/site/dsr/site/initializer/internal/fragment/renderer/BaseSectionFragmentRenderer.java
@@ -22,8 +22,6 @@ import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
-import jakarta.servlet.http.HttpServletRequest;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -59,11 +57,6 @@ public abstract class BaseSectionFragmentRenderer implements FragmentRenderer {
 			return FragmentRenderer.super.getConfigurationJSONObject(
 				fragmentRendererContext);
 		}
-	}
-
-	@Override
-	public boolean isSelectable(HttpServletRequest httpServletRequest) {
-		return true;
 	}
 
 	protected String getConfigurationPath() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95001

## What Is Being Fixed

The Spaces programming collection was selectable in the page editor on every site, including non-CMS sites where it serves no purpose and only clutters the collection picker.

## How It Is Being Fixed

SpacesComponentSectionFragmentRenderer.isSelectable now returns true only when the scope group is a CMS site (group.isCMS()), so the collection is hidden by default everywhere else. The redundant isSelectable override in the site-dsr BaseSectionFragmentRenderer, which only returned the inherited default of true, was removed. A unit test covers both the CMS and non-CMS cases.

## PR Check

**pr-check: PASS** — tested on `0bde1e1bfeecd5d9f45a37bfa11167083f903255`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "0bde1e1bfeecd5d9f45a37bfa11167083f903255"} -->