### PR TITLE
LPD-95772 Recompute page structure tree drop target during drag

### DIFF
--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -886,17 +886,6 @@ export class PageEditorPage {
 			{steps: 5}
 		);
 
-		// Calculate drop data
-
-		const targetBox = await targetNode.boundingBox();
-
-		const y =
-			position === 'middle'
-				? targetBox.height / 2
-				: position === 'bottom'
-					? targetBox.height - 2
-					: 2;
-
 		const cssClass =
 			position === 'middle'
 				? /drag-over-middle/
@@ -904,14 +893,23 @@ export class PageEditorPage {
 					? /drag-over-bottom/
 					: /drag-over-top/;
 
-		const approachY = position === 'top' ? y + 4 : y - 4;
-
-		// Move over the target until the drop indicator appears. Each pass
-		// moves to a nearby point first and then to the real drop point, so
-		// the pointer position always changes and Chromium keeps firing
-		// dragover events.
+		// Move over the target until the drop indicator appears. The target
+		// box is recomputed on every pass because starting the drag can shift
+		// the tree. Each pass also approaches from a nearby point so the
+		// pointer keeps moving and Chromium keeps firing dragover events.
 
 		await expect(async () => {
+			const targetBox = await targetNode.boundingBox();
+
+			const y =
+				position === 'middle'
+					? targetBox.height / 2
+					: position === 'bottom'
+						? targetBox.height - 2
+						: 2;
+
+			const approachY = position === 'top' ? y + 4 : y - 4;
+
 			await this.page.mouse.move(
 				targetBox.x + targetBox.width / 2,
 				targetBox.y + approachY,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95772

## What Is Being Fixed

The Playwright test "Check correct item is selected when dragging into a collection item from tree" in layout-content-page-editor-web failed deterministically. The dragTreeNode helper in PageEditorPage.ts captured the drop target's bounding box once and reused it across its retry loop. Starting the drag selects the source node, which auto-expands a fragment that has editable children (Heading reveals its element-text child). That inserts a row and shifts the collection item down, so the cached coordinates pointed at the wrong node, the drop indicator never appeared, and the test timed out. A sibling test passed only because its source is a widget with no children to expand.

## How It Is Being Fixed

The target bounding box is now recomputed on every pass of the retry loop, so the pointer re-aims after the tree settles instead of reusing a stale position.

## Why Are There No Tests?

This change fixes the Playwright test harness itself (a page-object helper) to repair an existing test rather than adding product code. The fix is validated by the previously failing test now passing 10 out of 10 consecutive runs, with no regression in the other dragTreeNode-based tests.

## PR Check

**pr-check: PASS** — tested on `78d9b4d4bf0dc01fa1ae2c7bfdfdfa19bedcd83d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "78d9b4d4bf0dc01fa1ae2c7bfdfdfa19bedcd83d"} -->
