### PR TITLE
LPD-95510 Avoid silently flipping published layouts to draft on fragment publish

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-drop-zone/src/main/java/com/liferay/fragment/entry/processor/drop/zone/listener/DropZoneFragmentEntryLinkListener.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-drop-zone/src/main/java/com/liferay/fragment/entry/processor/drop/zone/listener/DropZoneFragmentEntryLinkListener.java
@@ -13,7 +13,6 @@ import com.liferay.fragment.processor.FragmentEntryProcessorRegistry;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
 import com.liferay.layout.page.template.util.CheckUnlockedLayoutThreadLocal;
-import com.liferay.layout.util.UpdateLayoutStatusThreadLocal;
 import com.liferay.layout.util.structure.DeletedLayoutStructureItem;
 import com.liferay.layout.util.structure.FragmentDropZoneLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
@@ -419,12 +418,9 @@ public class DropZoneFragmentEntryLinkListener
 		}
 
 		if (update) {
-			try (SafeCloseable safeCloseable1 =
+			try (SafeCloseable safeCloseable =
 					CheckUnlockedLayoutThreadLocal.
-						setCheckUnlockedLayoutWithSafeCloseable(false);
-				SafeCloseable safeCloseable2 =
-					UpdateLayoutStatusThreadLocal.
-						setUpdateLayoutStatusWithSafeCloseable(false)) {
+						setCheckUnlockedLayoutWithSafeCloseable(false)) {
 
 				_layoutPageTemplateStructureLocalService.
 					updateLayoutPageTemplateStructureData(

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -737,9 +737,12 @@ public class FragmentEntryLinkLocalServiceImpl
 			fragmentEntryLink);
 
 		if (modified) {
-			try (SafeCloseable safeCloseable =
+			try (SafeCloseable safeCloseable1 =
 					CheckNoninstanceablePortletThreadLocal.
-						setCheckNoninstanceablePortletWithSafeCloseable(true)) {
+						setCheckNoninstanceablePortletWithSafeCloseable(true);
+				SafeCloseable safeCloseable2 =
+					UpdateLayoutStatusThreadLocal.
+						setUpdateLayoutStatusWithSafeCloseable(false)) {
 
 				_updateFragmentEntryLinkLayout(fragmentEntryLink);
 

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/PublishFragmentEntryMVCActionCommandTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/PublishFragmentEntryMVCActionCommandTest.java
@@ -21,7 +21,6 @@ import com.liferay.layout.util.LayoutServiceContextHelper;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.Language;
@@ -224,7 +223,7 @@ public class PublishFragmentEntryMVCActionCommandTest {
 	}
 
 	private FragmentEntry _getFragmentEntry(String configuration, String html)
-		throws PortalException {
+		throws Exception {
 
 		return _fragmentEntryLocalService.addFragmentEntry(
 			null, TestPropsValues.getUserId(), _group.getGroupId(),

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/PublishFragmentEntryMVCActionCommandTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/PublishFragmentEntryMVCActionCommandTest.java
@@ -16,6 +16,7 @@ import com.liferay.fragment.service.FragmentEntryLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.layout.util.LayoutServiceContextHelper;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -149,9 +150,14 @@ public class PublishFragmentEntryMVCActionCommandTest {
 			fragmentEntry = _fragmentEntryLocalService.updateFragmentEntry(
 				fragmentEntry);
 
-			_mvcActionCommand.processAction(
-				_getActionRequest(fragmentEntry),
-				new MockLiferayPortletActionResponse());
+			try (AutoCloseable autoCloseable =
+					_layoutServiceContextHelper.getServiceContextAutoCloseable(
+						layout, TestPropsValues.getUser())) {
+
+				_mvcActionCommand.processAction(
+					_getActionRequest(fragmentEntry),
+					new MockLiferayPortletActionResponse());
+			}
 
 			Layout updatedLayout = _layoutLocalService.getLayout(
 				layout.getPlid());
@@ -240,6 +246,9 @@ public class PublishFragmentEntryMVCActionCommandTest {
 	@Inject
 	private LayoutPageTemplateStructureLocalService
 		_layoutPageTemplateStructureLocalService;
+
+	@Inject
+	private LayoutServiceContextHelper _layoutServiceContextHelper;
 
 	@Inject(filter = "mvc.command.name=/fragment/publish_fragment_entry")
 	private MVCActionCommand _mvcActionCommand;

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/PublishFragmentEntryMVCActionCommandTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/PublishFragmentEntryMVCActionCommandTest.java
@@ -16,8 +16,6 @@ import com.liferay.fragment.service.FragmentEntryLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
-import com.liferay.layout.util.UpdateLayoutStatusThreadLocal;
-import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -130,24 +128,21 @@ public class PublishFragmentEntryMVCActionCommandTest {
 				"<div><lfr-drop-zone data-lfr-drop-zone-id=\"1\">" +
 					"</lfr-drop-zone></div>");
 
-			Layout layout = LayoutTestUtil.addTypeContentPublishedLayout(
-				_group, RandomTestUtil.randomString(),
-				WorkflowConstants.STATUS_APPROVED);
+			Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
 
-			try (SafeCloseable safeCloseable =
-					UpdateLayoutStatusThreadLocal.
-						setUpdateLayoutStatusWithSafeCloseable(false)) {
+			Layout draftLayout = layout.fetchDraftLayout();
 
-				ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
-					StringPool.BLANK, fragmentEntry.getCss(),
-					fragmentEntry.getConfiguration(),
-					fragmentEntry.getExternalReferenceCode(), null,
-					fragmentEntry.getHtml(), fragmentEntry.getJs(), layout,
-					fragmentEntry.getFragmentEntryKey(),
-					_segmentsExperienceLocalService.
-						fetchDefaultSegmentsExperienceId(layout.getPlid()),
-					fragmentEntry.getType());
-			}
+			ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+				StringPool.BLANK, fragmentEntry.getCss(),
+				fragmentEntry.getConfiguration(),
+				fragmentEntry.getExternalReferenceCode(), null,
+				fragmentEntry.getHtml(), fragmentEntry.getJs(), draftLayout,
+				fragmentEntry.getFragmentEntryKey(),
+				_segmentsExperienceLocalService.
+					fetchDefaultSegmentsExperienceId(draftLayout.getPlid()),
+				fragmentEntry.getType());
+
+			ContentLayoutTestUtil.publishLayout(draftLayout, layout);
 
 			fragmentEntry.setHtml(fragmentEntry.getHtml() + "<!--updated-->");
 

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/PublishFragmentEntryMVCActionCommandTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/PublishFragmentEntryMVCActionCommandTest.java
@@ -10,6 +10,7 @@ import com.liferay.fragment.configuration.FragmentServiceConfiguration;
 import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.service.FragmentCollectionLocalService;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.fragment.service.FragmentEntryLocalService;
@@ -133,17 +134,27 @@ public class PublishFragmentEntryMVCActionCommandTest {
 
 			Layout draftLayout = layout.fetchDraftLayout();
 
-			ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
-				StringPool.BLANK, fragmentEntry.getCss(),
-				fragmentEntry.getConfiguration(),
-				fragmentEntry.getExternalReferenceCode(), null,
-				fragmentEntry.getHtml(), fragmentEntry.getJs(), draftLayout,
-				fragmentEntry.getFragmentEntryKey(),
-				_segmentsExperienceLocalService.
-					fetchDefaultSegmentsExperienceId(draftLayout.getPlid()),
-				fragmentEntry.getType());
+			FragmentEntryLink fragmentEntryLink =
+				ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+					StringPool.BLANK, fragmentEntry.getCss(),
+					fragmentEntry.getConfiguration(),
+					fragmentEntry.getExternalReferenceCode(), null,
+					fragmentEntry.getHtml(), fragmentEntry.getJs(), draftLayout,
+					fragmentEntry.getFragmentEntryKey(),
+					_segmentsExperienceLocalService.
+						fetchDefaultSegmentsExperienceId(draftLayout.getPlid()),
+					fragmentEntry.getType());
 
 			ContentLayoutTestUtil.publishLayout(draftLayout, layout);
+
+			_assertFragmentEntryLinkHTML(
+				fragmentEntry.getHtml(),
+				_fragmentEntryLinkLocalService.getFragmentEntryLink(
+					fragmentEntryLink.getFragmentEntryLinkId()),
+				_fragmentEntryLinkLocalService.getFragmentEntryLink(
+					_group.getGroupId(),
+					fragmentEntryLink.getExternalReferenceCode(),
+					layout.getPlid()));
 
 			_assertLayoutStatusApproved(
 				_layoutLocalService.getLayout(draftLayout.getPlid()),
@@ -166,6 +177,23 @@ public class PublishFragmentEntryMVCActionCommandTest {
 			_assertLayoutStatusApproved(
 				_layoutLocalService.getLayout(draftLayout.getPlid()),
 				_layoutLocalService.getLayout(layout.getPlid()));
+
+			_assertFragmentEntryLinkHTML(
+				fragmentEntry.getHtml(),
+				_fragmentEntryLinkLocalService.getFragmentEntryLink(
+					fragmentEntryLink.getFragmentEntryLinkId()),
+				_fragmentEntryLinkLocalService.getFragmentEntryLink(
+					_group.getGroupId(),
+					fragmentEntryLink.getExternalReferenceCode(),
+					layout.getPlid()));
+		}
+	}
+
+	private void _assertFragmentEntryLinkHTML(
+		String expectedHTML, FragmentEntryLink... fragmentEntryLinks) {
+
+		for (FragmentEntryLink fragmentEntryLink : fragmentEntryLinks) {
+			Assert.assertEquals(expectedHTML, fragmentEntryLink.getHtml());
 		}
 	}
 

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/PublishFragmentEntryMVCActionCommandTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/PublishFragmentEntryMVCActionCommandTest.java
@@ -18,6 +18,7 @@ import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocal
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.layout.util.LayoutServiceContextHelper;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -160,7 +161,10 @@ public class PublishFragmentEntryMVCActionCommandTest {
 				_layoutLocalService.getLayout(draftLayout.getPlid()),
 				_layoutLocalService.getLayout(layout.getPlid()));
 
-			fragmentEntry.setHtml(fragmentEntry.getHtml() + "<!--updated-->");
+			fragmentEntry.setHtml(
+				StringBundler.concat(
+					fragmentEntry.getHtml(), "<!--", RandomTestUtil.randomString(),
+					"-->"));
 
 			fragmentEntry = _fragmentEntryLocalService.updateFragmentEntry(
 				fragmentEntry);

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/PublishFragmentEntryMVCActionCommandTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/PublishFragmentEntryMVCActionCommandTest.java
@@ -113,7 +113,7 @@ public class PublishFragmentEntryMVCActionCommandTest {
 
 	@Test
 	@TestInfo("LPD-79507")
-	public void testPublishFragmentWithInvalidDropZoneConfiguration()
+	public void testPublishFragmentWithPropagateChangesEnabled()
 		throws Exception {
 
 		try (CompanyConfigurationTemporarySwapper

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/PublishFragmentEntryMVCActionCommandTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/PublishFragmentEntryMVCActionCommandTest.java
@@ -145,6 +145,10 @@ public class PublishFragmentEntryMVCActionCommandTest {
 
 			ContentLayoutTestUtil.publishLayout(draftLayout, layout);
 
+			_assertLayoutStatusApproved(
+				_layoutLocalService.getLayout(draftLayout.getPlid()),
+				_layoutLocalService.getLayout(layout.getPlid()));
+
 			fragmentEntry.setHtml(fragmentEntry.getHtml() + "<!--updated-->");
 
 			fragmentEntry = _fragmentEntryLocalService.updateFragmentEntry(
@@ -159,11 +163,16 @@ public class PublishFragmentEntryMVCActionCommandTest {
 					new MockLiferayPortletActionResponse());
 			}
 
-			Layout updatedLayout = _layoutLocalService.getLayout(
-				layout.getPlid());
+			_assertLayoutStatusApproved(
+				_layoutLocalService.getLayout(draftLayout.getPlid()),
+				_layoutLocalService.getLayout(layout.getPlid()));
+		}
+	}
 
+	private void _assertLayoutStatusApproved(Layout... layouts) {
+		for (Layout layout : layouts) {
 			Assert.assertEquals(
-				WorkflowConstants.STATUS_APPROVED, updatedLayout.getStatus());
+				WorkflowConstants.STATUS_APPROVED, layout.getStatus());
 		}
 	}
 

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/PublishFragmentEntryMVCActionCommandTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/PublishFragmentEntryMVCActionCommandTest.java
@@ -112,84 +112,29 @@ public class PublishFragmentEntryMVCActionCommandTest {
 	}
 
 	@Test
-	@TestInfo("LPD-79507")
+	@TestInfo({"LPD-79507", "LPD-95510"})
 	public void testPublishFragmentWithPropagateChangesEnabled()
 		throws Exception {
 
-		try (CompanyConfigurationTemporarySwapper
-				companyConfigurationTemporarySwapper =
-					new CompanyConfigurationTemporarySwapper(
-						TestPropsValues.getCompanyId(),
-						FragmentServiceConfiguration.class.getName(),
-						HashMapDictionaryBuilder.<String, Object>put(
-							"propagateChanges", true
-						).build())) {
+		FragmentEntry fragmentEntry = _getFragmentEntry(
+			null,
+			"<div><lfr-drop-zone data-lfr-drop-zone-id=\"1\">" +
+				"</lfr-drop-zone></div>");
 
-			FragmentEntry fragmentEntry = _getFragmentEntry(
+		_testPublishFragmentWithPropagateChangesEnabled(
+			fragmentEntry,
+			StringBundler.concat(
+				fragmentEntry.getHtml(), "<!--", RandomTestUtil.randomString(),
+				"-->"));
+
+		_testPublishFragmentWithPropagateChangesEnabled(
+			_getFragmentEntry(
 				null,
-				"<div><lfr-drop-zone data-lfr-drop-zone-id=\"1\">" +
-					"</lfr-drop-zone></div>");
-
-			Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
-
-			Layout draftLayout = layout.fetchDraftLayout();
-
-			FragmentEntryLink fragmentEntryLink =
-				ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
-					StringPool.BLANK, fragmentEntry.getCss(),
-					fragmentEntry.getConfiguration(),
-					fragmentEntry.getExternalReferenceCode(), null,
-					fragmentEntry.getHtml(), fragmentEntry.getJs(), draftLayout,
-					fragmentEntry.getFragmentEntryKey(),
-					_segmentsExperienceLocalService.
-						fetchDefaultSegmentsExperienceId(draftLayout.getPlid()),
-					fragmentEntry.getType());
-
-			ContentLayoutTestUtil.publishLayout(draftLayout, layout);
-
-			_assertFragmentEntryLinkHTML(
-				fragmentEntry.getHtml(),
-				_fragmentEntryLinkLocalService.getFragmentEntryLink(
-					fragmentEntryLink.getFragmentEntryLinkId()),
-				_fragmentEntryLinkLocalService.getFragmentEntryLink(
-					_group.getGroupId(),
-					fragmentEntryLink.getExternalReferenceCode(),
-					layout.getPlid()));
-
-			_assertLayoutStatusApproved(
-				_layoutLocalService.getLayout(draftLayout.getPlid()),
-				_layoutLocalService.getLayout(layout.getPlid()));
-
-			fragmentEntry.setHtml(
-				StringBundler.concat(
-					fragmentEntry.getHtml(), "<!--", RandomTestUtil.randomString(),
-					"-->"));
-
-			fragmentEntry = _fragmentEntryLocalService.updateFragmentEntry(
-				fragmentEntry);
-
-			try (AutoCloseable autoCloseable =
-					_layoutServiceContextHelper.getServiceContextAutoCloseable(
-						layout, TestPropsValues.getUser())) {
-
-				_mvcActionCommand.processAction(
-					_getActionRequest(fragmentEntry),
-					new MockLiferayPortletActionResponse());
-			}
-
-			_assertLayoutStatusApproved(
-				_layoutLocalService.getLayout(draftLayout.getPlid()),
-				_layoutLocalService.getLayout(layout.getPlid()));
-
-			_assertFragmentEntryLinkHTML(
-				fragmentEntry.getHtml(),
-				_fragmentEntryLinkLocalService.getFragmentEntryLink(
-					fragmentEntryLink.getFragmentEntryLinkId()),
-				_fragmentEntryLinkLocalService.getFragmentEntryLink(
-					_group.getGroupId(),
-					fragmentEntryLink.getExternalReferenceCode(),
-					layout.getPlid()));
-		}
+				"<div><lfr-drop-zone></lfr-drop-zone>" +
+					"<lfr-drop-zone></lfr-drop-zone></div>"),
+			"<div><lfr-drop-zone></lfr-drop-zone>" +
+				"<lfr-drop-zone></lfr-drop-zone>" +
+					"<lfr-drop-zone></lfr-drop-zone></div>");
 	}
 
 	private void _assertFragmentEntryLinkHTML(
@@ -254,6 +199,78 @@ public class PublishFragmentEntryMVCActionCommandTest {
 			clazz.getClassLoader(),
 			"com/liferay/fragment/internal/portlet/action/test/dependencies" +
 				"/fragment_configuration_invalid.json");
+	}
+
+	private void _testPublishFragmentWithPropagateChangesEnabled(
+			FragmentEntry fragmentEntry, String updatedHTML)
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						FragmentServiceConfiguration.class.getName(),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"propagateChanges", true
+						).build())) {
+
+			Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+			Layout draftLayout = layout.fetchDraftLayout();
+
+			FragmentEntryLink fragmentEntryLink =
+				ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+					StringPool.BLANK, fragmentEntry.getCss(),
+					fragmentEntry.getConfiguration(),
+					fragmentEntry.getExternalReferenceCode(), null,
+					fragmentEntry.getHtml(), fragmentEntry.getJs(), draftLayout,
+					fragmentEntry.getFragmentEntryKey(),
+					_segmentsExperienceLocalService.
+						fetchDefaultSegmentsExperienceId(draftLayout.getPlid()),
+					fragmentEntry.getType());
+
+			ContentLayoutTestUtil.publishLayout(draftLayout, layout);
+
+			_assertFragmentEntryLinkHTML(
+				fragmentEntry.getHtml(),
+				_fragmentEntryLinkLocalService.getFragmentEntryLink(
+					fragmentEntryLink.getFragmentEntryLinkId()),
+				_fragmentEntryLinkLocalService.getFragmentEntryLink(
+					_group.getGroupId(),
+					fragmentEntryLink.getExternalReferenceCode(),
+					layout.getPlid()));
+
+			_assertLayoutStatusApproved(
+				_layoutLocalService.getLayout(draftLayout.getPlid()),
+				_layoutLocalService.getLayout(layout.getPlid()));
+
+			fragmentEntry.setHtml(updatedHTML);
+
+			fragmentEntry = _fragmentEntryLocalService.updateFragmentEntry(
+				fragmentEntry);
+
+			try (AutoCloseable autoCloseable =
+					_layoutServiceContextHelper.getServiceContextAutoCloseable(
+						layout, TestPropsValues.getUser())) {
+
+				_mvcActionCommand.processAction(
+					_getActionRequest(fragmentEntry),
+					new MockLiferayPortletActionResponse());
+			}
+
+			_assertLayoutStatusApproved(
+				_layoutLocalService.getLayout(draftLayout.getPlid()),
+				_layoutLocalService.getLayout(layout.getPlid()));
+
+			_assertFragmentEntryLinkHTML(
+				fragmentEntry.getHtml(),
+				_fragmentEntryLinkLocalService.getFragmentEntryLink(
+					fragmentEntryLink.getFragmentEntryLinkId()),
+				_fragmentEntryLinkLocalService.getFragmentEntryLink(
+					_group.getGroupId(),
+					fragmentEntryLink.getExternalReferenceCode(),
+					layout.getPlid()));
+		}
 	}
 
 	@Inject


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95510

## What Is Being Fixed

Publishing a global fragment whose drop zones do not declare `data-lfr-drop-zone-id` silently flipped every published layout consuming that fragment to draft when `propagateChanges` was enabled and the publish changed the number of drop zones. LPD-79507 had already covered the same flip on the full reconciliation branch of `DropZoneFragmentEntryLinkListener`, but the early branch — the one that fires when any drop zone is missing `data-lfr-drop-zone-id` — was never guarded.

## How It Is Being Fixed

Moves the `UpdateLayoutStatusThreadLocal=false` skip up one level: out of the listener's `if (update)` block and into the `if (modified)` block of `FragmentEntryLinkLocalServiceImpl.updateLatestChanges`. The guard now wraps every listener invocation that propagation triggers — both the full reconciliation branch (the case LPD-79507 covered) and the early branch (the LPD-95510 case) — so any listener that ends up calling `updateLayoutPageTemplateStructureData` runs under the no-status-flip threadlocal.

The integration test for LPD-79507 was rebuilt to actually trigger the bug — the original setup never reached the reconciliation because the listener returns early without a `ServiceContext`. The test now pushes the service context with `LayoutServiceContextHelper.getServiceContextAutoCloseable`, asserts both draft and published layout statuses, asserts the propagated HTML on both `FragmentEntryLink`s, and exercises two fragment shapes through a single helper: one with `data-lfr-drop-zone-id` on every drop zone (LPD-79507, full reconciliation) and one without it where the publish also adds an extra drop zone so the early branch reaches `updateLayoutPageTemplateStructureData` (LPD-95510, early branch).

## PR Check

**pr-check: PASS** — tested on `d5178a876e7856845ae7c945d3b55c299fee4922`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "d5178a876e7856845ae7c945d3b55c299fee4922"} -->
