### PR TITLE
LPD-95521 Regenerate the upgrade table and SQL for the renamed entity

### DIFF
--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v6_1_0/util/LayoutPageTemplateStructureRelElementVariationTable.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v6_1_0/util/LayoutPageTemplateStructureRelElementVariationTable.java
@@ -27,9 +27,9 @@ public class LayoutPageTemplateStructureRelElementVariationTable {
 		};
 	}
 
-	private static final String _TABLE_NAME = "LPTStructureElementVariation";
+	private static final String _TABLE_NAME = "LPTSRelElementVariation";
 
 	private static final String _TABLE_SQL_CREATE =
-		"create table LPTStructureElementVariation (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,lptStructureElementVariationId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,audienceEntryERC VARCHAR(75) null,hide STRING null,html STRING null,js STRING null,name VARCHAR(75) null,plid LONG,segmentsExperienceERC VARCHAR(75) null,targetElement VARCHAR(75) null,primary key (lptStructureElementVariationId, ctCollectionId))";
+		"create table LPTSRelElementVariation (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,lptsRelElementVariationId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,audienceEntryERC VARCHAR(75) null,hide STRING null,html STRING null,js STRING null,name VARCHAR(75) null,plid LONG,segmentsExperienceERC VARCHAR(75) null,targetElement VARCHAR(75) null,primary key (lptsRelElementVariationId, ctCollectionId))";
 
 }

--- a/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/sql/tables.sql
@@ -21,29 +21,6 @@ create table LPTSRelElementVariation (
 	primary key (lptsRelElementVariationId, ctCollectionId)
 );
 
-create table LPTStructureElementVariation (
-	mvccVersion LONG default 0 not null,
-	ctCollectionId LONG default 0 not null,
-	uuid_ VARCHAR(75) null,
-	externalReferenceCode VARCHAR(75) null,
-	lptStructureElementVariationId LONG not null,
-	groupId LONG,
-	companyId LONG,
-	userId LONG,
-	userName VARCHAR(75) null,
-	createDate DATE null,
-	modifiedDate DATE null,
-	audienceEntryERC VARCHAR(75) null,
-	hide STRING null,
-	html STRING null,
-	js STRING null,
-	name VARCHAR(75) null,
-	plid LONG,
-	segmentsExperienceERC VARCHAR(75) null,
-	targetElement VARCHAR(75) null,
-	primary key (lptStructureElementVariationId, ctCollectionId)
-);
-
 create table LayoutPageTemplateCollection (
 	mvccVersion LONG default 0 not null,
 	ctCollectionId LONG default 0 not null,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95521

## What Is Being Fixed

The `LayoutPageTemplateStructureRelElementVariation` entity was renamed (table `LPTStructureElementVariation` → `LPTSRelElementVariation`, id column `lptStructureElementVariationId` → `lptsRelElementVariationId`), but two generated artifacts still carried the old name: the `v6_1_0` upgrade-table snapshot and `tables.sql`, which also retained an orphaned `LPTStructureElementVariation` create statement.

## How It Is Being Fixed

Regenerated the `v6_1_0` upgrade-table snapshot with UpgradeTableBuilder and the module SQL with Service Builder so both reflect the renamed table and column. `tables.sql` no longer contains the stale `LPTStructureElementVariation` table.

## Why Are There No Tests?

The change is regenerated Service Builder / upgrade-table output (SQL DDL and the upgrade snapshot) produced from an entity rename; there is no hand-written logic to unit test.

## PR Check

**pr-check: PASS** — tested on `d43b355453ea78308602dd09d8d19affb21e794b`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "d43b355453ea78308602dd09d8d19affb21e794b"} -->
