### PR TITLE
LPD-95400 Fix friendlyURLHistory test by not reselecting active locale

### DIFF
--- a/modules/test/playwright/tests/layout-admin-web/main/pages/PageConfigurationPage.ts
+++ b/modules/test/playwright/tests/layout-admin-web/main/pages/PageConfigurationPage.ts
@@ -68,6 +68,21 @@ export class PageConfigurationPage {
 		);
 	}
 
+	private async selectLanguage(toggle: Locator, option: Locator) {
+		await clickAndExpectToBeVisible({target: option, trigger: toggle});
+
+		const isActive = await option.evaluate((element) =>
+			element.classList.contains('active')
+		);
+
+		if (isActive) {
+			await toggle.click();
+		}
+		else {
+			await option.click();
+		}
+	}
+
 	async selectMasterLayout(name: string) {
 		await this.page.getByLabel('Change Master').click();
 
@@ -89,27 +104,22 @@ export class PageConfigurationPage {
 	}
 
 	async setFriendlyURL(friendlyURL: string, language: 'spanish' | 'english') {
-		await clickAndExpectToBeVisible({
-			autoClick: true,
-			target: this.page.getByRole('menuitem', {name: language}),
-			trigger: this.page
-				.getByLabel('Current translation')
-				.nth(1)
-				.locator('..'),
-		});
+		const toggle = this.page
+			.getByLabel('Current translation')
+			.nth(1)
+			.locator('..');
+
+		await this.selectLanguage(
+			toggle,
+			this.page.getByRole('menuitem', {name: language})
+		);
 
 		await this.friendlyURL.fill(friendlyURL);
 
-		await clickAndExpectToBeVisible({
-			autoClick: true,
-			target: this.page
-				.getByRole('menuitem')
-				.filter({hasText: 'default'}),
-			trigger: this.page
-				.getByLabel('Current translation')
-				.nth(1)
-				.locator('..'),
-		});
+		await this.selectLanguage(
+			toggle,
+			this.page.getByRole('menuitem').filter({hasText: 'default'})
+		);
 
 		await this.save();
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95400

## What Is Being Fixed

The Playwright test `friendly-url-web/main/friendlyURLHistory.spec.ts` was failing. Its `setFriendlyURL` helper (in the `layout-admin-web` `PageConfigurationPage` page object) unconditionally clicked the translation dropdown menu item for the requested language and then for the default language. When the requested language was already the active translation — the case for the default English locale — its menu item renders as an active, non-clickable item, so the click was intercepted by the surrounding list item and the test failed.

## How It Is Being Fixed

A shared `selectLanguage` helper now opens the translation dropdown and checks whether the target option is already active (its menu item carries the `active` class). When it is, the helper closes the dropdown instead of reselecting it; otherwise it clicks the option. `setFriendlyURL` routes both the switch-to-language and restore-to-default steps through this helper, so it no longer clicks an already-selected locale.

## Why Are There No Tests?

This change only modifies test code — a Playwright page object shared by the friendly URL tests — to fix existing failing tests; it changes no production code, so no new tests are added. The fix was validated by running `friendlyURLHistory.spec.ts` and the other `setFriendlyURL` caller (`pageFriendlyURL.spec.ts`) repeatedly with no failures.

## PR Check

**pr-check: PASS** — tested on `23f153d42662268922b37ccac4852813eb639dba`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "23f153d42662268922b37ccac4852813eb639dba"} -->
