### PR TITLE
LPD-95422 Fix master page categories test for inline category selector

### DIFF
--- a/modules/test/playwright/tests/layout-page-template-admin-web/main/masterPagesEdition.spec.ts
+++ b/modules/test/playwright/tests/layout-page-template-admin-web/main/masterPagesEdition.spec.ts
@@ -102,20 +102,12 @@ test(
 			trigger: page.getByLabel('Select Animals'),
 		});
 
-		const iframe = page.frameLocator('iframe[title="Select Animals"]');
+		const selectAnimalsModal = page.getByRole('dialog');
 
-		await iframe
-			.locator('li')
-			.filter({hasText: 'Cats'})
-			.getByRole('checkbox')
-			.check();
-		await iframe
-			.locator('li')
-			.filter({hasText: 'Dogs'})
-			.getByRole('checkbox')
-			.check();
+		await selectAnimalsModal.getByRole('treeitem', {name: 'Cats'}).click();
+		await selectAnimalsModal.getByRole('treeitem', {name: 'Dogs'}).click();
 
-		await page.getByRole('button', {name: 'Done'}).click();
+		await selectAnimalsModal.getByRole('button', {name: 'Done'}).click();
 
 		await page.locator('input[name="ObjectField_lemonSize"]').fill('Small');
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95422

## What Is Being Fixed

The Playwright test "Categories field can be used in a master page" (@LPS-161638) fails on master. The "Select Animals" category picker was migrated from an iframe-based item selector to the inline Clay TreeItemSelectorModal in LPD-88409, so the test's `iframe[title="Select Animals"]` frame locator no longer resolves and the checkbox interaction times out.

## How It Is Being Fixed

The test now targets the inline dialog (`getByRole('dialog')`) and clicks the category tree items instead of checking a checkbox inside an iframe. Verified locally against the page-management-site project: the test passes.

## Why Are There No Tests?

This change is itself a test-only fix — it repairs an existing Playwright test broken by the LPD-88409 UI migration. There is no product code change, so no additional test coverage is warranted.

## PR Check

**pr-check: PASS** — tested on `c21703d2a8c88f503f31c2977c7f16599c33d2d3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "c21703d2a8c88f503f31c2977c7f16599c33d2d3"} -->
