### PR TITLE
LPD-95278 Fix flaky removed-fragment message test by awaiting movement

### DIFF
--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/sidebar.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/sidebar.spec.ts
@@ -1028,6 +1028,13 @@ test.describe('Fragments Panel', () => {
 			await page.getByLabel(`Add ${fragmentName}`).focus();
 
 			await page.keyboard.press('Enter');
+
+			// Wait for the keyboard movement to start before committing it
+
+			await expect(
+				page.locator('.page-editor__keyboard-movement-preview__content')
+			).toBeVisible();
+
 			await page.keyboard.press('Enter');
 
 			await expect(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95278

## What Is Being Fixed

The Playwright test `Correct message is displayed when adding a removed fragment` (`layout-content-page-editor-web/main/sidebar.spec.ts`) is flaky. On the `[master] ci:test:page-management` routine it has failed intermittently (06-02, 06-15, 06-17) with passes in between, and locally it failed 2 of 3 runs.

The "Add" button in the Fragments panel starts a keyboard-movement-based add (`setMovementSources`). The test presses `Enter` twice back-to-back: the first starts the movement, the second is meant to commit it. When the second `Enter` lands before the `KeyboardMovementManager` is ready to commit, the move never commits, the add never fires, and the expected "the fragment can no longer be added because it has been deleted" error never appears.

## How It Is Being Fixed

Wait for the keyboard movement preview to render between the two `Enter` presses, so the commit only happens once the movement mode is active. This removes the race regardless of system load. After the change the test passed 5/5 consecutive local runs, where it was previously flaky.

## Why Are There No Tests?

The change is a small correction to an existing Playwright test (adding a wait for the movement preview); it fixes test reliability rather than adding product code, so no new test is warranted.

## PR Check

**pr-check: PASS** — tested on `135ac0c336ebfa2547fdb7648ab7e46a6fad89c5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "135ac0c336ebfa2547fdb7648ab7e46a6fad89c5"} -->
