### PR TITLE
LPD-95308 Fix input error message font size

### DIFF
--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/checkbox/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/checkbox/index.html
@@ -20,7 +20,7 @@
 	</div>
 
 	[#if input.errorMessage?has_content]
-		<p class="font-weight-semi-bold mt-1 text-danger" id="${fragmentElementId}-checkbox-error-message">
+		<p class="font-weight-semi-bold mt-1 text-3 text-danger" id="${fragmentElementId}-checkbox-error-message">
 			<svg class="lexicon-icon lexicon-icon-info-circle" focusable="false" role="presentation">
 				<use xlink:href="${siteSpritemap}#info-circle" />
 			</svg>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-input/index.html
@@ -20,7 +20,7 @@
 			[/#if]
 		</div>
 		[#if input.errorMessage?has_content]
-			<p class="font-weight-semi-bold mt-1 text-danger" id="${fragmentElementId}-date-input-error">
+			<p class="font-weight-semi-bold mt-1 text-3 text-danger" id="${fragmentElementId}-date-input-error">
 				<svg class="lexicon-icon lexicon-icon-info-circle" focusable="false" role="presentation">
 					<use xlink:href="${siteSpritemap}#info-circle" />
 				</svg>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-time-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-time-input/index.html
@@ -21,7 +21,7 @@
 		</div>
 
 		[#if input.errorMessage?has_content]
-			<p class="font-weight-semi-bold mt-1 text-danger" id="${fragmentElementId}-date-input-error">
+			<p class="font-weight-semi-bold mt-1 text-3 text-danger" id="${fragmentElementId}-date-input-error">
 				<svg class="lexicon-icon lexicon-icon-info-circle" focusable="false" role="presentation">
 					<use xlink:href="${siteSpritemap}#info-circle" />
 				</svg>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/email-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/email-input/index.html
@@ -35,7 +35,7 @@
 			</p>
 		[/#if]
 
-		<p class="font-weight-semi-bold mt-1 text-danger[#if !input.errorMessage?has_content] sr-only[/#if]" id="${fragmentElementId}-email-input-error">
+		<p class="font-weight-semi-bold mt-1 text-3 text-danger[#if !input.errorMessage?has_content] sr-only[/#if]" id="${fragmentElementId}-email-input-error">
 			[@clay["icon"] symbol="info-circle" /]
 
 			<span data-invalid-feedback="${languageUtil.get(locale, "please-enter-a-valid-email-address")}" data-valid-feedback="${languageUtil.get(locale, "current-text-length-is-valid")}" id="${fragmentElementId}-email-input-error-message" role="alert">

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/file-upload/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/file-upload/index.html
@@ -46,7 +46,7 @@
 			</div>
 		[/#if]
 
-		<p class="font-weight-semi-bold mt-1 text-danger[#if !input.errorMessage?has_content] sr-only[/#if]" id="${fragmentElementId}-file-upload-error">
+		<p class="font-weight-semi-bold mt-1 text-3 text-danger[#if !input.errorMessage?has_content] sr-only[/#if]" id="${fragmentElementId}-file-upload-error">
 			[@clay["icon"] symbol="info-circle" /]
 
 			<span data-file-size-feedback="${languageUtil.format(locale, "please-enter-a-file-with-a-valid-file-size-no-larger-than-x-mb", input.attributes.maxFileSize!"")}" id="${fragmentElementId}-file-upload-error-message" role="alert">

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/friendly-url-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/friendly-url-input/index.html
@@ -19,7 +19,7 @@
 				<input aria-labelledby="${fragmentElementId}-friendly-url-input-label [#if input.errorMessage?has_content]${fragmentElementId}-friendly-url-input-error-message[/#if]" class="form-control form-control-sm" id="${fragmentElementId}-friendly-url-input" name="${input.name}" [#if input.readOnly]readonly[/#if] type="text" [#if input.value??]value="${input.value}"[/#if] />
 
 				[#if input.errorMessage?has_content]
-					<p class="font-weight-semi-bold mt-1 text-danger" id="${fragmentElementId}-friendly-url-input-error">
+					<p class="font-weight-semi-bold mt-1 text-3 text-danger" id="${fragmentElementId}-friendly-url-input-error">
 						[@clay["icon"] symbol="info-circle" /]
 
 						<span id="${fragmentElementId}-friendly-url-input-error-message">

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/multiple-select-from-list/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/multiple-select-from-list/index.html
@@ -43,7 +43,7 @@
 	</div>
 
 	[#if input.errorMessage?has_content]
-		<p class="font-weight-semi-bold mt-1 text-danger" id="${fragmentElementId}-multiselect-list-error-message">
+		<p class="font-weight-semi-bold mt-1 text-3 text-danger" id="${fragmentElementId}-multiselect-list-error-message">
 			<svg class="lexicon-icon lexicon-icon-info-circle" focusable="false" role="presentation">
 				<use xlink:href="${siteSpritemap}#info-circle" />
 			</svg>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/multiselector-dropdown/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/multiselector-dropdown/index.html
@@ -115,7 +115,7 @@
 		[/#if]
 
 		[#if input.errorMessage?has_content]
-			<p class="font-weight-semi-bold mt-1 text-danger" id="${fragmentElementId}-error-message">
+			<p class="font-weight-semi-bold mt-1 text-3 text-danger" id="${fragmentElementId}-error-message">
 				<svg class="lexicon-icon lexicon-icon-info-circle" focusable="false" role="presentation">
 					<use xlink:href="${siteSpritemap}#info-circle" />
 				</svg>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/numeric-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/numeric-input/index.html
@@ -21,7 +21,7 @@
 		</div>
 
 		[#if input.errorMessage?has_content]
-			<p class="font-weight-semi-bold mt-1 text-danger" id="${fragmentElementId}-numeric-input-error">
+			<p class="font-weight-semi-bold mt-1 text-3 text-danger" id="${fragmentElementId}-numeric-input-error">
 				<svg class="lexicon-icon lexicon-icon-info-circle" focusable="false" role="presentation">
 					<use xlink:href="${siteSpritemap}#info-circle" />
 				</svg>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/phone-number-input/index.html
@@ -221,7 +221,7 @@
 		[/#if]
 
 		[#if input.errorMessage?has_content]
-			<p class="font-weight-semi-bold mt-1 text-danger" id="${fragmentElementId}-error-message">
+			<p class="font-weight-semi-bold mt-1 text-3 text-danger" id="${fragmentElementId}-error-message">
 				[@clay["icon"] symbol="info-circle" /]
 
 				<span>${input.errorMessage}</span>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/rich-text-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/rich-text-input/index.html
@@ -28,7 +28,7 @@
 			[/#if]
 		</div>
 
-		<p class="font-weight-semi-bold mt-1 text-danger[#if !input.errorMessage?has_content] d-none[/#if]" id="${fragmentElementId}-error-message">
+		<p class="font-weight-semi-bold mt-1 text-3 text-danger[#if !input.errorMessage?has_content] d-none[/#if]" id="${fragmentElementId}-error-message">
 			[@clay["icon"] symbol="info-circle" /]
 
 			<span data-required-error="${languageUtil.get(locale, 'this-field-is-required')}" id="${fragmentElementId}-error-message-text" role="status">

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/select-from-list/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/select-from-list/index.html
@@ -80,7 +80,7 @@
 		[/#if]
 
 		[#if input.errorMessage?has_content]
-			<p class="font-weight-semi-bold mt-1 text-danger" id="${fragmentElementId}-select-from-list-input-error-message">
+			<p class="font-weight-semi-bold mt-1 text-3 text-danger" id="${fragmentElementId}-select-from-list-input-error-message">
 				<svg class="lexicon-icon lexicon-icon-info-circle" focusable="false" role="presentation">
 					<use xlink:href="${siteSpritemap}#info-circle" />
 				</svg>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/text-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/text-input/index.html
@@ -21,7 +21,7 @@
 			</p>
 		[/#if]
 
-		<p class="font-weight-semi-bold mt-1 text-danger[#if !input.errorMessage?has_content] sr-only[/#if]" id="${fragmentElementId}-text-input-error">
+		<p class="font-weight-semi-bold mt-1 text-3 text-danger[#if !input.errorMessage?has_content] sr-only[/#if]" id="${fragmentElementId}-text-input-error">
 			[@clay["icon"] symbol="info-circle" /]
 
 			<span data-length-feedback="${languageUtil.get(locale, "maximum-number-of-characters-exceeded")}" data-valid-feedback="${languageUtil.get(locale, "current-text-length-is-valid")}" id="${fragmentElementId}-text-input-error-message" role="alert">

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/textarea/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/textarea/index.html
@@ -24,7 +24,7 @@
 			</p>
 		[/#if]
 
-		<p class="font-weight-semi-bold mt-1 text-danger[#if !input.errorMessage?has_content] sr-only[/#if]" id="${fragmentElementId}-textarea-error">
+		<p class="font-weight-semi-bold mt-1 text-3 text-danger[#if !input.errorMessage?has_content] sr-only[/#if]" id="${fragmentElementId}-textarea-error">
 			[@clay["icon"] symbol="info-circle" /]
 
 			<span data-length-feedback="${languageUtil.get(locale, "maximum-number-of-characters-exceeded")}" data-valid-feedback="${languageUtil.get(locale, "current-text-length-is-valid")}" id="${fragmentElementId}-textarea-error-message" role="alert">

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/video-previewer-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/video-previewer-input/index.html
@@ -26,7 +26,7 @@
 			</p>
 		[/#if]
 
-		<p class="font-weight-semi-bold mt-1 text-danger[#if !input.errorMessage?has_content] sr-only[/#if]" id="${fragmentElementId}-video-previewer-error">
+		<p class="font-weight-semi-bold mt-1 text-3 text-danger[#if !input.errorMessage?has_content] sr-only[/#if]" id="${fragmentElementId}-video-previewer-error">
 			[@clay["icon"] symbol="info-circle" /]
 
 			<span data-length-feedback="${languageUtil.get(locale, "maximum-number-of-characters-exceeded")}" data-valid-feedback="${languageUtil.get(locale, "current-text-length-is-valid")}" id="${fragmentElementId}-video-previewer-error-message" role="alert">


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95308

## What Is Being Fixed

The validation error message in the Phone Number input fragment renders at
16px instead of the expected 14px. The error message paragraph uses the classes
`font-weight-semi-bold mt-1 text-danger`, which set the font weight and margin
but never a font size, so it inherits the 1rem (16px) body size, while Clay's
standard form helper text (`.form-text`) is 0.875rem (14px). The same markup is
shared by the rest of the input fragments, so they all render their error
message at 16px too.

## How It Is Being Fixed

Added the `text-3` Clay utility (0.875rem) to the error message paragraph so it
matches the 14px form helper text size. The first commit fixes the Phone Number
input (the reported case); the second applies the same change to the remaining
input fragments for consistency.

## Why Are There No Tests?

No tests were added because this is a very minor styling matter — just a
font-size adjustment.

## PR Check

**pr-check: PASS** — tested on `31b5b547d86c8102aecc4be0f4061b351d8cd537`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "31b5b547d86c8102aecc4be0f4061b351d8cd537"} -->
