### PR TITLE
LPD-95298 Report missing references with the correct asset class name

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/CollectionUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/CollectionUtil.java
@@ -288,7 +288,9 @@ public class CollectionUtil {
 				InfoItemFormVariationsProvider.class, className);
 
 		if (infoItemFormVariationsProvider == null) {
-			LogUtil.logOptionalReference(itemExternalReference, scopeGroupId);
+			LogUtil.logOptionalReference(
+				className, itemExternalReference.getExternalReferenceCode(),
+				itemExternalReference.getScope(), scopeGroupId);
 
 			return null;
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/FragmentEntryReferenceUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/FragmentEntryReferenceUtil.java
@@ -67,7 +67,7 @@ public class FragmentEntryReferenceUtil {
 
 			if (fragmentEntry == null) {
 				LogUtil.logOptionalReference(
-					fragmentItemExternalReference.getClassName(),
+					FragmentEntry.class.getName(),
 					fragmentItemExternalReference.getExternalReferenceCode(),
 					fragmentItemExternalReference.getScope(), scopeGroupId);
 			}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/SubtypeUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/SubtypeUtil.java
@@ -30,7 +30,9 @@ public class SubtypeUtil {
 				InfoItemFormVariationsProvider.class, className);
 
 		if (infoItemFormVariationsProvider == null) {
-			LogUtil.logOptionalReference(itemExternalReference, groupId);
+			LogUtil.logOptionalReference(
+				className, itemExternalReference.getExternalReferenceCode(),
+				itemExternalReference.getScope(), groupId);
 
 			return itemExternalReference.getExternalReferenceCode();
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/test/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/CollectionUtilTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/test/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/CollectionUtilTest.java
@@ -7,9 +7,16 @@ package com.liferay.headless.admin.site.internal.dto.v1_0.util;
 
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.headless.admin.site.dto.v1_0.ClassNameReference;
+import com.liferay.headless.admin.site.dto.v1_0.ItemExternalReference;
+import com.liferay.headless.admin.site.dto.v1_0.RepeatableFieldsCollectionProviderReference;
+import com.liferay.headless.admin.site.internal.util.LogUtil;
 import com.liferay.info.collection.provider.InfoCollectionProvider;
 import com.liferay.info.collection.provider.RelatedInfoItemCollectionProvider;
+import com.liferay.info.collection.provider.RepeatableFieldInfoItemCollectionProvider;
 import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.item.InfoItemServiceRegistryUtil;
+import com.liferay.info.item.provider.InfoItemFormVariationsProvider;
+import com.liferay.info.item.provider.RepeatableFieldsInfoItemFormProvider;
 import com.liferay.info.list.provider.item.selector.criterion.InfoListProviderItemSelectorReturnType;
 import com.liferay.object.constants.ObjectDefinitionSettingConstants;
 import com.liferay.object.model.ObjectDefinition;
@@ -18,6 +25,7 @@ import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectDefinitionSettingLocalServiceUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -46,6 +54,8 @@ public class CollectionUtilTest {
 	public static void tearDownClass() {
 		_companyThreadLocalMockedStatic.close();
 		_exportImportThreadLocalMockedStatic.close();
+		_infoItemServiceRegistryUtilMockedStatic.close();
+		_logUtilMockedStatic.close();
 		_objectDefinitionLocalServiceUtilMockedStatic.close();
 		_objectDefinitionSettingLocalServiceUtilMockedStatic.close();
 	}
@@ -121,6 +131,73 @@ public class CollectionUtilTest {
 		);
 	}
 
+	@Test
+	@TestInfo("LPD-95298")
+	public void testGetCollectionJSONObjectWithRepeatableFieldsCollectionProviderReference()
+		throws Exception {
+
+		String className = RandomTestUtil.randomString();
+		String externalReferenceCode = RandomTestUtil.randomString();
+		long scopeGroupId = RandomTestUtil.randomLong();
+
+		_infoItemServiceRegistryUtilMockedStatic.when(
+			() -> InfoItemServiceRegistryUtil.getFirstInfoItemService(
+				RepeatableFieldsInfoItemFormProvider.class, className)
+		).thenReturn(
+			Mockito.mock(RepeatableFieldsInfoItemFormProvider.class)
+		);
+
+		_infoItemServiceRegistryUtilMockedStatic.when(
+			() -> InfoItemServiceRegistryUtil.getFirstInfoItemService(
+				InfoItemFormVariationsProvider.class, className)
+		).thenReturn(
+			Mockito.mock(InfoItemFormVariationsProvider.class)
+		);
+
+		JSONObject jsonObject = CollectionUtil.getCollectionJSONObject(
+			_getRepeatableFieldsCollectionProviderReference(
+				className, externalReferenceCode),
+			_COMPANY_ID, _infoItemServiceRegistry, scopeGroupId);
+
+		Assert.assertEquals(
+			externalReferenceCode, jsonObject.getString("itemSubtypeKey"));
+		Assert.assertEquals(className, jsonObject.getString("itemType"));
+		Assert.assertEquals(
+			RepeatableFieldInfoItemCollectionProvider.class.getName(),
+			jsonObject.getString("key"));
+
+		_logUtilMockedStatic.verify(
+			() -> LogUtil.logOptionalReference(
+				Mockito.eq(className), Mockito.eq(externalReferenceCode),
+				Mockito.any(), Mockito.eq(scopeGroupId)),
+			Mockito.never());
+
+		_infoItemServiceRegistryUtilMockedStatic.when(
+			() -> InfoItemServiceRegistryUtil.getFirstInfoItemService(
+				InfoItemFormVariationsProvider.class, className)
+		).thenReturn(
+			null
+		);
+
+		jsonObject = CollectionUtil.getCollectionJSONObject(
+			_getRepeatableFieldsCollectionProviderReference(
+				className, externalReferenceCode),
+			_COMPANY_ID, _infoItemServiceRegistry, scopeGroupId);
+
+		Assert.assertEquals(
+			externalReferenceCode, jsonObject.getString("itemSubtypeKey"));
+		Assert.assertEquals(className, jsonObject.getString("itemType"));
+		Assert.assertEquals(
+			RepeatableFieldInfoItemCollectionProvider.class.getName(),
+			jsonObject.getString("key"));
+
+		_logUtilMockedStatic.verify(
+			() -> LogUtil.logOptionalReference(
+				Mockito.eq(className), Mockito.eq(externalReferenceCode),
+				Mockito.any(), Mockito.eq(scopeGroupId)),
+			Mockito.times(2));
+	}
+
 	private void _assertCollectionJSONObject(JSONObject jsonObject) {
 		Assert.assertEquals(_OLD_CLASS_NAME, jsonObject.getString("itemType"));
 		Assert.assertEquals(_KEY, jsonObject.getString("key"));
@@ -136,6 +213,28 @@ public class CollectionUtilTest {
 		classNameReference.setClassName(() -> _OLD_CLASS_NAME);
 
 		return classNameReference;
+	}
+
+	private RepeatableFieldsCollectionProviderReference
+		_getRepeatableFieldsCollectionProviderReference(
+			String className, String externalReferenceCode) {
+
+		RepeatableFieldsCollectionProviderReference
+			repeatableFieldsCollectionProviderReference =
+				new RepeatableFieldsCollectionProviderReference();
+
+		ItemExternalReference itemExternalReference =
+			new ItemExternalReference();
+
+		itemExternalReference.setExternalReferenceCode(externalReferenceCode);
+
+		repeatableFieldsCollectionProviderReference.setClassName(className);
+		repeatableFieldsCollectionProviderReference.setFieldName(
+			RandomTestUtil.randomString());
+		repeatableFieldsCollectionProviderReference.setSubTypeExternalReference(
+			itemExternalReference);
+
+		return repeatableFieldsCollectionProviderReference;
 	}
 
 	private void _setUpCompanyThreadLocal() {
@@ -269,6 +368,11 @@ public class CollectionUtilTest {
 	private static final MockedStatic<ExportImportThreadLocal>
 		_exportImportThreadLocalMockedStatic = Mockito.mockStatic(
 			ExportImportThreadLocal.class);
+	private static final MockedStatic<InfoItemServiceRegistryUtil>
+		_infoItemServiceRegistryUtilMockedStatic = Mockito.mockStatic(
+			InfoItemServiceRegistryUtil.class);
+	private static final MockedStatic<LogUtil> _logUtilMockedStatic =
+		Mockito.mockStatic(LogUtil.class);
 	private static final MockedStatic<ObjectDefinitionLocalServiceUtil>
 		_objectDefinitionLocalServiceUtilMockedStatic = Mockito.mockStatic(
 			ObjectDefinitionLocalServiceUtil.class);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/test/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/FragmentEntryReferenceUtilTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/test/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/FragmentEntryReferenceUtilTest.java
@@ -1,0 +1,153 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.dto.v1_0.util;
+
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.service.FragmentEntryLocalServiceUtil;
+import com.liferay.headless.admin.site.dto.v1_0.FragmentItemExternalReference;
+import com.liferay.headless.admin.site.dto.v1_0.FragmentReference;
+import com.liferay.headless.admin.site.internal.util.LogUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Alberto Javier Moreno Lage
+ */
+public class FragmentEntryReferenceUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@AfterClass
+	public static void tearDownClass() {
+		_fragmentEntryLocalServiceUtilMockedStatic.close();
+		_itemScopeUtilMockedStatic.close();
+		_logUtilMockedStatic.close();
+	}
+
+	@Before
+	public void setUp() {
+		_itemScopeUtilMockedStatic.when(
+			() -> ItemScopeUtil.getItemGroupId(
+				Mockito.anyLong(), Mockito.any(), Mockito.anyLong())
+		).thenReturn(
+			_SCOPE_GROUP_ID
+		);
+	}
+
+	@Test
+	public void testGetFragmentEntryReferenceWhenFragmentEntryIsFound()
+		throws Exception {
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+		String fragmentEntryKey = RandomTestUtil.randomString();
+
+		FragmentEntry fragmentEntry = Mockito.mock(FragmentEntry.class);
+
+		Mockito.when(
+			fragmentEntry.getFragmentEntryKey()
+		).thenReturn(
+			fragmentEntryKey
+		);
+
+		_fragmentEntryLocalServiceUtilMockedStatic.when(
+			() ->
+				FragmentEntryLocalServiceUtil.
+					fetchFragmentEntryByExternalReferenceCode(
+						externalReferenceCode, _SCOPE_GROUP_ID)
+		).thenReturn(
+			fragmentEntry
+		);
+
+		FragmentEntryReference fragmentEntryReference =
+			FragmentEntryReferenceUtil.getFragmentEntryReference(
+				_COMPANY_ID,
+				_getFragmentItemExternalReference(externalReferenceCode),
+				_SCOPE_GROUP_ID);
+
+		Assert.assertEquals(
+			externalReferenceCode,
+			fragmentEntryReference.getFragmentEntryERC());
+		Assert.assertEquals(
+			fragmentEntryKey, fragmentEntryReference.getFragmentEntryKey());
+	}
+
+	@Test
+	public void testGetFragmentEntryReferenceWhenFragmentEntryIsMissing()
+		throws Exception {
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		_fragmentEntryLocalServiceUtilMockedStatic.when(
+			() ->
+				FragmentEntryLocalServiceUtil.
+					fetchFragmentEntryByExternalReferenceCode(
+						externalReferenceCode, _SCOPE_GROUP_ID)
+		).thenReturn(
+			null
+		);
+
+		FragmentEntryReference fragmentEntryReference =
+			FragmentEntryReferenceUtil.getFragmentEntryReference(
+				_COMPANY_ID,
+				_getFragmentItemExternalReference(externalReferenceCode),
+				_SCOPE_GROUP_ID);
+
+		Assert.assertEquals(
+			externalReferenceCode,
+			fragmentEntryReference.getFragmentEntryERC());
+		Assert.assertNull(fragmentEntryReference.getFragmentEntryKey());
+
+		// A missing fragment item external reference must be reported as a
+		// FragmentEntry, never with a null class name
+
+		_logUtilMockedStatic.verify(
+			() -> LogUtil.logOptionalReference(
+				Mockito.eq(FragmentEntry.class.getName()),
+				Mockito.eq(externalReferenceCode), Mockito.any(),
+				Mockito.eq(_SCOPE_GROUP_ID)));
+	}
+
+	private FragmentItemExternalReference _getFragmentItemExternalReference(
+		String externalReferenceCode) {
+
+		FragmentItemExternalReference fragmentItemExternalReference =
+			new FragmentItemExternalReference();
+
+		fragmentItemExternalReference.setExternalReferenceCode(
+			externalReferenceCode);
+		fragmentItemExternalReference.setFragmentReferenceType(
+			FragmentReference.FragmentReferenceType.
+				FRAGMENT_ITEM_EXTERNAL_REFERENCE);
+
+		return fragmentItemExternalReference;
+	}
+
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
+
+	private static final long _SCOPE_GROUP_ID = RandomTestUtil.randomLong();
+
+	private static final MockedStatic<FragmentEntryLocalServiceUtil>
+		_fragmentEntryLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			FragmentEntryLocalServiceUtil.class);
+	private static final MockedStatic<ItemScopeUtil>
+		_itemScopeUtilMockedStatic = Mockito.mockStatic(ItemScopeUtil.class);
+	private static final MockedStatic<LogUtil> _logUtilMockedStatic =
+		Mockito.mockStatic(LogUtil.class);
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/test/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/FragmentEntryReferenceUtilTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/test/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/FragmentEntryReferenceUtilTest.java
@@ -51,9 +51,7 @@ public class FragmentEntryReferenceUtilTest {
 	}
 
 	@Test
-	public void testGetFragmentEntryReferenceWhenFragmentEntryIsFound()
-		throws Exception {
-
+	public void testGetFragmentEntryReference() throws Exception {
 		String externalReferenceCode = RandomTestUtil.randomString();
 		String fragmentEntryKey = RandomTestUtil.randomString();
 
@@ -85,13 +83,13 @@ public class FragmentEntryReferenceUtilTest {
 			fragmentEntryReference.getFragmentEntryERC());
 		Assert.assertEquals(
 			fragmentEntryKey, fragmentEntryReference.getFragmentEntryKey());
-	}
 
-	@Test
-	public void testGetFragmentEntryReferenceWhenFragmentEntryIsMissing()
-		throws Exception {
-
-		String externalReferenceCode = RandomTestUtil.randomString();
+		_logUtilMockedStatic.verify(
+			() -> LogUtil.logOptionalReference(
+				Mockito.eq(FragmentEntry.class.getName()),
+				Mockito.eq(externalReferenceCode), Mockito.any(),
+				Mockito.eq(_SCOPE_GROUP_ID)),
+			Mockito.never());
 
 		_fragmentEntryLocalServiceUtilMockedStatic.when(
 			() ->
@@ -102,7 +100,7 @@ public class FragmentEntryReferenceUtilTest {
 			null
 		);
 
-		FragmentEntryReference fragmentEntryReference =
+		fragmentEntryReference =
 			FragmentEntryReferenceUtil.getFragmentEntryReference(
 				_COMPANY_ID,
 				_getFragmentItemExternalReference(externalReferenceCode),
@@ -112,9 +110,6 @@ public class FragmentEntryReferenceUtilTest {
 			externalReferenceCode,
 			fragmentEntryReference.getFragmentEntryERC());
 		Assert.assertNull(fragmentEntryReference.getFragmentEntryKey());
-
-		// A missing fragment item external reference must be reported as a
-		// FragmentEntry, never with a null class name
 
 		_logUtilMockedStatic.verify(
 			() -> LogUtil.logOptionalReference(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/test/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/FragmentEntryReferenceUtilTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/test/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/FragmentEntryReferenceUtilTest.java
@@ -10,6 +10,7 @@ import com.liferay.fragment.service.FragmentEntryLocalServiceUtil;
 import com.liferay.headless.admin.site.dto.v1_0.FragmentItemExternalReference;
 import com.liferay.headless.admin.site.dto.v1_0.FragmentReference;
 import com.liferay.headless.admin.site.internal.util.LogUtil;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
@@ -51,6 +52,7 @@ public class FragmentEntryReferenceUtilTest {
 	}
 
 	@Test
+	@TestInfo("LPD-95298")
 	public void testGetFragmentEntryReference() throws Exception {
 		String externalReferenceCode = RandomTestUtil.randomString();
 		String fragmentEntryKey = RandomTestUtil.randomString();

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/test/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/SubtypeUtilTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/test/java/com/liferay/headless/admin/site/internal/dto/v1_0/util/SubtypeUtilTest.java
@@ -1,0 +1,95 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.dto.v1_0.util;
+
+import com.liferay.headless.admin.site.dto.v1_0.ItemExternalReference;
+import com.liferay.headless.admin.site.internal.util.LogUtil;
+import com.liferay.info.item.InfoItemServiceRegistryUtil;
+import com.liferay.info.item.provider.InfoItemFormVariationsProvider;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public class SubtypeUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@AfterClass
+	public static void tearDownClass() {
+		_infoItemServiceRegistryUtilMockedStatic.close();
+		_logUtilMockedStatic.close();
+	}
+
+	@Test
+	@TestInfo("LPD-95298")
+	public void testGetClassTypeKey() {
+		String className = RandomTestUtil.randomString();
+		String externalReferenceCode = RandomTestUtil.randomString();
+		long groupId = RandomTestUtil.randomLong();
+
+		ItemExternalReference itemExternalReference =
+			new ItemExternalReference();
+
+		itemExternalReference.setExternalReferenceCode(externalReferenceCode);
+
+		_infoItemServiceRegistryUtilMockedStatic.when(
+			() -> InfoItemServiceRegistryUtil.getFirstInfoItemService(
+				InfoItemFormVariationsProvider.class, className)
+		).thenReturn(
+			Mockito.mock(InfoItemFormVariationsProvider.class)
+		);
+
+		Assert.assertEquals(
+			externalReferenceCode,
+			SubtypeUtil.getClassTypeKey(
+				className, groupId, itemExternalReference));
+
+		_logUtilMockedStatic.verify(
+			() -> LogUtil.logOptionalReference(
+				Mockito.eq(className), Mockito.eq(externalReferenceCode),
+				Mockito.any(), Mockito.eq(groupId)),
+			Mockito.never());
+
+		_infoItemServiceRegistryUtilMockedStatic.when(
+			() -> InfoItemServiceRegistryUtil.getFirstInfoItemService(
+				InfoItemFormVariationsProvider.class, className)
+		).thenReturn(
+			null
+		);
+
+		Assert.assertEquals(
+			externalReferenceCode,
+			SubtypeUtil.getClassTypeKey(
+				className, groupId, itemExternalReference));
+
+		_logUtilMockedStatic.verify(
+			() -> LogUtil.logOptionalReference(
+				Mockito.eq(className), Mockito.eq(externalReferenceCode),
+				Mockito.any(), Mockito.eq(groupId)));
+	}
+
+	private static final MockedStatic<InfoItemServiceRegistryUtil>
+		_infoItemServiceRegistryUtilMockedStatic = Mockito.mockStatic(
+			InfoItemServiceRegistryUtil.class);
+	private static final MockedStatic<LogUtil> _logUtilMockedStatic =
+		Mockito.mockStatic(LogUtil.class);
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95298

## What Is Being Fixed

During a site import, references that cannot be resolved to an existing entity were being logged with the wrong class name — for fragment references the literal class name carried in the import payload was used instead of `FragmentEntry`, and for class subtype references and repeatable-field form variation references the asset class name was missing from the log entry. The result is a warning that does not identify the entity type the import was looking for, which makes the missing reference hard to act on.

## How It Is Being Fixed

`FragmentEntryReferenceUtil` now reports unresolved fragment references using `FragmentEntry.class.getName()` as the asset class name instead of the value from the import payload. `SubtypeUtil` and `CollectionUtil` (the repeatable-fields branch) now pass the asset class name explicitly into `LogUtil.logOptionalReference`, so the warning identifies which entity type was being resolved. Each fix carries its own unit test under the module's `internal/dto/v1_0/util` test package.

## PR Check

**pr-check: PASS** — tested on `2486f157aae80bffe5f81f42dd709bcb562ada11`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "2486f157aae80bffe5f81f42dd709bcb562ada11"} -->
