### PR TITLE
LPD-84614 Index CMS object entries by rootDescendantNode

### DIFF
--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/AttachmentBase.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/AttachmentBase.tsx
@@ -217,7 +217,7 @@ export default function AttachmentBase({
 		else if (isVisible) {
 			searchParams.set(
 				'filter',
-				"cmsRoot eq true and cmsSection eq 'files' and status in (0)"
+				"cmsRoot eq true and cmsSection eq 'files' and rootDescendantNode eq false and status in (0)"
 			);
 		}
 

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/util/CMSFilesItemSelectorModal.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/util/CMSFilesItemSelectorModal.tsx
@@ -42,7 +42,7 @@ function getSpaceRootFilesURL(groupId: string) {
 
 	return `${ROOT_URL}?${new URLSearchParams({
 		...BASE_SEARCH_PARAMS,
-		filter: `cmsRoot eq true and cmsSection eq 'files' and status in (0) and scopeGroupId eq ${groupId}`,
+		filter: `cmsRoot eq true and cmsSection eq 'files' and rootDescendantNode eq false and status in (0) and scopeGroupId eq ${groupId}`,
 	}).toString()}`;
 }
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/search/spi/model/index/contributor/ObjectEntryModelDocumentContributor.java
@@ -431,6 +431,9 @@ public class ObjectEntryModelDocumentContributor
 			"objectFolderExternalReferenceCode",
 			objectFolder.getExternalReferenceCode(), true);
 
+		document.addKeyword(
+			"rootDescendantNode", objectEntry.isRootDescendantNode());
+
 		if (FeatureFlagManagerUtil.isEnabled(
 				objectEntry.getCompanyId(), "LPD-17564")) {
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryModelDocumentContributorTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryModelDocumentContributorTest.java
@@ -7,14 +7,17 @@ package com.liferay.object.internal.search.spi.model.index.contributor.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.field.builder.AssigneeObjectFieldBuilder;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectEntryFolder;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.rest.test.util.ObjectEntryTestUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.string.StringBundler;
@@ -25,6 +28,7 @@ import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.DocumentImpl;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
@@ -44,6 +48,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 
 import org.junit.Assert;
@@ -140,6 +145,20 @@ public class ObjectEntryModelDocumentContributorTest {
 			value.contains(
 				StringBundler.concat(
 					objectFieldName, ": ", objectFieldValue, "pt_BR")));
+
+		Assert.assertEquals("false", document.get("rootDescendantNode"));
+
+		objectEntry.setRootObjectEntryId(objectEntry.getObjectEntryId());
+
+		document = _getDocument(modifiableSystemObjectDefinition, objectEntry);
+
+		Assert.assertEquals("false", document.get("rootDescendantNode"));
+
+		objectEntry.setRootObjectEntryId(objectEntry.getObjectEntryId() + 1);
+
+		document = _getDocument(modifiableSystemObjectDefinition, objectEntry);
+
+		Assert.assertEquals("true", document.get("rootDescendantNode"));
 	}
 
 	@FeatureFlag("LPD-17564")
@@ -249,6 +268,52 @@ public class ObjectEntryModelDocumentContributorTest {
 					objectFieldName, ": ", user.getFullName())));
 	}
 
+	@FeatureFlag("LPD-17564")
+	@Test
+	public void testContributeWithCMSAttributes() throws Exception {
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			objectDefinition, new HashMap<String, Serializable>());
+
+		ObjectEntryFolder objectEntryFolder =
+			_objectEntryFolderLocalService.addObjectEntryFolder(
+				ObjectEntryFolderConstants.EXTERNAL_REFERENCE_CODE_CONTENTS,
+				TestPropsValues.getGroupId(), TestPropsValues.getUserId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				RandomTestUtil.randomString(),
+				HashMapBuilder.put(
+					LocaleUtil.ENGLISH, RandomTestUtil.randomString()
+				).build(),
+				RandomTestUtil.randomString(), new ServiceContext());
+
+		objectEntry.setObjectEntryFolderId(
+			objectEntryFolder.getObjectEntryFolderId());
+
+		Document document = _getDocument(objectDefinition, objectEntry);
+
+		Assert.assertEquals("object", document.get("cms_kind"));
+		Assert.assertEquals("true", document.get("cms_root"));
+		Assert.assertEquals("contents", document.get("cms_section"));
+	}
+
+	private Document _getDocument(
+			ObjectDefinition objectDefinition, ObjectEntry objectEntry)
+		throws Exception {
+
+		Document document = new DocumentImpl();
+
+		ModelDocumentContributor<ObjectEntry>
+			objectEntryModelDocumentContributor =
+				_getObjectEntryModelDocumentContributor(objectDefinition);
+
+		objectEntryModelDocumentContributor.contribute(document, objectEntry);
+
+		return document;
+	}
+
 	private ModelDocumentContributor<ObjectEntry>
 			_getObjectEntryModelDocumentContributor(
 				ObjectDefinition objectDefinition)
@@ -275,6 +340,9 @@ public class ObjectEntryModelDocumentContributorTest {
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
 
 	@Inject
 	private ObjectFieldLocalService _objectFieldLocalService;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryModelDocumentContributorTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/search/spi/model/index/contributor/test/ObjectEntryModelDocumentContributorTest.java
@@ -47,8 +47,8 @@ import java.io.Serializable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 
 import org.junit.Assert;
@@ -117,14 +117,8 @@ public class ObjectEntryModelDocumentContributorTest {
 				).build()
 			).build());
 
-		Document document = new DocumentImpl();
-
-		ModelDocumentContributor<ObjectEntry>
-			objectEntryModelDocumentContributor =
-				_getObjectEntryModelDocumentContributor(
-					modifiableSystemObjectDefinition);
-
-		objectEntryModelDocumentContributor.contribute(document, objectEntry);
+		Document document = _getDocument(
+			modifiableSystemObjectDefinition, objectEntry);
 
 		Field field = document.getField(Field.DISPLAY_DATE);
 
@@ -186,10 +180,6 @@ public class ObjectEntryModelDocumentContributorTest {
 		objectDefinition = _objectDefinitionLocalService.getObjectDefinition(
 			objectDefinition.getObjectDefinitionId());
 
-		ModelDocumentContributor<ObjectEntry>
-			objectEntryModelDocumentContributor =
-				_getObjectEntryModelDocumentContributor(objectDefinition);
-
 		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
 
 		long roleClassNameId = _classNameLocalService.getClassNameId(
@@ -207,10 +197,7 @@ public class ObjectEntryModelDocumentContributorTest {
 				).build()
 			).build());
 
-		Document roleDocument = new DocumentImpl();
-
-		objectEntryModelDocumentContributor.contribute(
-			roleDocument, roleObjectEntry);
+		Document roleDocument = _getDocument(objectDefinition, roleObjectEntry);
 
 		Field roleField = roleDocument.getField("objectEntryContent");
 
@@ -245,10 +232,7 @@ public class ObjectEntryModelDocumentContributorTest {
 				).build()
 			).build());
 
-		Document userDocument = new DocumentImpl();
-
-		objectEntryModelDocumentContributor.contribute(
-			userDocument, userObjectEntry);
+		Document userDocument = _getDocument(objectDefinition, userObjectEntry);
 
 		Field userField = userDocument.getField("objectEntryContent");
 
@@ -275,7 +259,7 @@ public class ObjectEntryModelDocumentContributorTest {
 			ObjectDefinitionTestUtil.publishObjectDefinition();
 
 		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
-			objectDefinition, new HashMap<String, Serializable>());
+			objectDefinition, Collections.emptyMap());
 
 		ObjectEntryFolder objectEntryFolder =
 			_objectEntryFolderLocalService.addObjectEntryFolder(

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/odata/entity/v1_0/SearchResultEntityModel.java
@@ -25,6 +25,8 @@ public class SearchResultEntityModel implements EntityModel {
 	public SearchResultEntityModel() {
 		_entityFieldsMap = EntityModel.toEntityFieldsMap(
 			new BooleanEntityField("cmsRoot", locale -> "cms_root"),
+			new BooleanEntityField(
+				"rootDescendantNode", locale -> "rootDescendantNode"),
 			new CollectionEntityField(
 				new IntegerEntityField("groupIds", locale -> Field.GROUP_ID)),
 			new CollectionEntityField(

--- a/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
+++ b/modules/apps/portal-search/portal-search-rest-test/src/testIntegration/java/com/liferay/portal/search/rest/resource/v1_0/test/SearchResultResourceTest.java
@@ -1555,7 +1555,7 @@ public class SearchResultResourceTest extends BaseSearchResultResourceTestCase {
 		"cmsSection", "extension", "dateDisplay", "dateExpiration",
 		"datePublish", "dateReview", "folderId",
 		"objectDefinitionExternalReferenceCode",
-		"objectFolderExternalReferenceCode"
+		"objectFolderExternalReferenceCode", "rootDescendantNode"
 	};
 
 	private AssetCategory _assetCategory;

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewContentsSectionDisplayContextTest.java
@@ -255,7 +255,8 @@ public class ViewContentsSectionDisplayContextTest
 
 	@Override
 	protected String getFilterString() {
-		return "cmsRoot eq true and cmsSection eq 'contents'";
+		return "cmsRoot eq true and cmsSection eq 'contents' and " +
+			"rootDescendantNode eq false";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewFilesSectionDisplayContextTest.java
@@ -144,7 +144,8 @@ public class ViewFilesSectionDisplayContextTest
 
 	@Override
 	protected String getFilterString() {
-		return "cmsRoot eq true and cmsSection eq 'files'";
+		return "cmsRoot eq true and cmsSection eq 'files' and " +
+			"rootDescendantNode eq false";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewRecycleBinSectionDisplayContextTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/display/context/test/ViewRecycleBinSectionDisplayContextTest.java
@@ -247,8 +247,8 @@ public class ViewRecycleBinSectionDisplayContextTest
 
 	@Override
 	protected String getFilterString() {
-		return "cmsRoot eq true and (cmsSection eq 'contents' or cmsSection " +
-			"eq 'files')";
+		return "cmsRoot eq true and (cmsSection eq 'contents' or cmsSection eq " +
+			"'files') and rootDescendantNode eq false";
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextUtil.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/SectionDisplayContextUtil.java
@@ -117,13 +117,14 @@ public class SectionDisplayContextUtil {
 			httpServletRequest.getAttribute(InfoDisplayWebKeys.INFO_ITEM),
 			rootObjectEntryFolderExternalReferenceCode);
 
-		StringBundler sb = new StringBundler(13);
+		StringBundler sb = new StringBundler(14);
 
 		sb.append("emptySearch=true&filter=");
 
 		if (objectEntryFolder != null) {
 			sb.append("folderId eq ");
 			sb.append(objectEntryFolder.getObjectEntryFolderId());
+			sb.append(" and rootDescendantNode eq false");
 
 			if (objectEntryFolder.getStatus() ==
 					WorkflowConstants.STATUS_IN_TRASH) {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewContentsSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewContentsSectionDisplayContext.java
@@ -74,7 +74,9 @@ public class ViewContentsSectionDisplayContext
 	@Override
 	protected String getCMSSectionFilterString() {
 		return appendStatus(
-			appendGroupIds("cmsRoot eq true and cmsSection eq 'contents'"));
+			appendGroupIds(
+				"cmsRoot eq true and cmsSection eq 'contents' and " +
+					"rootDescendantNode eq false"));
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFilesSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewFilesSectionDisplayContext.java
@@ -78,7 +78,9 @@ public class ViewFilesSectionDisplayContext
 	@Override
 	protected String getCMSSectionFilterString() {
 		return appendStatus(
-			appendGroupIds("cmsRoot eq true and cmsSection eq 'files'"));
+			appendGroupIds(
+				"cmsRoot eq true and cmsSection eq 'files' and " +
+					"rootDescendantNode eq false"));
 	}
 
 	@Override

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRecycleBinSectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewRecycleBinSectionDisplayContext.java
@@ -201,7 +201,7 @@ public class ViewRecycleBinSectionDisplayContext
 	protected String getCMSSectionFilterString() {
 		String filterString =
 			"cmsRoot eq true and (cmsSection eq 'contents' or cmsSection eq " +
-				"'files')";
+				"'files') and rootDescendantNode eq false";
 
 		List<Long> groupIds = _getTrashEnabledDepotEntryGroupIds();
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceContentsSummarySectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceContentsSummarySectionDisplayContext.java
@@ -98,7 +98,7 @@ public class ViewSpaceContentsSummarySectionDisplayContext
 	protected String getCMSSectionFilterString() {
 		return String.format(
 			"cmsRoot eq true and cmsSection eq 'contents' and groupIds/any" +
-				"(g:g eq %s)",
+				"(g:g eq %s) and rootDescendantNode eq false",
 			_groupId);
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceFilesSummarySectionDisplayContext.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/display/context/ViewSpaceFilesSummarySectionDisplayContext.java
@@ -98,7 +98,7 @@ public class ViewSpaceFilesSummarySectionDisplayContext
 	protected String getCMSSectionFilterString() {
 		return String.format(
 			"cmsRoot eq true and cmsSection eq 'files' and groupIds/any" +
-				"(g:g eq %s)",
+				"(g:g eq %s) and rootDescendantNode eq false",
 			_groupId);
 	}
 

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/bulk_actions_monitor/util/index.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/bulk_actions_monitor/util/index.ts
@@ -63,7 +63,7 @@ export function composeCreateTaskURL(
 		const {folderId, groupIds} =
 			getFolderIdAndGroupIdsFromFilter(scopeFilter);
 
-		scopeFilter = `cmsRoot eq true and cmsSection eq 'contents' and status in (0, 2, 3)`;
+		scopeFilter = `cmsRoot eq true and cmsSection eq 'contents' and rootDescendantNode eq false and status in (0, 2, 3)`;
 
 		if (folderId) {
 			scopeFilter += ` and folderId eq ${folderId}`;

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/EmptyRecycleBinModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/EmptyRecycleBinModalContent.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import {triggerAssetBulkAction} from '../props_transformer/actions/triggerAssetBulkAction';
 
 const CMS_RECYCLE_BIN_FILTER =
-	"cmsRoot eq true and (cmsSection eq 'contents' or cmsSection eq 'files') and status eq 8";
+	"cmsRoot eq true and (cmsSection eq 'contents' or cmsSection eq 'files') and rootDescendantNode eq false and status eq 8";
 
 export default function EmptyRecycleBinModalContent({
 	closeModal,

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/bulk_action_task/util/index.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/bulk_action_task/util/index.test.tsx
@@ -106,7 +106,7 @@ describe('Bulk Actions Monitor Utils', () => {
 			);
 
 			expect(taskUrl).toBe(
-				`${Liferay.ThemeDisplay.getPortalURL()}/o/cms/translations?type=ExportTranslationBulkAction&emptySearch=true&filter=cmsRoot+eq+true+and+cmsSection+eq+%27contents%27+and+status+in+%280%2C+2%2C+3%29+and+folderId+eq+123+and+groupIds%2Fany%28g%3Ag+in+%28456%29%29`
+				`${Liferay.ThemeDisplay.getPortalURL()}/o/cms/translations?type=ExportTranslationBulkAction&emptySearch=true&filter=cmsRoot+eq+true+and+cmsSection+eq+%27contents%27+and+rootDescendantNode+eq+false+and+status+in+%280%2C+2%2C+3%29+and+folderId+eq+123+and+groupIds%2Fany%28g%3Ag+in+%28456%29%29`
 			);
 		});
 	});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-84614

## What Is Being Fixed

CMS structures nest their content as object entries linked in a tree. There was no way to tell a nested (descendant) entry apart from a root entry at search time, so nested children appeared in the CMS content, files, and recycle-bin lists and in the attachment item selector, even though only roots should be listed there.

## How It Is Being Fixed

The object entry indexer now writes a `rootDescendantNode` keyword to each entry's search document, and that keyword is registered as a filterable search property so it can be used in OData filters. The CMS list display contexts and the attachment item selector now filter on `rootDescendantNode eq false`, so nested children are excluded from those views, with each filter's properties kept in alphabetical order. An integration test covers the indexed attribute, and `rootDescendantNode` is added to the search REST resource test's ignored entity fields alongside the sibling CMS fields. The CMS list display context tests are updated to expect the new filter.

This is the second of two PRs for LPD-84614; the CMS object-relationship edge modeling, the upgrade process, and the related struts/info-item changes are in the companion PR. The two are file-disjoint and can merge in either order.

## PR Check

**pr-check: PASS** — tested on `0f08730f8a2caac3aa624e8c6baf03677b1ef1f8`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "0f08730f8a2caac3aa624e8c6baf03677b1ef1f8"} -->
