### PR TITLE
LPD-95740 Restore CKEditor 5 support in sample editor config contributor

### DIFF
--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-1/src/index.ts
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-1/src/index.ts
@@ -34,6 +34,15 @@ const editorConfigTransformer: EditorConfigTransformer<any> = (config) => {
 		}
 	}
 
+	// CKEditor 5
+
+	if (config.editorType === 'ckeditor5') {
+		return {
+			...config,
+			toolbar: ['accessibilityHelp', '|', 'undo', 'redo'],
+		};
+	}
+
 	// CKEditor
 
 	const toolbar: string | [string[]] = config.toolbar;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95740

## What Is Being Fixed

LPD-89734 removed the CKEditor 5 branch from
liferay-sample-editor-config-contributor-1. Without it the transformer fell
through to the CKEditor 4 classic handler for CKEditor 5 configs and returned a
broken config that wiped the fragment rich-text editor toolbar, breaking the
fragments.spec.ts editorConfigContributor test.

## How It Is Being Fixed

Restore the CKEditor 5 block in the sample using a toolbar-replace approach that
matches the original liferay-sample-editor-config-contributor, so the sample
again demonstrates a short custom toolbar containing accessibilityHelp and the
existing test passes.

## Notes

Reviewed and approved by the frontend team on
https://github.com/liferay-frontend/liferay-portal/pull/5592. This PR rebases
that work onto master and forwards it to page management. Supersedes #5592.

## Why Are There No Tests?

The fix restores behavior covered by the existing fragments.spec.ts
editorConfigContributor test, which was failing due to the LPD-89734 regression
and passes again with this change.

## PR Check

**pr-check: PASS** — tested on `70953965ec87e6f38461f031c92bbf86c32cb6dd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "70953965ec87e6f38461f031c92bbf86c32cb6dd"} -->
