### PR TITLE
LPD-95122 Fix flaky scope dropdown deprecation badge Playwright test

### DIFF
--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/widgets.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/widgets.spec.ts
@@ -518,20 +518,24 @@ test(
 			.locator('.dropdown-menu')
 			.getByRole('menuitem', {name: layoutTitle});
 
-		await expect(async () => {
-			await dropdownButton.click({timeout: 2000});
+		await clickAndExpectToBeVisible({
+			target: dropdownOption,
+			timeout: 5000,
+			trigger: dropdownButton,
+		});
 
-			await expect(dropdownOption).toBeVisible({timeout: 1000});
-			await expect(dropdownOption).toContainText('deprecated');
-
-			await dropdownOption.click({timeout: 2000});
-
-			await expect(
-				page.getByText(`${layoutTitle} (Scope) deprecated`)
-			).toBeVisible({timeout: 2000});
-		}).toPass();
+		await expect(dropdownOption).toContainText(/deprecated/i);
 
 		// Check that the page is set as scope
 
+		await dropdownOption.click();
+
+		const scopeName = page.locator('.scope-name', {
+			hasText: `${layoutTitle} (Scope)`,
+		});
+
+		await expect(scopeName).toBeVisible({timeout: 5000});
+
+		await expect(scopeName).toContainText(/deprecated/i);
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95122

## What Is Being Fixed

The Playwright test "Check that the scope dropdown in Product Menu have the deprecation badge and that the page is set as scope" (@LPD-46225) was failing deterministically. The feature works correctly; the test's interaction and assertions were at fault.

## How It Is Being Fixed

The dropdown was opened by re-clicking the "Choose Scope" toggle inside a retry loop with a one-second window, which fought the dropdown's asynchronously loaded scope list (a loading spinner shows first) and left the list closed when the assertion ran. It is now opened with clickAndExpectToBeVisible, which only clicks when the target is not yet visible, so it is never toggled closed, with a timeout that outlasts the async load. The deprecation badge assertion was case-sensitive against text that renders as "Deprecated", so it now matches case-insensitively. The final scope check looked for the literal text "<title> (Scope) deprecated", which is not a single text node; it now targets the .scope-name element and asserts both the scope and the deprecated badge.

## PR Check

**pr-check: PASS** — tested on `49819a666dabe68434ad0f246e9f25ebb6839e3d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Per-Module Compile and JavaScript Unit Tests matched the diff regex but do not apply: modules/test/playwright is not an OSGi module (no bnd.bnd) and Playwright execution is out of pr-check scope. The test was verified directly and passes reliably across repeated runs.

<!-- pr-check {"result": "success", "sha": "49819a666dabe68434ad0f246e9f25ebb6839e3d"} -->