### PR TITLE
LPD-95400 Simplify the friendlyURL test translation helper

### DIFF
--- a/modules/test/playwright/tests/layout-admin-web/main/pages/PageConfigurationPage.ts
+++ b/modules/test/playwright/tests/layout-admin-web/main/pages/PageConfigurationPage.ts
@@ -68,21 +68,6 @@ export class PageConfigurationPage {
 		);
 	}
 
-	private async selectLanguage(toggle: Locator, option: Locator) {
-		await clickAndExpectToBeVisible({target: option, trigger: toggle});
-
-		const isActive = await option.evaluate((element) =>
-			element.classList.contains('active')
-		);
-
-		if (isActive) {
-			await toggle.click();
-		}
-		else {
-			await option.click();
-		}
-	}
-
 	async selectMasterLayout(name: string) {
 		await this.page.getByLabel('Change Master').click();
 
@@ -104,22 +89,32 @@ export class PageConfigurationPage {
 	}
 
 	async setFriendlyURL(friendlyURL: string, language: 'spanish' | 'english') {
-		const toggle = this.page
-			.getByLabel('Current translation')
-			.nth(1)
-			.locator('..');
+		const selectLanguage = async (name: string) => {
+			const toggle = this.page.locator(
+				'.form-group.friendly-url .input-localized-trigger'
+			);
 
-		await this.selectLanguage(
-			toggle,
-			this.page.getByRole('menuitem', {name: language})
-		);
+			const option = this.page.getByRole('menuitem', {name});
+
+			await clickAndExpectToBeVisible({target: option, trigger: toggle});
+
+			const isActive = await option.evaluate((element) =>
+				element.classList.contains('active')
+			);
+
+			if (isActive) {
+				await toggle.click();
+			}
+			else {
+				await option.click();
+			}
+		};
+
+		await selectLanguage(language);
 
 		await this.friendlyURL.fill(friendlyURL);
 
-		await this.selectLanguage(
-			toggle,
-			this.page.getByRole('menuitem').filter({hasText: 'default'})
-		);
+		await selectLanguage('default');
 
 		await this.save();
 	}

--- a/modules/test/playwright/tests/layout-admin-web/main/pages/PageConfigurationPage.ts
+++ b/modules/test/playwright/tests/layout-admin-web/main/pages/PageConfigurationPage.ts
@@ -68,6 +68,21 @@ export class PageConfigurationPage {
 		);
 	}
 
+	private async selectLanguage(toggle: Locator, option: Locator) {
+		await clickAndExpectToBeVisible({target: option, trigger: toggle});
+
+		const isActive = await option.evaluate((element) =>
+			element.classList.contains('active')
+		);
+
+		if (isActive) {
+			await toggle.click();
+		}
+		else {
+			await option.click();
+		}
+	}
+
 	async selectMasterLayout(name: string) {
 		await this.page.getByLabel('Change Master').click();
 
@@ -89,27 +104,22 @@ export class PageConfigurationPage {
 	}
 
 	async setFriendlyURL(friendlyURL: string, language: 'spanish' | 'english') {
-		await clickAndExpectToBeVisible({
-			autoClick: true,
-			target: this.page.getByRole('menuitem', {name: language}),
-			trigger: this.page
-				.getByLabel('Current translation')
-				.nth(1)
-				.locator('..'),
-		});
+		const toggle = this.page
+			.getByLabel('Current translation')
+			.nth(1)
+			.locator('..');
+
+		await this.selectLanguage(
+			toggle,
+			this.page.getByRole('menuitem', {name: language})
+		);
 
 		await this.friendlyURL.fill(friendlyURL);
 
-		await clickAndExpectToBeVisible({
-			autoClick: true,
-			target: this.page
-				.getByRole('menuitem')
-				.filter({hasText: 'default'}),
-			trigger: this.page
-				.getByLabel('Current translation')
-				.nth(1)
-				.locator('..'),
-		});
+		await this.selectLanguage(
+			toggle,
+			this.page.getByRole('menuitem').filter({hasText: 'default'})
+		);
 
 		await this.save();
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95400

## What Is Being Fixed

The setFriendlyURL Playwright helper unconditionally clicked the translation
dropdown menu item for the requested language and then for the default one. When
the requested language was already the active translation, its menu item renders
as an active, non-clickable item and the click was intercepted by the
surrounding list item, so the friendlyURLHistory test failed. The helper also
relied on brittle locators (a positional .nth(1) plus a .locator('..') hop to
the parent button) to reach the translation toggle.

## How It Is Being Fixed

The helper now opens the dropdown and only clicks the option when it is not
already the active one; otherwise it just closes the dropdown. On top of that
fix the helper was simplified: the shared selectLanguage step became a local
function inside setFriendlyURL since it is used nowhere else, it now takes the
language as a plain string and builds the menu item locator itself, and the
toggle is reached through stable scoped class selectors
(.form-group.friendly-url .input-localized-trigger) instead of the positional
nth/parent chain. Both translation lookups now share a single locator strategy.

## Why Are There No Tests?

The change only refactors existing Playwright test infrastructure (the
PageConfigurationPage page object); no product code is touched. It is covered by
the existing friendlyURLHistory.spec.ts and pageFriendlyURL.spec.ts specs, which
were run locally and pass (10/10).

## PR Check

**pr-check: PASS** — tested on `db55d4f280fbbe522971604bf32e8f1f425be0bb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "db55d4f280fbbe522971604bf32e8f1f425be0bb"} -->
