### PR TITLE
LPD-95787 Make LayoutStructureRulesHelper reference dynamic

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/struts/EvaluateLayoutStructureRulesStrutsAction.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/struts/EvaluateLayoutStructureRulesStrutsAction.java
@@ -40,6 +40,8 @@ import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Lourdes Fernández Besada
@@ -141,8 +143,11 @@ public class EvaluateLayoutStructureRulesStrutsAction implements StrutsAction {
 	@Reference
 	private LayoutStructureProvider _layoutStructureProvider;
 
-	@Reference
-	private LayoutStructureRulesHelper _layoutStructureRulesHelper;
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY
+	)
+	private volatile LayoutStructureRulesHelper _layoutStructureRulesHelper;
 
 	@Reference
 	private RequestContextMapper _requestContextMapper;

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/ServletContextUtil.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/ServletContextUtil.java
@@ -183,7 +183,8 @@ public class ServletContextUtil {
 			ServletContextUtil.class, LayoutStructureProvider.class);
 	private static final Snapshot<LayoutStructureRulesHelper>
 		_layoutStructureRulesHelperSnapshot = new Snapshot<>(
-			ServletContextUtil.class, LayoutStructureRulesHelper.class);
+			ServletContextUtil.class, LayoutStructureRulesHelper.class, null,
+			true);
 	private static final Snapshot<ListObjectReferenceFactoryRegistry>
 		_listObjectReferenceFactoryRegistrySnapshot = new Snapshot<>(
 			ServletContextUtil.class, ListObjectReferenceFactoryRegistry.class);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95787

## What Is Being Fixed

In the standalone CMS, the Space details page intermittently shows an empty box where the space sites summary section used to be. `CMSViewSpaceSitesSummaryJSPSectionFragmentRenderer` overrides the stock renderer with a no-op render, and `CMSLayoutStructureRulesHelper` (a higher-ranked `LayoutStructureRulesHelper`) is meant to hide the now-empty fragment's container. The override only took effect on some machines: the renderer override always wins because `FragmentRenderer` is resolved dynamically through a `ServiceTrackerMap`, but `LayoutStructureRulesHelper` was resolved statically, so whether the higher-ranked override won depended on bundle activation order and differed from machine to machine (and even between restarts).

## How It Is Being Fixed

The two consumers of `LayoutStructureRulesHelper` bound the service once and never switched to a higher-ranked implementation registered afterward. `ServletContextUtil` (the render path) used a non-dynamic `Snapshot`, which resolves the highest-ranked service at the first lookup and only re-resolves if that service unregisters. `EvaluateLayoutStructureRulesStrutsAction` (the rule-evaluation path) used a static, reluctant `@Reference`. Make the snapshot dynamic and the reference greedy and dynamic so the highest-ranked `LayoutStructureRulesHelper` is always used regardless of start order.

## Why Are There No Tests?

This is an OSGi service-binding configuration change (dynamic snapshot and a greedy/dynamic reference). The underlying ranking behavior is already covered by `SnapshotTest`, and exercising the bind timing in an integration test adds flakiness without meaningful signal.

## PR Check

**pr-check: PASS** — tested on `6f78cc6908b043b563495492f67b5d779da927fb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "6f78cc6908b043b563495492f67b5d779da927fb"} -->
