### PR TITLE
LPD-95797 Fix CMSObjectRelationshipEdgeUpgradeProcessTest setup

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/test/CMSObjectRelationshipEdgeUpgradeProcessTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/upgrade/v1_0_0/test/CMSObjectRelationshipEdgeUpgradeProcessTest.java
@@ -48,6 +48,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+import com.liferay.site.cms.site.initializer.test.util.CMSTestUtil;
 
 import java.io.Serializable;
 
@@ -80,6 +81,9 @@ public class CMSObjectRelationshipEdgeUpgradeProcessTest {
 	@Before
 	public void setUp() throws Exception {
 		UserTestUtil.setUser(TestPropsValues.getUser());
+
+		CMSTestUtil.getOrAddGroup(
+			CMSObjectRelationshipEdgeUpgradeProcessTest.class);
 
 		_cmsContentStructuresObjectFolder =
 			_objectFolderLocalService.getObjectFolderByExternalReferenceCode(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95797

## What Is Being Fixed

CMSObjectRelationshipEdgeUpgradeProcessTest relied on the CMS group already existing, but it was never provisioned in setUp, so the test could fail when the group was absent.

## How It Is Being Fixed

Call CMSTestUtil.getOrAddGroup(CMSObjectRelationshipEdgeUpgradeProcessTest.class) in setUp so the CMS group exists before each test runs.

## Why Are There No Tests?

This change only fixes the setup of an existing integration test; it adds no production code, so the existing suite is the coverage.

## PR Check

**pr-check: PASS** — tested on `ca92f29dd7c36e0a87462d4e19af817fd1fa35f2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "ca92f29dd7c36e0a87462d4e19af817fd1fa35f2"} -->
