### PR TITLE
LPD-84614 Mark CMS object relationships as edge

### DIFF
--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BulkActionResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/BulkActionResourceImpl.java
@@ -960,6 +960,10 @@ public class BulkActionResourceImpl extends BaseBulkActionResourceImpl {
 					objectDefinitionId);
 
 			for (ObjectRelationship objectRelationship : objectRelationships) {
+				if (objectRelationship.isEdge()) {
+					continue;
+				}
+
 				ObjectRelatedModelsProvider objectRelatedModelsProvider =
 					_objectRelatedModelsProviderRegistry.
 						getObjectRelatedModelsProvider(

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/tree/util/ObjectDefinitionTreeUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/tree/util/ObjectDefinitionTreeUtil.java
@@ -82,7 +82,11 @@ public class ObjectDefinitionTreeUtil {
 			objectDefinitionPersistence.findByPrimaryKey(
 				objectRelationship.getObjectDefinitionId1());
 
-		if (ArrayUtil.isEmpty(objectDefinition1.getRootObjectDefinitionIds())) {
+		if (ArrayUtil.isEmpty(
+				getRootObjectDefinitionIds(
+					objectDefinition1.getObjectDefinitionId(),
+					objectDefinitionSettingLocalService))) {
+
 			_setRootObjectDefinitionIds(
 				new long[] {objectDefinition1.getObjectDefinitionId()},
 				objectDefinition1, objectDefinitionSettingLocalService,
@@ -133,7 +137,9 @@ public class ObjectDefinitionTreeUtil {
 				}
 
 				_setRootObjectDefinitionIds(
-					objectDefinition1.getRootObjectDefinitionIds(),
+					getRootObjectDefinitionIds(
+						objectDefinition1.getObjectDefinitionId(),
+						objectDefinitionSettingLocalService),
 					nodeObjectDefinition, objectDefinitionSettingLocalService,
 					new long[] {objectDefinition2.getObjectDefinitionId()});
 
@@ -147,7 +153,9 @@ public class ObjectDefinitionTreeUtil {
 		}
 		else {
 			if (ArrayUtil.isNotEmpty(
-					objectDefinition2.getRootObjectDefinitionIds())) {
+					getRootObjectDefinitionIds(
+						objectDefinition2.getObjectDefinitionId(),
+						objectDefinitionSettingLocalService))) {
 
 				return;
 			}
@@ -164,7 +172,9 @@ public class ObjectDefinitionTreeUtil {
 		}
 
 		for (long rootObjectDefinitionId :
-				objectDefinition1.getRootObjectDefinitionIds()) {
+				getRootObjectDefinitionIds(
+					objectDefinition1.getObjectDefinitionId(),
+					objectDefinitionSettingLocalService)) {
 
 			ObjectDefinition rootObjectDefinition =
 				objectDefinitionPersistence.findByPrimaryKey(

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/AttachmentBase.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/AttachmentBase.tsx
@@ -217,7 +217,7 @@ export default function AttachmentBase({
 		else if (isVisible) {
 			searchParams.set(
 				'filter',
-				"cmsRoot eq true and cmsSection eq 'files' and status in (0)"
+				"cmsRoot eq true and rootDescendantNode eq false and cmsSection eq 'files' and status in (0)"
 			);
 		}
 

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/util/CMSFilesItemSelectorModal.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/util/CMSFilesItemSelectorModal.tsx
@@ -42,7 +42,7 @@ function getSpaceRootFilesURL(groupId: string) {
 
 	return `${ROOT_URL}?${new URLSearchParams({
 		...BASE_SEARCH_PARAMS,
-		filter: `cmsRoot eq true and cmsSection eq 'files' and status in (0) and scopeGroupId eq ${groupId}`,
+		filter: `cmsRoot eq true and rootDescendantNode eq false and cmsSection eq 'files' and status in (0) and scopeGroupId eq ${groupId}`,
 	}).toString()}`;
 }
 

--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemFormProviderUtil.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemFormProviderUtil.java
@@ -379,15 +379,7 @@ public class ObjectEntryInfoItemFormProviderUtil {
 						ObjectRelationshipLocalServiceUtil.
 							getObjectRelationships(
 								objectDefinition.getObjectDefinitionId(),
-								ObjectRelationshipConstants.
-									DELETION_TYPE_DISASSOCIATE,
-								false)) {
-
-					if (!objectRelationship.compareType(
-							ObjectRelationshipConstants.TYPE_MANY_TO_MANY)) {
-
-						continue;
-					}
+								true)) {
 
 					unsafeConsumer.accept(
 						objectFieldInfoFieldConverter.
@@ -428,8 +420,9 @@ public class ObjectEntryInfoItemFormProviderUtil {
 						Objects.equals(
 							objectDefinition.getObjectDefinitionId(),
 							objectRelationship.getObjectDefinitionId2()) ||
-						FeatureFlagManagerUtil.isEnabled(
-							objectDefinition.getCompanyId(), "LPD-60546")) {
+						(!objectRelationship.isEdge() &&
+						 FeatureFlagManagerUtil.isEnabled(
+							 objectDefinition.getCompanyId(), "LPD-60546"))) {
 
 						continue;
 					}

--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/util/ObjectEntryInfoItemUtil.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/util/ObjectEntryInfoItemUtil.java
@@ -84,6 +84,9 @@ public class ObjectEntryInfoItemUtil {
 				"objectEntryVersion", objectEntryVersion);
 		}
 
+		dtoConverterContext.setAttribute(
+			"skipCheckRootDescendantNode", Boolean.TRUE);
+
 		try {
 			return objectEntryManager.getObjectEntry(
 				themeDisplay.getCompanyId(), dtoConverterContext,

--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/util/ObjectEntryInfoItemUtil.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/util/ObjectEntryInfoItemUtil.java
@@ -7,14 +7,18 @@ package com.liferay.object.info.item.util;
 
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntryVersion;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
+import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManagerRegistry;
 import com.liferay.object.scope.ObjectScopeProvider;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
 import com.liferay.object.service.ObjectEntryLocalServiceUtil;
 import com.liferay.object.service.ObjectEntryVersionLocalServiceUtil;
+import com.liferay.object.service.ObjectFieldLocalServiceUtil;
+import com.liferay.object.service.ObjectRelationshipLocalServiceUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
@@ -28,6 +32,7 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 
@@ -84,10 +89,38 @@ public class ObjectEntryInfoItemUtil {
 				"objectEntryVersion", objectEntryVersion);
 		}
 
-		dtoConverterContext.setAttribute(
-			"skipCheckRootDescendantNode", Boolean.TRUE);
-
 		try {
+			if (serviceBuilderObjectEntry.isRootDescendantNode() &&
+				(objectEntryManager instanceof DefaultObjectEntryManager)) {
+
+				DefaultObjectEntryManager defaultObjectEntryManager =
+					(DefaultObjectEntryManager)objectEntryManager;
+
+				for (ObjectRelationship objectRelationship :
+						ObjectRelationshipLocalServiceUtil.
+							getObjectRelationshipsByObjectDefinitionId2(
+								objectDefinition.getObjectDefinitionId(),
+								true)) {
+
+					ObjectField objectField =
+						ObjectFieldLocalServiceUtil.getObjectField(
+							objectRelationship.getObjectFieldId2());
+
+					long parentObjectEntryId = MapUtil.getLong(
+						serviceBuilderObjectEntry.getValues(),
+						objectField.getName());
+
+					if (parentObjectEntryId == 0) {
+						continue;
+					}
+
+					return defaultObjectEntryManager.getRelatedObjectEntry(
+						dtoConverterContext,
+						serviceBuilderObjectEntry.getObjectEntryId(),
+						objectRelationship, parentObjectEntryId);
+				}
+			}
+
 			return objectEntryManager.getObjectEntry(
 				themeDisplay.getCompanyId(), dtoConverterContext,
 				serviceBuilderObjectEntry.getExternalReferenceCode(),

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -2450,7 +2450,11 @@ public class DefaultObjectEntryManagerImpl
 			serviceBuilderObjectEntry);
 		_checkObjectEntryObjectDefinitionId(
 			objectDefinition, serviceBuilderObjectEntry);
-		_checkRootDescendantNode(serviceBuilderObjectEntry, false);
+		_checkRootDescendantNode(
+			serviceBuilderObjectEntry,
+			GetterUtil.getBoolean(
+				dtoConverterContext.getAttribute(
+					"skipCheckRootDescendantNode")));
 
 		return _toObjectEntry(
 			dtoConverterContext, objectDefinition, serviceBuilderObjectEntry,

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -2450,11 +2450,7 @@ public class DefaultObjectEntryManagerImpl
 			serviceBuilderObjectEntry);
 		_checkObjectEntryObjectDefinitionId(
 			objectDefinition, serviceBuilderObjectEntry);
-		_checkRootDescendantNode(
-			serviceBuilderObjectEntry,
-			GetterUtil.getBoolean(
-				dtoConverterContext.getAttribute(
-					"skipCheckRootDescendantNode")));
+		_checkRootDescendantNode(serviceBuilderObjectEntry, false);
 
 		return _toObjectEntry(
 			dtoConverterContext, objectDefinition, serviceBuilderObjectEntry,

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -431,6 +431,9 @@ public class ObjectEntryModelDocumentContributor
 			"objectFolderExternalReferenceCode",
 			objectFolder.getExternalReferenceCode(), true);
 
+		document.addKeyword(
+			"rootDescendantNode", objectEntry.isRootDescendantNode());
+
 		if (FeatureFlagManagerUtil.isEnabled(
 				objectEntry.getCompanyId(), "LPD-17564")) {
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -2329,8 +2329,9 @@ public class ObjectEntryLocalServiceImpl
 				_objectDefinitionPersistence.findByPrimaryKey(
 					node.getPrimaryKey());
 
-			Indexer<ObjectEntry> indexer = IndexerRegistryUtil.getIndexer(
-				objectDefinition.getClassName());
+			Indexer<ObjectEntry> indexer =
+				IndexerRegistryUtil.nullSafeGetIndexer(
+					objectDefinition.getClassName());
 
 			_performActions(
 				objectDefinition.getObjectDefinitionId(),

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -2457,7 +2457,10 @@ public class ObjectEntryLocalServiceImpl
 				userId, objectDefinition, objectEntry);
 		}
 
-		if (objectDefinition.isRootNode()) {
+		if (objectDefinition.isRootNode() &&
+			(status != WorkflowConstants.STATUS_IN_TRASH) &&
+			!originalObjectEntry.isInTrash()) {
+
 			_updateRootDescendantNodeObjectEntryStatus(
 				userId, objectEntry, serviceContext);
 		}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryModelDocumentContributorTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryModelDocumentContributorTest.java
@@ -7,14 +7,17 @@ package com.liferay.object.internal.search.spi.model.index.contributor.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.field.builder.AssigneeObjectFieldBuilder;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.rest.test.util.ObjectEntryTestUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.StringBundler;
@@ -25,6 +28,7 @@ import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentImpl;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
@@ -44,6 +48,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 
 import org.junit.Assert;
@@ -140,6 +145,20 @@ public class ObjectEntryModelDocumentContributorTest {
 			value.contains(
 				StringBundler.concat(
 					objectFieldName, ": ", objectFieldValue, "pt_BR")));
+
+		Assert.assertEquals("false", document.get("rootDescendantNode"));
+
+		objectEntry.setRootObjectEntryId(objectEntry.getObjectEntryId());
+
+		document = _getDocument(modifiableSystemObjectDefinition, objectEntry);
+
+		Assert.assertEquals("false", document.get("rootDescendantNode"));
+
+		objectEntry.setRootObjectEntryId(objectEntry.getObjectEntryId() + 1);
+
+		document = _getDocument(modifiableSystemObjectDefinition, objectEntry);
+
+		Assert.assertEquals("true", document.get("rootDescendantNode"));
 	}
 
 	@FeatureFlag("LPD-17564")
@@ -249,6 +268,52 @@ public class ObjectEntryModelDocumentContributorTest {
 					objectFieldName, ": ", user.getFullName())));
 	}
 
+	@FeatureFlag("LPD-17564")
+	@Test
+	public void testContributeWithCMSAttributes() throws Exception {
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			objectDefinition, new HashMap<String, Serializable>());
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.addObjectEntryFolder(
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
+				TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				RandomTestUtil.randomString(),
+				HashMapBuilder.put(
+					LocaleUtil.ENGLISH, RandomTestUtil.randomString()
+				).build(),
+				RandomTestUtil.randomString(), new ServiceContext());
+
+		objectEntry.setObjectEntryFolderId(
+			objectEntryFolder.getObjectEntryFolderId());
+
+		Document document = _getDocument(objectDefinition, objectEntry);
+
+		Assert.assertEquals("object", document.get("cms_kind"));
+		Assert.assertEquals("true", document.get("cms_root"));
+		Assert.assertEquals("contents", document.get("cms_section"));
+	}
+
+	private Document _getDocument(
+			ObjectDefinition objectDefinition, ObjectEntry objectEntry)
+		throws Exception {
+
+		Document document = new DocumentImpl();
+
+		ModelDocumentContributor<ObjectEntry>
+			objectEntryModelDocumentContributor =
+				_getObjectEntryModelDocumentContributor(objectDefinition);
+
+		objectEntryModelDocumentContributor.contribute(document, objectEntry);
+
+		return document;
+	}
+
 	private ModelDocumentContributor<ObjectEntry>
 			_getObjectEntryModelDocumentContributor(
 				ObjectDefinition objectDefinition)
@@ -275,6 +340,9 @@ public class ObjectEntryModelDocumentContributorTest {
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 
 	@Inject
 	private ObjectFieldLocalService _objectFieldLocalService;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -5997,6 +5997,77 @@ public class ObjectEntryLocalServiceTest {
 
 	@FeatureFlag("LPD-17564")
 	@Test
+	public void testMoveObjectEntryToTrashWithObjectDefinitionTree()
+		throws Exception {
+
+		TreeTestUtil.createObjectDefinitionTree(
+			_objectDefinitionLocalService, _objectRelationshipLocalService,
+			true,
+			LinkedHashMapBuilder.put(
+				"A", new String[] {"AA"}
+			).put(
+				"AA", new String[0]
+			).build());
+
+		try {
+			ObjectDefinition rootObjectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					TestPropsValues.getCompanyId(), "C_A");
+
+			TreeTestUtil.createObjectEntryTree(
+				"1", _objectDefinitionLocalService, _objectEntryLocalService,
+				_objectFieldLocalService, _objectRelationshipLocalService,
+				rootObjectDefinition.getObjectDefinitionId());
+
+			ObjectDefinition childObjectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					TestPropsValues.getCompanyId(), "C_AA");
+
+			ObjectEntry childObjectEntry =
+				_objectEntryLocalService.getObjectEntry(
+					"AA1", ObjectDefinitionConstants.GROUP_ID_DEFAULT,
+					childObjectDefinition.getObjectDefinitionId());
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_APPROVED,
+				childObjectEntry.getStatus());
+
+			ObjectEntry rootObjectEntry =
+				_objectEntryLocalService.getObjectEntry(
+					"A1", ObjectDefinitionConstants.GROUP_ID_DEFAULT,
+					rootObjectDefinition.getObjectDefinitionId());
+
+			rootObjectEntry = _objectEntryLocalService.moveObjectEntryToTrash(
+				TestPropsValues.getUserId(), rootObjectEntry,
+				ServiceContextTestUtil.getServiceContext());
+
+			childObjectEntry = _objectEntryLocalService.getObjectEntry(
+				childObjectEntry.getObjectEntryId());
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_IN_TRASH,
+				childObjectEntry.getStatus());
+
+			_objectEntryLocalService.restoreObjectEntryFromTrash(
+				TestPropsValues.getUserId(), rootObjectEntry,
+				ServiceContextTestUtil.getServiceContext());
+
+			childObjectEntry = _objectEntryLocalService.getObjectEntry(
+				childObjectEntry.getObjectEntryId());
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_APPROVED,
+				childObjectEntry.getStatus());
+		}
+		finally {
+			TreeTestUtil.deleteObjectDefinitionHierarchy(
+				_objectDefinitionLocalService, new String[] {"C_A", "C_AA"},
+				_objectEntryLocalService, _objectRelationshipLocalService);
+		}
+	}
+
+	@FeatureFlag("LPD-17564")
+	@Test
 	public void testMoveObjectEntryToTrashWithObjectEntryFolder()
 		throws Exception {
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFieldValuesProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFieldValuesProviderTest.java
@@ -35,6 +35,7 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectFieldSetting;
+import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectActionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
@@ -430,6 +431,128 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 		}
 		finally {
 			ServiceContextThreadLocal.popServiceContext();
+		}
+	}
+
+	@FeatureFlag("LPD-17564")
+	@Test
+	public void testObjectEntryInfoItemFieldValuesProviderWithObjectRelationship()
+		throws Exception {
+
+		ObjectDefinition parentObjectDefinition = _addObjectDefinition(
+			new TextObjectFieldBuilder(
+			).labelMap(
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+			).name(
+				"parentTitle"
+			).build());
+
+		parentObjectDefinition =
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				TestPropsValues.getUserId(),
+				parentObjectDefinition.getObjectDefinitionId());
+
+		ObjectDefinition childObjectDefinition = _addObjectDefinition(
+			new TextObjectFieldBuilder(
+			).labelMap(
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString())
+			).name(
+				"childTitle"
+			).build());
+
+		childObjectDefinition =
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				TestPropsValues.getUserId(),
+				childObjectDefinition.getObjectDefinitionId());
+
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				null, TestPropsValues.getUserId(),
+				parentObjectDefinition.getObjectDefinitionId(),
+				childObjectDefinition.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_CASCADE, true,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				"edgeRelationship", false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		ObjectEntry parentObjectEntry = _objectEntryLocalService.addObjectEntry(
+			_group.getGroupId(), TestPropsValues.getUserId(),
+			parentObjectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"parentTitle", "Parent Title Value"
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		String childTitleValue = RandomTestUtil.randomString();
+
+		ObjectEntry childObjectEntry = _objectEntryLocalService.addObjectEntry(
+			_group.getGroupId(), TestPropsValues.getUserId(),
+			childObjectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"childTitle", childTitleValue
+			).put(
+				"r_edgeRelationship_" +
+					parentObjectDefinition.getPKObjectFieldName(),
+				parentObjectEntry.getObjectEntryId()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay(StringPool.BLANK, "UTC"));
+
+		serviceContext.setRequest(mockHttpServletRequest);
+
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+		try {
+			InfoItemFieldValuesProvider<ObjectEntry>
+				infoItemFieldValuesProvider =
+					_infoItemServiceRegistry.getFirstInfoItemService(
+						InfoItemFieldValuesProvider.class,
+						childObjectDefinition.getClassName());
+
+			InfoItemFieldValues infoItemFieldValues =
+				infoItemFieldValuesProvider.getInfoItemFieldValues(
+					childObjectEntry);
+
+			InfoFieldValue<Object> childTitleInfoFieldValue =
+				infoItemFieldValues.getInfoFieldValue("childTitle");
+
+			Assert.assertNotNull(
+				"Edge child entry field values should not be empty",
+				childTitleInfoFieldValue);
+
+			Assert.assertEquals(
+				childTitleValue, childTitleInfoFieldValue.getValue());
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+
+			objectRelationship =
+				_objectRelationshipLocalService.updateObjectRelationship(
+					objectRelationship.getExternalReferenceCode(),
+					objectRelationship.getObjectRelationshipId(),
+					objectRelationship.getParameterObjectFieldId(),
+					objectRelationship.getDeletionType(), false,
+					objectRelationship.getLabelMap(), null);
+
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship);
+
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				childObjectDefinition);
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				parentObjectDefinition);
 		}
 	}
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFieldValuesProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFieldValuesProviderTest.java
@@ -472,7 +472,7 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 				childObjectDefinition.getObjectDefinitionId(), 0,
 				ObjectRelationshipConstants.DELETION_TYPE_CASCADE, true,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				"edgeRelationship", false,
+				"oneToManyRelationshipName", false,
 				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
 
 		ObjectEntry parentObjectEntry = _objectEntryLocalService.addObjectEntry(
@@ -481,7 +481,7 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
 			null,
 			HashMapBuilder.<String, Serializable>put(
-				"parentTitle", "Parent Title Value"
+				"parentTitle", RandomTestUtil.randomString()
 			).build(),
 			ServiceContextTestUtil.getServiceContext());
 
@@ -495,24 +495,13 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 			HashMapBuilder.<String, Serializable>put(
 				"childTitle", childTitleValue
 			).put(
-				"r_edgeRelationship_" +
+				"r_oneToManyRelationshipName_" +
 					parentObjectDefinition.getPKObjectFieldName(),
 				parentObjectEntry.getObjectEntryId()
 			).build(),
 			ServiceContextTestUtil.getServiceContext());
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
-
-		MockHttpServletRequest mockHttpServletRequest =
-			new MockHttpServletRequest();
-
-		mockHttpServletRequest.setAttribute(
-			WebKeys.THEME_DISPLAY, _getThemeDisplay(StringPool.BLANK, "UTC"));
-
-		serviceContext.setRequest(mockHttpServletRequest);
-
-		ServiceContextThreadLocal.pushServiceContext(serviceContext);
+		_pushServiceContext(_getThemeDisplay(StringPool.BLANK, "UTC"));
 
 		try {
 			InfoItemFieldValuesProvider<ObjectEntry>
@@ -527,10 +516,6 @@ public class ObjectEntryInfoItemFieldValuesProviderTest {
 
 			InfoFieldValue<Object> childTitleInfoFieldValue =
 				infoItemFieldValues.getInfoFieldValue("childTitle");
-
-			Assert.assertNotNull(
-				"Edge child entry field values should not be empty",
-				childTitleInfoFieldValue);
 
 			Assert.assertEquals(
 				childTitleValue, childTitleInfoFieldValue.getValue());

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFormProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFormProviderTest.java
@@ -27,7 +27,6 @@ import com.liferay.object.constants.ObjectActionExecutorConstants;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
-import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.field.builder.AttachmentObjectFieldBuilder;
 import com.liferay.object.field.builder.PicklistObjectFieldBuilder;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
@@ -393,74 +392,26 @@ public class ObjectEntryInfoItemFormProviderTest {
 	}
 
 	private void _testGetInfoFormWithEdgeObjectRelationship() throws Exception {
-		ObjectDefinition parentObjectDefinition =
-			ObjectDefinitionTestUtil.publishObjectDefinition(
-				Collections.singletonList(
-					new TextObjectFieldBuilder(
-					).labelMap(
-						LocalizedMapUtil.getLocalizedMap(
-							RandomTestUtil.randomString())
-					).name(
-						"parentTitle"
-					).build()));
+		Node node = _tree.getNode(_objectDefinitionAA.getObjectDefinitionId());
 
-		ObjectDefinition childObjectDefinition =
-			ObjectDefinitionTestUtil.publishObjectDefinition(
-				Collections.singletonList(
-					new TextObjectFieldBuilder(
-					).labelMap(
-						LocalizedMapUtil.getLocalizedMap(
-							RandomTestUtil.randomString())
-					).name(
-						"childTitle"
-					).build()));
+		Edge edge = node.getEdge();
 
 		ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.addObjectRelationship(
-				null, TestPropsValues.getUserId(),
-				parentObjectDefinition.getObjectDefinitionId(),
-				childObjectDefinition.getObjectDefinitionId(), 0,
-				ObjectRelationshipConstants.DELETION_TYPE_CASCADE, true,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				"a" + RandomTestUtil.randomString(), false,
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+			_objectRelationshipLocalService.getObjectRelationship(
+				edge.getObjectRelationshipId());
 
-		try {
-			InfoForm parentInfoForm = _getInfoForm(parentObjectDefinition);
+		InfoForm parentInfoForm = _getInfoForm(_objectDefinitionA);
 
-			InfoFieldSet infoFieldSet =
-				(InfoFieldSet)parentInfoForm.getInfoFieldSetEntry(
-					parentObjectDefinition.getName());
+		InfoFieldSet infoFieldSet =
+			(InfoFieldSet)parentInfoForm.getInfoFieldSetEntry(
+				_objectDefinitionA.getName());
 
-			InfoFieldSet relationshipInfoFieldSet =
-				(InfoFieldSet)infoFieldSet.getInfoFieldSetEntry(
-					objectRelationship.getName());
+		InfoFieldSet relationshipInfoFieldSet =
+			(InfoFieldSet)infoFieldSet.getInfoFieldSetEntry(
+				objectRelationship.getName());
 
-			Assert.assertNotNull(
-				"Child fields should appear in parent InfoForm for edge " +
-					"relationships",
-				relationshipInfoFieldSet);
-
-			Assert.assertNotNull(
-				relationshipInfoFieldSet.getInfoFieldSetEntry("childTitle"));
-		}
-		finally {
-			objectRelationship =
-				_objectRelationshipLocalService.updateObjectRelationship(
-					objectRelationship.getExternalReferenceCode(),
-					objectRelationship.getObjectRelationshipId(),
-					objectRelationship.getParameterObjectFieldId(),
-					objectRelationship.getDeletionType(), false,
-					objectRelationship.getLabelMap(), null);
-
-			_objectRelationshipLocalService.deleteObjectRelationship(
-				objectRelationship);
-
-			_objectDefinitionLocalService.deleteObjectDefinition(
-				childObjectDefinition);
-			_objectDefinitionLocalService.deleteObjectDefinition(
-				parentObjectDefinition);
-		}
+		Assert.assertNotNull(
+			relationshipInfoFieldSet.getInfoFieldSetEntry("able"));
 	}
 
 	private void _testGetInfoFormWithEnableObjectEntrySchedule()

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFormProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemFormProviderTest.java
@@ -27,6 +27,7 @@ import com.liferay.object.constants.ObjectActionExecutorConstants;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
+import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.field.builder.AttachmentObjectFieldBuilder;
 import com.liferay.object.field.builder.PicklistObjectFieldBuilder;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
@@ -256,6 +257,7 @@ public class ObjectEntryInfoItemFormProviderTest {
 	@Test
 	public void testGetInfoForm() throws Exception {
 		_testGetInfoFormWithAttachmentObjectField();
+		_testGetInfoFormWithEdgeObjectRelationship();
 		_testGetInfoFormWithEnableObjectEntrySchedule();
 		_testGetInfoFormWithObjectAction();
 		_testGetInfoFormWithObjectRelationship();
@@ -388,6 +390,77 @@ public class ObjectEntryInfoItemFormProviderTest {
 			objectField.getObjectFieldId() + "#mimeType", _childInfoForm);
 		_assertInfoField(
 			objectField.getObjectFieldId() + "#size", _childInfoForm);
+	}
+
+	private void _testGetInfoFormWithEdgeObjectRelationship() throws Exception {
+		ObjectDefinition parentObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).name(
+						"parentTitle"
+					).build()));
+
+		ObjectDefinition childObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).name(
+						"childTitle"
+					).build()));
+
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				null, TestPropsValues.getUserId(),
+				parentObjectDefinition.getObjectDefinitionId(),
+				childObjectDefinition.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_CASCADE, true,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				"a" + RandomTestUtil.randomString(), false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		try {
+			InfoForm parentInfoForm = _getInfoForm(parentObjectDefinition);
+
+			InfoFieldSet infoFieldSet =
+				(InfoFieldSet)parentInfoForm.getInfoFieldSetEntry(
+					parentObjectDefinition.getName());
+
+			InfoFieldSet relationshipInfoFieldSet =
+				(InfoFieldSet)infoFieldSet.getInfoFieldSetEntry(
+					objectRelationship.getName());
+
+			Assert.assertNotNull(
+				"Child fields should appear in parent InfoForm for edge " +
+					"relationships",
+				relationshipInfoFieldSet);
+
+			Assert.assertNotNull(
+				relationshipInfoFieldSet.getInfoFieldSetEntry("childTitle"));
+		}
+		finally {
+			objectRelationship =
+				_objectRelationshipLocalService.updateObjectRelationship(
+					objectRelationship.getExternalReferenceCode(),
+					objectRelationship.getObjectRelationshipId(),
+					objectRelationship.getParameterObjectFieldId(),
+					objectRelationship.getDeletionType(), false,
+					objectRelationship.getLabelMap(), null);
+
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship);
+
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				childObjectDefinition);
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				parentObjectDefinition);
+		}
 	}
 
 	private void _testGetInfoFormWithEnableObjectEntrySchedule()

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/updater/test/ObjectEntryInfoItemFieldValuesUpdaterTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/updater/test/ObjectEntryInfoItemFieldValuesUpdaterTest.java
@@ -12,6 +12,7 @@ import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.test.util.DLTestUtil;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.InfoFieldValue;
+import com.liferay.info.field.RelatedInfoFieldValue;
 import com.liferay.info.field.type.FileInfoFieldType;
 import com.liferay.info.field.type.TextInfoFieldType;
 import com.liferay.info.item.InfoItemFieldValues;
@@ -22,20 +23,24 @@ import com.liferay.object.constants.ObjectDefinitionSettingConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.definition.setting.builder.ObjectDefinitionSettingBuilder;
 import com.liferay.object.field.builder.AttachmentObjectFieldBuilder;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.field.setting.builder.ObjectFieldSettingBuilder;
+import com.liferay.object.info.item.util.ObjectEntryInfoItemUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectFieldSetting;
 import com.liferay.object.model.ObjectFolder;
+import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.related.models.test.util.ObjectEntryTestUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectFolderLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.object.web.internal.info.item.BaseObjectEntryInfoItemTestCase;
 import com.liferay.petra.string.CharPool;
@@ -164,6 +169,158 @@ public class ObjectEntryInfoItemFieldValuesUpdaterTest
 		Assert.assertEquals(ptValue, localizedValues.get("pt_BR"));
 
 		_objectDefinitionLocalService.deleteObjectDefinition(objectDefinition);
+	}
+
+	@Test
+	public void testUpdateFromInfoItemFieldValuesWithObjectRelationship()
+		throws Exception {
+
+		ObjectDefinition parentObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						RandomTestUtil.randomLocaleStringMap()
+					).localized(
+						true
+					).name(
+						"text"
+					).build()));
+
+		ObjectDefinition childObjectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						RandomTestUtil.randomLocaleStringMap()
+					).name(
+						"text"
+					).build()));
+
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				null, TestPropsValues.getUserId(),
+				parentObjectDefinition.getObjectDefinitionId(),
+				childObjectDefinition.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_CASCADE, true,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				StringUtil.randomId(), false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		String enValue = RandomTestUtil.randomString();
+
+		ObjectEntry parentObjectEntry = ObjectEntryTestUtil.addObjectEntry(
+			0, parentObjectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"text_i18n",
+				HashMapBuilder.put(
+					"en_US", enValue
+				).build()
+			).build());
+
+		String ptValue = RandomTestUtil.randomString();
+		String childTextValue = RandomTestUtil.randomString();
+
+		String externalReferenceCode = StringUtil.randomId();
+
+		String namespace = ObjectEntryInfoItemUtil.getInfoFieldNamespace(
+			childObjectDefinition, objectRelationship);
+
+		try {
+			_updateFromInfoItemFieldValues(
+				InfoItemFieldValues.builder(
+				).infoFieldValue(
+					new InfoFieldValue<>(
+						InfoField.builder(
+						).infoFieldType(
+							TextInfoFieldType.INSTANCE
+						).namespace(
+							ObjectField.class.getSimpleName()
+						).name(
+							"text"
+						).localizable(
+							true
+						).build(),
+						InfoLocalizedValue.builder(
+						).value(
+							LocaleUtil.BRAZIL, ptValue
+						).value(
+							LocaleUtil.US, enValue
+						).build())
+				).infoFieldValue(
+					new InfoFieldValue<>(
+						InfoField.builder(
+						).infoFieldType(
+							TextInfoFieldType.INSTANCE
+						).namespace(
+							namespace
+						).name(
+							"text"
+						).build(),
+						new RelatedInfoFieldValue<>(
+							HashMapBuilder.
+								<RelatedInfoFieldValue.
+									RelatedInfoFieldValueIdentifier,
+								 InfoFieldValue<Object>>put(
+									new RelatedInfoFieldValue.
+										RelatedInfoFieldValueIdentifier(
+											externalReferenceCode,
+											parentObjectEntry.
+												getExternalReferenceCode()),
+									new InfoFieldValue<>(
+										InfoField.builder(
+										).infoFieldType(
+											TextInfoFieldType.INSTANCE
+										).namespace(
+											namespace
+										).name(
+											"text"
+										).build(),
+										childTextValue)
+								).build()))
+				).build(),
+				parentObjectDefinition, parentObjectEntry);
+
+			Map<String, Serializable> values =
+				objectEntryLocalService.getValues(
+					parentObjectEntry.getObjectEntryId());
+
+			Map<String, Object> localizedValues =
+				(Map<String, Object>)values.get("text_i18n");
+
+			Assert.assertEquals(enValue, localizedValues.get("en_US"));
+			Assert.assertEquals(ptValue, localizedValues.get("pt_BR"));
+
+			List<ObjectEntry> objectEntries =
+				objectEntryLocalService.getObjectEntries(
+					0, childObjectDefinition.getObjectDefinitionId(),
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+			Assert.assertEquals(
+				objectEntries.toString(), 1, objectEntries.size());
+
+			ObjectEntry childObjectEntry = objectEntries.get(0);
+
+			Assert.assertEquals(
+				childTextValue,
+				MapUtil.getString(childObjectEntry.getValues(), "text"));
+		}
+		finally {
+			objectRelationship =
+				_objectRelationshipLocalService.updateObjectRelationship(
+					objectRelationship.getExternalReferenceCode(),
+					objectRelationship.getObjectRelationshipId(), 0,
+					ObjectRelationshipConstants.DELETION_TYPE_CASCADE, false,
+					objectRelationship.getLabelMap(), null);
+
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				objectRelationship);
+
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				childObjectDefinition);
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				parentObjectDefinition);
+		}
 	}
 
 	private ObjectDefinition _addCMSObjectDefinition(
@@ -536,5 +693,8 @@ public class ObjectEntryInfoItemFieldValuesUpdaterTest
 
 	@Inject
 	private ObjectFolderLocalService _objectFolderLocalService;
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
 }

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
@@ -25,6 +25,8 @@ public class SearchResultEntityModel implements EntityModel {
 	public SearchResultEntityModel() {
 		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new BooleanEntityField("cmsRoot", locale -> "cms_root"),
+			new BooleanEntityField(
+				"rootDescendantNode", locale -> "rootDescendantNode"),
 			new CollectionEntityField(
 				new IntegerEntityField("groupIds", locale -> Field.GROUP_ID)),
 			new CollectionEntityField(

--- a/modules/apps/site/site-cms-site-initializer-test/build.gradle
+++ b/modules/apps/site/site-cms-site-initializer-test/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-workflow:portal-workflow-api")
 	testIntegrationImplementation project(":apps:portal-workflow:portal-workflow-kaleo-api")
 	testIntegrationImplementation project(":apps:portal:portal-instance-lifecycle-api")
+	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:product-navigation:product-navigation-personal-menu-api")
 	testIntegrationImplementation project(":apps:segments:segments-api")
 	testIntegrationImplementation project(":apps:sharing:sharing-api")

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/DeleteStructureStrutsActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/DeleteStructureStrutsActionTest.java
@@ -6,20 +6,29 @@
 package com.liferay.site.cms.site.initializer.internal.struts.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
-import com.liferay.object.test.util.ObjectRelationshipTestUtil;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.struts.StrutsAction;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -54,16 +63,38 @@ public class DeleteStructureStrutsActionTest {
 		ObjectDefinition objectDefinition3 =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition();
 
-		ObjectRelationshipTestUtil.addObjectRelationship(
-			_objectRelationshipLocalService, objectDefinition1,
-			objectDefinition2);
+		_objectRelationshipLocalService.addObjectRelationship(
+			null, TestPropsValues.getUserId(),
+			objectDefinition1.getObjectDefinitionId(),
+			objectDefinition2.getObjectDefinitionId(), 0,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE, true,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			StringUtil.randomId(), false,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
 
-		ObjectRelationshipTestUtil.addObjectRelationship(
-			_objectRelationshipLocalService, objectDefinition2,
-			objectDefinition3);
+		_objectRelationshipLocalService.addObjectRelationship(
+			null, TestPropsValues.getUserId(),
+			objectDefinition2.getObjectDefinitionId(),
+			objectDefinition3.getObjectDefinitionId(), 0,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE, true,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			StringUtil.randomId(), false,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
 
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
+		themeDisplay.setLocale(LocaleUtil.US);
+		themeDisplay.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
 
 		mockHttpServletRequest.setParameter(
 			"objectDefinitionId",
@@ -90,6 +121,79 @@ public class DeleteStructureStrutsActionTest {
 			_objectDefinitionLocalService.fetchObjectDefinition(
 				objectDefinition3.getObjectDefinitionId()));
 	}
+
+	@FeatureFlag("LPD-34594")
+	@Test
+	@TestInfo("LPD-77022")
+	public void testExecuteWithObjectRelationships() throws Exception {
+		ObjectDefinition objectDefinition1 =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+		ObjectDefinition objectDefinition2 =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+		ObjectDefinition objectDefinition3 =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		_objectRelationshipLocalService.addObjectRelationship(
+			null, TestPropsValues.getUserId(),
+			objectDefinition1.getObjectDefinitionId(),
+			objectDefinition2.getObjectDefinitionId(), 0,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE, true,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			StringUtil.randomId(), false,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		_objectRelationshipLocalService.addObjectRelationship(
+			null, TestPropsValues.getUserId(),
+			objectDefinition2.getObjectDefinitionId(),
+			objectDefinition3.getObjectDefinitionId(), 0,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE, true,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			StringUtil.randomId(), false,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
+		themeDisplay.setLocale(LocaleUtil.US);
+		themeDisplay.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		mockHttpServletRequest.setParameter(
+			"objectDefinitionId",
+			String.valueOf(objectDefinition1.getObjectDefinitionId()));
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		_deleteStructureStrutsAction.execute(
+			mockHttpServletRequest, mockHttpServletResponse);
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject(
+			mockHttpServletResponse.getContentAsString());
+
+		Assert.assertEquals(jsonObject.toString(), 0, jsonObject.length());
+
+		Assert.assertNull(
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				objectDefinition1.getObjectDefinitionId()));
+		Assert.assertNull(
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				objectDefinition2.getObjectDefinitionId()));
+		Assert.assertNull(
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				objectDefinition3.getObjectDefinitionId()));
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
 
 	@Inject(filter = "path=/cms/delete-structure")
 	private StrutsAction _deleteStructureStrutsAction;

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
@@ -6,28 +6,34 @@
 package com.liferay.site.cms.site.initializer.internal.struts.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.admin.rest.dto.v1_0.ObjectDefinition;
+import com.liferay.object.admin.rest.dto.v1_0.ObjectRelationship;
 import com.liferay.object.admin.rest.resource.v1_0.ObjectDefinitionResource;
-import com.liferay.object.model.ObjectDefinition;
-import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.object.test.util.ObjectRelationshipTestUtil;
-import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.struts.StrutsAction;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -41,9 +47,9 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 /**
+ * @author Víctor Galán
  * @author Yuri Monteiro
  */
-@FeatureFlag("LPD-17564")
 @RunWith(Arquillian.class)
 public class UpdateStructureStrutsActionTest {
 
@@ -54,13 +60,95 @@ public class UpdateStructureStrutsActionTest {
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
 
+	@FeatureFlag("LPD-34594")
+	@Test
+	@TestInfo("LPD-77022")
+	public void testExecute() throws Exception {
+		com.liferay.object.model.ObjectDefinition
+			serviceBuilderObjectDefinition1 =
+				ObjectDefinitionTestUtil.publishObjectDefinition();
+		com.liferay.object.model.ObjectDefinition
+			serviceBuilderObjectDefinition2 =
+				ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		com.liferay.object.model.ObjectRelationship
+			serviceBuilderObjectRelationship =
+				_objectRelationshipLocalService.addObjectRelationship(
+					null, TestPropsValues.getUserId(),
+					serviceBuilderObjectDefinition1.getObjectDefinitionId(),
+					serviceBuilderObjectDefinition2.getObjectDefinitionId(), 0,
+					ObjectRelationshipConstants.DELETION_TYPE_CASCADE, true,
+					LocalizedMapUtil.getLocalizedMap(
+						RandomTestUtil.randomString()),
+					StringUtil.randomId(), false,
+					ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		Assert.assertTrue(serviceBuilderObjectRelationship.isEdge());
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
+		themeDisplay.setLocale(LocaleUtil.US);
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		mockHttpServletRequest.setParameter(
+			"deletedObjectRelationships",
+			JSONUtil.putAll(
+				JSONUtil.put(
+					"objectDefinitionERC",
+					serviceBuilderObjectDefinition1.getExternalReferenceCode()
+				).put(
+					"objectRelationshipERC",
+					serviceBuilderObjectRelationship.getExternalReferenceCode()
+				)
+			).toString());
+
+		ObjectDefinition dtoObjectDefinition = _getObjectDefinition(
+			serviceBuilderObjectDefinition1.getExternalReferenceCode());
+
+		mockHttpServletRequest.setParameter(
+			"objectDefinition", dtoObjectDefinition.toString());
+
+		mockHttpServletRequest.setParameter("objectRelationships", "[]");
+		mockHttpServletRequest.setParameter(
+			"repeatableGroupObjectDefinitions", "[]");
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		_updateStructureStrutsAction.execute(
+			mockHttpServletRequest, mockHttpServletResponse);
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject(
+			mockHttpServletResponse.getContentAsString());
+
+		Assert.assertEquals(jsonObject.toString(), 0, jsonObject.length());
+
+		Assert.assertNull(
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				serviceBuilderObjectRelationship.getObjectRelationshipId()));
+
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			serviceBuilderObjectDefinition1.getObjectDefinitionId());
+		_objectDefinitionLocalService.deleteObjectDefinition(
+			serviceBuilderObjectDefinition2.getObjectDefinitionId());
+	}
+
+	@FeatureFlag("LPD-17564")
 	@Test
 	@TestInfo("LPD-92696")
-	public void testExecute() throws Exception {
+	public void testExecuteDoesNotDeleteObjectRelationships() throws Exception {
 		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
 		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition();
 
-		ObjectRelationship objectRelationship =
+		com.liferay.object.model.ObjectRelationship objectRelationship =
 			ObjectRelationshipTestUtil.addObjectRelationship(
 				_objectRelationshipLocalService, _objectDefinition1,
 				_objectDefinition2);
@@ -72,7 +160,7 @@ public class UpdateStructureStrutsActionTest {
 			_getMockHttpServletRequest(_objectDefinition1),
 			mockHttpServletResponse);
 
-		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+		JSONObject jsonObject = _jsonFactory.createJSONObject(
 			mockHttpServletResponse.getContentAsString());
 
 		Assert.assertEquals(jsonObject.toString(), 0, jsonObject.length());
@@ -86,7 +174,7 @@ public class UpdateStructureStrutsActionTest {
 	}
 
 	private HttpServletRequest _getMockHttpServletRequest(
-			ObjectDefinition objectDefinition)
+			com.liferay.object.model.ObjectDefinition objectDefinition)
 		throws Exception {
 
 		MockHttpServletRequest mockHttpServletRequest =
@@ -109,6 +197,25 @@ public class UpdateStructureStrutsActionTest {
 		return mockHttpServletRequest;
 	}
 
+	private ObjectDefinition _getObjectDefinition(String externalReferenceCode)
+		throws Exception {
+
+		ObjectDefinitionResource.Builder builder =
+			_objectDefinitionResourceFactory.create();
+
+		ObjectDefinitionResource objectDefinitionResource = builder.user(
+			TestPropsValues.getUser()
+		).build();
+
+		ObjectDefinition objectDefinition =
+			objectDefinitionResource.getObjectDefinitionByExternalReferenceCode(
+				externalReferenceCode);
+
+		objectDefinition.setObjectRelationships((ObjectRelationship[])null);
+
+		return objectDefinition;
+	}
+
 	private String _getObjectDefinitionJSON(long objectDefinitionId)
 		throws Exception {
 
@@ -118,13 +225,12 @@ public class UpdateStructureStrutsActionTest {
 				TestPropsValues.getUser()
 			).build();
 
-		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+		JSONObject jsonObject = _jsonFactory.createJSONObject(
 			String.valueOf(
 				objectDefinitionResource.getObjectDefinition(
 					objectDefinitionId)));
 
-		jsonObject.put(
-			"objectRelationships", JSONFactoryUtil.createJSONArray());
+		jsonObject.put("objectRelationships", _jsonFactory.createJSONArray());
 
 		return jsonObject.toString();
 	}
@@ -132,11 +238,17 @@ public class UpdateStructureStrutsActionTest {
 	@Inject
 	private CompanyLocalService _companyLocalService;
 
-	@DeleteAfterTestRun
-	private ObjectDefinition _objectDefinition1;
+	@Inject
+	private JSONFactory _jsonFactory;
 
 	@DeleteAfterTestRun
-	private ObjectDefinition _objectDefinition2;
+	private com.liferay.object.model.ObjectDefinition _objectDefinition1;
+
+	@DeleteAfterTestRun
+	private com.liferay.object.model.ObjectDefinition _objectDefinition2;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@Inject
 	private ObjectDefinitionResource.Factory _objectDefinitionResourceFactory;

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/test/CMSObjectRelationshipEdgeUpgradeProcessTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/test/CMSObjectRelationshipEdgeUpgradeProcessTest.java
@@ -1,0 +1,596 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.upgrade.v1_0_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectDefinitionSettingConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.field.builder.TextObjectFieldBuilder;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.ObjectFolder;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectDefinitionSettingLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.service.ObjectFolderLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.object.test.util.ObjectRelationshipTestUtil;
+import com.liferay.object.test.util.TreeTestUtil;
+import com.liferay.portal.kernel.feature.flag.constants.FeatureFlagConstants;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeException;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+import java.io.Serializable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Víctor Galán
+ */
+@FeatureFlag("LPD-34594")
+@RunWith(Arquillian.class)
+public class CMSObjectRelationshipEdgeUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		UserTestUtil.setUser(TestPropsValues.getUser());
+
+		_cmsContentStructuresObjectFolder =
+			_objectFolderLocalService.getObjectFolderByExternalReferenceCode(
+				ObjectFolderConstants.
+					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
+				TestPropsValues.getCompanyId());
+		_cmsFileTypesObjectFolder =
+			_objectFolderLocalService.getObjectFolderByExternalReferenceCode(
+				ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES,
+				TestPropsValues.getCompanyId());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		for (ObjectDefinition objectDefinition : _objectDefinitions) {
+			TreeTestUtil.unbind(
+				objectDefinition.getObjectDefinitionId(),
+				_objectRelationshipLocalService);
+		}
+
+		for (ObjectDefinition objectDefinition : _objectDefinitions) {
+			_objectDefinitionLocalService.deleteObjectDefinition(
+				objectDefinition.getObjectDefinitionId());
+		}
+
+		_objectDefinitions.clear();
+	}
+
+	@Test
+	public void testUpgradeObjectDefinitions() throws Exception {
+		ObjectDefinition objectDefinition1 = _addCMSObjectDefinition(
+			_cmsContentStructuresObjectFolder);
+		ObjectDefinition objectDefinition2 = _addCMSObjectDefinition(
+			_cmsContentStructuresObjectFolder);
+		ObjectDefinition objectDefinition3 = _addCMSObjectDefinition(
+			_cmsContentStructuresObjectFolder);
+
+		ObjectDefinition fileObjectDefinition1 = _addCMSObjectDefinition(
+			_cmsFileTypesObjectFolder);
+		ObjectDefinition fileObjectDefinition2 = _addCMSObjectDefinition(
+			_cmsFileTypesObjectFolder);
+		ObjectDefinition fileObjectDefinition3 = _addCMSObjectDefinition(
+			_cmsFileTypesObjectFolder);
+
+		ObjectDefinition customObjectDefinition1 = _addObjectDefinition();
+		ObjectDefinition customObjectDefinition2 = _addObjectDefinition();
+		ObjectDefinition customObjectDefinition3 = _addObjectDefinition();
+
+		ObjectRelationship objectRelationship1 = _addObjectRelationship(
+			objectDefinition2, objectDefinition1);
+		ObjectRelationship objectRelationship2 = _addObjectRelationship(
+			objectDefinition3, objectDefinition2);
+
+		ObjectRelationship fileObjectRelationship1 = _addObjectRelationship(
+			fileObjectDefinition2, fileObjectDefinition1);
+		ObjectRelationship fileObjectRelationship2 = _addObjectRelationship(
+			fileObjectDefinition3, fileObjectDefinition2);
+
+		ObjectRelationship customObjectRelationship1 = _addObjectRelationship(
+			customObjectDefinition2, customObjectDefinition1);
+		ObjectRelationship customObjectRelationship2 = _addObjectRelationship(
+			customObjectDefinition3, customObjectDefinition2);
+
+		_runUpgrade();
+
+		_assertObjectRelationshipEdge(
+			true, objectRelationship1.getObjectRelationshipId());
+		_assertObjectRelationshipEdge(
+			true, objectRelationship2.getObjectRelationshipId());
+		_assertObjectRelationshipEdge(
+			true, fileObjectRelationship1.getObjectRelationshipId());
+		_assertObjectRelationshipEdge(
+			true, fileObjectRelationship2.getObjectRelationshipId());
+
+		_assertObjectRelationshipEdge(
+			false, customObjectRelationship1.getObjectRelationshipId());
+		_assertObjectRelationshipEdge(
+			false, customObjectRelationship2.getObjectRelationshipId());
+	}
+
+	@Test
+	public void testUpgradeObjectEntries() throws Exception {
+		Locale locale = LocaleUtil.fromLanguageId(
+			UpgradeProcessUtil.getDefaultLanguageId(
+				TestPropsValues.getCompanyId()));
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				locale, RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				locale, RandomTestUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
+
+		long depotGroupId = depotEntry.getGroupId();
+
+		ObjectDefinition rootObjectDefinition = _addCMSObjectDefinition();
+		ObjectDefinition childObjectDefinition = _addCMSObjectDefinition();
+		ObjectDefinition grandchildObjectDefinition = _addCMSObjectDefinition();
+
+		ObjectRelationship objectRelationship1 = _addObjectRelationship(
+			childObjectDefinition, rootObjectDefinition);
+		ObjectRelationship objectRelationship2 = _addObjectRelationship(
+			grandchildObjectDefinition, childObjectDefinition);
+
+		ObjectEntry rootObjectEntry = _addObjectEntry(
+			depotGroupId, rootObjectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"able", RandomTestUtil.randomString()
+			).build());
+
+		long rootObjectEntryId = rootObjectEntry.getObjectEntryId();
+
+		ObjectField objectField = _objectFieldLocalService.getObjectField(
+			objectRelationship1.getObjectFieldId2());
+
+		ObjectEntry childObjectEntry = _addObjectEntry(
+			depotGroupId, childObjectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"able", RandomTestUtil.randomString()
+			).put(
+				objectField.getName(), rootObjectEntryId
+			).build());
+
+		long childObjectEntryId = childObjectEntry.getObjectEntryId();
+
+		objectField = _objectFieldLocalService.getObjectField(
+			objectRelationship2.getObjectFieldId2());
+
+		ObjectEntry grandchildObjectEntry = _addObjectEntry(
+			depotGroupId, grandchildObjectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"able", RandomTestUtil.randomString()
+			).put(
+				objectField.getName(), childObjectEntryId
+			).build());
+
+		_runUpgrade();
+
+		_assertObjectRelationshipEdge(
+			true, objectRelationship1.getObjectRelationshipId());
+		_assertObjectRelationshipEdge(
+			true, objectRelationship2.getObjectRelationshipId());
+
+		childObjectEntry = _objectEntryLocalService.getObjectEntry(
+			childObjectEntryId);
+
+		Assert.assertEquals(
+			rootObjectEntryId, childObjectEntry.getRootObjectEntryId());
+
+		grandchildObjectEntry = _objectEntryLocalService.getObjectEntry(
+			grandchildObjectEntry.getObjectEntryId());
+
+		Assert.assertEquals(
+			rootObjectEntryId, grandchildObjectEntry.getRootObjectEntryId());
+	}
+
+	@Test
+	public void testUpgradeObjectRelationshipsCascadeDeletionType()
+		throws Exception {
+
+		_testUpgradeObjectRelationshipsCascadeDeletionType(false);
+		_testUpgradeObjectRelationshipsCascadeDeletionType(true);
+	}
+
+	@Test
+	public void testUpgradeObjectRelationshipsDisassociateDeletionType()
+		throws Exception {
+
+		ObjectDefinition objectDefinition = _addCMSObjectDefinition();
+		ObjectDefinition cascadeObjectDefinition = _addCMSObjectDefinition();
+		ObjectDefinition disassociateObjectDefinition =
+			_addCMSObjectDefinition();
+
+		ObjectRelationship cascadeObjectRelationship = _addObjectRelationship(
+			cascadeObjectDefinition, objectDefinition);
+		ObjectRelationship disassociateObjectRelationship =
+			_addObjectRelationship(
+				disassociateObjectDefinition,
+				ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE,
+				objectDefinition);
+
+		_runUpgrade();
+
+		_assertObjectRelationshipEdge(
+			true, cascadeObjectRelationship.getObjectRelationshipId());
+		_assertObjectRelationshipEdge(
+			false, disassociateObjectRelationship.getObjectRelationshipId());
+	}
+
+	@Test
+	public void testUpgradeWithDepthGreaterThanAllowed() throws Exception {
+		ObjectDefinition[] objectDefinitions = new ObjectDefinition[6];
+
+		for (int i = 0; i < objectDefinitions.length; i++) {
+			objectDefinitions[i] = _addCMSObjectDefinition();
+		}
+
+		for (int i = 0; i < (objectDefinitions.length - 1); i++) {
+			_addObjectRelationship(
+				objectDefinitions[i + 1], objectDefinitions[i]);
+		}
+
+		try {
+			_runUpgrade();
+
+			Assert.fail(
+				"Expected an UpgradeException for exceeding the maximum " +
+					"nesting depth");
+		}
+		catch (UpgradeException upgradeException) {
+			String message = upgradeException.getMessage();
+
+			Assert.assertTrue(
+				message, message.contains("maximum nesting depth"));
+
+			for (ObjectDefinition objectDefinition : objectDefinitions) {
+				Assert.assertTrue(
+					message, message.contains(objectDefinition.getShortName()));
+			}
+		}
+	}
+
+	@Test
+	public void testUpgradeWithExistingEdgeObjectRelationships()
+		throws Exception {
+
+		ObjectDefinition rootObjectDefinition = _addCMSObjectDefinition();
+		ObjectDefinition childObjectDefinition = _addCMSObjectDefinition();
+		ObjectDefinition grandchildObjectDefinition = _addCMSObjectDefinition();
+
+		ObjectRelationship objectRelationship1 = _addObjectRelationship(
+			childObjectDefinition, rootObjectDefinition);
+		ObjectRelationship objectRelationship2 = _addObjectRelationship(
+			grandchildObjectDefinition, childObjectDefinition);
+
+		_runUpgrade();
+
+		_assertObjectRelationshipEdge(
+			true, objectRelationship1.getObjectRelationshipId());
+		_assertObjectRelationshipEdge(
+			true, objectRelationship2.getObjectRelationshipId());
+
+		long rootObjectDefinitionId =
+			rootObjectDefinition.getObjectDefinitionId();
+
+		_assertRootObjectDefinitionIds(
+			rootObjectDefinitionId, childObjectDefinition);
+		_assertRootObjectDefinitionIds(
+			rootObjectDefinitionId, grandchildObjectDefinition);
+
+		long[] childRootObjectDefinitionIds = _getRootObjectDefinitionIds(
+			childObjectDefinition);
+		long[] grandchildRootObjectDefinitionIds = _getRootObjectDefinitionIds(
+			grandchildObjectDefinition);
+
+		_runUpgrade();
+
+		_assertObjectRelationshipEdge(
+			true, objectRelationship1.getObjectRelationshipId());
+		_assertObjectRelationshipEdge(
+			true, objectRelationship2.getObjectRelationshipId());
+
+		Assert.assertArrayEquals(
+			childRootObjectDefinitionIds,
+			_getRootObjectDefinitionIds(childObjectDefinition));
+		Assert.assertArrayEquals(
+			grandchildRootObjectDefinitionIds,
+			_getRootObjectDefinitionIds(grandchildObjectDefinition));
+	}
+
+	@Test
+	public void testUpgradeWithObjectRelationshipsCycle() throws Exception {
+		ObjectDefinition objectDefinition1 = _addCMSObjectDefinition();
+		ObjectDefinition objectDefinition2 = _addCMSObjectDefinition();
+
+		ObjectRelationship objectRelationship1 = _addObjectRelationship(
+			objectDefinition2, objectDefinition1);
+		ObjectRelationship objectRelationship2 = _addObjectRelationship(
+			objectDefinition1, objectDefinition2);
+
+		try {
+			_runUpgrade();
+
+			Assert.fail(
+				"Expected an UpgradeException for a cycle in the CMS object " +
+					"relationships");
+		}
+		catch (UpgradeException upgradeException) {
+			String message = upgradeException.getMessage();
+
+			Assert.assertTrue(message, message.contains("form a cycle"));
+			Assert.assertTrue(
+				message, message.contains(objectRelationship1.getName()));
+			Assert.assertTrue(
+				message, message.contains(objectRelationship2.getName()));
+		}
+	}
+
+	private ObjectDefinition _addCMSObjectDefinition() throws Exception {
+		return _addCMSObjectDefinition(_cmsContentStructuresObjectFolder);
+	}
+
+	private ObjectDefinition _addCMSObjectDefinition(ObjectFolder objectFolder)
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				false, false, false, ObjectDefinitionTestUtil.getRandomName(),
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).userId(
+						TestPropsValues.getUserId()
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).name(
+						"able"
+					).build()),
+				objectFolder.getObjectFolderId(),
+				ObjectDefinitionConstants.SCOPE_DEPOT,
+				TestPropsValues.getUserId());
+
+		_objectDefinitionSettingLocalService.addObjectDefinitionSetting(
+			TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS, "true");
+
+		_objectDefinitions.add(objectDefinition);
+
+		return objectDefinition;
+	}
+
+	private ObjectDefinition _addObjectDefinition() throws Exception {
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).userId(
+						TestPropsValues.getUserId()
+					).labelMap(
+						LocalizedMapUtil.getLocalizedMap(
+							RandomTestUtil.randomString())
+					).name(
+						"able"
+					).build()),
+				ObjectDefinitionConstants.SCOPE_COMPANY);
+
+		_objectDefinitions.add(objectDefinition);
+
+		return objectDefinition;
+	}
+
+	private ObjectEntry _addObjectEntry(
+			long groupId, long objectDefinitionId,
+			Map<String, Serializable> values)
+		throws Exception {
+
+		return _objectEntryLocalService.addObjectEntry(
+			groupId, TestPropsValues.getUserId(), objectDefinitionId,
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			null, values, ServiceContextTestUtil.getServiceContext());
+	}
+
+	private ObjectRelationship _addObjectRelationship(
+			ObjectDefinition childObjectDefinition,
+			ObjectDefinition parentObjectDefinition)
+		throws Exception {
+
+		return ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectRelationshipLocalService, parentObjectDefinition,
+			childObjectDefinition);
+	}
+
+	private ObjectRelationship _addObjectRelationship(
+			ObjectDefinition childObjectDefinition, String deletionType,
+			ObjectDefinition parentObjectDefinition)
+		throws Exception {
+
+		return ObjectRelationshipTestUtil.addObjectRelationship(
+			_objectRelationshipLocalService, parentObjectDefinition,
+			childObjectDefinition, deletionType);
+	}
+
+	private void _assertObjectRelationshipEdge(
+			boolean expected, long objectRelationshipId)
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.getObjectRelationship(
+				objectRelationshipId);
+
+		Assert.assertEquals(expected, objectRelationship.isEdge());
+	}
+
+	private void _assertRootObjectDefinitionIds(
+			long expectedRootObjectDefinitionId,
+			ObjectDefinition objectDefinition)
+		throws Exception {
+
+		objectDefinition = _objectDefinitionLocalService.getObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
+
+		Assert.assertTrue(
+			ArrayUtil.contains(
+				objectDefinition.getRootObjectDefinitionIds(),
+				expectedRootObjectDefinitionId));
+	}
+
+	private long[] _getRootObjectDefinitionIds(
+			ObjectDefinition objectDefinition)
+		throws Exception {
+
+		objectDefinition = _objectDefinitionLocalService.getObjectDefinition(
+			objectDefinition.getObjectDefinitionId());
+
+		return objectDefinition.getRootObjectDefinitionIds();
+	}
+
+	private void _runUpgrade() throws Exception {
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator, _CLASS_NAME);
+
+		upgradeProcess.upgrade();
+	}
+
+	private void _testUpgradeObjectRelationshipsCascadeDeletionType(
+			boolean featureFlagEnabled)
+		throws Exception {
+
+		ObjectDefinition firstObjectDefinition = _addCMSObjectDefinition();
+		ObjectDefinition secondObjectDefinition = _addCMSObjectDefinition();
+		ObjectDefinition thirdObjectDefinition = _addCMSObjectDefinition();
+		ObjectDefinition fourthObjectDefinition = _addCMSObjectDefinition();
+
+		ObjectRelationship firstObjectRelationship = _addObjectRelationship(
+			secondObjectDefinition, firstObjectDefinition);
+		ObjectRelationship secondObjectRelationship = _addObjectRelationship(
+			thirdObjectDefinition, firstObjectDefinition);
+		ObjectRelationship thirdObjectRelationship = _addObjectRelationship(
+			fourthObjectDefinition, secondObjectDefinition);
+		ObjectRelationship fourthObjectRelationship = _addObjectRelationship(
+			fourthObjectDefinition, thirdObjectDefinition);
+
+		PropsUtil.set(
+			FeatureFlagConstants.getKey("LPD-34594"),
+			String.valueOf(featureFlagEnabled));
+
+		try {
+			_runUpgrade();
+		}
+		finally {
+			PropsUtil.set(FeatureFlagConstants.getKey("LPD-34594"), "true");
+		}
+
+		_assertObjectRelationshipEdge(
+			true, firstObjectRelationship.getObjectRelationshipId());
+		_assertObjectRelationshipEdge(
+			true, secondObjectRelationship.getObjectRelationshipId());
+		_assertObjectRelationshipEdge(
+			true, thirdObjectRelationship.getObjectRelationshipId());
+		_assertObjectRelationshipEdge(
+			true, fourthObjectRelationship.getObjectRelationshipId());
+
+		long firstObjectDefinitionId =
+			firstObjectDefinition.getObjectDefinitionId();
+
+		_assertRootObjectDefinitionIds(
+			firstObjectDefinitionId, secondObjectDefinition);
+		_assertRootObjectDefinitionIds(
+			firstObjectDefinitionId, thirdObjectDefinition);
+		_assertRootObjectDefinitionIds(
+			firstObjectDefinitionId, fourthObjectDefinition);
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.site.cms.site.initializer.internal.upgrade.v1_0_0." +
+			"CMSObjectRelationshipEdgeUpgradeProcess";
+
+	private ObjectFolder _cmsContentStructuresObjectFolder;
+	private ObjectFolder _cmsFileTypesObjectFolder;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	private final List<ObjectDefinition> _objectDefinitions = new ArrayList<>();
+
+	@Inject
+	private ObjectDefinitionSettingLocalService
+		_objectDefinitionSettingLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ObjectFieldLocalService _objectFieldLocalService;
+
+	@Inject
+	private ObjectFolderLocalService _objectFolderLocalService;
+
+	@Inject
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.site.cms.site.initializer.internal.upgrade.registry.SiteCMSSiteInitializerUpgradeStepRegistrator"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextUtil.java
@@ -117,13 +117,14 @@ public class SectionDisplayContextUtil {
 			httpServletRequest.getAttribute(InfoDisplayWebKeys.INFO_ITEM),
 			rootObjectEntryFolderExternalReferenceCode);
 
-		StringBundler sb = new StringBundler(13);
+		StringBundler sb = new StringBundler(14);
 
 		sb.append("emptySearch=true&filter=");
 
 		if (objectEntryFolder != null) {
 			sb.append("folderId eq ");
 			sb.append(objectEntryFolder.getObjectEntryFolderId());
+			sb.append(" and rootDescendantNode eq false");
 
 			if (objectEntryFolder.getStatus() ==
 					WorkflowConstants.STATUS_IN_TRASH) {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewContentsSectionDisplayContext.java
@@ -74,7 +74,9 @@ public class ViewContentsSectionDisplayContext
 	@Override
 	protected String getCMSSectionFilterString() {
 		return appendStatus(
-			appendGroupIds("cmsRoot eq true and cmsSection eq 'contents'"));
+			appendGroupIds(
+				"cmsRoot eq true and rootDescendantNode eq false and " +
+					"cmsSection eq 'contents'"));
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFilesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFilesSectionDisplayContext.java
@@ -78,7 +78,9 @@ public class ViewFilesSectionDisplayContext
 	@Override
 	protected String getCMSSectionFilterString() {
 		return appendStatus(
-			appendGroupIds("cmsRoot eq true and cmsSection eq 'files'"));
+			appendGroupIds(
+				"cmsRoot eq true and rootDescendantNode eq false and " +
+					"cmsSection eq 'files'"));
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRecycleBinSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRecycleBinSectionDisplayContext.java
@@ -200,8 +200,8 @@ public class ViewRecycleBinSectionDisplayContext
 	@Override
 	protected String getCMSSectionFilterString() {
 		String filterString =
-			"cmsRoot eq true and (cmsSection eq 'contents' or cmsSection eq " +
-				"'files')";
+			"cmsRoot eq true and rootDescendantNode eq false and (cmsSection " +
+				"eq 'contents' or cmsSection eq 'files')";
 
 		List<Long> groupIds = _getTrashEnabledDepotEntryGroupIds();
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceContentsSummarySectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceContentsSummarySectionDisplayContext.java
@@ -97,8 +97,8 @@ public class ViewSpaceContentsSummarySectionDisplayContext
 	@Override
 	protected String getCMSSectionFilterString() {
 		return String.format(
-			"cmsRoot eq true and cmsSection eq 'contents' and groupIds/any" +
-				"(g:g eq %s)",
+			"cmsRoot eq true and rootDescendantNode eq false and cmsSection " +
+				"eq 'contents' and groupIds/any(g:g eq %s)",
 			_groupId);
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceFilesSummarySectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceFilesSummarySectionDisplayContext.java
@@ -97,8 +97,8 @@ public class ViewSpaceFilesSummarySectionDisplayContext
 	@Override
 	protected String getCMSSectionFilterString() {
 		return String.format(
-			"cmsRoot eq true and cmsSection eq 'files' and groupIds/any" +
-				"(g:g eq %s)",
+			"cmsRoot eq true and rootDescendantNode eq false and cmsSection " +
+				"eq 'files' and groupIds/any(g:g eq %s)",
 			_groupId);
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/DeleteStructureStrutsAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/DeleteStructureStrutsAction.java
@@ -5,22 +5,26 @@
 
 package com.liferay.site.cms.site.initializer.internal.struts;
 
+import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectDefinitionService;
-import com.liferay.object.service.ObjectRelationshipService;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.struts.StrutsAction;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -28,7 +32,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
@@ -54,6 +57,14 @@ public class DeleteStructureStrutsAction implements StrutsAction {
 		try {
 			long objectDefinitionId = ParamUtil.getLong(
 				httpServletRequest, "objectDefinitionId");
+
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)httpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			_objectDefinitionModelResourcePermission.check(
+				themeDisplay.getPermissionChecker(), objectDefinitionId,
+				ActionKeys.DELETE);
 
 			_deleteStructures(objectDefinitionId);
 		}
@@ -107,19 +118,20 @@ public class DeleteStructureStrutsAction implements StrutsAction {
 		visitedObjectDefinitionIds.add(objectDefinitionId);
 
 		List<ObjectRelationship> objectRelationships =
-			_objectRelationshipService.getObjectRelationships(
-				objectDefinitionId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+			_objectRelationshipLocalService.getObjectRelationships(
+				objectDefinitionId, true);
 
 		for (ObjectRelationship objectRelationship : objectRelationships) {
-			if (!Objects.equals(
-					objectRelationship.getDeletionType(), "cascade")) {
-
-				continue;
-			}
-
 			_getObjectDefinitionIds(
 				objectRelationship.getObjectDefinitionId2(),
 				objectDefinitionIds, visitedObjectDefinitionIds);
+
+			_objectRelationshipLocalService.updateObjectRelationship(
+				objectRelationship.getExternalReferenceCode(),
+				objectRelationship.getObjectRelationshipId(),
+				objectRelationship.getParameterObjectFieldId(),
+				objectRelationship.getDeletionType(), false,
+				objectRelationship.getLabelMap(), null);
 		}
 
 		objectDefinitionIds.add(objectDefinitionId);
@@ -138,11 +150,17 @@ public class DeleteStructureStrutsAction implements StrutsAction {
 	@Reference
 	private Language _language;
 
+	@Reference(
+		target = "(model.class.name=com.liferay.object.model.ObjectDefinition)"
+	)
+	private ModelResourcePermission<ObjectDefinition>
+		_objectDefinitionModelResourcePermission;
+
 	@Reference
 	private ObjectDefinitionService _objectDefinitionService;
 
 	@Reference
-	private ObjectRelationshipService _objectRelationshipService;
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
 	private class DeleteStructuresCallable implements Callable<Void> {
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
@@ -127,12 +127,28 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 				serviceBuilderObjectRelationship :
 					_objectRelationshipLocalService.
 						getObjectRelationshipsByObjectDefinitionId2(
-							objectDefinitionId, false)) {
+							objectDefinitionId, true)) {
 
-			if (!serviceBuilderObjectRelationship.isReverse()) {
-				_objectRelationshipLocalService.deleteObjectRelationship(
-					serviceBuilderObjectRelationship);
+			if (serviceBuilderObjectRelationship.isReverse()) {
+				continue;
 			}
+
+			if (serviceBuilderObjectRelationship.isEdge()) {
+				serviceBuilderObjectRelationship =
+					_objectRelationshipLocalService.updateObjectRelationship(
+						serviceBuilderObjectRelationship.
+							getExternalReferenceCode(),
+						serviceBuilderObjectRelationship.
+							getObjectRelationshipId(),
+						serviceBuilderObjectRelationship.
+							getParameterObjectFieldId(),
+						serviceBuilderObjectRelationship.getDeletionType(),
+						false, serviceBuilderObjectRelationship.getLabelMap(),
+						null);
+			}
+
+			_objectRelationshipLocalService.deleteObjectRelationship(
+				serviceBuilderObjectRelationship);
 		}
 	}
 
@@ -326,6 +342,24 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 										"objectRelationshipERC"),
 									_companyId,
 									objectDefinition.getObjectDefinitionId());
+
+					if (serviceBuilderObjectRelationship.isEdge()) {
+						serviceBuilderObjectRelationship =
+							_objectRelationshipLocalService.
+								updateObjectRelationship(
+									serviceBuilderObjectRelationship.
+										getExternalReferenceCode(),
+									serviceBuilderObjectRelationship.
+										getObjectRelationshipId(),
+									serviceBuilderObjectRelationship.
+										getParameterObjectFieldId(),
+									serviceBuilderObjectRelationship.
+										getDeletionType(),
+									false,
+									serviceBuilderObjectRelationship.
+										getLabelMap(),
+									null);
+					}
 
 					_objectRelationshipLocalService.deleteObjectRelationship(
 						serviceBuilderObjectRelationship);

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/registry/SiteCMSSiteInitializerUpgradeStepRegistrator.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/registry/SiteCMSSiteInitializerUpgradeStepRegistrator.java
@@ -8,9 +8,12 @@ package com.liferay.site.cms.site.initializer.internal.upgrade.registry;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.rest.filter.factory.FilterFactory;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectDefinitionSettingLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFolderLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.object.service.persistence.ObjectDefinitionPersistence;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -41,6 +44,8 @@ public class SiteCMSSiteInitializerUpgradeStepRegistrator
 			"1.0.0", "2.0.0",
 			new CMSObjectRelationshipEdgeUpgradeProcess(
 				_companyLocalService, _objectDefinitionLocalService,
+				_objectDefinitionPersistence,
+				_objectDefinitionSettingLocalService, _objectEntryLocalService,
 				_objectFolderLocalService, _objectRelationshipLocalService));
 	}
 
@@ -59,7 +64,17 @@ public class SiteCMSSiteInitializerUpgradeStepRegistrator
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@Reference
+	private ObjectDefinitionPersistence _objectDefinitionPersistence;
+
+	@Reference
+	private ObjectDefinitionSettingLocalService
+		_objectDefinitionSettingLocalService;
+
+	@Reference
 	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
 
 	@Reference
 	private ObjectFolderLocalService _objectFolderLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/registry/SiteCMSSiteInitializerUpgradeStepRegistrator.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/registry/SiteCMSSiteInitializerUpgradeStepRegistrator.java
@@ -9,16 +9,21 @@ import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.rest.filter.factory.FilterFactory;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.object.service.ObjectFolderLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.petra.sql.dsl.expression.Predicate;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.site.cms.site.initializer.internal.upgrade.v1_0_0.CMSDefaultPermissionsUpgradeProcess;
+import com.liferay.site.cms.site.initializer.internal.upgrade.v1_0_0.CMSObjectRelationshipEdgeUpgradeProcess;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Adolfo Pérez
+ * @author Víctor Galán
  */
 @Component(service = UpgradeStepRegistrator.class)
 public class SiteCMSSiteInitializerUpgradeStepRegistrator
@@ -31,7 +36,16 @@ public class SiteCMSSiteInitializerUpgradeStepRegistrator
 			new CMSDefaultPermissionsUpgradeProcess(
 				_filterFactory, _groupLocalService,
 				_objectDefinitionLocalService, _objectEntryFolderLocalService));
+
+		registry.register(
+			"1.0.0", "2.0.0",
+			new CMSObjectRelationshipEdgeUpgradeProcess(
+				_companyLocalService, _objectDefinitionLocalService,
+				_objectFolderLocalService, _objectRelationshipLocalService));
 	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
 
 	@Reference(
 		target = "(filter.factory.key=" + ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT + ")"
@@ -46,5 +60,11 @@ public class SiteCMSSiteInitializerUpgradeStepRegistrator
 
 	@Reference
 	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+	@Reference
+	private ObjectFolderLocalService _objectFolderLocalService;
+
+	@Reference
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/CMSObjectRelationshipEdgeUpgradeProcess.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/CMSObjectRelationshipEdgeUpgradeProcess.java
@@ -7,15 +7,20 @@ package com.liferay.site.cms.site.initializer.internal.upgrade.v1_0_0;
 
 import com.liferay.object.constants.ObjectFolderConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.definition.tree.util.ObjectDefinitionTreeUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectFolder;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectDefinitionSettingLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFolderLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.object.service.persistence.ObjectDefinitionPersistence;
 import com.liferay.object.tree.constants.TreeConstants;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -36,11 +41,18 @@ public class CMSObjectRelationshipEdgeUpgradeProcess extends UpgradeProcess {
 	public CMSObjectRelationshipEdgeUpgradeProcess(
 		CompanyLocalService companyLocalService,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
+		ObjectDefinitionPersistence objectDefinitionPersistence,
+		ObjectDefinitionSettingLocalService objectDefinitionSettingLocalService,
+		ObjectEntryLocalService objectEntryLocalService,
 		ObjectFolderLocalService objectFolderLocalService,
 		ObjectRelationshipLocalService objectRelationshipLocalService) {
 
 		_companyLocalService = companyLocalService;
 		_objectDefinitionLocalService = objectDefinitionLocalService;
+		_objectDefinitionPersistence = objectDefinitionPersistence;
+		_objectDefinitionSettingLocalService =
+			objectDefinitionSettingLocalService;
+		_objectEntryLocalService = objectEntryLocalService;
 		_objectFolderLocalService = objectFolderLocalService;
 		_objectRelationshipLocalService = objectRelationshipLocalService;
 	}
@@ -218,6 +230,21 @@ public class CMSObjectRelationshipEdgeUpgradeProcess extends UpgradeProcess {
 				currentObjectRelationship.getParameterObjectFieldId(),
 				currentObjectRelationship.getDeletionType(), true,
 				currentObjectRelationship.getLabelMap(), null);
+
+			if (FeatureFlagManagerUtil.isEnabled(
+					currentObjectRelationship.getCompanyId(), "LPD-34594")) {
+
+				continue;
+			}
+
+			objectRelationship =
+				_objectRelationshipLocalService.fetchObjectRelationship(
+					currentObjectRelationship.getObjectRelationshipId());
+
+			ObjectDefinitionTreeUtil.bindObjectDefinitions(
+				_objectDefinitionLocalService, _objectDefinitionPersistence,
+				_objectDefinitionSettingLocalService, _objectEntryLocalService,
+				objectRelationship, _objectRelationshipLocalService);
 		}
 	}
 
@@ -228,6 +255,10 @@ public class CMSObjectRelationshipEdgeUpgradeProcess extends UpgradeProcess {
 
 	private final CompanyLocalService _companyLocalService;
 	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
+	private final ObjectDefinitionPersistence _objectDefinitionPersistence;
+	private final ObjectDefinitionSettingLocalService
+		_objectDefinitionSettingLocalService;
+	private final ObjectEntryLocalService _objectEntryLocalService;
 	private final ObjectFolderLocalService _objectFolderLocalService;
 	private final ObjectRelationshipLocalService
 		_objectRelationshipLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/CMSObjectRelationshipEdgeUpgradeProcess.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/CMSObjectRelationshipEdgeUpgradeProcess.java
@@ -1,0 +1,235 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.cms.site.initializer.internal.upgrade.v1_0_0;
+
+import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.constants.ObjectRelationshipConstants;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectFolder;
+import com.liferay.object.model.ObjectRelationship;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectFolderLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.object.tree.constants.TreeConstants;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeException;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * @author Víctor Galán
+ */
+public class CMSObjectRelationshipEdgeUpgradeProcess extends UpgradeProcess {
+
+	public CMSObjectRelationshipEdgeUpgradeProcess(
+		CompanyLocalService companyLocalService,
+		ObjectDefinitionLocalService objectDefinitionLocalService,
+		ObjectFolderLocalService objectFolderLocalService,
+		ObjectRelationshipLocalService objectRelationshipLocalService) {
+
+		_companyLocalService = companyLocalService;
+		_objectDefinitionLocalService = objectDefinitionLocalService;
+		_objectFolderLocalService = objectFolderLocalService;
+		_objectRelationshipLocalService = objectRelationshipLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		_companyLocalService.forEachCompanyId(
+			companyId -> _upgradeCompany(companyId));
+	}
+
+	private void _checkMaxDepth(List<ObjectDefinition> objectDefinitionPath)
+		throws UpgradeException {
+
+		if ((objectDefinitionPath.size() - 1) > TreeConstants.MAX_HEIGHT) {
+			throw new UpgradeException(
+				_getExceptionMessage(objectDefinitionPath));
+		}
+
+		ObjectDefinition currentObjectDefinition = objectDefinitionPath.get(
+			objectDefinitionPath.size() - 1);
+
+		long currentObjectDefinitionId =
+			currentObjectDefinition.getObjectDefinitionId();
+
+		for (ObjectRelationship objectRelationship :
+				_objectRelationshipLocalService.getObjectRelationships(
+					currentObjectDefinitionId,
+					ObjectRelationshipConstants.DELETION_TYPE_CASCADE, false)) {
+
+			if (objectRelationship.isSelf() ||
+				!Objects.equals(
+					objectRelationship.getType(),
+					ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
+
+				continue;
+			}
+
+			ObjectDefinition childObjectDefinition =
+				_objectDefinitionLocalService.fetchObjectDefinition(
+					objectRelationship.getObjectDefinitionId2());
+
+			if ((childObjectDefinition == null) ||
+				objectDefinitionPath.contains(childObjectDefinition)) {
+
+				continue;
+			}
+
+			objectDefinitionPath.add(childObjectDefinition);
+
+			_checkMaxDepth(objectDefinitionPath);
+
+			objectDefinitionPath.remove(objectDefinitionPath.size() - 1);
+		}
+	}
+
+	private List<ObjectRelationship> _getCMSObjectRelationships(
+		long companyId) {
+
+		List<ObjectRelationship> objectRelationships = new ArrayList<>();
+		Set<Long> objectDefinitionIds = new HashSet<>();
+
+		for (String externalReferenceCode :
+				_CMS_ROOT_FOLDER_EXTERNAL_REFERENCE_CODES) {
+
+			ObjectFolder objectFolder =
+				_objectFolderLocalService.
+					fetchObjectFolderByExternalReferenceCode(
+						externalReferenceCode, companyId);
+
+			if (objectFolder == null) {
+				continue;
+			}
+
+			for (ObjectDefinition objectDefinition :
+					_objectDefinitionLocalService.
+						getObjectFolderObjectDefinitions(
+							objectFolder.getObjectFolderId())) {
+
+				_getObjectRelationships(
+					objectDefinition.getObjectDefinitionId(),
+					objectDefinitionIds, objectRelationships);
+			}
+		}
+
+		return objectRelationships;
+	}
+
+	private String _getExceptionMessage(
+		List<ObjectDefinition> objectDefinitionPath) {
+
+		List<String> shortNames = new ArrayList<>(objectDefinitionPath.size());
+
+		for (ObjectDefinition objectDefinition : objectDefinitionPath) {
+			shortNames.add(objectDefinition.getShortName());
+		}
+
+		return StringBundler.concat(
+			"This CMS chain exceeds the maximum nesting depth (",
+			TreeConstants.MAX_HEIGHT, "). ",
+			StringUtil.merge(shortNames, " -> "));
+	}
+
+	private void _getObjectRelationships(
+		long objectDefinitionId, Set<Long> objectDefinitionIds,
+		List<ObjectRelationship> objectRelationships) {
+
+		if (!objectDefinitionIds.add(objectDefinitionId)) {
+			return;
+		}
+
+		for (ObjectRelationship objectRelationship :
+				_objectRelationshipLocalService.getObjectRelationships(
+					objectDefinitionId,
+					ObjectRelationshipConstants.DELETION_TYPE_CASCADE, false)) {
+
+			if (objectRelationship.isSelf() ||
+				!Objects.equals(
+					objectRelationship.getType(),
+					ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
+
+				continue;
+			}
+
+			objectRelationships.add(objectRelationship);
+
+			_getObjectRelationships(
+				objectRelationship.getObjectDefinitionId2(),
+				objectDefinitionIds, objectRelationships);
+		}
+	}
+
+	private void _upgradeCompany(long companyId) throws PortalException {
+		for (String externalReferenceCode :
+				_CMS_ROOT_FOLDER_EXTERNAL_REFERENCE_CODES) {
+
+			ObjectFolder objectFolder =
+				_objectFolderLocalService.
+					fetchObjectFolderByExternalReferenceCode(
+						externalReferenceCode, companyId);
+
+			if (objectFolder == null) {
+				continue;
+			}
+
+			for (ObjectDefinition objectDefinition :
+					_objectDefinitionLocalService.
+						getObjectFolderObjectDefinitions(
+							objectFolder.getObjectFolderId())) {
+
+				_checkMaxDepth(ListUtil.fromArray(objectDefinition));
+			}
+		}
+
+		List<ObjectRelationship> objectRelationships =
+			_getCMSObjectRelationships(companyId);
+
+		if (objectRelationships.isEmpty()) {
+			return;
+		}
+
+		for (ObjectRelationship objectRelationship : objectRelationships) {
+			ObjectRelationship currentObjectRelationship =
+				_objectRelationshipLocalService.fetchObjectRelationship(
+					objectRelationship.getObjectRelationshipId());
+
+			if ((currentObjectRelationship == null) ||
+				currentObjectRelationship.isEdge()) {
+
+				continue;
+			}
+
+			_objectRelationshipLocalService.updateObjectRelationship(
+				currentObjectRelationship.getExternalReferenceCode(),
+				currentObjectRelationship.getObjectRelationshipId(),
+				currentObjectRelationship.getParameterObjectFieldId(),
+				currentObjectRelationship.getDeletionType(), true,
+				currentObjectRelationship.getLabelMap(), null);
+		}
+	}
+
+	private static final String[] _CMS_ROOT_FOLDER_EXTERNAL_REFERENCE_CODES = {
+		ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
+		ObjectFolderConstants.EXTERNAL_REFERENCE_CODE_FILE_TYPES
+	};
+
+	private final CompanyLocalService _companyLocalService;
+	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
+	private final ObjectFolderLocalService _objectFolderLocalService;
+	private final ObjectRelationshipLocalService
+		_objectRelationshipLocalService;
+
+}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/CMSObjectRelationshipEdgeUpgradeProcess.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/CMSObjectRelationshipEdgeUpgradeProcess.java
@@ -18,7 +18,9 @@ import com.liferay.object.service.ObjectFolderLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.service.persistence.ObjectDefinitionPersistence;
 import com.liferay.object.tree.constants.TreeConstants;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -108,8 +110,8 @@ public class CMSObjectRelationshipEdgeUpgradeProcess extends UpgradeProcess {
 		}
 	}
 
-	private List<ObjectRelationship> _getCMSObjectRelationships(
-		long companyId) {
+	private List<ObjectRelationship> _getCMSObjectRelationships(long companyId)
+		throws UpgradeException {
 
 		List<ObjectRelationship> objectRelationships = new ArrayList<>();
 		Set<Long> objectDefinitionIds = new HashSet<>();
@@ -137,22 +139,19 @@ public class CMSObjectRelationshipEdgeUpgradeProcess extends UpgradeProcess {
 			}
 		}
 
-		return objectRelationships;
+		return _sortObjectRelationships(objectRelationships);
 	}
 
 	private String _getExceptionMessage(
 		List<ObjectDefinition> objectDefinitionPath) {
 
-		List<String> shortNames = new ArrayList<>(objectDefinitionPath.size());
-
-		for (ObjectDefinition objectDefinition : objectDefinitionPath) {
-			shortNames.add(objectDefinition.getShortName());
-		}
-
 		return StringBundler.concat(
 			"This CMS chain exceeds the maximum nesting depth (",
 			TreeConstants.MAX_HEIGHT, "). ",
-			StringUtil.merge(shortNames, " -> "));
+			StringUtil.merge(
+				TransformUtil.transform(
+					objectDefinitionPath, ObjectDefinition::getShortName),
+				" -> "));
 	}
 
 	private void _getObjectRelationships(
@@ -182,6 +181,49 @@ public class CMSObjectRelationshipEdgeUpgradeProcess extends UpgradeProcess {
 				objectRelationship.getObjectDefinitionId2(),
 				objectDefinitionIds, objectRelationships);
 		}
+	}
+
+	private List<ObjectRelationship> _sortObjectRelationships(
+			List<ObjectRelationship> objectRelationships)
+		throws UpgradeException {
+
+		List<ObjectRelationship> sortedObjectRelationships = new ArrayList<>(
+			objectRelationships.size());
+
+		while (!objectRelationships.isEmpty()) {
+			List<ObjectRelationship> rootObjectRelationships =
+				new ArrayList<>();
+
+			for (ObjectRelationship objectRelationship : objectRelationships) {
+				long objectDefinitionId1 =
+					objectRelationship.getObjectDefinitionId1();
+
+				if (!ListUtil.exists(
+						objectRelationships,
+						parentObjectRelationship ->
+							parentObjectRelationship.getObjectDefinitionId2() ==
+								objectDefinitionId1)) {
+
+					rootObjectRelationships.add(objectRelationship);
+				}
+			}
+
+			if (rootObjectRelationships.isEmpty()) {
+				String objectRelationshipNames = StringUtil.merge(
+					TransformUtil.transform(
+						objectRelationships, ObjectRelationship::getName),
+					StringPool.COMMA_AND_SPACE);
+
+				throw new UpgradeException(
+					"These CMS object relationships form a cycle: " +
+						objectRelationshipNames);
+			}
+
+			objectRelationships.removeAll(rootObjectRelationships);
+			sortedObjectRelationships.addAll(rootObjectRelationships);
+		}
+
+		return sortedObjectRelationships;
 	}
 
 	private void _upgradeCompany(long companyId) throws PortalException {
@@ -224,22 +266,19 @@ public class CMSObjectRelationshipEdgeUpgradeProcess extends UpgradeProcess {
 				continue;
 			}
 
-			_objectRelationshipLocalService.updateObjectRelationship(
-				currentObjectRelationship.getExternalReferenceCode(),
-				currentObjectRelationship.getObjectRelationshipId(),
-				currentObjectRelationship.getParameterObjectFieldId(),
-				currentObjectRelationship.getDeletionType(), true,
-				currentObjectRelationship.getLabelMap(), null);
+			objectRelationship =
+				_objectRelationshipLocalService.updateObjectRelationship(
+					currentObjectRelationship.getExternalReferenceCode(),
+					currentObjectRelationship.getObjectRelationshipId(),
+					currentObjectRelationship.getParameterObjectFieldId(),
+					currentObjectRelationship.getDeletionType(), true,
+					currentObjectRelationship.getLabelMap(), null);
 
 			if (FeatureFlagManagerUtil.isEnabled(
-					currentObjectRelationship.getCompanyId(), "LPD-34594")) {
+					objectRelationship.getCompanyId(), "LPD-34594")) {
 
 				continue;
 			}
-
-			objectRelationship =
-				_objectRelationshipLocalService.fetchObjectRelationship(
-					currentObjectRelationship.getObjectRelationshipId());
 
 			ObjectDefinitionTreeUtil.bindObjectDefinitions(
 				_objectDefinitionLocalService, _objectDefinitionPersistence,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/bulk_actions_monitor/util/index.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/bulk_actions_monitor/util/index.ts
@@ -63,7 +63,7 @@ export function composeCreateTaskURL(
 		const {folderId, groupIds} =
 			getFolderIdAndGroupIdsFromFilter(scopeFilter);
 
-		scopeFilter = `cmsRoot eq true and cmsSection eq 'contents' and status in (0, 2, 3)`;
+		scopeFilter = `cmsRoot eq true and rootDescendantNode eq false and cmsSection eq 'contents' and status in (0, 2, 3)`;
 
 		if (folderId) {
 			scopeFilter += ` and folderId eq ${folderId}`;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/EmptyRecycleBinModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/EmptyRecycleBinModalContent.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import {triggerAssetBulkAction} from '../props_transformer/actions/triggerAssetBulkAction';
 
 const CMS_RECYCLE_BIN_FILTER =
-	"cmsRoot eq true and (cmsSection eq 'contents' or cmsSection eq 'files') and status eq 8";
+	"cmsRoot eq true and rootDescendantNode eq false and (cmsSection eq 'contents' or cmsSection eq 'files') and status eq 8";
 
 export default function EmptyRecycleBinModalContent({
 	closeModal,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/buildObjectDefinition.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/buildObjectDefinition.ts
@@ -184,6 +184,7 @@ function buildRelationships({
 	for (const referencedStructure of referencedStructures) {
 		relationships.push({
 			deletionType: 'cascade',
+			edge: true,
 			externalReferenceCode: referencedStructure.relationshipERC,
 			label: {
 				en_US: referencedStructure.name,
@@ -198,6 +199,7 @@ function buildRelationships({
 	for (const repeatableGroup of repeatableGroups) {
 		relationships.push({
 			deletionType: 'cascade',
+			edge: true,
 			externalReferenceCode: repeatableGroup.relationshipERC,
 			label: repeatableGroup.label,
 			name: repeatableGroup.relationshipName,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/buildStructure.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/buildStructure.ts
@@ -120,7 +120,7 @@ export function buildChildren({
 
 			children.set(repeatableGroup.uuid, repeatableGroup);
 		}
-		else if (objectRelationship.deletionType === 'cascade') {
+		else if (objectRelationship.edge) {
 			const referencedStructure = buildReferencedStructure({
 				ancestors: [
 					...ancestors,
@@ -467,7 +467,7 @@ function getRelatedContentObjectRelationships(
 				objectRelationship.objectDefinitionExternalReferenceCode2 ===
 					mainObjectDefinition.externalReferenceCode &&
 				objectRelationship.type === 'oneToMany' &&
-				objectRelationship.deletionType === 'disassociate'
+				!objectRelationship.edge
 			) {
 				relationships.push(objectRelationship);
 			}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/state/refreshReferencedStructures.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/state/refreshReferencedStructures.ts
@@ -204,7 +204,7 @@ export default function refreshReferencedStructures({
 
 				children.set(repeatableGroup.uuid, repeatableGroup);
 			}
-			else if (objectRelationship.deletionType === 'cascade') {
+			else if (objectRelationship.edge) {
 				const referencedStructure = buildReferencedStructure({
 					ancestors,
 					erc: objectRelationship.objectDefinitionExternalReferenceCode2,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/state/updateHistory.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/state/updateHistory.ts
@@ -37,14 +37,33 @@ export default function updateHistory({
 				deletedChildren: [...nextHistory.deletedChildren, child],
 			};
 
-			if (child.type === 'related-content' && !child.multiselection) {
+			if (
+				child.type === 'repeatable-group' ||
+				child.type === 'related-content' ||
+				child.type === 'referenced-structure'
+			) {
+				let parentERC =
+					child.parent === structure.uuid
+						? structure.erc
+						: findChild({
+								root: structure,
+								uuid: child.parent,
+							})?.erc || '';
+
+				if (child.type === 'related-content' && !child.multiselection) {
+					parentERC = child.relatedStructureERC;
+				}
+
 				nextHistory = {
 					...nextHistory,
 					deletedRelationships: [
 						...nextHistory.deletedRelationships,
 						{
-							relationshipERC: child.erc,
-							structureERC: child.relatedStructureERC,
+							relationshipERC:
+								child.type === 'related-content'
+									? child.erc
+									: child.relationshipERC,
+							structureERC: parentERC,
 						},
 					],
 				};

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/bulk_action_task/util/index.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/bulk_action_task/util/index.test.tsx
@@ -106,7 +106,7 @@ describe('Bulk Actions Monitor Utils', () => {
 			);
 
 			expect(taskUrl).toBe(
-				`${Liferay.ThemeDisplay.getPortalURL()}/o/cms/translations?type=ExportTranslationBulkAction&emptySearch=true&filter=cmsRoot+eq+true+and+cmsSection+eq+%27contents%27+and+status+in+%280%2C+2%2C+3%29+and+folderId+eq+123+and+groupIds%2Fany%28g%3Ag+in+%28456%29%29`
+				`${Liferay.ThemeDisplay.getPortalURL()}/o/cms/translations?type=ExportTranslationBulkAction&emptySearch=true&filter=cmsRoot+eq+true+and+rootDescendantNode+eq+false+and+cmsSection+eq+%27contents%27+and+status+in+%280%2C+2%2C+3%29+and+folderId+eq+123+and+groupIds%2Fany%28g%3Ag+in+%28456%29%29`
 			);
 		});
 	});

--- a/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/utils/buildObjectDefinition.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/utils/buildObjectDefinition.test.ts
@@ -4,7 +4,9 @@
  */
 
 import {
+	ReferencedStructure,
 	RelatedContent,
+	RepeatableGroup,
 	StructureChild,
 } from '../../../../src/main/resources/META-INF/resources/js/structure_builder/types/Structure';
 import {Uuid} from '../../../../src/main/resources/META-INF/resources/js/structure_builder/types/Uuid';
@@ -302,6 +304,99 @@ describe('buildObjectDefinition', () => {
 				objectDefinitionExternalReferenceCode1: 'structureERC',
 				objectDefinitionExternalReferenceCode2: 'related-structure-erc',
 				type: 'manyToMany',
+			},
+		]);
+	});
+
+	it('builds objectDefinition with edge relationships for referenced structures', () => {
+		const referencedStructure: ReferencedStructure = {
+			children: new Map(),
+			editURL: '',
+			erc: 'ref-structure-erc',
+			label: {en_US: 'Referenced Structure'},
+			name: 'refStructure',
+			parent: getUuid(),
+			relationshipERC: 'ref-rel-erc',
+			relationshipName: 'refRelationship',
+			spaces: [],
+			type: 'referenced-structure',
+			uuid: getUuid(),
+			workflows: {},
+		};
+
+		const children: Map<Uuid, StructureChild> = new Map<
+			Uuid,
+			StructureChild
+		>([
+			[referencedStructure.uuid, referencedStructure],
+			[TEXT_FIELD.uuid, TEXT_FIELD],
+		]);
+
+		const result = buildObjectDefinition({
+			children,
+			erc: 'structureERC',
+			label: {en_US: 'Structure'},
+			name: 'myStructure',
+			spaces: [],
+			status: 'draft',
+		});
+
+		expect(result.objectRelationships).toEqual([
+			{
+				deletionType: 'cascade',
+				edge: true,
+				externalReferenceCode: 'ref-rel-erc',
+				label: {en_US: 'refStructure'},
+				name: 'refRelationship',
+				objectDefinitionExternalReferenceCode1: 'structureERC',
+				objectDefinitionExternalReferenceCode2: 'ref-structure-erc',
+				type: 'oneToMany',
+			},
+		]);
+	});
+
+	it('builds objectDefinition with edge relationships for repeatable groups', () => {
+		const groupUuid = getUuid();
+
+		const repeatableGroup: RepeatableGroup = {
+			children: new Map(),
+			erc: 'group-erc',
+			label: {en_US: 'Repeatable Group'},
+			name: 'repeatableGroup',
+			parent: getUuid(),
+			relationshipERC: 'group-rel-erc',
+			relationshipName: 'groupRelationship',
+			type: 'repeatable-group',
+			uuid: groupUuid,
+		};
+
+		const children: Map<Uuid, StructureChild> = new Map<
+			Uuid,
+			StructureChild
+		>([
+			[repeatableGroup.uuid, repeatableGroup],
+			[TEXT_FIELD.uuid, TEXT_FIELD],
+		]);
+
+		const result = buildObjectDefinition({
+			children,
+			erc: 'structureERC',
+			label: {en_US: 'Structure'},
+			name: 'myStructure',
+			spaces: [],
+			status: 'draft',
+		});
+
+		expect(result.objectRelationships).toEqual([
+			{
+				deletionType: 'cascade',
+				edge: true,
+				externalReferenceCode: 'group-rel-erc',
+				label: {en_US: 'Repeatable Group'},
+				name: 'groupRelationship',
+				objectDefinitionExternalReferenceCode1: 'structureERC',
+				objectDefinitionExternalReferenceCode2: 'group-erc',
+				type: 'oneToMany',
 			},
 		]);
 	});

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
@@ -1776,11 +1776,6 @@ test(
 			trigger: card.locator('button'),
 		});
 
-		await page
-			.getByRole('dialog')
-			.getByRole('button', {name: 'Delete Entry'})
-			.click();
-
 		await waitForAlert(page, `Success:${title} was moved`, {
 			autoClose: false,
 		});
@@ -1861,17 +1856,17 @@ test(
 
 		// Fill the fields
 
-		const firstText = page
+		const titleTextboxes = page
 			.locator('.lfr-layout-structure-item-form-relationship')
-			.getByRole('textbox', {exact: true, name: 'Title'})
-			.first();
+			.getByRole('textbox', {exact: true, name: 'Title'});
+
+		await expect(titleTextboxes).toHaveCount(2);
+
+		const firstText = titleTextboxes.first();
 
 		await firstText.fill('First Text');
 
-		const secondText = page
-			.locator('.lfr-layout-structure-item-form-relationship')
-			.getByRole('textbox', {exact: true, name: 'Title'})
-			.last();
+		const secondText = titleTextboxes.last();
 
 		await secondText.fill('Second Text');
 
@@ -1899,11 +1894,6 @@ test(
 			target: page.getByRole('menuitem', {name: 'Delete'}),
 			trigger: card.locator('button'),
 		});
-
-		await page
-			.getByRole('dialog')
-			.getByRole('button', {name: 'Delete Entry'})
-			.click();
 
 		await waitForAlert(page, `Success:${title} was moved`, {
 			autoClose: false,

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contents.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contents.spec.ts
@@ -388,7 +388,18 @@ test(
 	{tag: '@LPD-83177'},
 	async ({contentsPage, page, structureBuilderPage, structuresPage}) => {
 
-		// Create a structure that references Basic Web Content
+		// Create a referenced structure
+
+		const referencedStructureLabel = `ReferencedStructureName${getRandomInt()}`;
+
+		await structureBuilderPage.createStructureFromData({
+			label: referencedStructureLabel,
+			name: referencedStructureLabel,
+			page: structureBuilderPage,
+			publish: true,
+		});
+
+		// Create a structure that references the previous one
 
 		const structureLabel = getRandomString();
 
@@ -400,7 +411,7 @@ test(
 		});
 
 		await structureBuilderPage.addReferencedStructures([
-			'Basic Web Content',
+			referencedStructureLabel,
 		]);
 
 		await structureBuilderPage.publishStructure();
@@ -423,13 +434,13 @@ test(
 
 		await contentsPage.saveContent();
 
-		// Navigate to structures and view usages of Basic Web Content
+		// Navigate to structures and view usages of the referenced structure
 
 		await structuresPage.goto();
 
 		await structuresPage.execItemAction({
 			action: 'View Usages',
-			filter: 'Basic Web Content',
+			filter: referencedStructureLabel,
 		});
 
 		// Assert the nested entry title is not shown
@@ -453,11 +464,6 @@ test(
 			target: page.getByRole('menuitem', {name: 'Delete'}),
 			trigger: card.locator('button'),
 		});
-
-		await page
-			.getByRole('dialog')
-			.getByRole('button', {name: 'Delete Entry'})
-			.click();
 
 		await waitForAlert(page, `Success:${contentTitle} was moved`, {
 			autoClose: false,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-84614

## What Is Being Fixed

CMS structures model their sections as object definitions linked by object relationships that form a tree. Those relationships were treated as regular relationships, so nested child entries surfaced in the CMS content lists and in View Usages, their search documents had no link back to the owning root, and trashing or deleting a parent cascaded incorrectly onto its descendants. CMS sites created before this change had no way to migrate their existing relationships.

## How It Is Being Fixed

CMS object relationships are now marked as edge relationships, and the tree of definitions is ordered root to leaf before binding so the hierarchy resolves deterministically. Nested tree children are excluded from the CMS content and recycle bin lists, edge relationships no longer count as usages, and descendant entries are no longer pushed to trash with their parent. Each nested object entry is indexed with a rootDescendantNode keyword that is registered as a filterable search property, so an entry resolves back to its root. An upgrade process marks existing CMS object relationships as edge and binds the root model and object definitions when the LPD-34594 feature flag is disabled. Integration, unit, and Playwright tests cover the indexing, the struts actions, the upgrade process, and the nested-entry behavior.

## PR Check

**pr-check: PASS** — tested on 

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {result: success, sha: 11cb61835a2dc0e864d336d7f34994ac4f7dd6ea} -->