### PR TITLE
LPD-91039 Connect email fields with Objects backend

### DIFF
--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/input/template/parser/InputTemplateNode.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/input/template/parser/InputTemplateNode.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Locale;
@@ -118,7 +119,14 @@ public class InputTemplateNode extends LinkedHashMap<String, Object> {
 					JSONFactoryUtil.createJSONObject();
 
 				for (Map.Entry<String, Object> entry : _attributes.entrySet()) {
-					attributesJSONObject.put(entry.getKey(), entry.getValue());
+					Object value = entry.getValue();
+
+					if (value instanceof Collection) {
+						value = JSONFactoryUtil.createJSONArray(
+							(Collection<?>)value);
+					}
+
+					attributesJSONObject.put(entry.getKey(), value);
 				}
 
 				attributesJSONObject.put("readOnly", _readOnly);

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/email-input/configuration.json
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/email-input/configuration.json
@@ -9,15 +9,6 @@
 					"localizable": true,
 					"name": "placeholder",
 					"type": "text"
-				},
-				{
-					"defaultValue": false,
-					"label": "show-characters-count",
-					"name": "showCharactersCount",
-					"type": "checkbox",
-					"typeOptions": {
-						"displayType": "toggle"
-					}
 				}
 			]
 		}

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/email-input/fragment.json
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/email-input/fragment.json
@@ -7,7 +7,7 @@
 	"type": "input",
 	"typeOptions": {
 		"fieldTypes": [
-			"text"
+			"email"
 		]
 	}
 }

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/email-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/email-input/index.html
@@ -1,4 +1,4 @@
-[#assign preferredDomains=(input.attributes.preferredDomains)!["@gmail.com", "@hotmail.com", "@liferay.com", "@outlook.com"] /]
+[#assign preferredDomains=(input.attributes.preferredDomains)![] /]
 
 <div class="email-input">
 	<div class="form-group [#if input.errorMessage?has_content]has-error[/#if] mb-0" id="${fragmentElementId}-form-group">

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/email-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/email-input/index.html
@@ -29,12 +29,6 @@
 			[/#if]
 		</div>
 
-		[#if configuration.showCharactersCount]
-			<p class="mt-1 text-secondary" id="${fragmentElementId}-length-info">
-				<span id="${fragmentElementId}-current-length">0</span> / [#if input.attributes.maxLength??]${input.attributes.maxLength}[/#if]
-			</p>
-		[/#if]
-
 		<p class="font-weight-semi-bold mt-1 text-3 text-danger[#if !input.errorMessage?has_content] sr-only[/#if]" id="${fragmentElementId}-email-input-error">
 			[@clay["icon"] symbol="info-circle" /]
 

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/email-input/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/email-input/index.js
@@ -1,6 +1,3 @@
-const currentLength = document.getElementById(
-	`${fragmentElementId}-current-length`
-);
 const dropdown = document.getElementById(`${fragmentElementId}-dropdown`);
 const error = document.getElementById(`${fragmentElementId}-email-input-error`);
 const errorMessage = document.getElementById(
@@ -10,7 +7,6 @@ const formGroup = document.getElementById(`${fragmentElementId}-form-group`);
 const inputElement = document.getElementById(
 	`${fragmentElementId}-email-input`
 );
-const lengthInfo = document.getElementById(`${fragmentElementId}-length-info`);
 
 function main() {
 	if (layoutMode === 'edit' && inputElement) {
@@ -28,14 +24,12 @@ function main() {
 			registerUnlocalizedInput,
 		}) => {
 			registerInputFeedback({
-				currentLengthContainer: currentLength,
 				errorContainer: error,
 				errorMessageContainer: errorMessage,
 				formGroup,
 				fragmentElement,
 				input,
 				inputElement,
-				lengthInfoContainer: lengthInfo,
 			});
 
 			const defaultLanguageId = input.attributes.defaultLanguageId;

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/helper/DefaultInputFragmentEntryConfigurationProviderImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/helper/DefaultInputFragmentEntryConfigurationProviderImpl.java
@@ -10,6 +10,7 @@ import com.liferay.fragment.helper.DefaultInputFragmentEntryConfigurationProvide
 import com.liferay.info.field.type.BooleanInfoFieldType;
 import com.liferay.info.field.type.DateInfoFieldType;
 import com.liferay.info.field.type.DateTimeInfoFieldType;
+import com.liferay.info.field.type.EmailInfoFieldType;
 import com.liferay.info.field.type.FileInfoFieldType;
 import com.liferay.info.field.type.FriendlyURLInfoFieldType;
 import com.liferay.info.field.type.HTMLInfoFieldType;
@@ -134,6 +135,9 @@ public class DefaultInputFragmentEntryConfigurationProviderImpl
 		).put(
 			DateTimeInfoFieldType.INSTANCE.getName(),
 			JSONUtil.put("key", "INPUTS-date-time-input")
+		).put(
+			EmailInfoFieldType.INSTANCE.getName(),
+			JSONUtil.put("key", "INPUTS-email-input")
 		).put(
 			FileInfoFieldType.INSTANCE.getName(),
 			JSONUtil.put("key", "INPUTS-file-upload")

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java
@@ -20,6 +20,7 @@ import com.liferay.info.field.InfoFieldValue;
 import com.liferay.info.field.RelatedInfoFieldValue;
 import com.liferay.info.field.type.DateInfoFieldType;
 import com.liferay.info.field.type.DateTimeInfoFieldType;
+import com.liferay.info.field.type.EmailInfoFieldType;
 import com.liferay.info.field.type.FileInfoFieldType;
 import com.liferay.info.field.type.InfoFieldType;
 import com.liferay.info.field.type.LongTextInfoFieldType;
@@ -411,6 +412,14 @@ public class FragmentEntryInputTemplateNodeContextHelperImpl
 		return inputTemplateNode;
 	}
 
+	private void _addEmailInfoFieldTypeInputTemplateNodeAttributes(
+		InfoField infoField, InputTemplateNode inputTemplateNode) {
+
+		inputTemplateNode.addAttribute(
+			"preferredDomains",
+			infoField.getAttribute(EmailInfoFieldType.PREFERRED_DOMAINS));
+	}
+
 	private void _addFileInfoFieldTypeInputTemplateNodeAttributes(
 		FragmentEntryLink fragmentEntryLink, long groupId,
 		HttpServletRequest httpServletRequest, InfoField infoField,
@@ -536,7 +545,11 @@ public class FragmentEntryInputTemplateNodeContextHelperImpl
 		InputTemplateNode inputTemplateNode, String label, Locale locale,
 		Locale siteDefaultLocale, String value, Map<Locale, String> valueI18n) {
 
-		if (infoField.getInfoFieldType() instanceof FileInfoFieldType) {
+		if (infoField.getInfoFieldType() instanceof EmailInfoFieldType) {
+			_addEmailInfoFieldTypeInputTemplateNodeAttributes(
+				infoField, inputTemplateNode);
+		}
+		else if (infoField.getInfoFieldType() instanceof FileInfoFieldType) {
 			_addFileInfoFieldTypeInputTemplateNodeAttributes(
 				fragmentEntryLink, groupId, httpServletRequest, infoField,
 				inputTemplateNode, value, valueI18n);

--- a/modules/apps/fragment/fragment-impl/src/main/resources/META-INF/resources/js/api/registerInputFeedback.ts
+++ b/modules/apps/fragment/fragment-impl/src/main/resources/META-INF/resources/js/api/registerInputFeedback.ts
@@ -66,6 +66,24 @@ export function registerInputFeedback({
 		focusInput(inputElement);
 	});
 
+	const clearValidityError = () => {
+		if (
+			formGroup.classList.contains('has-error') &&
+			inputElement.validity.valid
+		) {
+			hideInputError({
+				...errorContainers,
+				message: errorMessageContainer.getAttribute(
+					'data-valid-feedback'
+				),
+			});
+		}
+	};
+
+	inputElement.addEventListener('change', clearValidityError);
+
+	inputElement.addEventListener('input', clearValidityError);
+
 	if (fragmentElement) {
 		fragmentElement.addEventListener('focusout', (event) => {
 			if (

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/exception/InfoFormValidationException.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/exception/InfoFormValidationException.java
@@ -39,6 +39,23 @@ public class InfoFormValidationException extends InfoFormException {
 			locale, "x-an-error-occurred", HtmlUtil.escape(fieldLabel), false);
 	}
 
+	public static class BlockedEmailAddressDomain
+		extends InvalidInfoFieldValue {
+
+		public BlockedEmailAddressDomain(String infoFieldUniqueId) {
+			super(infoFieldUniqueId);
+		}
+
+		@Override
+		public String getLocalizedMessage(Locale locale) {
+			return LanguageUtil.get(
+				locale,
+				"the-email-address-domain-is-not-allowed-enter-an-email-" +
+					"address-with-a-different-domain");
+		}
+
+	}
+
 	public static class CustomValidation extends InfoFormValidationException {
 
 		public CustomValidation(String infoFieldUniqueId, String message) {
@@ -228,6 +245,20 @@ public class InfoFormValidationException extends InfoFormException {
 
 		private final CaptchaException _captchaException;
 		private final long _fragmentEntryLinkId;
+
+	}
+
+	public static class InvalidEmailAddress extends InvalidInfoFieldValue {
+
+		public InvalidEmailAddress(String infoFieldUniqueId) {
+			super(infoFieldUniqueId);
+		}
+
+		@Override
+		public String getLocalizedMessage(Locale locale) {
+			return LanguageUtil.get(
+				locale, "please-enter-a-valid-email-address");
+		}
 
 	}
 

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/field/type/EmailInfoFieldType.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/field/type/EmailInfoFieldType.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.info.field.type;
+
+import java.util.List;
+
+/**
+ * @author Sandro Chinea
+ */
+public class EmailInfoFieldType implements InfoFieldType {
+
+	public static final EmailInfoFieldType INSTANCE = new EmailInfoFieldType();
+
+	public static final Attribute<EmailInfoFieldType, List<String>>
+		PREFERRED_DOMAINS = new Attribute<>();
+
+	@Override
+	public String getName() {
+		return "email";
+	}
+
+	private EmailInfoFieldType() {
+	}
+
+}

--- a/modules/apps/info/info-api/src/main/resources/com/liferay/info/field/type/packageinfo
+++ b/modules/apps/info/info-api/src/main/resources/com/liferay/info/field/type/packageinfo
@@ -1,1 +1,1 @@
-version 6.6.0
+version 6.7.0

--- a/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/request/helper/InfoRequestFieldValuesProviderHelper.java
+++ b/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/request/helper/InfoRequestFieldValuesProviderHelper.java
@@ -13,6 +13,7 @@ import com.liferay.info.field.RelatedInfoFieldValue;
 import com.liferay.info.field.type.BooleanInfoFieldType;
 import com.liferay.info.field.type.DateInfoFieldType;
 import com.liferay.info.field.type.DateTimeInfoFieldType;
+import com.liferay.info.field.type.EmailInfoFieldType;
 import com.liferay.info.field.type.FileInfoFieldType;
 import com.liferay.info.field.type.FriendlyURLInfoFieldType;
 import com.liferay.info.field.type.HTMLInfoFieldType;
@@ -528,7 +529,8 @@ public class InfoRequestFieldValuesProviderHelper {
 			return GetterUtil.getLong(value);
 		}
 
-		if (infoField.getInfoFieldType() instanceof FileInfoFieldType ||
+		if (infoField.getInfoFieldType() instanceof EmailInfoFieldType ||
+			infoField.getInfoFieldType() instanceof FileInfoFieldType ||
 			infoField.getInfoFieldType() instanceof FriendlyURLInfoFieldType ||
 			infoField.getInfoFieldType() instanceof HTMLInfoFieldType ||
 			infoField.getInfoFieldType() instanceof LongTextInfoFieldType ||

--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/field/converter/ObjectFieldInfoFieldConverter.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/field/converter/ObjectFieldInfoFieldConverter.java
@@ -8,6 +8,7 @@ package com.liferay.object.info.field.converter;
 import com.liferay.dynamic.data.mapping.expression.DDMExpressionFactory;
 import com.liferay.info.constants.InfoDisplayWebKeys;
 import com.liferay.info.field.InfoField;
+import com.liferay.info.field.type.EmailInfoFieldType;
 import com.liferay.info.field.type.FileInfoFieldType;
 import com.liferay.info.field.type.LongTextInfoFieldType;
 import com.liferay.info.field.type.MultiselectInfoFieldType;
@@ -65,6 +66,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -185,6 +187,14 @@ public class ObjectFieldInfoFieldConverter {
 			).attribute(
 				NumberInfoFieldType.DECIMAL_PART_MAX_LENGTH, 16
 			);
+		}
+		else if (Objects.equals(
+					objectField.getBusinessType(),
+					ObjectFieldConstants.BUSINESS_TYPE_EMAIL_ADDRESS)) {
+
+			finalStep.attribute(
+				EmailInfoFieldType.PREFERRED_DOMAINS,
+				_getPreferredDomains(objectField));
 		}
 		else if (Objects.equals(
 					objectField.getBusinessType(),
@@ -535,6 +545,23 @@ public class ObjectFieldInfoFieldConverter {
 				Objects.equals(defaultValue, listTypeEntry.getKey()),
 				new FunctionInfoLocalizedValue<>(listTypeEntry::getName),
 				listTypeEntry.getKey()));
+	}
+
+	private List<String> _getPreferredDomains(ObjectField objectField) {
+		if (!GetterUtil.getBoolean(
+				ObjectFieldSettingUtil.getValue(
+					ObjectFieldSettingConstants.NAME_AUTOCOMPLETE_ENABLED,
+					objectField))) {
+
+			return Collections.emptyList();
+		}
+
+		return ListUtil.fromArray(
+			StringUtil.split(
+				ObjectFieldSettingUtil.getValue(
+					ObjectFieldSettingConstants.NAME_AUTOCOMPLETE_DOMAINS,
+					objectField),
+				StringPool.COMMA));
 	}
 
 	private String _getRelationshipLabelFieldName(

--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/field/type/util/ObjectFieldInfoFieldTypeUtil.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/field/type/util/ObjectFieldInfoFieldTypeUtil.java
@@ -8,6 +8,7 @@ package com.liferay.object.info.field.type.util;
 import com.liferay.info.field.type.BooleanInfoFieldType;
 import com.liferay.info.field.type.DateInfoFieldType;
 import com.liferay.info.field.type.DateTimeInfoFieldType;
+import com.liferay.info.field.type.EmailInfoFieldType;
 import com.liferay.info.field.type.FileInfoFieldType;
 import com.liferay.info.field.type.HTMLInfoFieldType;
 import com.liferay.info.field.type.InfoFieldType;
@@ -67,6 +68,12 @@ public class ObjectFieldInfoFieldTypeUtil {
 					 ObjectFieldConstants.BUSINESS_TYPE_PRECISION_DECIMAL)) {
 
 			return NumberInfoFieldType.INSTANCE;
+		}
+		else if (Objects.equals(
+					objectField.getBusinessType(),
+					ObjectFieldConstants.BUSINESS_TYPE_EMAIL_ADDRESS)) {
+
+			return EmailInfoFieldType.INSTANCE;
 		}
 		else if (Objects.equals(
 					objectField.getBusinessType(),

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandler.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandler.java
@@ -124,6 +124,26 @@ public class ObjectEntryInfoItemExceptionRequestHandler {
 		}
 
 		if (exception instanceof
+				ObjectEntryValuesException.BlockedEmailAddressDomain) {
+
+			ObjectEntryValuesException.BlockedEmailAddressDomain
+				objectEntryValuesException =
+					(ObjectEntryValuesException.BlockedEmailAddressDomain)
+						exception;
+
+			String infoFieldUniqueId = _getInfoFieldUniqueId(
+				groupId, infoItemFormProvider, objectDefinition,
+				objectEntryValuesException.getObjectFieldName());
+
+			if (infoFieldUniqueId == null) {
+				throw new InfoFormException();
+			}
+
+			throw new InfoFormValidationException.BlockedEmailAddressDomain(
+				infoFieldUniqueId);
+		}
+
+		if (exception instanceof
 				ObjectEntryValuesException.ExceedsIntegerSize) {
 
 			ObjectEntryValuesException.ExceedsIntegerSize
@@ -234,6 +254,25 @@ public class ObjectEntryInfoItemExceptionRequestHandler {
 
 			throw new InfoFormValidationException.ExceedsMaxLength(
 				infoFieldUniqueId, objectEntryValuesException.getMaxLength());
+		}
+
+		if (exception instanceof
+				ObjectEntryValuesException.InvalidEmailAddress) {
+
+			ObjectEntryValuesException.InvalidEmailAddress
+				objectEntryValuesException =
+					(ObjectEntryValuesException.InvalidEmailAddress)exception;
+
+			String infoFieldUniqueId = _getInfoFieldUniqueId(
+				groupId, infoItemFormProvider, objectDefinition,
+				objectEntryValuesException.getObjectFieldName());
+
+			if (infoFieldUniqueId == null) {
+				throw new InfoFormException();
+			}
+
+			throw new InfoFormValidationException.InvalidEmailAddress(
+				infoFieldUniqueId);
 		}
 
 		if (exception instanceof

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/types/ObjectDefinition.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/types/ObjectDefinition.ts
@@ -11,6 +11,7 @@ export type ObjectField = {
 		| 'Decimal'
 		| 'Date'
 		| 'DateTime'
+		| 'EmailAddress'
 		| 'Integer'
 		| 'MultiselectPicklist'
 		| 'Long'

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/components/AddChildDropdown.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/components/AddChildDropdown.tsx
@@ -49,11 +49,22 @@ export default function AddChildDropdown({
 
 	const {data: objectDefinitions, status} = useCache('object-definitions');
 
-	const fieldTypes = Liferay.FeatureFlags['LPD-70672']
-		? FIELD_TYPES
-		: FIELD_TYPES.filter(
-				(type) => type !== 'email' && type !== 'phone-number'
-			);
+	const phoneNumberEnabled = !!Liferay.FeatureFlags['LPD-70672'];
+
+	const emailEnabled =
+		phoneNumberEnabled && !!Liferay.FeatureFlags['LPD-70673'];
+
+	const fieldTypes = FIELD_TYPES.filter((type) => {
+		if (type === 'email') {
+			return emailEnabled;
+		}
+
+		if (type === 'phone-number') {
+			return phoneNumberEnabled;
+		}
+
+		return true;
+	});
 
 	const addField = (type: Field['type']) =>
 		dispatch({

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/components/field_components/EmailFieldComponents.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/components/field_components/EmailFieldComponents.tsx
@@ -119,7 +119,7 @@ function AdvancedTabComponent({
 							items={toItems(emailField.settings.blockedDomains)}
 							onItemsChange={(items: DomainItem[]) => {
 								updateSettings({
-									blockedDomains: fromItems(items),
+									blockedDomains: toDomains(items),
 								});
 							}}
 						/>
@@ -153,7 +153,8 @@ function AdvancedTabComponent({
 							)}
 							onItemsChange={(items: DomainItem[]) => {
 								updateSettings({
-									autocompleteDomains: fromItems(items),
+									autocompleteDomains: toDomains(items),
+									autocompleteEnabled: Boolean(items.length),
 								});
 							}}
 						/>
@@ -164,10 +165,26 @@ function AdvancedTabComponent({
 	);
 }
 
-function toItems(values?: string[]): DomainItem[] {
-	return (values ?? []).map((value) => ({label: value, value}));
+function toItems(value?: string): DomainItem[] {
+	if (!value) {
+		return [];
+	}
+
+	return value.split(',').map((domain) => ({label: domain, value: domain}));
 }
 
-function fromItems(items: DomainItem[]): string[] {
-	return items.map((item) => item.value);
+function toDomains(items: DomainItem[]): string | undefined {
+	return (
+		items.map((item) => normalizeDomain(item.value)).join(',') || undefined
+	);
+}
+
+function normalizeDomain(value: string): string {
+	const domain = value.trim();
+
+	if (!domain || domain.startsWith('@')) {
+		return domain;
+	}
+
+	return `@${domain}`;
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/buildStructure.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/buildStructure.ts
@@ -311,7 +311,26 @@ function getFieldSettings(objectField: ObjectField): Field['settings'] {
 		objectFieldSettings[objectFieldSetting.name] = objectFieldSetting.value;
 	}
 
-	if (objectField.businessType === 'Attachment') {
+	if (objectField.businessType === 'EmailAddress') {
+		if (objectFieldSettings.autocompleteDomains) {
+			settings.autocompleteDomains =
+				objectFieldSettings.autocompleteDomains;
+		}
+
+		if (objectFieldSettings.autocompleteEnabled) {
+			settings.autocompleteEnabled =
+				objectFieldSettings.autocompleteEnabled;
+		}
+
+		if (objectFieldSettings.blockedDomains) {
+			settings.blockedDomains = objectFieldSettings.blockedDomains;
+		}
+
+		if (objectFieldSettings.uniqueValues) {
+			settings.uniqueValues = objectFieldSettings.uniqueValues;
+		}
+	}
+	else if (objectField.businessType === 'Attachment') {
 		settings.acceptedFileExtensions =
 			objectFieldSettings.acceptedFileExtensions;
 		settings.fileSource = objectFieldSettings.fileSource;
@@ -377,6 +396,7 @@ function getFieldType(objectField: ObjectField): FieldType {
 		Date: 'date',
 		DateTime: 'datetime',
 		Decimal: 'decimal',
+		EmailAddress: 'email',
 		Integer: 'integer',
 		LongText: 'long-text',
 		PhoneNumber: 'phone-number',

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/field.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/field.ts
@@ -94,7 +94,7 @@ export function getFieldBusinessType(
 		case 'decimal':
 			return 'Decimal';
 		case 'email':
-			return 'Text';
+			return 'EmailAddress';
 		case 'integer':
 			return 'Integer';
 		case 'long-text':
@@ -170,8 +170,9 @@ export type DateTimeField = BaseField & {
 
 export type EmailField = BaseField & {
 	settings: {
-		autocompleteDomains?: string[];
-		blockedDomains?: string[];
+		autocompleteDomains?: string;
+		autocompleteEnabled?: boolean;
+		blockedDomains?: string;
 	};
 	type: 'email';
 } & UniqueValuesSettingsField;

--- a/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/utils/buildObjectDefinition.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/utils/buildObjectDefinition.test.ts
@@ -40,6 +40,25 @@ const DATE_TIME_FIELD: Field = {
 	uuid: getUuid(),
 };
 
+const EMAIL_FIELD: Field = {
+	erc: 'email-field',
+	indexableConfig: {indexed: false},
+	label: {en_US: 'Email Field'},
+	localized: false,
+	locked: false,
+	name: 'emailField',
+	parent: getUuid(),
+	required: false,
+	settings: {
+		autocompleteDomains: '@liferay.com,@gmail.com',
+		autocompleteEnabled: true,
+		blockedDomains: '@example.com',
+		uniqueValues: true,
+	},
+	type: 'email',
+	uuid: getUuid(),
+};
+
 const TEXT_FIELD: Field = {
 	erc: 'text-field',
 	indexableConfig: {indexed: true, indexedAsKeyword: true},
@@ -209,6 +228,60 @@ describe('buildObjectDefinition', () => {
 			},
 			titleObjectFieldName: 'title',
 		});
+	});
+
+	it('builds an email field as an EmailAddress business type with its connected settings', () => {
+		const result = buildObjectDefinition({
+			children: getChildren([EMAIL_FIELD]),
+			erc: 'structureERC',
+			label: {en_US: 'Structure'},
+			name: 'myStructure',
+			spaces: [],
+			status: 'draft',
+		});
+
+		expect(result.objectFields).toEqual([
+			{
+				DBType: 'String',
+				businessType: 'EmailAddress',
+				externalReferenceCode: 'email-field',
+				indexed: false,
+				label: {en_US: 'Email Field'},
+				localized: false,
+				name: 'emailField',
+				objectFieldSettings: [
+					{
+						name: 'autocompleteDomains',
+						value: '@liferay.com,@gmail.com',
+					},
+					{name: 'autocompleteEnabled', value: true},
+					{name: 'blockedDomains', value: '@example.com'},
+					{name: 'uniqueValues', value: true},
+				],
+				required: false,
+				system: false,
+			},
+		]);
+	});
+
+	it('omits autocomplete settings when the email field has no autocomplete domains', () => {
+		const result = buildObjectDefinition({
+			children: getChildren([
+				{
+					...EMAIL_FIELD,
+					settings: {blockedDomains: '@example.com'},
+				},
+			]),
+			erc: 'structureERC',
+			label: {en_US: 'Structure'},
+			name: 'myStructure',
+			spaces: [],
+			status: 'draft',
+		});
+
+		expect(result.objectFields?.[0].objectFieldSettings).toEqual([
+			{name: 'blockedDomains', value: '@example.com'},
+		]);
 	});
 
 	it('builds objectDefinition with spaces and workflows selected', () => {

--- a/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/utils/buildStructure.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/utils/buildStructure.test.ts
@@ -85,6 +85,24 @@ const SAMPLE_STRUCTURE_FIELDS: Field[] = [
 		uuid: getUuid(),
 	},
 	{
+		erc: 'email-field',
+		indexableConfig: {indexed: false},
+		label: {en_US: 'email-field'},
+		localized: false,
+		locked: false,
+		name: 'email-field',
+		parent,
+		required: false,
+		settings: {
+			autocompleteDomains: '@liferay.com',
+			autocompleteEnabled: true,
+			blockedDomains: '@example.com',
+			uniqueValues: true,
+		},
+		type: 'email',
+		uuid: getUuid(),
+	},
+	{
 		erc: 'integer-field',
 		indexableConfig: {indexed: false},
 		label: {en_US: 'integer-field'},
@@ -245,6 +263,37 @@ describe('buildStructure', () => {
 				expect.objectContaining({type})
 			);
 		}
+	});
+
+	it('Restores email field settings from the EmailAddress business type', () => {
+		const objectDefinition = buildObjectDefinition({
+			children: getChildren(SAMPLE_STRUCTURE_FIELDS),
+			erc: 'main-structure-erc',
+			label: {en_US: 'Main Structure'},
+			name: 'mainStructure',
+			spaces: [],
+		});
+
+		const structure = buildStructure({
+			mainObjectDefinition: objectDefinition,
+			objectDefinitions: {},
+		});
+
+		const emailField = Array.from(structure.children.values()).find(
+			(child) => child.erc === 'email-field'
+		);
+
+		expect(emailField).toEqual(
+			expect.objectContaining({
+				settings: {
+					autocompleteDomains: '@liferay.com',
+					autocompleteEnabled: true,
+					blockedDomains: '@example.com',
+					uniqueValues: true,
+				},
+				type: 'email',
+			})
+		);
 	});
 
 	it('Includes allowed system fields for L_CMS_BLOG and filters unknown ones', () => {

--- a/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/emailField.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/emailField.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
+import {getRandomInt} from '../../../utils/getRandomInt';
+import getRandomString from '../../../utils/getRandomString';
+import {cmsPagesTest} from '../main/fixtures/cmsPagesTest';
+import {structureBuilderPagesTest} from './fixtures/structureBuilderPagesTest';
+import {FieldType} from './pages/StructureBuilderPage';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+		'LPD-70672': {enabled: true},
+		'LPD-70673': {enabled: true},
+	}),
+	loginTest(),
+	structureBuilderPagesTest
+);
+
+test(
+	'Email field maps to the EmailAddress business type, round-trips its domain settings and enforces blocked domains',
+	{tag: ['@LPD-91039']},
+	async ({contentsPage, page, structureBuilderPage}) => {
+		const structureLabel = `Structure${getRandomInt()}`;
+		const validTitle = getRandomString();
+		const blockedTitle = getRandomString();
+
+		// Create a structure with an Email field
+
+		await structureBuilderPage.createStructureFromData({
+			label: structureLabel,
+			name: structureLabel,
+			page: structureBuilderPage,
+		});
+
+		await structureBuilderPage.addField('Email' as FieldType);
+
+		// Accept Unique Values Only lives in the General tab
+
+		await page
+			.getByRole('checkbox', {name: 'Accept Unique Values Only'})
+			.check();
+
+		// Blocked and autocomplete domains live in the Advanced tab. The UI
+		// prepends "@" automatically, so the user can type the bare domain
+
+		await page.getByRole('tab', {name: 'Advanced'}).click();
+
+		const blockedDomains = page.getByRole('combobox', {
+			name: 'Blocked Domains',
+		});
+
+		await blockedDomains.fill('gmail.com');
+		await blockedDomains.press('Enter');
+
+		const autocompleteDomains = page.getByRole('combobox', {
+			exact: true,
+			name: 'Domains',
+		});
+
+		await autocompleteDomains.fill('liferay.com');
+		await autocompleteDomains.press('Enter');
+
+		// Publishing serializes the field as the EmailAddress business type with
+		// its settings — the Objects backend would reject it otherwise
+
+		const structureId = await structureBuilderPage.publishStructure();
+
+		// Reopen the structure: the settings round-trip through the Objects
+		// backend and are restored in the builder
+
+		await structureBuilderPage.editStructure(structureId);
+
+		await structureBuilderPage.selectFields([{label: 'Email'}]);
+
+		await expect(
+			page.getByRole('checkbox', {name: 'Accept Unique Values Only'})
+		).toBeChecked();
+
+		await page.getByRole('tab', {name: 'Advanced'}).click();
+
+		await expect(
+			page.getByRole('gridcell', {exact: true, name: '@gmail.com'})
+		).toBeVisible();
+
+		await expect(
+			page.getByRole('gridcell', {exact: true, name: '@liferay.com'})
+		).toBeVisible();
+
+		// A valid, non-blocked email is stored
+
+		await contentsPage.goto();
+
+		await contentsPage.createContent(structureLabel);
+
+		await contentsPage.fillData([
+			{label: 'Title', value: validTitle},
+			{label: 'Email', value: 'user@liferay.com'},
+		]);
+
+		await contentsPage.saveContent();
+
+		// An email with a blocked domain is rejected by the backend
+
+		await contentsPage.createContent(structureLabel);
+
+		await contentsPage.fillData([
+			{label: 'Title', value: blockedTitle},
+			{label: 'Email', value: 'user@gmail.com'},
+		]);
+
+		await clickAndExpectToBeVisible({
+			target: page.getByText('The Email is invalid.'),
+			trigger: contentsPage.publishButton,
+		});
+
+		// The backend error is surfaced on the email fragment
+
+		await expect(
+			page.getByText(
+				'The email address domain is not allowed. Enter an email ' +
+					'address with a different domain.'
+			)
+		).toBeVisible();
+
+		// Cleanup — the structure is auto-deleted, but its stored content is not
+
+		await contentsPage.goto();
+
+		await contentsPage.deleteContent(validTitle);
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91039

## What Is Being Fixed

Email fields in the CMS structure builder were not wired to the Objects
backend. The builder could not create or load email object fields, the email
input fragment ignored the configured domains, and submitted email values were
not validated, so blocked domains and malformed addresses produced no
descriptive feedback.

## How It Is Being Fixed

Email object fields now map to a new EmailInfoFieldType built on the
EmailAddress business type, gated behind the Objects backend feature flag. The
structure builder builds and loads email object definitions and renders them
through the email input fragment, prepending "@" to each configured domain and
feeding the configured domains into the fragment. On submit, the field value is
read and validated; blocked domains and invalid addresses raise descriptive
InfoFormValidationException errors, and the input error clears as soon as the
value becomes valid again. Coverage comes from a Playwright spec and Jest unit
tests.

## PR Check

**pr-check: PASS** — tested on `1ff91b0ac584a373fc5e88c5ac33ad253ef500bb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "1ff91b0ac584a373fc5e88c5ac33ad253ef500bb"} -->
