### PR TITLE
LPD-95273 Fix flaky Move Items keyboard test by awaiting preview

### DIFF
--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/keyboard.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/keyboard.spec.ts
@@ -578,7 +578,7 @@ test(
 
 		// Check drag preview label
 
-		expect(
+		await expect(
 			page.locator('.page-editor__keyboard-movement-preview__content')
 		).toHaveText('2 Items');
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95273

## Failing Test







## Root Cause

The  assertion on the keyboard movement preview was not awaited, so it ran as a floating promise concurrently with the / presses that follow. The  commits the move and tears down the movement preview, so the floating assertion never matched before the element was removed, surfacing as  after the 15s timeout on slower CI. The same early key presses also raced the move itself, intermittently leaving the heading inactive locally. No product code or test change in the failing build's range touched this flow; the missing  is a long-standing latent defect that surfaces as flakiness.

## Fix

Await the preview assertion so the test waits for the movement preview to render before driving the movement. After the change the test passed 5/5 consecutive local runs, where it was previously flaky.

- 