### PR TITLE
LPD-95403 Carry client extension configuration across environments

### DIFF
--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/internal/exportimport/data/handler/test/ClientExtensionEntryRelStagedModelDataHandlerTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/internal/exportimport/data/handler/test/ClientExtensionEntryRelStagedModelDataHandlerTest.java
@@ -9,13 +9,16 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
 import com.liferay.client.extension.model.ClientExtensionEntryRel;
 import com.liferay.client.extension.service.ClientExtensionEntryRelLocalService;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.test.util.lar.BaseStagedModelDataHandlerTestCase;
 import com.liferay.layout.set.model.adapter.StagedLayoutSet;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.StagedModel;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -29,8 +32,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
@@ -44,6 +49,51 @@ public class ClientExtensionEntryRelStagedModelDataHandlerTest
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
+
+	@Test
+	@TestInfo("LPD-95403")
+	public void testImportKeepsClientExtensionEntryRelMissingFromSourceGroup()
+		throws Exception {
+
+		LayoutSet layoutSet = stagingGroup.getPublicLayoutSet();
+
+		ClientExtensionEntryRel clientExtensionEntryRel =
+			_clientExtensionEntryRelLocalService.addClientExtensionEntryRel(
+				TestPropsValues.getUserId(), stagingGroup.getGroupId(),
+				_portal.getClassNameId(LayoutSet.class),
+				layoutSet.getLayoutSetId(), RandomTestUtil.randomString(),
+				ClientExtensionEntryConstants.TYPE_THEME_FAVICON,
+				StringPool.BLANK,
+				ServiceContextTestUtil.getServiceContext(
+					stagingGroup.getGroupId()));
+
+		StagedLayoutSet stagedLayoutSet = ModelAdapterUtil.adapt(
+			layoutSet, LayoutSet.class, StagedLayoutSet.class);
+
+		initExport();
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, stagedLayoutSet);
+
+		_clientExtensionEntryRelLocalService.deleteClientExtensionEntryRel(
+			clientExtensionEntryRel);
+
+		try (SafeCloseable safeCloseable = initImportWithSafeCloseable()) {
+			StagedModelDataHandlerUtil.importStagedModel(
+				portletDataContext, readExportedStagedModel(stagedLayoutSet));
+		}
+
+		LayoutSet liveLayoutSet = liveGroup.getPublicLayoutSet();
+
+		List<ClientExtensionEntryRel> clientExtensionEntryRels =
+			_clientExtensionEntryRelLocalService.getClientExtensionEntryRels(
+				_portal.getClassNameId(LayoutSet.class),
+				liveLayoutSet.getLayoutSetId());
+
+		Assert.assertEquals(
+			clientExtensionEntryRels.toString(), 1,
+			clientExtensionEntryRels.size());
+	}
 
 	@Override
 	protected Map<String, List<StagedModel>> addDependentStagedModelsMap(

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
@@ -571,13 +571,6 @@ public class StagedLayoutSetStagedModelDataHandler
 
 		_deleteUnnecessaryClientExtensionEntryRels(
 			clientExtensionEntryRelsElements, importedStagedLayoutSet);
-
-		for (Element clientExtensionEntryRelsElement :
-				clientExtensionEntryRelsElements) {
-
-			StagedModelDataHandlerUtil.importStagedModel(
-				portletDataContext, clientExtensionEntryRelsElement);
-		}
 	}
 
 	private void _importFaviconFileEntry(

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
@@ -296,29 +296,31 @@ public class StagedLayoutSetStagedModelDataHandler
 	}
 
 	private void _deleteUnnecessaryClientExtensionEntryRels(
-		StagedLayoutSet stagedLayoutSet,
+		List<Element> clientExtensionEntryRelsElements,
 		StagedLayoutSet importedStagedLayoutSet) {
+
+		Set<String> importedUuids = new HashSet<>();
+
+		for (Element clientExtensionEntryRelsElement :
+				clientExtensionEntryRelsElements) {
+
+			importedUuids.add(
+				clientExtensionEntryRelsElement.attributeValue("uuid"));
+		}
 
 		LayoutSet importedLayoutSet = importedStagedLayoutSet.getLayoutSet();
 
-		List<ClientExtensionEntryRel> importedClientExtensionEntryRels =
+		List<ClientExtensionEntryRel> clientExtensionEntryRels =
 			_clientExtensionEntryRelLocalService.getClientExtensionEntryRels(
 				_portal.getClassNameId(LayoutSet.class),
 				importedLayoutSet.getLayoutSetId());
 
-		for (ClientExtensionEntryRel importedClientExtensionEntryRel :
-				importedClientExtensionEntryRels) {
+		for (ClientExtensionEntryRel clientExtensionEntryRel :
+				clientExtensionEntryRels) {
 
-			ClientExtensionEntryRel stagedClientExtensionEntryRel =
+			if (!importedUuids.contains(clientExtensionEntryRel.getUuid())) {
 				_clientExtensionEntryRelLocalService.
-					fetchClientExtensionEntryRelByUuidAndGroupId(
-						importedClientExtensionEntryRel.getUuid(),
-						stagedLayoutSet.getGroupId());
-
-			if (stagedClientExtensionEntryRel == null) {
-				_clientExtensionEntryRelLocalService.
-					deleteClientExtensionEntryRel(
-						importedClientExtensionEntryRel);
+					deleteClientExtensionEntryRel(clientExtensionEntryRel);
 			}
 		}
 	}
@@ -563,12 +565,12 @@ public class StagedLayoutSetStagedModelDataHandler
 			StagedLayoutSet importedStagedLayoutSet)
 		throws Exception {
 
-		_deleteUnnecessaryClientExtensionEntryRels(
-			stagedLayoutSet, importedStagedLayoutSet);
-
 		List<Element> clientExtensionEntryRelsElements =
 			portletDataContext.getReferenceDataElements(
 				stagedLayoutSet, ClientExtensionEntryRel.class);
+
+		_deleteUnnecessaryClientExtensionEntryRels(
+			clientExtensionEntryRelsElements, importedStagedLayoutSet);
 
 		for (Element clientExtensionEntryRelsElement :
 				clientExtensionEntryRelsElements) {

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
@@ -214,7 +214,7 @@ public class StagedLayoutSetStagedModelDataHandler
 					portletDataContext, importedStagedLayoutSet);
 		}
 
-		_importClientExtensionEntryRels(
+		_deleteUnnecessaryClientExtensionEntryRels(
 			portletDataContext, stagedLayoutSet, importedStagedLayoutSet);
 		_importLogo(portletDataContext);
 		_importTheme(portletDataContext, stagedLayoutSet);
@@ -296,8 +296,12 @@ public class StagedLayoutSetStagedModelDataHandler
 	}
 
 	private void _deleteUnnecessaryClientExtensionEntryRels(
-		List<Element> clientExtensionEntryRelsElements,
+		PortletDataContext portletDataContext, StagedLayoutSet stagedLayoutSet,
 		StagedLayoutSet importedStagedLayoutSet) {
+
+		List<Element> clientExtensionEntryRelsElements =
+			portletDataContext.getReferenceDataElements(
+				stagedLayoutSet, ClientExtensionEntryRel.class);
 
 		Set<String> importedUuids = new HashSet<>();
 
@@ -557,20 +561,6 @@ public class StagedLayoutSetStagedModelDataHandler
 				layoutElement.attributeValue("layout-parent-layout-id")));
 
 		return actions.contains(Constants.SKIP);
-	}
-
-	private void _importClientExtensionEntryRels(
-			PortletDataContext portletDataContext,
-			StagedLayoutSet stagedLayoutSet,
-			StagedLayoutSet importedStagedLayoutSet)
-		throws Exception {
-
-		List<Element> clientExtensionEntryRelsElements =
-			portletDataContext.getReferenceDataElements(
-				stagedLayoutSet, ClientExtensionEntryRel.class);
-
-		_deleteUnnecessaryClientExtensionEntryRels(
-			clientExtensionEntryRelsElements, importedStagedLayoutSet);
 	}
 
 	private void _importFaviconFileEntry(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95403

## What Is Being Fixed

When a layout set is published or imported across environments, the CSS (and other) client extension configuration attached to the layout set was lost on the target. On import the framework imports the `ClientExtensionEntryRel` references before the `LayoutSet` itself is processed; the layout set handler then deleted every `ClientExtensionEntryRel` whose UUID it could not find via a lookup in the *source* group. Across environments the source group does not exist on the target, so that lookup always returned null and every just-imported `ClientExtensionEntryRel` was deleted. The redundant import loop that followed could not restore them, because `importStagedModel` short-circuits on paths it has already processed.

## How It Is Being Fixed

The delete pass now compares against the set of UUIDs actually present in the current import (the LAR reference elements) rather than a source-group lookup, so a `ClientExtensionEntryRel` is removed only when it is genuinely absent from the import. The now-redundant import loop is removed, since the `ClientExtensionEntryRel` references are already imported by `ClientExtensionEntryRelStagedModelDataHandler` before the `LayoutSet` is processed. A regression test exports a layout set carrying a `ClientExtensionEntryRel`, deletes it from the source group to reproduce the cross-environment condition, imports, and asserts it survives.

## PR Check

**pr-check: PASS** — tested on `c83d8e4243183f6568ab53dabb39ab3b05c12177`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "c83d8e4243183f6568ab53dabb39ab3b05c12177"} -->
