### PR TITLE
LPD-95122 Fix flaky Product Menu scope dropdown Playwright test

### DIFF
--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/widgets.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/widgets.spec.ts
@@ -506,13 +506,17 @@ test(
 
 		// Check the label in the dropdown at the Product Menu
 
-		await productMenuPage.openProductMenuButton.click();
-
-		await productMenuPage.contentAndDataButton.click();
+		await productMenuPage.openProductMenuIfClosed();
 
 		// Open the dropdown to select the scope
 
 		const dropdownButton = page.getByLabel('Choose Scope');
+
+		await clickAndExpectToBeVisible({
+			target: dropdownButton,
+			timeout: 5000,
+			trigger: productMenuPage.contentAndDataButton,
+		});
 
 		const dropdownOption = page
 			.locator('.dropdown-menu')

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/widgets.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/widgets.spec.ts
@@ -518,20 +518,24 @@ test(
 			.locator('.dropdown-menu')
 			.getByRole('menuitem', {name: layoutTitle});
 
-		await expect(async () => {
-			await dropdownButton.click({timeout: 2000});
+		await clickAndExpectToBeVisible({
+			target: dropdownOption,
+			timeout: 5000,
+			trigger: dropdownButton,
+		});
 
-			await expect(dropdownOption).toBeVisible({timeout: 1000});
-			await expect(dropdownOption).toContainText('deprecated');
-
-			await dropdownOption.click({timeout: 2000});
-
-			await expect(
-				page.getByText(`${layoutTitle} (Scope) deprecated`)
-			).toBeVisible({timeout: 2000});
-		}).toPass();
+		await expect(dropdownOption).toContainText(/deprecated/i);
 
 		// Check that the page is set as scope
 
+		await dropdownOption.click();
+
+		const scopeName = page.locator('.scope-name', {
+			hasText: `${layoutTitle} (Scope)`,
+		});
+
+		await expect(scopeName).toBeVisible({timeout: 5000});
+
+		await expect(scopeName).toContainText(/deprecated/i);
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95122

## What Is Being Fixed

The Playwright test that checks the deprecation badge on the Product Menu scope dropdown was flaky. It opened the dropdown by re-clicking its toggle inside a `toPass` retry loop with a one-second window, which fought the dropdown's asynchronously loaded scope list and left it closed when the assertion ran. The deprecation badge assertion was case-sensitive against text that renders as `Deprecated`, and the final scope check looked for a single text node that does not exist. On top of that, the clicks that open the Product Menu and the Content & Data panel fired bare right after a full `page.goto`, before the toggle was hydrated and before the panel existed, which is the most fragile point in the flow.

## How It Is Being Fixed

The dropdown is now opened with `clickAndExpectToBeVisible` so it is never toggled closed, the badge is matched case-insensitively, and the selected scope is verified through the `.scope-name` element. The two clicks right after `page.goto` are now wrapped in the same retry pattern: opening the Product Menu goes through the idempotent `openProductMenuIfClosed`, and the Content & Data click uses `clickAndExpectToBeVisible` with the scope toggle as its target. The whole chain (open menu -> Content & Data -> Choose Scope -> option) now retries consistently instead of relying on bare clicks. Verified stable across five consecutive runs with `--repeat-each=5`.

## PR Check

**pr-check: PASS** — tested on `97e3e90204e8b91e234995e58ed8d21338219fb2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "97e3e90204e8b91e234995e58ed8d21338219fb2"} -->
