### PR TITLE
LPD-90839 Compact experience priorities instead of rejecting gaps

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageExperience.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/PageExperience.java
@@ -281,7 +281,7 @@ public class PageExperience implements Serializable {
 	private Supplier<String> _pageSpecificationExternalReferenceCodeSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "The experience's priority. It must be a unique value within the page specification. The default experience will always be assigned priority 0. A priority higher than 0 will result in an experience being active and a priority lower than 0 will result in an experience being inactive."
+		description = "The experience's priority. It must be a unique value within the page specification. The default experience is always assigned priority 0; a positive priority results in an active experience and a negative priority results in an inactive one. After every create, update, or delete operation, the server compacts the priorities of the remaining experiences into sequential values (1, 2, 3, ... for active experiences and -1, -2, -3, ... for inactive experiences), so the priority returned or persisted may differ from the one supplied in the request."
 	)
 	public Integer getPriority() {
 		if (_prioritySupplier != null) {
@@ -317,7 +317,7 @@ public class PageExperience implements Serializable {
 	}
 
 	@GraphQLField(
-		description = "The experience's priority. It must be a unique value within the page specification. The default experience will always be assigned priority 0. A priority higher than 0 will result in an experience being active and a priority lower than 0 will result in an experience being inactive."
+		description = "The experience's priority. It must be a unique value within the page specification. The default experience is always assigned priority 0; a positive priority results in an active experience and a negative priority results in an inactive one. After every create, update, or delete operation, the server compacts the priorities of the remaining experiences into sequential values (1, 2, 3, ... for active experiences and -1, -2, -3, ... for inactive experiences), so the priority returned or persisted may differ from the one supplied in the request."
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer priority;
@@ -669,4 +669,4 @@ public class PageExperience implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-944388258
+// LIFERAY-REST-BUILDER-HASH:-291290306

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
@@ -2877,7 +2877,7 @@ components:
                 priority:
                     # @review
                     description:
-                        The experience's priority. It must be a unique value within the page specification. The default experience will always be assigned priority 0. A priority higher than 0 will result in an experience being active and a priority lower than 0 will result in an experience being inactive.
+                        The experience's priority. It must be a unique value within the page specification. The default experience is always assigned priority 0; a positive priority results in an active experience and a negative priority results in an inactive one. After every create, update, or delete operation, the server compacts the priorities of the remaining experiences into sequential values (1, 2, 3, ... for active experiences and -1, -2, -3, ... for inactive experiences), so the priority returned or persisted may differ from the one supplied in the request.
                     type: integer
                 segmentItemExternalReference:
                     $ref: "#/components/schemas/ItemExternalReference"
@@ -6373,7 +6373,7 @@ paths:
         delete:
             # @review
             description:
-                Deletes an experience of a specific page specification of a site page within a site. The default experience cannot be deleted.
+                Deletes an experience of a specific page specification of a site page within a site. The default experience cannot be deleted. Priorities of the remaining experiences are compacted after the change, so their priorities may differ from the values previously returned. See PageExperience.priority.
             operationId: deleteSitePageExperience
             parameters:
                 -   in: path
@@ -6445,7 +6445,7 @@ paths:
         patch:
             # @review
             description:
-                Updates an experience of a specific page specification of a site page within a site. Updates only the fields received in the request body, leaving any other fields untouched.
+                Updates an experience of a specific page specification of a site page within a site. Updates only the fields received in the request body, leaving any other fields untouched. Priorities of the remaining experiences are compacted after the change, so the priority returned may differ from the one supplied. See PageExperience.priority.
             operationId: patchSitePageExperience
             parameters:
                 -   in: path
@@ -6491,7 +6491,7 @@ paths:
         put:
             # @review
             description:
-                Updates an experience of a specific page specification of a site page within a site.
+                Updates an experience of a specific page specification of a site page within a site. Priorities of the remaining experiences are compacted after the change, so the priority returned may differ from the one supplied. See PageExperience.priority.
             operationId: putSitePageExperience
             parameters:
                 -   in: path
@@ -6746,7 +6746,7 @@ paths:
         post:
             # @review
             description:
-                Adds a new experience to a page specification of a site page.
+                Adds a new experience to a page specification of a site page. Priorities of the experiences are compacted after the change, so the priority returned may differ from the one supplied. See PageExperience.priority.
             operationId: postSitePageSpecificationPageExperience
             parameters:
                 -   in: path

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageExperienceResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/BasePageExperienceResourceImpl.java
@@ -74,7 +74,7 @@ public abstract class BasePageExperienceResourceImpl
 	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-experiences/{pageExperienceExternalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
-		description = "Deletes an experience of a specific page specification of a site page within a site. The default experience cannot be deleted."
+		description = "Deletes an experience of a specific page specification of a site page within a site. The default experience cannot be deleted. Priorities of the remaining experiences are compacted after the change, so their priorities may differ from the values previously returned. See PageExperience.priority."
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -243,7 +243,7 @@ public abstract class BasePageExperienceResourceImpl
 	 * curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-experiences/{pageExperienceExternalReferenceCode}' -d $'{"externalReferenceCode": ___, "key": ___, "name_i18n": ___, "pageElements": ___, "pageSpecificationExternalReferenceCode": ___, "priority": ___, "segmentItemExternalReference": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
-		description = "Updates an experience of a specific page specification of a site page within a site. Updates only the fields received in the request body, leaving any other fields untouched."
+		description = "Updates an experience of a specific page specification of a site page within a site. Updates only the fields received in the request body, leaving any other fields untouched. Priorities of the remaining experiences are compacted after the change, so the priority returned may differ from the one supplied. See PageExperience.priority."
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -337,7 +337,7 @@ public abstract class BasePageExperienceResourceImpl
 	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-specifications/{pageSpecificationExternalReferenceCode}/page-experiences' -d $'{"externalReferenceCode": ___, "key": ___, "name_i18n": ___, "pageElements": ___, "pageSpecificationExternalReferenceCode": ___, "priority": ___, "segmentItemExternalReference": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
-		description = "Adds a new experience to a page specification of a site page."
+		description = "Adds a new experience to a page specification of a site page. Priorities of the experiences are compacted after the change, so the priority returned may differ from the one supplied. See PageExperience.priority."
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -396,7 +396,7 @@ public abstract class BasePageExperienceResourceImpl
 	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-site/v1.0/sites/{siteExternalReferenceCode}/page-experiences/{pageExperienceExternalReferenceCode}' -d $'{"externalReferenceCode": ___, "key": ___, "name_i18n": ___, "pageElements": ___, "pageSpecificationExternalReferenceCode": ___, "priority": ___, "segmentItemExternalReference": ___, "uuid": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
-		description = "Updates an experience of a specific page specification of a site page within a site."
+		description = "Updates an experience of a specific page specification of a site page within a site. Priorities of the remaining experiences are compacted after the change, so the priority returned may differ from the one supplied. See PageExperience.priority."
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -1185,4 +1185,4 @@ public abstract class BasePageExperienceResourceImpl
 		LogFactoryUtil.getLog(BasePageExperienceResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:85636177
+// LIFERAY-REST-BUILDER-HASH:-1138931728

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
@@ -17,6 +17,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
@@ -63,6 +64,7 @@ public class PageExperienceResourceTest
 
 	@Override
 	@Test
+	@TestInfo("LPD-90839")
 	public void testDeleteSitePageExperience() throws Exception {
 		PageExperience postPageExperience =
 			testPostSitePageSpecificationPageExperience_addPageExperience(
@@ -83,6 +85,8 @@ public class PageExperienceResourceTest
 				fetchSegmentsExperienceByExternalReferenceCode(
 					postPageExperience.getExternalReferenceCode(),
 					testGroup.getGroupId()));
+
+		_testDeleteSitePageExperienceWithPriority();
 
 		try {
 			pageExperienceResource.deleteSitePageExperience(
@@ -131,6 +135,7 @@ public class PageExperienceResourceTest
 
 	@Override
 	@Test
+	@TestInfo("LPD-90839")
 	public void testPatchSitePageExperience() throws Exception {
 		PageExperience postPageExperience =
 			testPostSitePageSpecificationPageExperience_addPageExperience(
@@ -144,6 +149,8 @@ public class PageExperienceResourceTest
 
 		assertEquals(postPageExperience, pathPageExperience);
 		assertValid(pathPageExperience);
+
+		_testPatchSitePageExperienceWithPriority();
 
 		try {
 			pageExperienceResource.patchSitePageExperience(
@@ -162,6 +169,7 @@ public class PageExperienceResourceTest
 
 	@Override
 	@Test
+	@TestInfo("LPD-90839")
 	public void testPostSitePageSpecificationPageExperience() throws Exception {
 		super.testPostSitePageSpecificationPageExperience();
 
@@ -198,10 +206,13 @@ public class PageExperienceResourceTest
 					_draftLayout.getExternalReferenceCode(), 5,
 					testGroup.getGroupId(), RandomTestUtil.randomString(),
 					null)));
+
+		_testPostSitePageSpecificationPageExperienceWithPriority();
 	}
 
 	@Override
 	@Test
+	@TestInfo("LPD-90839")
 	public void testPutSitePageExperience() throws Exception {
 		PageExperience pageExperience =
 			PageExperiencesTestUtil.getPageExperience(
@@ -223,6 +234,12 @@ public class PageExperienceResourceTest
 				testGroup.getGroupId()));
 
 		_testPutSitePageExperience(pageExperience);
+
+		pageExperienceResource.deleteSitePageExperience(
+			testGroup.getExternalReferenceCode(),
+			pageExperience.getExternalReferenceCode());
+
+		_testPutSitePageExperienceWithPriority();
 	}
 
 	@Override
@@ -377,7 +394,117 @@ public class PageExperienceResourceTest
 		pageExperience.setPageSpecificationExternalReferenceCode(
 			_draftLayout.getExternalReferenceCode());
 
+		int lowestPriority = _segmentsExperienceLocalService.getLowestPriority(
+			testGroup.getGroupId(), _draftLayout.getPlid());
+
+		pageExperience.setPriority(lowestPriority - 1);
+
 		return pageExperience;
+	}
+
+	private void _testDeleteSitePageExperienceWithPriority() throws Exception {
+		PageExperience pageExperience1 =
+			testPostSitePageSpecificationPageExperience_addPageExperience(
+				PageExperiencesTestUtil.getPageExperience(
+					_draftLayout.getExternalReferenceCode(), 1,
+					testGroup.getGroupId(), null));
+		PageExperience pageExperience2 =
+			testPostSitePageSpecificationPageExperience_addPageExperience(
+				PageExperiencesTestUtil.getPageExperience(
+					_draftLayout.getExternalReferenceCode(), 2,
+					testGroup.getGroupId(), null));
+		PageExperience pageExperience3 =
+			testPostSitePageSpecificationPageExperience_addPageExperience(
+				PageExperiencesTestUtil.getPageExperience(
+					_draftLayout.getExternalReferenceCode(), 3,
+					testGroup.getGroupId(), null));
+
+		Assert.assertEquals(Integer.valueOf(1), pageExperience1.getPriority());
+		Assert.assertEquals(Integer.valueOf(2), pageExperience2.getPriority());
+		Assert.assertEquals(Integer.valueOf(3), pageExperience3.getPriority());
+
+		pageExperienceResource.deleteSitePageExperience(
+			testGroup.getExternalReferenceCode(),
+			pageExperience2.getExternalReferenceCode());
+
+		pageExperience1 = pageExperienceResource.getSitePageExperience(
+			testGroup.getExternalReferenceCode(),
+			pageExperience1.getExternalReferenceCode());
+
+		Assert.assertEquals(Integer.valueOf(1), pageExperience1.getPriority());
+
+		pageExperience3 = pageExperienceResource.getSitePageExperience(
+			testGroup.getExternalReferenceCode(),
+			pageExperience3.getExternalReferenceCode());
+
+		Assert.assertEquals(Integer.valueOf(2), pageExperience3.getPriority());
+	}
+
+	private void _testPatchSitePageExperienceWithPriority() throws Exception {
+		PageExperience pageExperience1 =
+			testPostSitePageSpecificationPageExperience_addPageExperience(
+				PageExperiencesTestUtil.getPageExperience(
+					_draftLayout.getExternalReferenceCode(), 1,
+					testGroup.getGroupId(), null));
+		PageExperience pageExperience2 =
+			testPostSitePageSpecificationPageExperience_addPageExperience(
+				PageExperiencesTestUtil.getPageExperience(
+					_draftLayout.getExternalReferenceCode(), 2,
+					testGroup.getGroupId(), null));
+		PageExperience pageExperience3 =
+			testPostSitePageSpecificationPageExperience_addPageExperience(
+				PageExperiencesTestUtil.getPageExperience(
+					_draftLayout.getExternalReferenceCode(), 3,
+					testGroup.getGroupId(), null));
+
+		Assert.assertEquals(Integer.valueOf(1), pageExperience1.getPriority());
+		Assert.assertEquals(Integer.valueOf(2), pageExperience2.getPriority());
+		Assert.assertEquals(Integer.valueOf(3), pageExperience3.getPriority());
+
+		pageExperience1.setPriority(100);
+
+		PageExperience patchedPageExperience =
+			pageExperienceResource.patchSitePageExperience(
+				testGroup.getExternalReferenceCode(),
+				pageExperience1.getExternalReferenceCode(), pageExperience1);
+
+		Assert.assertEquals(
+			Integer.valueOf(3), patchedPageExperience.getPriority());
+
+		pageExperience2 = pageExperienceResource.getSitePageExperience(
+			testGroup.getExternalReferenceCode(),
+			pageExperience2.getExternalReferenceCode());
+
+		Assert.assertEquals(Integer.valueOf(1), pageExperience2.getPriority());
+
+		pageExperience3 = pageExperienceResource.getSitePageExperience(
+			testGroup.getExternalReferenceCode(),
+			pageExperience3.getExternalReferenceCode());
+
+		Assert.assertEquals(Integer.valueOf(2), pageExperience3.getPriority());
+
+		pageExperience2.setPriority(2);
+
+		PageExperience swappedPageExperience =
+			pageExperienceResource.patchSitePageExperience(
+				testGroup.getExternalReferenceCode(),
+				pageExperience2.getExternalReferenceCode(), pageExperience2);
+
+		Assert.assertEquals(
+			Integer.valueOf(2), swappedPageExperience.getPriority());
+
+		pageExperience3 = pageExperienceResource.getSitePageExperience(
+			testGroup.getExternalReferenceCode(),
+			pageExperience3.getExternalReferenceCode());
+
+		Assert.assertEquals(Integer.valueOf(1), pageExperience3.getPriority());
+
+		patchedPageExperience = pageExperienceResource.getSitePageExperience(
+			testGroup.getExternalReferenceCode(),
+			patchedPageExperience.getExternalReferenceCode());
+
+		Assert.assertEquals(
+			Integer.valueOf(3), patchedPageExperience.getPriority());
 	}
 
 	private void _testPostSitePageSpecificationPageExperience(
@@ -421,6 +548,37 @@ public class PageExperienceResourceTest
 		}
 	}
 
+	private void _testPostSitePageSpecificationPageExperienceWithPriority()
+		throws Exception {
+
+		PageExperience activePageExperience1 =
+			testPostSitePageSpecificationPageExperience_addPageExperience(
+				PageExperiencesTestUtil.getPageExperience(
+					_draftLayout.getExternalReferenceCode(), 100,
+					testGroup.getGroupId(), null));
+
+		Assert.assertEquals(
+			Integer.valueOf(1), activePageExperience1.getPriority());
+
+		PageExperience activePageExperience2 =
+			testPostSitePageSpecificationPageExperience_addPageExperience(
+				PageExperiencesTestUtil.getPageExperience(
+					_draftLayout.getExternalReferenceCode(), 50,
+					testGroup.getGroupId(), null));
+
+		Assert.assertEquals(
+			Integer.valueOf(2), activePageExperience2.getPriority());
+
+		PageExperience inactivePageExperience =
+			testPostSitePageSpecificationPageExperience_addPageExperience(
+				PageExperiencesTestUtil.getPageExperience(
+					_draftLayout.getExternalReferenceCode(), -100,
+					testGroup.getGroupId(), null));
+
+		Assert.assertEquals(
+			Integer.valueOf(-1), inactivePageExperience.getPriority());
+	}
+
 	private PageExperience _testPutSitePageExperience(
 			PageExperience pageExperience)
 		throws Exception {
@@ -434,6 +592,50 @@ public class PageExperienceResourceTest
 		assertValid(putSitePageExperience);
 
 		return putSitePageExperience;
+	}
+
+	private void _testPutSitePageExperienceWithPriority() throws Exception {
+		PageExperience pageExperience1 =
+			testPostSitePageSpecificationPageExperience_addPageExperience(
+				PageExperiencesTestUtil.getPageExperience(
+					_draftLayout.getExternalReferenceCode(), 1,
+					testGroup.getGroupId(), null));
+		PageExperience pageExperience2 =
+			testPostSitePageSpecificationPageExperience_addPageExperience(
+				PageExperiencesTestUtil.getPageExperience(
+					_draftLayout.getExternalReferenceCode(), 2,
+					testGroup.getGroupId(), null));
+		PageExperience pageExperience3 =
+			testPostSitePageSpecificationPageExperience_addPageExperience(
+				PageExperiencesTestUtil.getPageExperience(
+					_draftLayout.getExternalReferenceCode(), 3,
+					testGroup.getGroupId(), null));
+
+		Assert.assertEquals(Integer.valueOf(1), pageExperience1.getPriority());
+		Assert.assertEquals(Integer.valueOf(2), pageExperience2.getPriority());
+		Assert.assertEquals(Integer.valueOf(3), pageExperience3.getPriority());
+
+		pageExperience1.setPriority(100);
+
+		PageExperience putSitePageExperience =
+			pageExperienceResource.putSitePageExperience(
+				testGroup.getExternalReferenceCode(),
+				pageExperience1.getExternalReferenceCode(), pageExperience1);
+
+		Assert.assertEquals(
+			Integer.valueOf(3), putSitePageExperience.getPriority());
+
+		pageExperience2 = pageExperienceResource.getSitePageExperience(
+			testGroup.getExternalReferenceCode(),
+			pageExperience2.getExternalReferenceCode());
+
+		Assert.assertEquals(Integer.valueOf(1), pageExperience2.getPriority());
+
+		pageExperience3 = pageExperienceResource.getSitePageExperience(
+			testGroup.getExternalReferenceCode(),
+			pageExperience3.getExternalReferenceCode());
+
+		Assert.assertEquals(Integer.valueOf(2), pageExperience3.getPriority());
 	}
 
 	private Layout _draftLayout;

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
@@ -442,12 +442,15 @@ public class PageExperienceResourceTest
 		PageExperience pageExperience2 = _addPageExperience(2);
 		PageExperience pageExperience3 = _addPageExperience(3);
 
-		pageExperience1.setPriority(100);
-
 		PageExperience patchedPageExperience =
 			pageExperienceResource.patchSitePageExperience(
 				testGroup.getExternalReferenceCode(),
-				pageExperience1.getExternalReferenceCode(), pageExperience1);
+				pageExperience1.getExternalReferenceCode(),
+				new PageExperience() {
+					{
+						setPriority(100);
+					}
+				});
 
 		Assert.assertEquals(
 			Integer.valueOf(3), patchedPageExperience.getPriority());
@@ -464,12 +467,15 @@ public class PageExperienceResourceTest
 
 		Assert.assertEquals(Integer.valueOf(2), pageExperience3.getPriority());
 
-		pageExperience2.setPriority(2);
-
 		PageExperience swappedPageExperience =
 			pageExperienceResource.patchSitePageExperience(
 				testGroup.getExternalReferenceCode(),
-				pageExperience2.getExternalReferenceCode(), pageExperience2);
+				pageExperience2.getExternalReferenceCode(),
+				new PageExperience() {
+					{
+						setPriority(2);
+					}
+				});
 
 		Assert.assertEquals(
 			Integer.valueOf(2), swappedPageExperience.getPriority());

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
@@ -533,10 +533,14 @@ public class PageExperienceResourceTest
 	private void _testPostSitePageSpecificationPageExperienceWithPriority()
 		throws Exception {
 
+		Layout layout = LayoutTestUtil.addTypeContentLayout(testGroup);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
 		PageExperience activePageExperience1 =
 			testPostSitePageSpecificationPageExperience_addPageExperience(
 				PageExperiencesTestUtil.getPageExperience(
-					_draftLayout.getExternalReferenceCode(), 100,
+					draftLayout.getExternalReferenceCode(), 100,
 					testGroup.getGroupId(), null));
 
 		Assert.assertEquals(
@@ -545,7 +549,7 @@ public class PageExperienceResourceTest
 		PageExperience activePageExperience2 =
 			testPostSitePageSpecificationPageExperience_addPageExperience(
 				PageExperiencesTestUtil.getPageExperience(
-					_draftLayout.getExternalReferenceCode(), 50,
+					draftLayout.getExternalReferenceCode(), 50,
 					testGroup.getGroupId(), null));
 
 		Assert.assertEquals(
@@ -554,7 +558,7 @@ public class PageExperienceResourceTest
 		PageExperience inactivePageExperience =
 			testPostSitePageSpecificationPageExperience_addPageExperience(
 				PageExperiencesTestUtil.getPageExperience(
-					_draftLayout.getExternalReferenceCode(), -100,
+					draftLayout.getExternalReferenceCode(), -100,
 					testGroup.getGroupId(), null));
 
 		Assert.assertEquals(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
@@ -141,11 +141,18 @@ public class PageExperienceResourceTest
 			testPostSitePageSpecificationPageExperience_addPageExperience(
 				randomPageExperience());
 
+		postPageExperience.setName_i18n(
+			Collections.singletonMap("en-US", RandomTestUtil.randomString()));
+
 		PageExperience pathPageExperience =
 			pageExperienceResource.patchSitePageExperience(
 				testGroup.getExternalReferenceCode(),
 				postPageExperience.getExternalReferenceCode(),
-				postPageExperience);
+				new PageExperience() {
+					{
+						setName_i18n(postPageExperience::getName_i18n);
+					}
+				});
 
 		assertEquals(postPageExperience, pathPageExperience);
 		assertValid(pathPageExperience);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
@@ -382,6 +382,19 @@ public class PageExperienceResourceTest
 			pageExperience);
 	}
 
+	private PageExperience _addPageExperience(int priority) throws Exception {
+		PageExperience pageExperience =
+			testPostSitePageSpecificationPageExperience_addPageExperience(
+				PageExperiencesTestUtil.getPageExperience(
+					_draftLayout.getExternalReferenceCode(), priority,
+					testGroup.getGroupId(), null));
+
+		Assert.assertEquals(
+			Integer.valueOf(priority), pageExperience.getPriority());
+
+		return pageExperience;
+	}
+
 	private PageExperience _getPageExperience() throws Exception {
 		PageExperience pageExperience = super.randomPageExperience();
 
@@ -403,25 +416,9 @@ public class PageExperienceResourceTest
 	}
 
 	private void _testDeleteSitePageExperienceWithPriority() throws Exception {
-		PageExperience pageExperience1 =
-			testPostSitePageSpecificationPageExperience_addPageExperience(
-				PageExperiencesTestUtil.getPageExperience(
-					_draftLayout.getExternalReferenceCode(), 1,
-					testGroup.getGroupId(), null));
-		PageExperience pageExperience2 =
-			testPostSitePageSpecificationPageExperience_addPageExperience(
-				PageExperiencesTestUtil.getPageExperience(
-					_draftLayout.getExternalReferenceCode(), 2,
-					testGroup.getGroupId(), null));
-		PageExperience pageExperience3 =
-			testPostSitePageSpecificationPageExperience_addPageExperience(
-				PageExperiencesTestUtil.getPageExperience(
-					_draftLayout.getExternalReferenceCode(), 3,
-					testGroup.getGroupId(), null));
-
-		Assert.assertEquals(Integer.valueOf(1), pageExperience1.getPriority());
-		Assert.assertEquals(Integer.valueOf(2), pageExperience2.getPriority());
-		Assert.assertEquals(Integer.valueOf(3), pageExperience3.getPriority());
+		PageExperience pageExperience1 = _addPageExperience(1);
+		PageExperience pageExperience2 = _addPageExperience(2);
+		PageExperience pageExperience3 = _addPageExperience(3);
 
 		pageExperienceResource.deleteSitePageExperience(
 			testGroup.getExternalReferenceCode(),
@@ -441,25 +438,9 @@ public class PageExperienceResourceTest
 	}
 
 	private void _testPatchSitePageExperienceWithPriority() throws Exception {
-		PageExperience pageExperience1 =
-			testPostSitePageSpecificationPageExperience_addPageExperience(
-				PageExperiencesTestUtil.getPageExperience(
-					_draftLayout.getExternalReferenceCode(), 1,
-					testGroup.getGroupId(), null));
-		PageExperience pageExperience2 =
-			testPostSitePageSpecificationPageExperience_addPageExperience(
-				PageExperiencesTestUtil.getPageExperience(
-					_draftLayout.getExternalReferenceCode(), 2,
-					testGroup.getGroupId(), null));
-		PageExperience pageExperience3 =
-			testPostSitePageSpecificationPageExperience_addPageExperience(
-				PageExperiencesTestUtil.getPageExperience(
-					_draftLayout.getExternalReferenceCode(), 3,
-					testGroup.getGroupId(), null));
-
-		Assert.assertEquals(Integer.valueOf(1), pageExperience1.getPriority());
-		Assert.assertEquals(Integer.valueOf(2), pageExperience2.getPriority());
-		Assert.assertEquals(Integer.valueOf(3), pageExperience3.getPriority());
+		PageExperience pageExperience1 = _addPageExperience(1);
+		PageExperience pageExperience2 = _addPageExperience(2);
+		PageExperience pageExperience3 = _addPageExperience(3);
 
 		pageExperience1.setPriority(100);
 
@@ -595,25 +576,9 @@ public class PageExperienceResourceTest
 	}
 
 	private void _testPutSitePageExperienceWithPriority() throws Exception {
-		PageExperience pageExperience1 =
-			testPostSitePageSpecificationPageExperience_addPageExperience(
-				PageExperiencesTestUtil.getPageExperience(
-					_draftLayout.getExternalReferenceCode(), 1,
-					testGroup.getGroupId(), null));
-		PageExperience pageExperience2 =
-			testPostSitePageSpecificationPageExperience_addPageExperience(
-				PageExperiencesTestUtil.getPageExperience(
-					_draftLayout.getExternalReferenceCode(), 2,
-					testGroup.getGroupId(), null));
-		PageExperience pageExperience3 =
-			testPostSitePageSpecificationPageExperience_addPageExperience(
-				PageExperiencesTestUtil.getPageExperience(
-					_draftLayout.getExternalReferenceCode(), 3,
-					testGroup.getGroupId(), null));
-
-		Assert.assertEquals(Integer.valueOf(1), pageExperience1.getPriority());
-		Assert.assertEquals(Integer.valueOf(2), pageExperience2.getPriority());
-		Assert.assertEquals(Integer.valueOf(3), pageExperience3.getPriority());
+		PageExperience pageExperience1 = _addPageExperience(1);
+		PageExperience pageExperience2 = _addPageExperience(2);
+		PageExperience pageExperience3 = _addPageExperience(3);
 
 		pageExperience1.setPriority(100);
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
@@ -395,6 +395,19 @@ public class PageExperienceResourceTest
 		return pageExperience;
 	}
 
+	private void _assertPageExperiencePriority(
+			int expectedPriority, String pageExperienceExternalReferenceCode)
+		throws Exception {
+
+		PageExperience pageExperience =
+			pageExperienceResource.getSitePageExperience(
+				testGroup.getExternalReferenceCode(),
+				pageExperienceExternalReferenceCode);
+
+		Assert.assertEquals(
+			Integer.valueOf(expectedPriority), pageExperience.getPriority());
+	}
+
 	private PageExperience _getPageExperience() throws Exception {
 		PageExperience pageExperience = super.randomPageExperience();
 
@@ -424,17 +437,10 @@ public class PageExperienceResourceTest
 			testGroup.getExternalReferenceCode(),
 			pageExperience2.getExternalReferenceCode());
 
-		pageExperience1 = pageExperienceResource.getSitePageExperience(
-			testGroup.getExternalReferenceCode(),
-			pageExperience1.getExternalReferenceCode());
-
-		Assert.assertEquals(Integer.valueOf(1), pageExperience1.getPriority());
-
-		pageExperience3 = pageExperienceResource.getSitePageExperience(
-			testGroup.getExternalReferenceCode(),
-			pageExperience3.getExternalReferenceCode());
-
-		Assert.assertEquals(Integer.valueOf(2), pageExperience3.getPriority());
+		_assertPageExperiencePriority(
+			1, pageExperience1.getExternalReferenceCode());
+		_assertPageExperiencePriority(
+			2, pageExperience3.getExternalReferenceCode());
 	}
 
 	private void _testPatchSitePageExperienceWithPriority() throws Exception {
@@ -455,17 +461,12 @@ public class PageExperienceResourceTest
 		Assert.assertEquals(
 			Integer.valueOf(3), patchedPageExperience.getPriority());
 
-		pageExperience2 = pageExperienceResource.getSitePageExperience(
-			testGroup.getExternalReferenceCode(),
-			pageExperience2.getExternalReferenceCode());
-
-		Assert.assertEquals(Integer.valueOf(1), pageExperience2.getPriority());
-
-		pageExperience3 = pageExperienceResource.getSitePageExperience(
-			testGroup.getExternalReferenceCode(),
-			pageExperience3.getExternalReferenceCode());
-
-		Assert.assertEquals(Integer.valueOf(2), pageExperience3.getPriority());
+		_assertPageExperiencePriority(
+			1, pageExperience2.getExternalReferenceCode());
+		_assertPageExperiencePriority(
+			2, pageExperience3.getExternalReferenceCode());
+		_assertPageExperiencePriority(
+			3, pageExperience1.getExternalReferenceCode());
 
 		PageExperience swappedPageExperience =
 			pageExperienceResource.patchSitePageExperience(
@@ -480,18 +481,12 @@ public class PageExperienceResourceTest
 		Assert.assertEquals(
 			Integer.valueOf(2), swappedPageExperience.getPriority());
 
-		pageExperience3 = pageExperienceResource.getSitePageExperience(
-			testGroup.getExternalReferenceCode(),
-			pageExperience3.getExternalReferenceCode());
-
-		Assert.assertEquals(Integer.valueOf(1), pageExperience3.getPriority());
-
-		patchedPageExperience = pageExperienceResource.getSitePageExperience(
-			testGroup.getExternalReferenceCode(),
-			patchedPageExperience.getExternalReferenceCode());
-
-		Assert.assertEquals(
-			Integer.valueOf(3), patchedPageExperience.getPriority());
+		_assertPageExperiencePriority(
+			1, pageExperience3.getExternalReferenceCode());
+		_assertPageExperiencePriority(
+			2, pageExperience2.getExternalReferenceCode());
+		_assertPageExperiencePriority(
+			3, pageExperience1.getExternalReferenceCode());
 	}
 
 	private void _testPostSitePageSpecificationPageExperience(
@@ -596,17 +591,12 @@ public class PageExperienceResourceTest
 		Assert.assertEquals(
 			Integer.valueOf(3), putSitePageExperience.getPriority());
 
-		pageExperience2 = pageExperienceResource.getSitePageExperience(
-			testGroup.getExternalReferenceCode(),
-			pageExperience2.getExternalReferenceCode());
-
-		Assert.assertEquals(Integer.valueOf(1), pageExperience2.getPriority());
-
-		pageExperience3 = pageExperienceResource.getSitePageExperience(
-			testGroup.getExternalReferenceCode(),
-			pageExperience3.getExternalReferenceCode());
-
-		Assert.assertEquals(Integer.valueOf(2), pageExperience3.getPriority());
+		_assertPageExperiencePriority(
+			1, pageExperience2.getExternalReferenceCode());
+		_assertPageExperiencePriority(
+			2, pageExperience3.getExternalReferenceCode());
+		_assertPageExperiencePriority(
+			3, pageExperience1.getExternalReferenceCode());
 	}
 
 	private Layout _draftLayout;

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceLocalService.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceLocalService.java
@@ -93,6 +93,40 @@ public interface SegmentsExperienceLocalService
 			ServiceContext serviceContext)
 		throws PortalException;
 
+	/**
+	 * Adds a segments experience to a page, generating its key automatically.
+	 *
+	 * <p>
+	 * The supplied priority is compacted with the priorities of the other
+	 * experiences on the page so the priority of the returned segments
+	 * experience may differ from the value supplied. See {@link
+	 * #addSegmentsExperience(String, long, long, String, String, String, long,
+	 * Map, int, boolean, UnicodeProperties, ServiceContext)} for the full
+	 * priority-compaction contract.
+	 * </p>
+	 *
+	 * @param externalReferenceCode the segments experience's external reference
+	 code
+	 * @param userId the primary key of the user
+	 * @param groupId the primary key of the group
+	 * @param segmentsEntryERC the external reference code of the segments entry
+	 the experience is associated with
+	 * @param segmentsEntryScopeERC the external reference code of the segments
+	 entry's scope
+	 * @param plid the primary key of the layout
+	 * @param nameMap the segments experience's locales and localized names
+	 * @param priority the requested priority within the page. It must be unique
+	 among the page's experiences, but it is compacted, so the
+	 persisted value may differ.
+	 * @param active whether the segments experience is active
+	 * @param typeSettingsUnicodeProperties the segments experience's type
+	 settings
+	 * @param serviceContext the service context to be applied. Can set the
+	 UUID, creation date, modification date, guest permissions, and
+	 group permissions for the segments experience.
+	 * @return the segments experience
+	 * @throws PortalException if a portal exception occurred
+	 */
 	public SegmentsExperience addSegmentsExperience(
 			String externalReferenceCode, long userId, long groupId,
 			String segmentsEntryERC, String segmentsEntryScopeERC, long plid,
@@ -101,6 +135,46 @@ public interface SegmentsExperienceLocalService
 			ServiceContext serviceContext)
 		throws PortalException;
 
+	/**
+	 * Adds a segments experience to a page and compacts the priorities of every
+	 * experience on that page.
+	 *
+	 * <p>
+	 * The supplied priority must be unique within the page but it is not
+	 * persisted verbatim. After the experience is created, the service renumbers
+	 * the priorities of all the experiences on the page into sequential values
+	 * (1, 2, 3, ... for active experiences and -1, -2, -3, ... for inactive
+	 * experiences), mirroring {@link #updateSegmentsExperiencePriority(long,
+	 * long, int)} and {@link #deleteSegmentsExperience(SegmentsExperience)}. The
+	 * priority of the returned segments experience as well as the priorities of
+	 * the other experiences on the same page, may therefore differ from the
+	 * value supplied.
+	 * </p>
+	 *
+	 * @param externalReferenceCode the segments experience's external reference
+	 code
+	 * @param userId the primary key of the user
+	 * @param groupId the primary key of the group
+	 * @param segmentsEntryERC the external reference code of the segments entry
+	 the experience is associated with
+	 * @param segmentsEntryScopeERC the external reference code of the segments
+	 entry's scope
+	 * @param segmentsExperienceKey the key that identifies the segments
+	 experience
+	 * @param plid the primary key of the layout
+	 * @param nameMap the segments experience's locales and localized names
+	 * @param priority the requested priority within the page. It must be unique
+	 among the page's experiences, but it is compacted as described
+	 above, so the persisted value may differ.
+	 * @param active whether the segments experience is active
+	 * @param typeSettingsUnicodeProperties the segments experience's type
+	 settings
+	 * @param serviceContext the service context to be applied. Can set the
+	 UUID, creation date, modification date, guest permissions, and
+	 group permissions for the segments experience.
+	 * @return the segments experience
+	 * @throws PortalException if a portal exception occurred
+	 */
 	public SegmentsExperience addSegmentsExperience(
 			String externalReferenceCode, long userId, long groupId,
 			String segmentsEntryERC, String segmentsEntryScopeERC,
@@ -189,6 +263,22 @@ public interface SegmentsExperienceLocalService
 			SegmentsExperience segmentsExperience)
 		throws PortalException;
 
+	/**
+	 * Deletes the segments experience with the external reference code and
+	 * compacts the priorities of the remaining experiences on the page.
+	 *
+	 * <p>
+	 * See {@link #deleteSegmentsExperience(SegmentsExperience)} for the full
+	 * priority-compaction contract.
+	 * </p>
+	 *
+	 * @param externalReferenceCode the external reference code of the segments
+	 experience
+	 * @param groupId the primary key of the group
+	 * @return the deleted segments experience
+	 * @throws PortalException if a segments experience with the external
+	 reference code could not be found
+	 */
 	public SegmentsExperience deleteSegmentsExperience(
 			String externalReferenceCode, long groupId)
 		throws PortalException;
@@ -482,6 +572,34 @@ public interface SegmentsExperienceLocalService
 			long userId, long segmentsExperienceId, boolean active)
 		throws PortalException;
 
+	/**
+	 * Updates the priority of a segments experience and compacts the priorities
+	 * of every experience on the page.
+	 *
+	 * <p>
+	 * If another experience already holds <code>newPriority</code>, the two
+	 * experiences swap priorities; otherwise the experience is simply moved to
+	 * <code>newPriority</code>. A <code>newPriority</code> of <code>0</code>
+	 * deactivates an active experience and activates an inactive one. After the
+	 * move, the service renumbers the priorities of all the experiences on the
+	 * page into sequential values (1, 2, 3, ... for active experiences and -1,
+	 * -2, -3, ... for inactive experiences) so the priority of the returned
+	 * segments experience as well as the priorities of the other experiences on
+	 * the same page, may differ from <code>newPriority</code>. This matches the
+	 * compaction performed by {@link #addSegmentsExperience(String, long, long,
+	 * String, String, String, long, Map, int, boolean, UnicodeProperties,
+	 * ServiceContext)} and {@link
+	 * #deleteSegmentsExperience(SegmentsExperience)}.
+	 * </p>
+	 *
+	 * @param userId the primary key of the user
+	 * @param segmentsExperienceId the primary key of the segments experience
+	 * @param newPriority the requested priority within the page. Use
+	 <code>0</code> to toggle the experience between active and
+	 inactive.
+	 * @return the updated segments experience
+	 * @throws PortalException if a portal exception occurred
+	 */
 	public SegmentsExperience updateSegmentsExperiencePriority(
 			long userId, long segmentsExperienceId, int newPriority)
 		throws PortalException;
@@ -502,4 +620,4 @@ public interface SegmentsExperienceLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1393386091
+// LIFERAY-SERVICE-BUILDER-HASH:-1415906460

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceLocalServiceUtil.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceLocalServiceUtil.java
@@ -77,6 +77,40 @@ public class SegmentsExperienceLocalServiceUtil {
 			typeSettingsUnicodeProperties, serviceContext);
 	}
 
+	/**
+	 * Adds a segments experience to a page, generating its key automatically.
+	 *
+	 * <p>
+	 * The supplied priority is compacted with the priorities of the other
+	 * experiences on the page so the priority of the returned segments
+	 * experience may differ from the value supplied. See {@link
+	 * #addSegmentsExperience(String, long, long, String, String, String, long,
+	 * Map, int, boolean, UnicodeProperties, ServiceContext)} for the full
+	 * priority-compaction contract.
+	 * </p>
+	 *
+	 * @param externalReferenceCode the segments experience's external reference
+	 code
+	 * @param userId the primary key of the user
+	 * @param groupId the primary key of the group
+	 * @param segmentsEntryERC the external reference code of the segments entry
+	 the experience is associated with
+	 * @param segmentsEntryScopeERC the external reference code of the segments
+	 entry's scope
+	 * @param plid the primary key of the layout
+	 * @param nameMap the segments experience's locales and localized names
+	 * @param priority the requested priority within the page. It must be unique
+	 among the page's experiences, but it is compacted, so the
+	 persisted value may differ.
+	 * @param active whether the segments experience is active
+	 * @param typeSettingsUnicodeProperties the segments experience's type
+	 settings
+	 * @param serviceContext the service context to be applied. Can set the
+	 UUID, creation date, modification date, guest permissions, and
+	 group permissions for the segments experience.
+	 * @return the segments experience
+	 * @throws PortalException if a portal exception occurred
+	 */
 	public static SegmentsExperience addSegmentsExperience(
 			String externalReferenceCode, long userId, long groupId,
 			String segmentsEntryERC, String segmentsEntryScopeERC, long plid,
@@ -92,6 +126,46 @@ public class SegmentsExperienceLocalServiceUtil {
 			typeSettingsUnicodeProperties, serviceContext);
 	}
 
+	/**
+	 * Adds a segments experience to a page and compacts the priorities of every
+	 * experience on that page.
+	 *
+	 * <p>
+	 * The supplied priority must be unique within the page but it is not
+	 * persisted verbatim. After the experience is created, the service renumbers
+	 * the priorities of all the experiences on the page into sequential values
+	 * (1, 2, 3, ... for active experiences and -1, -2, -3, ... for inactive
+	 * experiences), mirroring {@link #updateSegmentsExperiencePriority(long,
+	 * long, int)} and {@link #deleteSegmentsExperience(SegmentsExperience)}. The
+	 * priority of the returned segments experience as well as the priorities of
+	 * the other experiences on the same page, may therefore differ from the
+	 * value supplied.
+	 * </p>
+	 *
+	 * @param externalReferenceCode the segments experience's external reference
+	 code
+	 * @param userId the primary key of the user
+	 * @param groupId the primary key of the group
+	 * @param segmentsEntryERC the external reference code of the segments entry
+	 the experience is associated with
+	 * @param segmentsEntryScopeERC the external reference code of the segments
+	 entry's scope
+	 * @param segmentsExperienceKey the key that identifies the segments
+	 experience
+	 * @param plid the primary key of the layout
+	 * @param nameMap the segments experience's locales and localized names
+	 * @param priority the requested priority within the page. It must be unique
+	 among the page's experiences, but it is compacted as described
+	 above, so the persisted value may differ.
+	 * @param active whether the segments experience is active
+	 * @param typeSettingsUnicodeProperties the segments experience's type
+	 settings
+	 * @param serviceContext the service context to be applied. Can set the
+	 UUID, creation date, modification date, guest permissions, and
+	 group permissions for the segments experience.
+	 * @return the segments experience
+	 * @throws PortalException if a portal exception occurred
+	 */
 	public static SegmentsExperience addSegmentsExperience(
 			String externalReferenceCode, long userId, long groupId,
 			String segmentsEntryERC, String segmentsEntryScopeERC,
@@ -218,6 +292,22 @@ public class SegmentsExperienceLocalServiceUtil {
 		return getService().deleteSegmentsExperience(segmentsExperience);
 	}
 
+	/**
+	 * Deletes the segments experience with the external reference code and
+	 * compacts the priorities of the remaining experiences on the page.
+	 *
+	 * <p>
+	 * See {@link #deleteSegmentsExperience(SegmentsExperience)} for the full
+	 * priority-compaction contract.
+	 * </p>
+	 *
+	 * @param externalReferenceCode the external reference code of the segments
+	 experience
+	 * @param groupId the primary key of the group
+	 * @return the deleted segments experience
+	 * @throws PortalException if a segments experience with the external
+	 reference code could not be found
+	 */
 	public static SegmentsExperience deleteSegmentsExperience(
 			String externalReferenceCode, long groupId)
 		throws PortalException {
@@ -626,6 +716,34 @@ public class SegmentsExperienceLocalServiceUtil {
 			userId, segmentsExperienceId, active);
 	}
 
+	/**
+	 * Updates the priority of a segments experience and compacts the priorities
+	 * of every experience on the page.
+	 *
+	 * <p>
+	 * If another experience already holds <code>newPriority</code>, the two
+	 * experiences swap priorities; otherwise the experience is simply moved to
+	 * <code>newPriority</code>. A <code>newPriority</code> of <code>0</code>
+	 * deactivates an active experience and activates an inactive one. After the
+	 * move, the service renumbers the priorities of all the experiences on the
+	 * page into sequential values (1, 2, 3, ... for active experiences and -1,
+	 * -2, -3, ... for inactive experiences) so the priority of the returned
+	 * segments experience as well as the priorities of the other experiences on
+	 * the same page, may differ from <code>newPriority</code>. This matches the
+	 * compaction performed by {@link #addSegmentsExperience(String, long, long,
+	 * String, String, String, long, Map, int, boolean, UnicodeProperties,
+	 * ServiceContext)} and {@link
+	 * #deleteSegmentsExperience(SegmentsExperience)}.
+	 * </p>
+	 *
+	 * @param userId the primary key of the user
+	 * @param segmentsExperienceId the primary key of the segments experience
+	 * @param newPriority the requested priority within the page. Use
+	 <code>0</code> to toggle the experience between active and
+	 inactive.
+	 * @return the updated segments experience
+	 * @throws PortalException if a portal exception occurred
+	 */
 	public static SegmentsExperience updateSegmentsExperiencePriority(
 			long userId, long segmentsExperienceId, int newPriority)
 		throws PortalException {
@@ -644,4 +762,4 @@ public class SegmentsExperienceLocalServiceUtil {
 			SegmentsExperienceLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-905342043
+// LIFERAY-SERVICE-BUILDER-HASH:-1808064386

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceLocalServiceWrapper.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceLocalServiceWrapper.java
@@ -76,6 +76,40 @@ public class SegmentsExperienceLocalServiceWrapper
 			typeSettingsUnicodeProperties, serviceContext);
 	}
 
+	/**
+	 * Adds a segments experience to a page, generating its key automatically.
+	 *
+	 * <p>
+	 * The supplied priority is compacted with the priorities of the other
+	 * experiences on the page so the priority of the returned segments
+	 * experience may differ from the value supplied. See {@link
+	 * #addSegmentsExperience(String, long, long, String, String, String, long,
+	 * Map, int, boolean, UnicodeProperties, ServiceContext)} for the full
+	 * priority-compaction contract.
+	 * </p>
+	 *
+	 * @param externalReferenceCode the segments experience's external reference
+	 code
+	 * @param userId the primary key of the user
+	 * @param groupId the primary key of the group
+	 * @param segmentsEntryERC the external reference code of the segments entry
+	 the experience is associated with
+	 * @param segmentsEntryScopeERC the external reference code of the segments
+	 entry's scope
+	 * @param plid the primary key of the layout
+	 * @param nameMap the segments experience's locales and localized names
+	 * @param priority the requested priority within the page. It must be unique
+	 among the page's experiences, but it is compacted, so the
+	 persisted value may differ.
+	 * @param active whether the segments experience is active
+	 * @param typeSettingsUnicodeProperties the segments experience's type
+	 settings
+	 * @param serviceContext the service context to be applied. Can set the
+	 UUID, creation date, modification date, guest permissions, and
+	 group permissions for the segments experience.
+	 * @return the segments experience
+	 * @throws PortalException if a portal exception occurred
+	 */
 	@Override
 	public SegmentsExperience addSegmentsExperience(
 			String externalReferenceCode, long userId, long groupId,
@@ -93,6 +127,46 @@ public class SegmentsExperienceLocalServiceWrapper
 			typeSettingsUnicodeProperties, serviceContext);
 	}
 
+	/**
+	 * Adds a segments experience to a page and compacts the priorities of every
+	 * experience on that page.
+	 *
+	 * <p>
+	 * The supplied priority must be unique within the page but it is not
+	 * persisted verbatim. After the experience is created, the service renumbers
+	 * the priorities of all the experiences on the page into sequential values
+	 * (1, 2, 3, ... for active experiences and -1, -2, -3, ... for inactive
+	 * experiences), mirroring {@link #updateSegmentsExperiencePriority(long,
+	 * long, int)} and {@link #deleteSegmentsExperience(SegmentsExperience)}. The
+	 * priority of the returned segments experience as well as the priorities of
+	 * the other experiences on the same page, may therefore differ from the
+	 * value supplied.
+	 * </p>
+	 *
+	 * @param externalReferenceCode the segments experience's external reference
+	 code
+	 * @param userId the primary key of the user
+	 * @param groupId the primary key of the group
+	 * @param segmentsEntryERC the external reference code of the segments entry
+	 the experience is associated with
+	 * @param segmentsEntryScopeERC the external reference code of the segments
+	 entry's scope
+	 * @param segmentsExperienceKey the key that identifies the segments
+	 experience
+	 * @param plid the primary key of the layout
+	 * @param nameMap the segments experience's locales and localized names
+	 * @param priority the requested priority within the page. It must be unique
+	 among the page's experiences, but it is compacted as described
+	 above, so the persisted value may differ.
+	 * @param active whether the segments experience is active
+	 * @param typeSettingsUnicodeProperties the segments experience's type
+	 settings
+	 * @param serviceContext the service context to be applied. Can set the
+	 UUID, creation date, modification date, guest permissions, and
+	 group permissions for the segments experience.
+	 * @return the segments experience
+	 * @throws PortalException if a portal exception occurred
+	 */
 	@Override
 	public SegmentsExperience addSegmentsExperience(
 			String externalReferenceCode, long userId, long groupId,
@@ -235,6 +309,22 @@ public class SegmentsExperienceLocalServiceWrapper
 			segmentsExperience);
 	}
 
+	/**
+	 * Deletes the segments experience with the external reference code and
+	 * compacts the priorities of the remaining experiences on the page.
+	 *
+	 * <p>
+	 * See {@link #deleteSegmentsExperience(SegmentsExperience)} for the full
+	 * priority-compaction contract.
+	 * </p>
+	 *
+	 * @param externalReferenceCode the external reference code of the segments
+	 experience
+	 * @param groupId the primary key of the group
+	 * @return the deleted segments experience
+	 * @throws PortalException if a segments experience with the external
+	 reference code could not be found
+	 */
 	@Override
 	public SegmentsExperience deleteSegmentsExperience(
 			String externalReferenceCode, long groupId)
@@ -716,6 +806,34 @@ public class SegmentsExperienceLocalServiceWrapper
 			userId, segmentsExperienceId, active);
 	}
 
+	/**
+	 * Updates the priority of a segments experience and compacts the priorities
+	 * of every experience on the page.
+	 *
+	 * <p>
+	 * If another experience already holds <code>newPriority</code>, the two
+	 * experiences swap priorities; otherwise the experience is simply moved to
+	 * <code>newPriority</code>. A <code>newPriority</code> of <code>0</code>
+	 * deactivates an active experience and activates an inactive one. After the
+	 * move, the service renumbers the priorities of all the experiences on the
+	 * page into sequential values (1, 2, 3, ... for active experiences and -1,
+	 * -2, -3, ... for inactive experiences) so the priority of the returned
+	 * segments experience as well as the priorities of the other experiences on
+	 * the same page, may differ from <code>newPriority</code>. This matches the
+	 * compaction performed by {@link #addSegmentsExperience(String, long, long,
+	 * String, String, String, long, Map, int, boolean, UnicodeProperties,
+	 * ServiceContext)} and {@link
+	 * #deleteSegmentsExperience(SegmentsExperience)}.
+	 * </p>
+	 *
+	 * @param userId the primary key of the user
+	 * @param segmentsExperienceId the primary key of the segments experience
+	 * @param newPriority the requested priority within the page. Use
+	 <code>0</code> to toggle the experience between active and
+	 inactive.
+	 * @return the updated segments experience
+	 * @throws PortalException if a portal exception occurred
+	 */
 	@Override
 	public SegmentsExperience updateSegmentsExperiencePriority(
 			long userId, long segmentsExperienceId, int newPriority)
@@ -765,4 +883,4 @@ public class SegmentsExperienceLocalServiceWrapper
 	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1307981150
+// LIFERAY-SERVICE-BUILDER-HASH:-1518698435

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceLocalServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceLocalServiceImpl.java
@@ -92,6 +92,40 @@ public class SegmentsExperienceLocalServiceImpl
 			typeSettingsUnicodeProperties, serviceContext);
 	}
 
+	/**
+	 * Adds a segments experience to a page, generating its key automatically.
+	 *
+	 * <p>
+	 * The supplied priority is compacted with the priorities of the other
+	 * experiences on the page so the priority of the returned segments
+	 * experience may differ from the value supplied. See {@link
+	 * #addSegmentsExperience(String, long, long, String, String, String, long,
+	 * Map, int, boolean, UnicodeProperties, ServiceContext)} for the full
+	 * priority-compaction contract.
+	 * </p>
+	 *
+	 * @param  externalReferenceCode the segments experience's external reference
+	 *         code
+	 * @param  userId the primary key of the user
+	 * @param  groupId the primary key of the group
+	 * @param  segmentsEntryERC the external reference code of the segments entry
+	 *         the experience is associated with
+	 * @param  segmentsEntryScopeERC the external reference code of the segments
+	 *         entry's scope
+	 * @param  plid the primary key of the layout
+	 * @param  nameMap the segments experience's locales and localized names
+	 * @param  priority the requested priority within the page. It must be unique
+	 *         among the page's experiences, but it is compacted, so the
+	 *         persisted value may differ.
+	 * @param  active whether the segments experience is active
+	 * @param  typeSettingsUnicodeProperties the segments experience's type
+	 *         settings
+	 * @param  serviceContext the service context to be applied. Can set the
+	 *         UUID, creation date, modification date, guest permissions, and
+	 *         group permissions for the segments experience.
+	 * @return the segments experience
+	 * @throws PortalException if a portal exception occurred
+	 */
 	@Override
 	public SegmentsExperience addSegmentsExperience(
 			String externalReferenceCode, long userId, long groupId,
@@ -108,6 +142,46 @@ public class SegmentsExperienceLocalServiceImpl
 			priority, active, typeSettingsUnicodeProperties, serviceContext);
 	}
 
+	/**
+	 * Adds a segments experience to a page and compacts the priorities of every
+	 * experience on that page.
+	 *
+	 * <p>
+	 * The supplied priority must be unique within the page but it is not
+	 * persisted verbatim. After the experience is created, the service renumbers
+	 * the priorities of all the experiences on the page into sequential values
+	 * (1, 2, 3, ... for active experiences and -1, -2, -3, ... for inactive
+	 * experiences), mirroring {@link #updateSegmentsExperiencePriority(long,
+	 * long, int)} and {@link #deleteSegmentsExperience(SegmentsExperience)}. The
+	 * priority of the returned segments experience as well as the priorities of
+	 * the other experiences on the same page, may therefore differ from the
+	 * value supplied.
+	 * </p>
+	 *
+	 * @param  externalReferenceCode the segments experience's external reference
+	 *         code
+	 * @param  userId the primary key of the user
+	 * @param  groupId the primary key of the group
+	 * @param  segmentsEntryERC the external reference code of the segments entry
+	 *         the experience is associated with
+	 * @param  segmentsEntryScopeERC the external reference code of the segments
+	 *         entry's scope
+	 * @param  segmentsExperienceKey the key that identifies the segments
+	 *         experience
+	 * @param  plid the primary key of the layout
+	 * @param  nameMap the segments experience's locales and localized names
+	 * @param  priority the requested priority within the page. It must be unique
+	 *         among the page's experiences, but it is compacted as described
+	 *         above, so the persisted value may differ.
+	 * @param  active whether the segments experience is active
+	 * @param  typeSettingsUnicodeProperties the segments experience's type
+	 *         settings
+	 * @param  serviceContext the service context to be applied. Can set the
+	 *         UUID, creation date, modification date, guest permissions, and
+	 *         group permissions for the segments experience.
+	 * @return the segments experience
+	 * @throws PortalException if a portal exception occurred
+	 */
 	@Override
 	public SegmentsExperience addSegmentsExperience(
 			String externalReferenceCode, long userId, long groupId,
@@ -230,6 +304,20 @@ public class SegmentsExperienceLocalServiceImpl
 		}
 	}
 
+	/**
+	 * Deletes the segments experience with the primary key and compacts the
+	 * priorities of the remaining experiences on the page.
+	 *
+	 * <p>
+	 * See {@link #deleteSegmentsExperience(SegmentsExperience)} for the full
+	 * priority-compaction contract.
+	 * </p>
+	 *
+	 * @param  segmentsExperienceId the primary key of the segments experience
+	 * @return the deleted segments experience
+	 * @throws PortalException if a segments experience with the primary key
+	 *         could not be found
+	 */
 	@Override
 	public SegmentsExperience deleteSegmentsExperience(
 			long segmentsExperienceId)
@@ -243,6 +331,26 @@ public class SegmentsExperienceLocalServiceImpl
 			segmentsExperience);
 	}
 
+	/**
+	 * Deletes a segments experience and compacts the priorities of the
+	 * remaining experiences on the page.
+	 *
+	 * <p>
+	 * After the experience is removed, the service renumbers the priorities of
+	 * the experiences left on the page into sequential values (1, 2, 3, ... for
+	 * active experiences and -1, -2, -3, ... for inactive experiences) so their
+	 * priorities may differ from the values previously returned. This matches
+	 * the compaction performed by {@link #addSegmentsExperience(String, long,
+	 * long, String, String, String, long, Map, int, boolean, UnicodeProperties,
+	 * ServiceContext)} and {@link #updateSegmentsExperiencePriority(long, long,
+	 * int)}. Compaction is skipped when the experience is removed as part of a
+	 * group deletion.
+	 * </p>
+	 *
+	 * @param  segmentsExperience the segments experience
+	 * @return the deleted segments experience
+	 * @throws PortalException if a portal exception occurred
+	 */
 	@Override
 	@SystemEvent(type = SystemEventConstants.TYPE_DELETE)
 	public SegmentsExperience deleteSegmentsExperience(
@@ -289,6 +397,22 @@ public class SegmentsExperienceLocalServiceImpl
 		return segmentsExperience;
 	}
 
+	/**
+	 * Deletes the segments experience with the external reference code and
+	 * compacts the priorities of the remaining experiences on the page.
+	 *
+	 * <p>
+	 * See {@link #deleteSegmentsExperience(SegmentsExperience)} for the full
+	 * priority-compaction contract.
+	 * </p>
+	 *
+	 * @param  externalReferenceCode the external reference code of the segments
+	 *         experience
+	 * @param  groupId the primary key of the group
+	 * @return the deleted segments experience
+	 * @throws PortalException if a segments experience with the external
+	 *         reference code could not be found
+	 */
 	@Override
 	public SegmentsExperience deleteSegmentsExperience(
 			String externalReferenceCode, long groupId)
@@ -549,6 +673,34 @@ public class SegmentsExperienceLocalServiceImpl
 		return segmentsExperiencePersistence.update(segmentsExperience);
 	}
 
+	/**
+	 * Updates the priority of a segments experience and compacts the priorities
+	 * of every experience on the page.
+	 *
+	 * <p>
+	 * If another experience already holds <code>newPriority</code>, the two
+	 * experiences swap priorities; otherwise the experience is simply moved to
+	 * <code>newPriority</code>. A <code>newPriority</code> of <code>0</code>
+	 * deactivates an active experience and activates an inactive one. After the
+	 * move, the service renumbers the priorities of all the experiences on the
+	 * page into sequential values (1, 2, 3, ... for active experiences and -1,
+	 * -2, -3, ... for inactive experiences) so the priority of the returned
+	 * segments experience as well as the priorities of the other experiences on
+	 * the same page, may differ from <code>newPriority</code>. This matches the
+	 * compaction performed by {@link #addSegmentsExperience(String, long, long,
+	 * String, String, String, long, Map, int, boolean, UnicodeProperties,
+	 * ServiceContext)} and {@link
+	 * #deleteSegmentsExperience(SegmentsExperience)}.
+	 * </p>
+	 *
+	 * @param  userId the primary key of the user
+	 * @param  segmentsExperienceId the primary key of the segments experience
+	 * @param  newPriority the requested priority within the page. Use
+	 *         <code>0</code> to toggle the experience between active and
+	 *         inactive.
+	 * @return the updated segments experience
+	 * @throws PortalException if a portal exception occurred
+	 */
 	@Override
 	public SegmentsExperience updateSegmentsExperiencePriority(
 			long userId, long segmentsExperienceId, int newPriority)

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceLocalServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceLocalServiceImpl.java
@@ -155,12 +155,19 @@ public class SegmentsExperienceLocalServiceImpl
 		segmentsExperience = segmentsExperiencePersistence.update(
 			segmentsExperience);
 
+		segmentsExperiencePersistence.flush();
+
 		// Resources
 
 		_resourceLocalService.addModelResources(
 			segmentsExperience, serviceContext);
 
-		return segmentsExperience;
+		// Segments experiences priorities
+
+		_compactSegmentsExperiencesPriorities(segmentsExperience);
+
+		return segmentsExperiencePersistence.findByPrimaryKey(
+			segmentsExperience.getSegmentsExperienceId());
 	}
 
 	@Override

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceLocalServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceLocalServiceTest.java
@@ -81,13 +81,12 @@ public class SegmentsExperienceLocalServiceTest {
 		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
 			_group.getGroupId());
 		Map<Locale, String> nameMap = RandomTestUtil.randomLocaleStringMap();
-		int priority = RandomTestUtil.randomInt();
 
 		SegmentsExperience segmentsExperience =
 			_segmentsExperienceLocalService.addSegmentsExperience(
 				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				segmentsEntry.getExternalReferenceCode(), null, _plid, nameMap,
-				priority, true, new UnicodeProperties(true),
+				true, new UnicodeProperties(true),
 				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		Assert.assertEquals(
@@ -132,17 +131,44 @@ public class SegmentsExperienceLocalServiceTest {
 	}
 
 	@Test
+	public void testAddSegmentsExperienceCompactsPriority()
+		throws Exception {
+
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId());
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.addSegmentsExperience(
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
+				segmentsEntry.getExternalReferenceCode(), null, _plid,
+				RandomTestUtil.randomLocaleStringMap(), 100, true,
+				new UnicodeProperties(true),
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		Assert.assertEquals(1, segmentsExperience.getPriority());
+
+		segmentsExperience =
+			_segmentsExperienceLocalService.addSegmentsExperience(
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
+				segmentsEntry.getExternalReferenceCode(), null, _plid,
+				RandomTestUtil.randomLocaleStringMap(), -100, true,
+				new UnicodeProperties(true),
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		Assert.assertEquals(-1, segmentsExperience.getPriority());
+	}
+
+	@Test
 	public void testAddSegmentsExperienceInactive() throws Exception {
 		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
 			_group.getGroupId());
 		Map<Locale, String> nameMap = RandomTestUtil.randomLocaleStringMap();
-		int priority = RandomTestUtil.randomInt();
 
 		SegmentsExperience segmentsExperience =
 			_segmentsExperienceLocalService.addSegmentsExperience(
 				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				segmentsEntry.getExternalReferenceCode(), null, _plid, nameMap,
-				priority, false, new UnicodeProperties(true),
+				false, new UnicodeProperties(true),
 				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		Assert.assertEquals(
@@ -260,8 +286,8 @@ public class SegmentsExperienceLocalServiceTest {
 		_segmentsExperienceLocalService.addSegmentsExperience(
 			null, TestPropsValues.getUserId(), _group.getGroupId(),
 			segmentsEntry.getExternalReferenceCode(), null, _plid,
-			Collections.emptyMap(), RandomTestUtil.randomInt(),
-			RandomTestUtil.randomBoolean(), new UnicodeProperties(true),
+			Collections.emptyMap(), RandomTestUtil.randomBoolean(),
+			new UnicodeProperties(true),
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 	}
 
@@ -275,7 +301,7 @@ public class SegmentsExperienceLocalServiceTest {
 				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				segmentsEntry.getExternalReferenceCode(), null, _plid,
 				RandomTestUtil.randomLocaleStringMap(),
-				RandomTestUtil.randomInt(), RandomTestUtil.randomBoolean(),
+				RandomTestUtil.randomBoolean(),
 				UnicodePropertiesBuilder.create(
 					true
 				).put(
@@ -701,6 +727,30 @@ public class SegmentsExperienceLocalServiceTest {
 		Assert.assertEquals(movedSegmentsExperience, segmentsExperience1);
 		Assert.assertEquals(priority1, segmentsExperience2.getPriority());
 		Assert.assertEquals(priority2, segmentsExperience1.getPriority());
+
+		SegmentsExperience segmentsExperience3 =
+			SegmentsTestUtil.addSegmentsExperience(_group.getGroupId(), _plid);
+
+		Assert.assertEquals(-3, segmentsExperience3.getPriority());
+
+		segmentsExperience1 =
+			_segmentsExperienceLocalService.updateSegmentsExperiencePriority(
+				TestPropsValues.getUserId(),
+				segmentsExperience1.getSegmentsExperienceId(), -100);
+
+		Assert.assertEquals(-3, segmentsExperience1.getPriority());
+
+		segmentsExperience2 =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				segmentsExperience2.getSegmentsExperienceId());
+
+		Assert.assertEquals(-1, segmentsExperience2.getPriority());
+
+		segmentsExperience3 =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				segmentsExperience3.getSegmentsExperienceId());
+
+		Assert.assertEquals(-2, segmentsExperience3.getPriority());
 	}
 
 	@Test

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceLocalServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceLocalServiceTest.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -131,6 +132,7 @@ public class SegmentsExperienceLocalServiceTest {
 	}
 
 	@Test
+	@TestInfo("LPD-90839")
 	public void testAddSegmentsExperienceCompactsPriority() throws Exception {
 		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
 			_group.getGroupId());

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceLocalServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceLocalServiceTest.java
@@ -131,9 +131,7 @@ public class SegmentsExperienceLocalServiceTest {
 	}
 
 	@Test
-	public void testAddSegmentsExperienceCompactsPriority()
-		throws Exception {
-
+	public void testAddSegmentsExperienceCompactsPriority() throws Exception {
 		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
 			_group.getGroupId());
 

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperimentLocalServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperimentLocalServiceTest.java
@@ -828,7 +828,7 @@ public class SegmentsExperimentLocalServiceTest {
 				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				segmentsEntry.getExternalReferenceCode(), null,
 				_draftLayout.getPlid(), RandomTestUtil.randomLocaleStringMap(),
-				2, true, new UnicodeProperties(true),
+				1, true, new UnicodeProperties(true),
 				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		segmentsExperience1 = _publishSegmentsExperience(segmentsExperience1);
@@ -838,7 +838,7 @@ public class SegmentsExperimentLocalServiceTest {
 				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				segmentsEntry.getExternalReferenceCode(), null,
 				_draftLayout.getPlid(), RandomTestUtil.randomLocaleStringMap(),
-				1, true, new UnicodeProperties(true),
+				2, true, new UnicodeProperties(true),
 				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 
 		segmentsExperience2 = _publishSegmentsExperience(segmentsExperience2);
@@ -854,7 +854,7 @@ public class SegmentsExperimentLocalServiceTest {
 		segmentsExperience3 = _publishSegmentsExperience(segmentsExperience3);
 
 		SegmentsExperiment segmentsExperiment = _addSegmentsExperiment(
-			segmentsExperience2);
+			segmentsExperience1);
 
 		SegmentsExperience variantSegmentsExperience =
 			_segmentsExperienceLocalService.appendSegmentsExperience(
@@ -888,15 +888,15 @@ public class SegmentsExperimentLocalServiceTest {
 			_segmentsExperienceLocalService.fetchSegmentsExperience(
 				segmentsExperience1.getSegmentsExperienceId());
 
-		Assert.assertTrue(segmentsExperience1.isActive());
-		Assert.assertEquals(2, segmentsExperience1.getPriority());
+		Assert.assertFalse(segmentsExperience1.isActive());
+		Assert.assertEquals(-2, segmentsExperience1.getPriority());
 
 		segmentsExperience2 =
 			_segmentsExperienceLocalService.fetchSegmentsExperience(
 				segmentsExperience2.getSegmentsExperienceId());
 
-		Assert.assertFalse(segmentsExperience2.isActive());
-		Assert.assertEquals(-2, segmentsExperience2.getPriority());
+		Assert.assertTrue(segmentsExperience2.isActive());
+		Assert.assertEquals(2, segmentsExperience2.getPriority());
 
 		segmentsExperience3 =
 			_segmentsExperienceLocalService.fetchSegmentsExperience(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90839

## What Is Being Fixed

Adding a page experience with a non-sequential priority (a gap) was rejected, forcing callers to know and supply the exact next priority value. This made the page experience headless API brittle and the priority semantics hard to reason about.

## How It Is Being Fixed

Instead of rejecting gaps on add, the segments experience local service now compacts the priorities of all experiences after each add into sequential values (1, 2, 3, ... for active experiences and -1, -2, -3, ... for inactive ones), mirroring the behavior already applied on update and delete. The persistence layer is flushed before compaction and the freshly persisted experience is returned so callers observe the compacted priority. The headless-admin-site OpenAPI descriptions are updated to document that the priority returned or persisted may differ from the one supplied.

The integration tests are tightened on top: the priority-compaction assertions run on a dedicated layout so they no longer depend on experiences created earlier in the same test, the page-experience creation, partial-patch, and priority assertions are factored into reusable helpers, and a pre-existing patch test is corrected to send only the changed field instead of the whole experience.

## PR Check

**pr-check: PASS** — tested on `d3dc71dd5c61fcadea69c785eb4a10a66f9f2c57`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "d3dc71dd5c61fcadea69c785eb4a10a66f9f2c57"} -->
