### PR TITLE
LPD-95956 Generically serialize input template node attributes to JSON

### DIFF
--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/input/template/parser/InputTemplateNode.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/input/template/parser/InputTemplateNode.java
@@ -5,11 +5,14 @@
 
 package com.liferay.fragment.input.template.parser;
 
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+import java.lang.reflect.Array;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -119,14 +122,8 @@ public class InputTemplateNode extends LinkedHashMap<String, Object> {
 					JSONFactoryUtil.createJSONObject();
 
 				for (Map.Entry<String, Object> entry : _attributes.entrySet()) {
-					Object value = entry.getValue();
-
-					if (value instanceof Collection) {
-						value = JSONFactoryUtil.createJSONArray(
-							(Collection<?>)value);
-					}
-
-					attributesJSONObject.put(entry.getKey(), value);
+					attributesJSONObject.put(
+						entry.getKey(), _toJSONValue(entry.getValue()));
 				}
 
 				attributesJSONObject.put("readOnly", _readOnly);
@@ -177,18 +174,78 @@ public class InputTemplateNode extends LinkedHashMap<String, Object> {
 			return _value;
 		}
 
-		@Override
-		public String toString() {
+		public JSONObject toJSONObject() {
 			return JSONUtil.put(
 				"label", _label
 			).put(
 				"value", _value
-			).toString();
+			);
+		}
+
+		@Override
+		public String toString() {
+			JSONObject jsonObject = toJSONObject();
+
+			return jsonObject.toString();
 		}
 
 		private final String _label;
 		private final String _value;
 
+	}
+
+	private Object _toJSONValue(Object value) {
+		if ((value == null) || (value instanceof JSONArray) ||
+			(value instanceof JSONObject)) {
+
+			return value;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
+
+			int length = Array.getLength(value);
+
+			for (int i = 0; i < length; i++) {
+				jsonArray.put(_toJSONValue(Array.get(value, i)));
+			}
+
+			return jsonArray;
+		}
+
+		if (value instanceof Collection) {
+			JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
+
+			for (Object element : (Collection<?>)value) {
+				jsonArray.put(_toJSONValue(element));
+			}
+
+			return jsonArray;
+		}
+
+		if (value instanceof Map) {
+			JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
+
+			Map<String, Object> map = (Map<String, Object>)value;
+
+			for (Map.Entry<String, Object> entry : map.entrySet()) {
+				jsonObject.put(
+					String.valueOf(entry.getKey()),
+					_toJSONValue(entry.getValue()));
+			}
+
+			return jsonObject;
+		}
+
+		if (value instanceof Option) {
+			Option option = (Option)value;
+
+			return option.toJSONObject();
+		}
+
+		return value;
 	}
 
 	private final Map<String, Object> _attributes = new HashMap<>();

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/input/template/parser/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/input/template/parser/packageinfo
@@ -1,1 +1,1 @@
-version 10.0.0
+version 10.1.0

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java
@@ -59,9 +59,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.InfoFormException;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -79,6 +77,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.KeyValuePair;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -468,8 +467,7 @@ public class FragmentEntryInputTemplateNodeContextHelperImpl
 			}
 		}
 
-		inputTemplateNode.addAttribute(
-			"fileNameI18n", _jsonFactory.createJSONObject(fileNameI18n));
+		inputTemplateNode.addAttribute("fileNameI18n", fileNameI18n);
 
 		inputTemplateNode.addAttribute("groupId", groupId);
 
@@ -500,8 +498,7 @@ public class FragmentEntryInputTemplateNodeContextHelperImpl
 			}
 		}
 
-		inputTemplateNode.addAttribute(
-			"previewURLI18n", _jsonFactory.createJSONObject(previewURLI18n));
+		inputTemplateNode.addAttribute("previewURLI18n", previewURLI18n);
 
 		boolean selectFromDocumentLibrary = false;
 
@@ -592,9 +589,7 @@ public class FragmentEntryInputTemplateNodeContextHelperImpl
 		}
 
 		inputTemplateNode.addAttribute(
-			"availableLanguageIds",
-			_jsonFactory.createJSONArray(
-				LocaleUtil.toLanguageIds(availableLocales)));
+			"availableLanguageIds", LocaleUtil.toLanguageIds(availableLocales));
 		inputTemplateNode.addAttribute(
 			"defaultLanguageId", LocaleUtil.toLanguageId(siteDefaultLocale));
 
@@ -750,8 +745,7 @@ public class FragmentEntryInputTemplateNodeContextHelperImpl
 		InfoField infoField, InputTemplateNode inputTemplateNode,
 		Locale locale) {
 
-		inputTemplateNode.addAttribute(
-			"countries", _getCountriesJSONObjects(locale));
+		inputTemplateNode.addAttribute("countries", _getCountries(locale));
 		inputTemplateNode.addAttribute(
 			"country",
 			infoField.getAttribute(PhoneNumberInfoFieldType.COUNTRY));
@@ -863,7 +857,7 @@ public class FragmentEntryInputTemplateNodeContextHelperImpl
 		return sb.toString();
 	}
 
-	private List<JSONObject> _getCountriesJSONObjects(Locale locale) {
+	private List<Map<String, Object>> _getCountries(Locale locale) {
 		ServiceContext serviceContext =
 			ServiceContextThreadLocal.getServiceContext();
 
@@ -890,7 +884,7 @@ public class FragmentEntryInputTemplateNodeContextHelperImpl
 			}
 		}
 
-		List<JSONObject> countriesJSONObjects = new ArrayList<>();
+		List<Map<String, Object>> countries = new ArrayList<>();
 
 		String languageId = LocaleUtil.toLanguageId(locale);
 
@@ -909,19 +903,19 @@ public class FragmentEntryInputTemplateNodeContextHelperImpl
 				continue;
 			}
 
-			countriesJSONObjects.add(
-				JSONUtil.put(
+			countries.add(
+				HashMapBuilder.<String, Object>put(
 					"a2", a2
 				).put(
 					"name", country.getTitle(languageId)
 				).put(
 					"prefix", idd
-				));
+				).build());
 		}
 
 		return ListUtil.sort(
-			countriesJSONObjects,
-			Comparator.comparing(country -> country.getString("name")));
+			countries,
+			Comparator.comparing(country -> (String)country.get("name")));
 	}
 
 	private Locale _getCurrentLocale(
@@ -1462,9 +1456,6 @@ public class FragmentEntryInputTemplateNodeContextHelperImpl
 
 	@Reference
 	private ItemSelector _itemSelector;
-
-	@Reference
-	private JSONFactory _jsonFactory;
 
 	@Reference
 	private Language _language;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95956

## What Is Being Fixed

Input fragment attributes exposed to the client are serialized by
`InputTemplateNode.toJSONObject()`. Previously only `Collection` values were
converted to a `JSONArray`; every other value was stored raw and serialized
through `JSONUtil.toString()`, which falls back to Java's `value.toString()`
for anything that is not a Liferay `JSONObject`/`JSONArray`/`String`. As a
result, attributes holding a `List<String>`, a `Map`, an array, or a list of
objects produced invalid JSON (e.g. `[a, b]` or `{k=v}`), while values that
happened to have a JSON-shaped `toString()` worked only by accident.

## How It Is Being Fixed

`toJSONObject()` now routes every attribute value through a recursive
converter that turns arrays and collections into `JSONArray`, maps into
`JSONObject`, and `Option`s into their JSON form, while passing existing JSON
values and primitives through unchanged. With the conversion centralized at the
serialization boundary, the implementation no longer wraps values as Liferay
JSON types when adding attributes, so `fileNameI18n`, `previewURLI18n`,
`availableLanguageIds`, and `countries` are stored as plain `Map`/array/`List`
and the now-unused `JSONFactory` reference is removed. Keeping the attribute map
generic also lets it render correctly in the FreeMarker template, which consumes
the same map directly.

## Why Are There No Tests?

No new test is needed: this change fixes the existing Playwright test
`site-cms-site-initializer/structure-builder/phoneNumberField.spec.ts`, which
already exercises this behavior.

## PR Check

**pr-check: PASS** — tested on `f5c134137ad651baff02fdcc3673aadfa557ab89`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "f5c134137ad651baff02fdcc3673aadfa557ab89"} -->
