### PR TITLE
LPD-95273 Fix flaky Move Items keyboard test by awaiting preview

### DIFF
--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/keyboard.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/keyboard.spec.ts
@@ -578,7 +578,7 @@ test(
 
 		// Check drag preview label
 
-		expect(
+		await expect(
 			page.locator('.page-editor__keyboard-movement-preview__content')
 		).toHaveText('2 Items');
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95273

## What Is Being Fixed

The Playwright test `Check that Move Items action from the browser toolbar works correctly` (`layout-content-page-editor-web/main/keyboard.spec.ts`) is flaky. It failed once on the `[master] ci:test:page-management` routine after a long passing streak, and reproduces intermittently locally. No product code or test change in the failing build's range touched the keyboard-movement flow.

The root cause is a missing `await` on the `toHaveText('2 Items')` assertion for the keyboard movement preview. Without it, the assertion runs as a floating promise concurrently with the `ArrowDown`/`Enter` presses that follow. The `Enter` commits the move and tears down the movement preview, so the floating assertion never matches before the element is removed, surfacing as `element(s) not found` after the 15s timeout on slower CI. The same early key presses also race the move itself, which is why a local run failed later at the `isActive(headingId)` assertion.

## How It Is Being Fixed

Await the preview assertion so the test waits for the movement preview to render before driving the movement. This makes the flow deterministic: the move only starts once the movement mode is confirmed active. After the change the test passed 5/5 consecutive local runs, where it was previously flaky.

## Why Are There No Tests?

The change is a one-line correction to an existing Playwright test (adding a missing `await`); it fixes test reliability rather than adding product code, so no new test is warranted.

## PR Check

**pr-check: PASS** — tested on `9e782c773eec65e23308c7750df48d3c3d91c1c5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "9e782c773eec65e23308c7750df48d3c3d91c1c5"} -->
