### PR TITLE
LPD-94764 Stabilize the page structure tree drag in Playwright tests

### DIFF
--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -877,7 +877,8 @@ export class PageEditorPage {
 
 		await this.page.mouse.down();
 
-		// Nudge the pointer so Chromium starts the native HTML5 drag
+		// Move the pointer slightly while pressed so Chromium starts the
+		// native HTML5 drag
 
 		await this.page.mouse.move(
 			sourceBox.x + sourceBox.width / 2,
@@ -903,14 +904,17 @@ export class PageEditorPage {
 					? /drag-over-bottom/
 					: /drag-over-top/;
 
-		const jiggleY = position === 'top' ? y + 4 : y - 4;
+		const approachY = position === 'top' ? y + 4 : y - 4;
 
-		// Move over the target until the drop indicator appears
+		// Move over the target until the drop indicator appears. Each pass
+		// moves to a nearby point first and then to the real drop point, so
+		// the pointer position always changes and Chromium keeps firing
+		// dragover events.
 
 		await expect(async () => {
 			await this.page.mouse.move(
 				targetBox.x + targetBox.width / 2,
-				targetBox.y + jiggleY,
+				targetBox.y + approachY,
 				{steps: 5}
 			);
 

--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -873,7 +873,17 @@ export class PageEditorPage {
 
 		await sourceNode.hover();
 
+		const sourceBox = await sourceNode.boundingBox();
+
 		await this.page.mouse.down();
+
+		// Nudge the pointer so Chromium starts the native HTML5 drag
+
+		await this.page.mouse.move(
+			sourceBox.x + sourceBox.width / 2,
+			sourceBox.y + sourceBox.height / 2 + 8,
+			{steps: 5}
+		);
 
 		// Calculate drop data
 
@@ -893,15 +903,22 @@ export class PageEditorPage {
 					? /drag-over-bottom/
 					: /drag-over-top/;
 
-		// Check hover is correct
+		const jiggleY = position === 'top' ? y + 4 : y - 4;
+
+		// Move over the target until the drop indicator appears
 
 		await expect(async () => {
-			await targetNode.hover({
-				position: {
-					x: targetBox.width / 2,
-					y,
-				},
-			});
+			await this.page.mouse.move(
+				targetBox.x + targetBox.width / 2,
+				targetBox.y + jiggleY,
+				{steps: 5}
+			);
+
+			await this.page.mouse.move(
+				targetBox.x + targetBox.width / 2,
+				targetBox.y + y,
+				{steps: 5}
+			);
 
 			await expect(targetNode).toHaveClass(cssClass, {
 				timeout: 1000,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94764

## What Is Being Fixed

The Playwright page structure tree drag-and-drop helper (`dragTreeNode` in
`PageEditorPage`) was flaky. Chromium's native HTML5 drag only starts when the
pointer moves while pressed, and the drop indicator only appears when the
pointer position actually changes between `dragover` events. The previous helper
did not reliably trigger these events, so the tree drag occasionally failed.

## How It Is Being Fixed

The helper now moves the pointer a few pixels while the button is pressed so
Chromium starts the native drag, and it retries the move over the target — first
to a nearby point and then to the real drop point — so the pointer position
always changes and Chromium keeps firing `dragover` events until the drop
indicator shows. A follow-up pass renames a local variable and rewords the
comments so the intent of each step is clear without changing behavior.

## Why Are There No Tests?

This change only improves an existing Playwright test helper — stabilizing the
drag interaction and clarifying its variable name and comments. It adds no
product code, so there is no new behavior to cover; the existing Playwright
suites that use `dragTreeNode` exercise it.

## PR Check

**pr-check: PASS** — tested on `1ef59e6ed7e179af9e5245e233c15ba7652b2cb4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "1ef59e6ed7e179af9e5245e233c15ba7652b2cb4"} -->
