### PR TITLE
LPD-93455 Allow repeated LAR imports of dynamic-data fragments

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker-test/src/testIntegration/java/com/liferay/fragment/entry/processor/freemarker/test/FreeMarkerFragmentEntryProcessorTest.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker-test/src/testIntegration/java/com/liferay/fragment/entry/processor/freemarker/test/FreeMarkerFragmentEntryProcessorTest.java
@@ -10,6 +10,7 @@ import com.liferay.asset.list.model.AssetListEntry;
 import com.liferay.asset.list.service.AssetListEntryLocalService;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.entry.processor.constants.FragmentEntryProcessorConstants;
 import com.liferay.fragment.exception.FragmentEntryContentException;
@@ -127,6 +128,22 @@ public class FreeMarkerFragmentEntryProcessorTest {
 	@After
 	public void tearDown() {
 		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	public void testAddFragmentEntryWithDynamicDataDuringImport()
+		throws Exception {
+
+		try {
+			ExportImportThreadLocal.setLayoutImportInProcess(true);
+
+			Assert.assertNotNull(
+				_addFragmentEntry(
+					"fragment_entry_with_rest_client_data.html", null));
+		}
+		finally {
+			ExportImportThreadLocal.setLayoutImportInProcess(false);
+		}
 	}
 
 	@Test

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker-test/src/testIntegration/java/com/liferay/fragment/entry/processor/freemarker/test/FreeMarkerFragmentEntryProcessorTest.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker-test/src/testIntegration/java/com/liferay/fragment/entry/processor/freemarker/test/FreeMarkerFragmentEntryProcessorTest.java
@@ -135,9 +135,9 @@ public class FreeMarkerFragmentEntryProcessorTest {
 	public void testAddFragmentEntryWithDynamicDataDuringImport()
 		throws Exception {
 
-		try {
-			ExportImportThreadLocal.setLayoutImportInProcess(true);
+		ExportImportThreadLocal.setLayoutImportInProcess(true);
 
+		try {
 			Assert.assertNotNull(
 				_addFragmentEntry(
 					"fragment_entry_with_rest_client_data.html", null));

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker-test/src/testIntegration/java/com/liferay/fragment/entry/processor/freemarker/test/FreeMarkerFragmentEntryProcessorTest.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker-test/src/testIntegration/java/com/liferay/fragment/entry/processor/freemarker/test/FreeMarkerFragmentEntryProcessorTest.java
@@ -131,6 +131,7 @@ public class FreeMarkerFragmentEntryProcessorTest {
 	}
 
 	@Test
+	@TestInfo("LPD-93455")
 	public void testAddFragmentEntryWithDynamicDataDuringImport()
 		throws Exception {
 

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker-test/src/testIntegration/resources/com/liferay/fragment/entry/processor/freemarker/test/dependencies/fragment_entry_with_rest_client_data.html
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker-test/src/testIntegration/resources/com/liferay/fragment/entry/processor/freemarker/test/dependencies/fragment_entry_with_rest_client_data.html
@@ -1,0 +1,9 @@
+[#assign
+	restGetSample = restClient.get("/o/headless-delivery/v1.0/sites/0/site-pages?fields=taxonomyCategoryBriefs")
+]
+
+[#if (restGetSample.taxonomyCategoryBriefs)??]
+	${restGetSample.taxonomyCategoryBriefs}
+[/#if]
+
+<h1>Sample</h1>

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker/src/main/java/com/liferay/fragment/entry/processor/freemarker/FreeMarkerFragmentEntryValidator.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker/src/main/java/com/liferay/fragment/entry/processor/freemarker/FreeMarkerFragmentEntryValidator.java
@@ -63,8 +63,7 @@ public class FreeMarkerFragmentEntryValidator
 					CompanyThreadLocal.getCompanyId());
 
 		if (!freeMarkerFragmentEntryProcessorConfiguration.enable() ||
-			!_isFreeMarkerTemplate(html) ||
-			ExportImportThreadLocal.isImportInProcess()) {
+			!_isFreeMarkerTemplate(html)) {
 
 			return;
 		}
@@ -134,6 +133,10 @@ public class FreeMarkerFragmentEntryValidator
 
 			template.prepare(httpServletRequest);
 
+			if (ExportImportThreadLocal.isImportInProcess()) {
+				template.put("restClient", new DummyRESTClient());
+			}
+
 			template.processTemplate(new DummyWriter());
 		}
 		catch (TemplateException templateException) {
@@ -144,6 +147,14 @@ public class FreeMarkerFragmentEntryValidator
 			httpServletRequest.setAttribute(
 				WebKeys.AUI_SCRIPT_DATA, scriptData);
 		}
+	}
+
+	public static class DummyRESTClient {
+
+		public Object get(String path) {
+			return Collections.emptyMap();
+		}
+
 	}
 
 	private String _getMessage(

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker/src/main/java/com/liferay/fragment/entry/processor/freemarker/FreeMarkerFragmentEntryValidator.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker/src/main/java/com/liferay/fragment/entry/processor/freemarker/FreeMarkerFragmentEntryValidator.java
@@ -5,6 +5,7 @@
 
 package com.liferay.fragment.entry.processor.freemarker;
 
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.fragment.entry.processor.freemarker.internal.configuration.FreeMarkerFragmentEntryProcessorConfiguration;
 import com.liferay.fragment.exception.FragmentEntryContentException;
 import com.liferay.fragment.input.template.parser.InputTemplateNode;
@@ -62,7 +63,8 @@ public class FreeMarkerFragmentEntryValidator
 					CompanyThreadLocal.getCompanyId());
 
 		if (!freeMarkerFragmentEntryProcessorConfiguration.enable() ||
-			!_isFreeMarkerTemplate(html)) {
+			!_isFreeMarkerTemplate(html) ||
+			ExportImportThreadLocal.isImportInProcess()) {
 
 			return;
 		}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentPortletDataHandler.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentPortletDataHandler.java
@@ -8,7 +8,6 @@ package com.liferay.fragment.internal.exportimport.data.handler;
 import com.liferay.exportimport.constants.ExportImportConstants;
 import com.liferay.exportimport.kernel.lar.BasePortletDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportDateUtil;
-import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.PortletDataHandler;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerBoolean;
@@ -17,19 +16,16 @@ import com.liferay.exportimport.kernel.lar.StagedModelType;
 import com.liferay.exportimport.kernel.staging.Staging;
 import com.liferay.exportimport.portlet.data.handler.helper.PortletDataHandlerHelper;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
-import com.liferay.fragment.configuration.FragmentServiceConfiguration;
 import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.constants.FragmentPortletKeys;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.layout.util.LayoutServiceContextHelper;
-import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.xml.Element;
-import com.liferay.staging.StagingGroupHelper;
 
 import jakarta.portlet.PortletPreferences;
 
@@ -179,25 +175,6 @@ public class FragmentPortletDataHandler extends BasePortletDataHandler {
 			return null;
 		}
 
-		FragmentServiceConfiguration fragmentServiceConfiguration =
-			_configurationProvider.getCompanyConfiguration(
-				FragmentServiceConfiguration.class,
-				portletDataContext.getCompanyId());
-
-		if (!fragmentServiceConfiguration.propagateChanges() ||
-			(ExportImportThreadLocal.isStagingInProcess() &&
-			 _stagingGroupHelper.isStagedPortlet(
-				 portletDataContext.getGroupId(),
-				 FragmentPortletKeys.FRAGMENT))) {
-
-			for (Element fragmentEntryElement : fragmentEntryElements) {
-				StagedModelDataHandlerUtil.importStagedModel(
-					portletDataContext, fragmentEntryElement);
-			}
-
-			return null;
-		}
-
 		try (AutoCloseable autoCloseable =
 				_layoutServiceContextHelper.getServiceContextAutoCloseable(
 					_companyLocalService.getCompany(
@@ -247,9 +224,6 @@ public class FragmentPortletDataHandler extends BasePortletDataHandler {
 	@Reference
 	private CompanyLocalService _companyLocalService;
 
-	@Reference
-	private ConfigurationProvider _configurationProvider;
-
 	@Reference(
 		target = "(model.class.name=com.liferay.fragment.model.FragmentCollection)",
 		unbind = "-"
@@ -275,8 +249,5 @@ public class FragmentPortletDataHandler extends BasePortletDataHandler {
 
 	@Reference
 	private Staging _staging;
-
-	@Reference
-	private StagingGroupHelper _stagingGroupHelper;
 
 }

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/staged/model/repository/FragmentEntryStagedModelRepository.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/staged/model/repository/FragmentEntryStagedModelRepository.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.LayoutService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -52,6 +53,13 @@ public class FragmentEntryStagedModelRepository
 
 		ServiceContext serviceContext = portletDataContext.createServiceContext(
 			fragmentEntry);
+
+		ServiceContext currentServiceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (currentServiceContext != null) {
+			serviceContext.setRequest(currentServiceContext.getRequest());
+		}
 
 		if (portletDataContext.isDataStrategyMirror()) {
 			serviceContext.setUuid(fragmentEntry.getUuid());

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/exportimport/test/FragmentExportImportTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/exportimport/test/FragmentExportImportTest.java
@@ -254,6 +254,8 @@ public class FragmentExportImportTest extends BasePortletExportImportTestCase {
 			_updateFragmentEntry(fragmentEntry, _getRESTClientHTML()));
 		_testExportImportPortletWithValidationWithFragmentEntryContentException(
 			_updateFragmentEntry(fragmentEntry, "${"));
+		_testExportImportPortletWithValidation(
+			_updateFragmentEntry(fragmentEntry, _getRESTClientHTML()));
 	}
 
 	@Test

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/exportimport/test/FragmentExportImportTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/exportimport/test/FragmentExportImportTest.java
@@ -252,6 +252,8 @@ public class FragmentExportImportTest extends BasePortletExportImportTestCase {
 			_updateFragmentEntry(fragmentEntry, "${"));
 		_testExportImportPortletWithValidation(
 			_updateFragmentEntry(fragmentEntry, _getRESTClientHTML()));
+		_testExportImportPortletWithValidationWithFragmentEntryContentException(
+			_updateFragmentEntry(fragmentEntry, "${"));
 	}
 
 	@Test

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/exportimport/test/FragmentExportImportTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/exportimport/test/FragmentExportImportTest.java
@@ -12,9 +12,11 @@ import com.liferay.exportimport.test.util.lar.BasePortletExportImportTestCase;
 import com.liferay.fragment.configuration.FragmentServiceConfiguration;
 import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.constants.FragmentPortletKeys;
+import com.liferay.fragment.exception.FragmentEntryContentException;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.processor.FragmentEntryProcessorRegistry;
 import com.liferay.fragment.service.FragmentCollectionLocalService;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.fragment.service.FragmentEntryLocalService;
@@ -31,6 +33,7 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
@@ -53,6 +56,7 @@ import com.liferay.segments.service.SegmentsExperienceLocalService;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -231,6 +235,24 @@ public class FragmentExportImportTest extends BasePortletExportImportTestCase {
 	}
 
 	@Test
+	@TestInfo("LPD-93455")
+	public void testExportImportPortletWithValidation() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				group, TestPropsValues.getUserId());
+
+		FragmentEntry fragmentEntry = _addFragmentEntry(
+			_fragmentCollectionLocalService.addFragmentCollection(
+				null, TestPropsValues.getUserId(),
+				serviceContext.getScopeGroupId(), RandomTestUtil.randomString(),
+				StringPool.BLANK, serviceContext),
+			RandomTestUtil.randomString(), serviceContext);
+
+		_testExportImportPortletWithValidationWithFragmentEntryContentException(
+			_updateFragmentEntry(fragmentEntry, "${"));
+	}
+
+	@Test
 	public void testImportUpdateFragmentEntryWithPropagationEnabled()
 		throws Exception {
 
@@ -345,10 +367,38 @@ public class FragmentExportImportTest extends BasePortletExportImportTestCase {
 			WorkflowConstants.STATUS_APPROVED, serviceContext);
 	}
 
+	private FragmentEntry _addFragmentEntry(
+			FragmentCollection fragmentCollection, String html,
+			ServiceContext serviceContext)
+		throws Exception {
+
+		return _fragmentEntryLocalService.addFragmentEntry(
+			null, TestPropsValues.getUserId(), serviceContext.getScopeGroupId(),
+			fragmentCollection.getFragmentCollectionId(), null,
+			RandomTestUtil.randomString(), StringPool.BLANK, html,
+			StringPool.BLANK, false, StringPool.BLANK, null, 0, false, false,
+			FragmentConstants.TYPE_COMPONENT, null,
+			WorkflowConstants.STATUS_APPROVED, serviceContext);
+	}
+
 	private void _assertContains(String text, String... strings) {
 		for (String string : strings) {
 			Assert.assertTrue(string, string.contains(text));
 		}
+	}
+
+	private void _assertFragmentEntryContentException(Exception exception) {
+		Throwable throwable = exception;
+
+		while (throwable != null) {
+			if (throwable instanceof FragmentEntryContentException) {
+				return;
+			}
+
+			throwable = throwable.getCause();
+		}
+
+		throw new AssertionError(exception);
 	}
 
 	private String _getLayoutContent(Layout layout, Locale locale)
@@ -369,6 +419,42 @@ public class FragmentExportImportTest extends BasePortletExportImportTestCase {
 		}
 	}
 
+	private void
+		_testExportImportPortletWithValidationWithFragmentEntryContentException(
+			FragmentEntry fragmentEntry) {
+
+		String expectedHTML = null;
+
+		FragmentEntry importedGroupFragmentEntry =
+			_fragmentEntryLocalService.fetchFragmentEntryByUuidAndGroupId(
+				fragmentEntry.getUuid(), importedGroup.getGroupId());
+
+		if (importedGroupFragmentEntry != null) {
+			expectedHTML = importedGroupFragmentEntry.getHtml();
+		}
+
+		try {
+			exportImportPortlet(FragmentPortletKeys.FRAGMENT, false);
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			_assertFragmentEntryContentException(exception);
+		}
+
+		importedGroupFragmentEntry =
+			_fragmentEntryLocalService.fetchFragmentEntryByUuidAndGroupId(
+				fragmentEntry.getUuid(), importedGroup.getGroupId());
+
+		if (expectedHTML == null) {
+			Assert.assertNull(importedGroupFragmentEntry);
+
+			return;
+		}
+
+		Assert.assertEquals(expectedHTML, importedGroupFragmentEntry.getHtml());
+	}
+
 	private FragmentEntry _updateFragmentEntry(FragmentEntry fragmentEntry)
 		throws Exception {
 
@@ -380,6 +466,35 @@ public class FragmentExportImportTest extends BasePortletExportImportTestCase {
 			fragmentEntry.getConfiguration(), fragmentEntry.getIcon(),
 			fragmentEntry.getPreviewFileEntryId(), fragmentEntry.isReadOnly(),
 			fragmentEntry.getTypeOptions(), fragmentEntry.getStatus());
+	}
+
+	private FragmentEntry _updateFragmentEntry(
+			FragmentEntry fragmentEntry, String html)
+		throws Exception {
+
+		try (AutoCloseable autoCloseable =
+				new CompanyConfigurationTemporarySwapper(
+					_group.getCompanyId(),
+					"com.liferay.fragment.entry.processor.freemarker." +
+						"internal.configuration." +
+							"FreeMarkerFragmentEntryProcessorConfiguration",
+					HashMapDictionaryBuilder.<String, Object>put(
+						"enable.freemarker", false
+					).build())) {
+
+			fragmentEntry.setHtml(html);
+
+			fragmentEntry = _fragmentEntryLocalService.updateFragmentEntry(
+				fragmentEntry);
+
+			ThreadLocal<Set<String>> validHTMLs =
+				ReflectionTestUtil.getFieldValue(
+					_fragmentEntryProcessorRegistry, "_validHTMLs");
+
+			validHTMLs.remove();
+
+			return fragmentEntry;
+		}
 	}
 
 	private static final String _HTML = StringBundler.concat(
@@ -403,6 +518,9 @@ public class FragmentExportImportTest extends BasePortletExportImportTestCase {
 
 	@Inject
 	private FragmentEntryLocalService _fragmentEntryLocalService;
+
+	@Inject
+	private FragmentEntryProcessorRegistry _fragmentEntryProcessorRegistry;
 
 	@Inject(filter = "jakarta.portlet.name=" + FragmentPortletKeys.FRAGMENT)
 	private PortletDataHandler _fragmentPortletDataHandler;

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/exportimport/test/FragmentExportImportTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/exportimport/test/FragmentExportImportTest.java
@@ -250,6 +250,8 @@ public class FragmentExportImportTest extends BasePortletExportImportTestCase {
 
 		_testExportImportPortletWithValidationWithFragmentEntryContentException(
 			_updateFragmentEntry(fragmentEntry, "${"));
+		_testExportImportPortletWithValidation(
+			_updateFragmentEntry(fragmentEntry, _getRESTClientHTML()));
 	}
 
 	@Test
@@ -417,6 +419,28 @@ public class FragmentExportImportTest extends BasePortletExportImportTestCase {
 				themeDisplay.getRequest(), themeDisplay.getResponse(), layout,
 				locale);
 		}
+	}
+
+	private String _getRESTClientHTML() {
+		return StringBundler.concat(
+			"[#assign restGetSample = restClient.get(",
+			"\"/o/headless-delivery/v1.0/sites/0/site-pages\")]\n",
+			"[#if (restGetSample.items)??]${restGetSample.items?size}",
+			"[/#if]\n<h1>", RandomTestUtil.randomString(), "</h1>");
+	}
+
+	private void _testExportImportPortletWithValidation(
+			FragmentEntry fragmentEntry)
+		throws Exception {
+
+		exportImportPortlet(FragmentPortletKeys.FRAGMENT, false);
+
+		FragmentEntry importedGroupFragmentEntry =
+			_fragmentEntryLocalService.getFragmentEntryByUuidAndGroupId(
+				fragmentEntry.getUuid(), importedGroup.getGroupId());
+
+		Assert.assertEquals(
+			fragmentEntry.getHtml(), importedGroupFragmentEntry.getHtml());
 	}
 
 	private void

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/exportimport/test/FragmentExportImportTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/exportimport/test/FragmentExportImportTest.java
@@ -447,6 +447,27 @@ public class FragmentExportImportTest extends BasePortletExportImportTestCase {
 			fragmentEntry.getHtml(), importedGroupFragmentEntry.getHtml());
 	}
 
+	private void _testExportImportPortletWithValidationWithFragmentEntryContentException() {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.exportimport.internal.lifecycle." +
+					"LoggerExportImportLifecycleListener",
+				LoggerTestUtil.ERROR)) {
+
+			try {
+				exportImportPortlet(FragmentPortletKeys.FRAGMENT, false);
+
+				Assert.fail();
+			}
+			catch (Exception exception) {
+				_assertFragmentEntryContentException(exception);
+			}
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertFalse(logEntries.toString(), logEntries.isEmpty());
+		}
+	}
+
 	private void
 		_testExportImportPortletWithValidationWithFragmentEntryContentException(
 			FragmentEntry fragmentEntry) {
@@ -461,14 +482,7 @@ public class FragmentExportImportTest extends BasePortletExportImportTestCase {
 			expectedHTML = importedGroupFragmentEntry.getHtml();
 		}
 
-		try {
-			exportImportPortlet(FragmentPortletKeys.FRAGMENT, false);
-
-			Assert.fail();
-		}
-		catch (Exception exception) {
-			_assertFragmentEntryContentException(exception);
-		}
+		_testExportImportPortletWithValidationWithFragmentEntryContentException();
 
 		importedGroupFragmentEntry =
 			_fragmentEntryLocalService.fetchFragmentEntryByUuidAndGroupId(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93455

## Why This Pull Request Is Being Resent

This pull request resends https://github.com/liferay-page-management/liferay-portal/pull/18602 to address the automated review comments raised when it was forwarded in https://github.com/brianchandotcom/liferay-portal/pull/177105:

1. Making `DummyRESTClient` private is **not** applied: the FreeMarker validator validates by executing the template, which reaches `restClient.get(...)` reflectively. A non-public stub fails that reflective call and aborts with a `FragmentEntryContentException` ("FreeMarker syntax is invalid"), so the class must stay public.

1. Dropping the unused return value of `_testExportImportPortletWithValidation` is applied: the helper now returns `void`.

1. Randomizing the non-asserted fragment HTML is applied: the initial fragment content now uses `RandomTestUtil.randomString()`.

## What Is Being Fixed

Importing a LAR a second time into the same site fails when a fragment's HTML reads live data (e.g. `restClient.get(...)`), aborting with a `FragmentEntryContentException` ("FreeMarker syntax is invalid ... evaluated to a string"). It is a false positive: the FreeMarker validator validates by *executing* the template, and during an import `restClient.get(...)` returns no live data, so the result resolves to a `String` and the property access fails. The fragment is valid and renders fine at runtime, so failing the import is wrong.

## How It Is Being Fixed

Rather than skipping validation during imports — which would disable it for every fragment, including genuinely malformed ones, on the path where content arrives from other environments — the validation keeps running and only the unavailable piece is neutralized. During an import the `restClient` placed in the template context is replaced with a stub that returns an empty result instead of a raw `String`, so templates reading live data validate cleanly while real template/syntax errors still fail. Two supporting changes make this work end to end: the import request is propagated so the validator actually runs on the import add path, and the per-import service-context creation from LPD-23540 is partially reverted so that context exists. Integration tests cover the invalid-FreeMarker and the REST-client cases, on add and on update, and confirm the expected import-failure error is logged (and captured, so it does not leak into the build log).

## PR Check

**pr-check: PASS** — tested on `46a3b6c0bd6f09248125f4d0c824e446549a867e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "46a3b6c0bd6f09248125f4d0c824e446549a867e"} -->
