### PR TITLE
LPD-91054 Always display system group FragmentCollections

### DIFF
--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
@@ -301,6 +301,7 @@ public class FragmentDisplayContext {
 				getFragmentCollectionId());
 
 		if ((fragmentCollection != null) &&
+			(fragmentCollection.getGroupId() != CompanyConstants.SYSTEM) &&
 			(fragmentCollection.getGroupId() !=
 				_themeDisplay.getCompanyGroupId()) &&
 			(fragmentCollection.getGroupId() !=

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContextTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContextTest.java
@@ -11,6 +11,7 @@ import com.liferay.fragment.model.FragmentComposition;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.service.FragmentCollectionLocalServiceUtil;
 import com.liferay.fragment.web.internal.security.permission.resource.FragmentPermission;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -238,6 +239,66 @@ public class FragmentDisplayContextTest {
 			_themeDisplay.getScopeGroupId()
 		).thenReturn(
 			groupId
+		);
+
+		try (MockedStatic<FragmentCollectionLocalServiceUtil>
+				fragmentCollectionLocalServiceUtilMockedStatic =
+					Mockito.mockStatic(
+						FragmentCollectionLocalServiceUtil.class)) {
+
+			fragmentCollectionLocalServiceUtilMockedStatic.when(
+				() ->
+					FragmentCollectionLocalServiceUtil.fetchFragmentCollection(
+						fragmentCollectionId)
+			).thenReturn(
+				fragmentCollection
+			);
+
+			FragmentDisplayContext fragmentDisplayContext =
+				new FragmentDisplayContext(
+					_httpServletRequest, _renderRequest, _renderResponse);
+
+			Assert.assertNotNull(
+				fragmentDisplayContext.getFragmentCollection());
+		}
+	}
+
+	@Test
+	@TestInfo("LPD-91054")
+	public void testGetFragmentCollectionFromSystemGroup() {
+		long fragmentCollectionId = RandomTestUtil.randomLong();
+
+		FragmentCollection fragmentCollection = Mockito.mock(
+			FragmentCollection.class);
+
+		Mockito.when(
+			fragmentCollection.getGroupId()
+		).thenReturn(
+			CompanyConstants.SYSTEM
+		);
+
+		Mockito.when(
+			_httpServletRequest.getParameter("fragmentCollectionId")
+		).thenReturn(
+			String.valueOf(fragmentCollectionId)
+		);
+
+		Mockito.when(
+			_httpServletRequest.getParameter("fragmentCollectionKey")
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		Mockito.when(
+			_themeDisplay.getCompanyGroupId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
+			_themeDisplay.getScopeGroupId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
 		);
 
 		try (MockedStatic<FragmentCollectionLocalServiceUtil>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91054

## What Is Being Fixed

Fragment collections deployed to every company through an auto-deployable fragment set (a `liferay-deploy-fragments.json` with `"companyWebId": "*"`) are persisted with a group ID of 0 — the system scope (`CompanyConstants.SYSTEM`) — rather than a site or company group ID. The Fragments admin display context only returned a fragment collection when its group ID matched the current scope group or the company group, so these system-scoped collections resolved to null and were neither shown nor editable at `.../control_panel/manage/-/fragments/fragment_collection`.

## How It Is Being Fixed

`FragmentDisplayContext.getFragmentCollection()` now also accepts a fragment collection whose group ID is `CompanyConstants.SYSTEM`, alongside the existing scope-group and company-group cases, so system-scoped collections stay visible. The new condition uses the `CompanyConstants.SYSTEM` constant — matching the existing `isLocked()` check in the same class — and is ordered consistently with it. A unit test covers the system-group case by stubbing the scope and company group IDs to distinct non-zero values, so the collection survives solely because of the system-group allowance.

## PR Check

**pr-check: PASS** — tested on `ed537a36783c316754180e734723668c61691538`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ed537a36783c316754180e734723668c61691538"} -->
