### PR TITLE
LPD-95038 LPD-95007 Fix UnsupportedOperationException in headless-admin-site resource methods

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
@@ -5004,6 +5004,9 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/DisplayPageTemplateFolder"
+                400:
+                    description:
+                        "The parent display page template folder external reference code does not point to a display page template folder, or the parent external reference codes do not match."
             # @review
             tags: ["DisplayPageTemplateFolder"]
     "/sites/{siteExternalReferenceCode}/display-page-template-folders/{displayPageTemplateFolderExternalReferenceCode}":
@@ -5158,6 +5161,9 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/DisplayPageTemplateFolder"
+                400:
+                    description:
+                        "The parent display page template folder external reference code does not point to a display page template folder, or the parent external reference codes do not match."
             tags: ["DisplayPageTemplateFolder"]
     "/sites/{siteExternalReferenceCode}/display-page-template-folders/{displayPageTemplateFolderExternalReferenceCode}/display-page-templates":
         get:
@@ -5252,6 +5258,9 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/DisplayPageTemplate"
+                400:
+                    description:
+                        "The page template set does not belong to this site."
             # @review
             tags: ["DisplayPageTemplate"]
     "/sites/{siteExternalReferenceCode}/display-page-template-folders/{displayPageTemplateFolderExternalReferenceCode}/permissions":
@@ -5555,6 +5564,9 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/DisplayPageTemplate"
+                409:
+                    description:
+                        "The default display page template must be published first."
             tags: ["DisplayPageTemplate"]
     "/sites/{siteExternalReferenceCode}/display-page-templates/{displayPageTemplateExternalReferenceCode}/friendly-url-history":
         get:
@@ -5831,6 +5843,9 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/MasterPage"
+                400:
+                    description:
+                        "Exactly two page specifications are required, a page specification is not approved, or the draft and published page specification external reference codes do not match."
             # @review
             tags: ["MasterPage"]
     "/sites/{siteExternalReferenceCode}/master-pages/{masterPageExternalReferenceCode}":
@@ -5985,6 +6000,9 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/MasterPage"
+                409:
+                    description:
+                        "The default master page must be published first."
             tags: ["MasterPage"]
     "/sites/{siteExternalReferenceCode}/master-pages/{masterPageExternalReferenceCode}/page-specifications":
         get:
@@ -6074,6 +6092,12 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/ContentPageSpecification"
+                400:
+                    description:
+                        "The page specification is not in draft status or is not approved, or a page experience is invalid."
+                409:
+                    description:
+                        "A page experience key is duplicated."
             # @review
             tags: ["MasterPage"]
     "/sites/{siteExternalReferenceCode}/master-pages/{masterPageExternalReferenceCode}/permissions":
@@ -6533,6 +6557,12 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/PageExperience"
+                400:
+                    description:
+                        "Only site pages can define additional page experiences."
+                409:
+                    description:
+                        "A page experience key is duplicated."
             tags: ["PageExperience"]
     "/sites/{siteExternalReferenceCode}/page-specifications/{pageSpecificationExternalReferenceCode}":
         delete:
@@ -6698,6 +6728,12 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/PageSpecification"
+                400:
+                    description:
+                        "A required or default page experience is missing, the default page experience priority is not zero, its external reference code does not match the target page's experience, or it references a segment."
+                409:
+                    description:
+                        "A page experience key is duplicated."
             tags: ["PageSpecification"]
     "/sites/{siteExternalReferenceCode}/page-specifications/{pageSpecificationExternalReferenceCode}/page-experiences":
         get:
@@ -6788,6 +6824,9 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/PageExperience"
+                400:
+                    description:
+                        "Only site pages can define additional page experiences."
             # @review
             tags: ["PageExperience"]
     "/sites/{siteExternalReferenceCode}/page-specifications/{pageSpecificationExternalReferenceCode}/page-experiences/{pageExperienceExternalReferenceCode}/page-elements":
@@ -6927,6 +6966,9 @@ paths:
                     content:
                         application/json: {}
                         application/xml: {}
+                404:
+                    description:
+                        "The page element could not be found."
             tags: ["PageElement"]
         get:
             # @review
@@ -6975,6 +7017,9 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/PageElement"
+                404:
+                    description:
+                        "The page element could not be found."
             tags: ["PageElement"]
         patch:
             # @review
@@ -7282,6 +7327,9 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/PageTemplateSet"
+                409:
+                    description:
+                        "A page template set with the same name already exists."
             # @review
             tags: ["PageTemplateSet"]
     "/sites/{siteExternalReferenceCode}/page-template-sets/{pageTemplateSetExternalReferenceCode}":
@@ -8126,6 +8174,9 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/SitePage"
+                400:
+                    description:
+                        "The wrong number of page specifications was provided, a page specification is not approved, a required or default page experience is missing, or the draft and published page specification external reference codes do not match."
             # @review
             tags: ["SitePage"]
     "/sites/{siteExternalReferenceCode}/site-pages/{sitePageExternalReferenceCode}":
@@ -8290,6 +8341,12 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/SitePage"
+                400:
+                    description:
+                        "A page specification is not approved, a required or default page experience is missing, the default page experience priority is not zero, its external reference code does not match the target page's experience, it references a segment, or the draft and published page specification external reference codes do not match."
+                409:
+                    description:
+                        "A page experience key is duplicated."
             tags: ["SitePage"]
     "/sites/{siteExternalReferenceCode}/site-pages/{sitePageExternalReferenceCode}/friendly-url-history":
         get:
@@ -8416,6 +8473,12 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/ContentPageSpecification"
+                400:
+                    description:
+                        "The page specification is not in draft status or is not approved, or a page experience is invalid."
+                409:
+                    description:
+                        "A page experience key is duplicated."
             # @review
             tags: ["SitePage"]
     "/sites/{siteExternalReferenceCode}/site-pages/{sitePageExternalReferenceCode}/permissions":
@@ -9229,6 +9292,9 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/UtilityPage"
+                409:
+                    description:
+                        "The default utility page must be published first."
             tags: ["UtilityPage"]
     "/sites/{siteExternalReferenceCode}/utility-pages/{utilityPageExternalReferenceCode}/friendly-url-history":
         get:

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/exception/DuplicatePageExperienceKeyException.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/exception/DuplicatePageExperienceKeyException.java
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Javier Moral
+ */
+public class DuplicatePageExperienceKeyException extends PortalException {
+
+	public DuplicatePageExperienceKeyException(String key) {
+		super("Duplicate page experience key " + key);
+
+		_key = key;
+	}
+
+	public String getKey() {
+		return _key;
+	}
+
+	private final String _key;
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/exception/InvalidDisplayPageTemplateFolderExternalReferenceCodeException.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/exception/InvalidDisplayPageTemplateFolderExternalReferenceCodeException.java
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.exception;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Javier Moral
+ */
+public class InvalidDisplayPageTemplateFolderExternalReferenceCodeException
+	extends PortalException {
+
+	public InvalidDisplayPageTemplateFolderExternalReferenceCodeException(
+		String externalReferenceCode) {
+
+		super(
+			StringBundler.concat(
+				"The external reference code ", externalReferenceCode,
+				" does not point to a display page template folder"));
+
+		_externalReferenceCode = externalReferenceCode;
+	}
+
+	public String getExternalReferenceCode() {
+		return _externalReferenceCode;
+	}
+
+	private final String _externalReferenceCode;
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/exception/MismatchedDisplayPageTemplateFolderExternalReferenceCodeException.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/exception/MismatchedDisplayPageTemplateFolderExternalReferenceCodeException.java
@@ -1,0 +1,15 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Javier Moral
+ */
+public class MismatchedDisplayPageTemplateFolderExternalReferenceCodeException
+	extends PortalException {
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/exception/NoSuchPageElementException.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/exception/NoSuchPageElementException.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Javier Moral
+ */
+public class NoSuchPageElementException extends PortalException {
+
+	public NoSuchPageElementException(String externalReferenceCode) {
+		super(
+			"No page element exists with the external reference code " +
+				externalReferenceCode);
+
+		_externalReferenceCode = externalReferenceCode;
+	}
+
+	public String getExternalReferenceCode() {
+		return _externalReferenceCode;
+	}
+
+	private final String _externalReferenceCode;
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/exception/PageExperienceException.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/exception/PageExperienceException.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Javier Moral
+ */
+public class PageExperienceException extends PortalException {
+
+	public static final int CONTENT_PAGES_ONLY = 1;
+
+	public static final int DEFAULT_EXPERIENCE_REQUIRED = 2;
+
+	public static final int DEFAULT_REFERENCES_SEGMENT = 3;
+
+	public static final int EXPERIENCE_REQUIRED = 4;
+
+	public static final int INVALID_DEFAULT_PRIORITY = 5;
+
+	public static final int MISMATCHED_EXTERNAL_REFERENCE_CODE = 6;
+
+	public PageExperienceException(int type, String message) {
+		super(message);
+
+		_type = type;
+	}
+
+	public int getType() {
+		return _type;
+	}
+
+	private final int _type;
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/exception/PageSpecificationException.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/exception/PageSpecificationException.java
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Javier Moral
+ */
+public class PageSpecificationException extends PortalException {
+
+	public static final int EXACTLY_ONE_REQUIRED = 1;
+
+	public static final int EXACTLY_TWO_REQUIRED = 2;
+
+	public static final int INVALID = 3;
+
+	public static final int MISMATCHED_EXTERNAL_REFERENCE_CODES = 4;
+
+	public PageSpecificationException(int type, String message) {
+		super(message);
+
+		_type = type;
+	}
+
+	public int getType() {
+		return _type;
+	}
+
+	private final int _type;
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageElementResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/PageElementResourceImpl.java
@@ -9,6 +9,7 @@ import com.liferay.fragment.processor.FragmentEntryProcessorRegistry;
 import com.liferay.headless.admin.site.dto.v1_0.PageElement;
 import com.liferay.headless.admin.site.internal.dto.v1_0.util.DTOConverterContextUtil;
 import com.liferay.headless.admin.site.internal.dto.v1_0.util.InfoFormUtil;
+import com.liferay.headless.admin.site.internal.exception.NoSuchPageElementException;
 import com.liferay.headless.admin.site.internal.resource.v1_0.layout.structure.item.importer.context.LayoutStructureItemImporterContext;
 import com.liferay.headless.admin.site.internal.resource.v1_0.util.LayoutStructureUtil;
 import com.liferay.headless.admin.site.resource.v1_0.PageElementResource;
@@ -22,7 +23,6 @@ import com.liferay.layout.util.structure.CollectionStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructureItemUtil;
-import com.liferay.layout.util.structure.exception.NoSuchLayoutStructureItemException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
@@ -101,7 +101,8 @@ public class PageElementResourceImpl extends BasePageElementResourceImpl {
 				pageElementExternalReferenceCode);
 
 		if (layoutStructureItem == null) {
-			throw new NoSuchLayoutStructureItemException();
+			throw new NoSuchPageElementException(
+				pageElementExternalReferenceCode);
 		}
 
 		layoutStructure.deleteLayoutStructureItem(
@@ -156,7 +157,8 @@ public class PageElementResourceImpl extends BasePageElementResourceImpl {
 				pageElementExternalReferenceCode);
 
 		if (layoutStructureItem == null) {
-			throw new NoSuchLayoutStructureItemException();
+			throw new NoSuchPageElementException(
+				pageElementExternalReferenceCode);
 		}
 
 		PageElement pageElement = _pageElementDTOConverter.toDTO(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/SitePageResourceImpl.java
@@ -1215,7 +1215,8 @@ public class SitePageResourceImpl
 	}
 
 	private void _validatePageSpecificationExternalReferenceCode(
-		ServiceContext serviceContext, SitePage sitePage) {
+			ServiceContext serviceContext, SitePage sitePage)
+		throws Exception {
 
 		PageSpecification[] pageSpecifications =
 			sitePage.getPageSpecifications();

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/DisplayPageTemplateFolderUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/DisplayPageTemplateFolderUtil.java
@@ -6,6 +6,8 @@
 package com.liferay.headless.admin.site.internal.resource.v1_0.util;
 
 import com.liferay.headless.admin.site.dto.v1_0.DisplayPageTemplateFolder;
+import com.liferay.headless.admin.site.internal.exception.InvalidDisplayPageTemplateFolderExternalReferenceCodeException;
+import com.liferay.headless.admin.site.internal.exception.MismatchedDisplayPageTemplateFolderExternalReferenceCodeException;
 import com.liferay.headless.common.spi.service.context.ServiceContextBuilder;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateCollectionTypeConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
@@ -86,7 +88,7 @@ public class DisplayPageTemplateFolderUtil {
 					parentDisplayPageTemplateFolder.
 						getExternalReferenceCode())) {
 
-				throw new UnsupportedOperationException();
+				throw new MismatchedDisplayPageTemplateFolderExternalReferenceCodeException();
 			}
 
 			parentLayoutPageTemplateCollection =
@@ -101,7 +103,12 @@ public class DisplayPageTemplateFolderUtil {
 				LayoutPageTemplateCollectionTypeConstants.DISPLAY_PAGE,
 				parentLayoutPageTemplateCollection.getType())) {
 
-			throw new UnsupportedOperationException();
+			String externalReferenceCode =
+				displayPageTemplateFolder.
+					getParentDisplayPageTemplateFolderExternalReferenceCode();
+
+			throw new InvalidDisplayPageTemplateFolderExternalReferenceCodeException(
+				externalReferenceCode);
 		}
 
 		return parentLayoutPageTemplateCollection.

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageExperienceUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageExperienceUtil.java
@@ -6,6 +6,9 @@
 package com.liferay.headless.admin.site.internal.resource.v1_0.util;
 
 import com.liferay.headless.admin.site.dto.v1_0.PageExperience;
+import com.liferay.headless.admin.site.internal.exception.DuplicatePageExperienceKeyException;
+import com.liferay.headless.admin.site.internal.exception.PageExperienceException;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
@@ -21,10 +24,13 @@ import java.util.Set;
 public class PageExperienceUtil {
 
 	public static PageExperience getDefaultPageExperience(
-		PageExperience[] pageExperiences) {
+			PageExperience[] pageExperiences)
+		throws PageExperienceException {
 
 		if (ArrayUtil.isEmpty(pageExperiences)) {
-			throw new UnsupportedOperationException();
+			throw new PageExperienceException(
+				PageExperienceException.EXPERIENCE_REQUIRED,
+				"No page experiences were provided");
 		}
 
 		for (PageExperience pageExperience : pageExperiences) {
@@ -36,17 +42,25 @@ public class PageExperienceUtil {
 			}
 		}
 
-		throw new UnsupportedOperationException();
+		throw new PageExperienceException(
+			PageExperienceException.DEFAULT_EXPERIENCE_REQUIRED,
+			"No default page experience was found");
 	}
 
 	public static void validatePageExperiences(
-		SegmentsExperience defaultSegmentsExperience,
-		PageExperience[] pageExperiences) {
+			SegmentsExperience defaultSegmentsExperience,
+			PageExperience[] pageExperiences)
+		throws PortalException {
 
-		if ((defaultSegmentsExperience == null) ||
-			ArrayUtil.isEmpty(pageExperiences)) {
+		if (defaultSegmentsExperience == null) {
+			throw new IllegalStateException(
+				"The default segments experience does not exist");
+		}
 
-			throw new UnsupportedOperationException();
+		if (ArrayUtil.isEmpty(pageExperiences)) {
+			throw new PageExperienceException(
+				PageExperienceException.EXPERIENCE_REQUIRED,
+				"No page experiences were provided");
 		}
 
 		Set<String> pageExperienceKeys = new HashSet<>(pageExperiences.length);
@@ -55,7 +69,8 @@ public class PageExperienceUtil {
 
 		for (PageExperience pageExperience : pageExperiences) {
 			if (!pageExperienceKeys.add(pageExperience.getKey())) {
-				throw new UnsupportedOperationException();
+				throw new DuplicatePageExperienceKeyException(
+					pageExperience.getKey());
 			}
 
 			if (Objects.equals(
@@ -66,15 +81,34 @@ public class PageExperienceUtil {
 			}
 		}
 
-		if ((defaultPageExperience == null) ||
-			!StringUtil.equals(
-				defaultSegmentsExperience.getExternalReferenceCode(),
-				defaultPageExperience.getExternalReferenceCode()) ||
-			((defaultPageExperience.getPriority() != null) &&
-			 (defaultPageExperience.getPriority() != 0)) ||
-			(defaultPageExperience.getSegmentItemExternalReference() != null)) {
+		if (defaultPageExperience == null) {
+			throw new PageExperienceException(
+				PageExperienceException.DEFAULT_EXPERIENCE_REQUIRED,
+				"No default page experience was found");
+		}
 
-			throw new UnsupportedOperationException();
+		if ((defaultPageExperience.getPriority() != null) &&
+			(defaultPageExperience.getPriority() != 0)) {
+
+			throw new PageExperienceException(
+				PageExperienceException.INVALID_DEFAULT_PRIORITY,
+				"The default page experience must have a priority of 0");
+		}
+
+		if (!StringUtil.equals(
+				defaultSegmentsExperience.getExternalReferenceCode(),
+				defaultPageExperience.getExternalReferenceCode())) {
+
+			throw new PageExperienceException(
+				PageExperienceException.MISMATCHED_EXTERNAL_REFERENCE_CODE,
+				"The external reference code does not match the target page " +
+					"experience external reference code");
+		}
+
+		if (defaultPageExperience.getSegmentItemExternalReference() != null) {
+			throw new PageExperienceException(
+				PageExperienceException.DEFAULT_REFERENCES_SEGMENT,
+				"The default page experience cannot reference a segment");
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
@@ -19,6 +19,7 @@ import com.liferay.headless.admin.site.dto.v1_0.PageSetPageSpecification;
 import com.liferay.headless.admin.site.dto.v1_0.PageSpecification;
 import com.liferay.headless.admin.site.dto.v1_0.WidgetInstancePageElementDefinition;
 import com.liferay.headless.admin.site.dto.v1_0.WidgetPageSpecification;
+import com.liferay.headless.admin.site.internal.exception.PageSpecificationException;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -34,14 +35,17 @@ import java.util.function.Consumer;
 public class PageSpecificationUtil {
 
 	public static PageSpecification getPageSpecification(
-		PageSpecification[] pageSpecifications) {
+			PageSpecification[] pageSpecifications)
+		throws PageSpecificationException {
 
 		if (ArrayUtil.isEmpty(pageSpecifications)) {
 			return null;
 		}
 
 		if (pageSpecifications.length != 1) {
-			throw new UnsupportedOperationException();
+			throw new PageSpecificationException(
+				PageSpecificationException.EXACTLY_ONE_REQUIRED,
+				"Exactly one page specification is required");
 		}
 
 		PageSpecification pageSpecification = pageSpecifications[0];
@@ -55,21 +59,25 @@ public class PageSpecificationUtil {
 				pageSpecification.getStatus(),
 				PageSpecification.Status.APPROVED)) {
 
-			throw new UnsupportedOperationException();
+			throw new PageSpecificationException(
+				PageSpecificationException.INVALID,
+				"The page specification is invalid or has not been approved");
 		}
 
 		return pageSpecification;
 	}
 
-	public static int getPublishedStatus(
-		PageSpecification[] pageSpecifications) {
+	public static int getPublishedStatus(PageSpecification[] pageSpecifications)
+		throws PageSpecificationException {
 
 		if (pageSpecifications == null) {
 			return WorkflowConstants.STATUS_DRAFT;
 		}
 
 		if (pageSpecifications.length != 2) {
-			throw new UnsupportedOperationException();
+			throw new PageSpecificationException(
+				PageSpecificationException.EXACTLY_TWO_REQUIRED,
+				"Exactly two page specifications are required");
 		}
 
 		PageSpecification[] sortedContentPageSpecifications =
@@ -89,14 +97,17 @@ public class PageSpecificationUtil {
 	}
 
 	public static PageSpecification[] getSortedContentPageSpecifications(
-		PageSpecification[] pageSpecifications) {
+			PageSpecification[] pageSpecifications)
+		throws PageSpecificationException {
 
 		if (pageSpecifications == null) {
 			return null;
 		}
 
 		if (pageSpecifications.length != 2) {
-			throw new UnsupportedOperationException();
+			throw new PageSpecificationException(
+				PageSpecificationException.EXACTLY_TWO_REQUIRED,
+				"Exactly two page specifications are required");
 		}
 
 		ContentPageSpecification draftContentPageSpecification;
@@ -124,7 +135,10 @@ public class PageSpecificationUtil {
 				publishedContentPageSpecification.
 					getDraftContentPageSpecificationExternalReferenceCode())) {
 
-			throw new UnsupportedOperationException();
+			throw new PageSpecificationException(
+				PageSpecificationException.MISMATCHED_EXTERNAL_REFERENCE_CODES,
+				"The draft and published page specifications have mismatched " +
+					"external reference codes");
 		}
 
 		return new PageSpecification[] {
@@ -133,7 +147,8 @@ public class PageSpecificationUtil {
 	}
 
 	public static WidgetPageSpecification getWidgetPageSpecification(
-		PageSpecification[] pageSpecifications) {
+			PageSpecification[] pageSpecifications)
+		throws PageSpecificationException {
 
 		return (WidgetPageSpecification)getPageSpecification(
 			pageSpecifications);

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/SegmentsExperienceUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/SegmentsExperienceUtil.java
@@ -10,6 +10,7 @@ import com.liferay.headless.admin.site.dto.v1_0.ItemExternalReference;
 import com.liferay.headless.admin.site.dto.v1_0.PageElement;
 import com.liferay.headless.admin.site.dto.v1_0.PageExperience;
 import com.liferay.headless.admin.site.internal.dto.v1_0.util.ItemScopeUtil;
+import com.liferay.headless.admin.site.internal.exception.PageExperienceException;
 import com.liferay.headless.admin.site.internal.resource.v1_0.layout.structure.item.importer.context.LayoutStructureItemImporterContext;
 import com.liferay.headless.admin.site.internal.util.LogUtil;
 import com.liferay.info.item.InfoItemServiceRegistry;
@@ -46,7 +47,9 @@ public class SegmentsExperienceUtil {
 		throws Exception {
 
 		if (!Objects.equals(layout.getType(), LayoutConstants.TYPE_CONTENT)) {
-			throw new UnsupportedOperationException();
+			throw new PageExperienceException(
+				PageExperienceException.CONTENT_PAGES_ONLY,
+				"Page experiences can only be added to content pages");
 		}
 
 		SegmentsEntryReference segmentsEntryReference =
@@ -143,9 +146,13 @@ public class SegmentsExperienceUtil {
 			).build());
 	}
 
-	public static void validateSegmentsExperienceLayout(Layout layout) {
+	public static void validateSegmentsExperienceLayout(Layout layout)
+		throws PageExperienceException {
+
 		if (!Objects.equals(layout.getType(), LayoutConstants.TYPE_CONTENT)) {
-			throw new UnsupportedOperationException();
+			throw new PageExperienceException(
+				PageExperienceException.CONTENT_PAGES_ONLY,
+				"Page experiences can only be added to content pages");
 		}
 
 		long plid = layout.getPlid();
@@ -159,7 +166,9 @@ public class SegmentsExperienceUtil {
 				fetchLayoutPageTemplateEntryByPlid(plid);
 
 		if (layoutPageTemplateEntry != null) {
-			throw new UnsupportedOperationException();
+			throw new PageExperienceException(
+				PageExperienceException.CONTENT_PAGES_ONLY,
+				"Page experiences cannot be added to a page template");
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/DisplayPageTemplateDisplayPageTemplateFolderExceptionProblemMapper.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/DisplayPageTemplateDisplayPageTemplateFolderExceptionProblemMapper.java
@@ -25,6 +25,9 @@ public class DisplayPageTemplateDisplayPageTemplateFolderExceptionProblemMapper
 			layoutPageTemplateEntryLayoutPageTemplateCollectionIdException) {
 
 		return ProblemUtil.getProblem(
+			"The page template set does not belong to this site",
+			Problem.Status.BAD_REQUEST,
+			"page-template-set-does-not-belong-to-this-site",
 			layoutPageTemplateEntryLayoutPageTemplateCollectionIdException);
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/DisplayPageTemplateMarkAsDefaultExceptionProblemMapper.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/DisplayPageTemplateMarkAsDefaultExceptionProblemMapper.java
@@ -7,7 +7,6 @@ package com.liferay.headless.admin.site.internal.vulcan.problem;
 
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.exception.LayoutPageTemplateEntryDefaultTemplateException;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.problem.Problem;
 import com.liferay.portal.vulcan.problem.ProblemMapper;
 
@@ -36,12 +35,8 @@ public class DisplayPageTemplateMarkAsDefaultExceptionProblemMapper
 			name = "master page";
 		}
 
-		return ProblemUtil.getProblem(
-			StringUtil.replace(
-				layoutPageTemplateEntryDefaultTemplateException.getMessage(),
-				"layout page template entry", name),
-			Problem.Status.CONFLICT,
-			layoutPageTemplateEntryDefaultTemplateException);
+		return ProblemUtil.getMustBePublishedFirstProblem(
+			name, layoutPageTemplateEntryDefaultTemplateException);
 	}
 
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/DuplicatePageExperienceKeyExceptionProblemMapper.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/DuplicatePageExperienceKeyExceptionProblemMapper.java
@@ -5,26 +5,28 @@
 
 package com.liferay.headless.admin.site.internal.vulcan.problem;
 
-import com.liferay.layout.utility.page.exception.DefaultLayoutUtilityPageEntryException;
+import com.liferay.headless.admin.site.internal.exception.DuplicatePageExperienceKeyException;
 import com.liferay.portal.vulcan.problem.Problem;
 import com.liferay.portal.vulcan.problem.ProblemMapper;
 
 import org.osgi.service.component.annotations.Component;
 
 /**
- * @author Lourdes Fernández Besada
+ * @author Javier Moral
  */
 @Component(service = ProblemMapper.class)
-public class UtilityPageMarkAsDefaultExceptionProblemMapper
-	implements ProblemMapper<DefaultLayoutUtilityPageEntryException> {
+public class DuplicatePageExperienceKeyExceptionProblemMapper
+	implements ProblemMapper<DuplicatePageExperienceKeyException> {
 
 	@Override
 	public Problem getProblem(
-		DefaultLayoutUtilityPageEntryException
-			defaultLayoutUtilityPageEntryException) {
+		DuplicatePageExperienceKeyException
+			duplicatePageExperienceKeyException) {
 
-		return ProblemUtil.getMustBePublishedFirstProblem(
-			"utility page", defaultLayoutUtilityPageEntryException);
+		return ProblemUtil.getDuplicateProblem(
+			"key", "page experience",
+			duplicatePageExperienceKeyException.getKey(),
+			duplicatePageExperienceKeyException);
 	}
 
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/InvalidDisplayPageTemplateFolderExternalReferenceCodeExceptionProblemMapper.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/InvalidDisplayPageTemplateFolderExternalReferenceCodeExceptionProblemMapper.java
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.vulcan.problem;
+
+import com.liferay.headless.admin.site.internal.exception.InvalidDisplayPageTemplateFolderExternalReferenceCodeException;
+import com.liferay.portal.vulcan.problem.Problem;
+import com.liferay.portal.vulcan.problem.ProblemMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Javier Moral
+ */
+@Component(service = ProblemMapper.class)
+public class
+	InvalidDisplayPageTemplateFolderExternalReferenceCodeExceptionProblemMapper
+		implements ProblemMapper
+			<InvalidDisplayPageTemplateFolderExternalReferenceCodeException> {
+
+	@Override
+	public Problem getProblem(
+		InvalidDisplayPageTemplateFolderExternalReferenceCodeException
+			invalidDisplayPageTemplateFolderExternalReferenceCodeException) {
+
+		return ProblemUtil.getReferenceTypeMismatchProblem(
+			"display page template folder",
+			invalidDisplayPageTemplateFolderExternalReferenceCodeException.
+				getExternalReferenceCode(),
+			invalidDisplayPageTemplateFolderExternalReferenceCodeException);
+	}
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/MismatchedDisplayPageTemplateFolderExternalReferenceCodeExceptionProblemMapper.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/MismatchedDisplayPageTemplateFolderExternalReferenceCodeExceptionProblemMapper.java
@@ -1,0 +1,37 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.vulcan.problem;
+
+import com.liferay.headless.admin.site.internal.exception.MismatchedDisplayPageTemplateFolderExternalReferenceCodeException;
+import com.liferay.portal.vulcan.problem.Problem;
+import com.liferay.portal.vulcan.problem.ProblemMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Javier Moral
+ */
+@Component(service = ProblemMapper.class)
+public class
+	MismatchedDisplayPageTemplateFolderExternalReferenceCodeExceptionProblemMapper
+		implements ProblemMapper
+			<MismatchedDisplayPageTemplateFolderExternalReferenceCodeException> {
+
+	@Override
+	public Problem getProblem(
+		MismatchedDisplayPageTemplateFolderExternalReferenceCodeException
+			mismatchedDisplayPageTemplateFolderExternalReferenceCodeException) {
+
+		return ProblemUtil.getProblem(
+			"The parent display page template folder external reference " +
+				"codes do not match",
+			Problem.Status.BAD_REQUEST,
+			"parent-display-page-template-folder-external-reference-codes-do-" +
+				"not-match",
+			mismatchedDisplayPageTemplateFolderExternalReferenceCodeException);
+	}
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/NoSuchPageElementExceptionProblemMapper.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/NoSuchPageElementExceptionProblemMapper.java
@@ -5,7 +5,9 @@
 
 package com.liferay.headless.admin.site.internal.vulcan.problem;
 
-import com.liferay.layout.util.structure.exception.NoSuchLayoutStructureItemException;
+import com.liferay.headless.admin.site.internal.exception.NoSuchPageElementException;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.problem.Problem;
 import com.liferay.portal.vulcan.problem.ProblemMapper;
 
@@ -16,14 +18,28 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(service = ProblemMapper.class)
 public class NoSuchPageElementExceptionProblemMapper
-	implements ProblemMapper<NoSuchLayoutStructureItemException> {
+	implements ProblemMapper<NoSuchPageElementException> {
 
 	@Override
 	public Problem getProblem(
-		NoSuchLayoutStructureItemException noSuchLayoutStructureItemException) {
+		NoSuchPageElementException noSuchPageElementException) {
+
+		String title = "The page element could not be found";
+
+		String detail = title;
+
+		String externalReferenceCode =
+			noSuchPageElementException.getExternalReferenceCode();
+
+		if (Validator.isNotNull(externalReferenceCode)) {
+			detail = StringBundler.concat(
+				"No page element with external reference code ",
+				externalReferenceCode, " exists in this page experience");
+		}
 
 		return ProblemUtil.getProblem(
-			Problem.Status.NOT_FOUND, noSuchLayoutStructureItemException);
+			detail, Problem.Status.NOT_FOUND, title, "page-element-not-found",
+			noSuchPageElementException);
 	}
 
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/PageExperienceExceptionProblemMapper.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/PageExperienceExceptionProblemMapper.java
@@ -1,0 +1,88 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.vulcan.problem;
+
+import com.liferay.headless.admin.site.internal.exception.PageExperienceException;
+import com.liferay.portal.vulcan.problem.Problem;
+import com.liferay.portal.vulcan.problem.ProblemMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Javier Moral
+ */
+@Component(service = ProblemMapper.class)
+public class PageExperienceExceptionProblemMapper
+	implements ProblemMapper<PageExperienceException> {
+
+	@Override
+	public Problem getProblem(PageExperienceException pageExperienceException) {
+		int type = pageExperienceException.getType();
+
+		if (type == PageExperienceException.DEFAULT_EXPERIENCE_REQUIRED) {
+			return ProblemUtil.getRequiredFieldProblem(
+				"default page experience", pageExperienceException);
+		}
+
+		if (type == PageExperienceException.EXPERIENCE_REQUIRED) {
+			return ProblemUtil.getRequiredFieldProblem(
+				"page experience", pageExperienceException);
+		}
+
+		return ProblemUtil.getProblem(
+			_getMessage(type), Problem.Status.BAD_REQUEST, _getType(type),
+			pageExperienceException);
+	}
+
+	private String _getMessage(int type) {
+		if (type == PageExperienceException.CONTENT_PAGES_ONLY) {
+			return "Only site pages can define additional page experiences";
+		}
+
+		if (type == PageExperienceException.DEFAULT_REFERENCES_SEGMENT) {
+			return "The default page experience cannot reference a segment";
+		}
+
+		if (type == PageExperienceException.INVALID_DEFAULT_PRIORITY) {
+			return "The default page experience must have a priority of 0";
+		}
+
+		if (type ==
+				PageExperienceException.MISMATCHED_EXTERNAL_REFERENCE_CODE) {
+
+			return "The external reference code does not match the target " +
+				"page's experience external reference code";
+		}
+
+		throw new IllegalArgumentException(
+			"Unknown PageExperienceException type: " + type);
+	}
+
+	private String _getType(int type) {
+		if (type == PageExperienceException.CONTENT_PAGES_ONLY) {
+			return "only-site-pages-can-define-additional-page-experiences";
+		}
+
+		if (type == PageExperienceException.DEFAULT_REFERENCES_SEGMENT) {
+			return "default-page-experience-cannot-reference-a-segment";
+		}
+
+		if (type == PageExperienceException.INVALID_DEFAULT_PRIORITY) {
+			return "default-page-experience-must-have-a-priority-of-0";
+		}
+
+		if (type ==
+				PageExperienceException.MISMATCHED_EXTERNAL_REFERENCE_CODE) {
+
+			return "external-reference-code-does-not-match-the-target-pages-" +
+				"experience-external-reference-code";
+		}
+
+		throw new IllegalArgumentException(
+			"Unknown PageExperienceException type: " + type);
+	}
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/PageSpecificationExceptionProblemMapper.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/PageSpecificationExceptionProblemMapper.java
@@ -1,0 +1,76 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.vulcan.problem;
+
+import com.liferay.headless.admin.site.internal.exception.PageSpecificationException;
+import com.liferay.portal.vulcan.problem.Problem;
+import com.liferay.portal.vulcan.problem.ProblemMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Javier Moral
+ */
+@Component(service = ProblemMapper.class)
+public class PageSpecificationExceptionProblemMapper
+	implements ProblemMapper<PageSpecificationException> {
+
+	@Override
+	public Problem getProblem(
+		PageSpecificationException pageSpecificationException) {
+
+		int type = pageSpecificationException.getType();
+
+		if (type == PageSpecificationException.EXACTLY_ONE_REQUIRED) {
+			return _getCountProblem(
+				"Exactly one page specification is required",
+				pageSpecificationException);
+		}
+
+		if (type == PageSpecificationException.EXACTLY_TWO_REQUIRED) {
+			return _getCountProblem(
+				"Exactly two page specifications are required",
+				pageSpecificationException);
+		}
+
+		if (type == PageSpecificationException.INVALID) {
+			return ProblemUtil.getProblem(
+				"The page specification is invalid or has not been approved",
+				Problem.Status.BAD_REQUEST,
+				"page-specification-is-invalid-or-has-not-been-approved",
+				pageSpecificationException);
+		}
+
+		if (type ==
+				PageSpecificationException.
+					MISMATCHED_EXTERNAL_REFERENCE_CODES) {
+
+			return ProblemUtil.getProblem(
+				"The draft and published page specifications have mismatched " +
+					"external reference codes",
+				Problem.Status.BAD_REQUEST,
+				"draft-and-published-page-specifications-have-mismatched-" +
+					"external-reference-codes",
+				pageSpecificationException);
+		}
+
+		throw new IllegalArgumentException(
+			"Unknown PageSpecificationException type: " + type);
+	}
+
+	private Problem _getCountProblem(
+		String detail, PageSpecificationException pageSpecificationException) {
+
+		return ProblemUtil.getProblem(
+			detail, Problem.Status.BAD_REQUEST,
+			"The number of page specifications does not match the page type " +
+				"requirements",
+			"number-of-page-specifications-does-not-match-the-page-type-" +
+				"requirements",
+			pageSpecificationException);
+	}
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/PageTemplateSetExceptionProblemMapper.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/PageTemplateSetExceptionProblemMapper.java
@@ -23,9 +23,9 @@ public class PageTemplateSetExceptionProblemMapper
 		DuplicateLayoutPageTemplateCollectionException
 			duplicateLayoutPageTemplateCollectionException) {
 
-		return ProblemUtil.getProblem(
-			"A page template set with the same name already exists",
-			Problem.Status.CONFLICT,
+		return ProblemUtil.getDuplicateProblem(
+			"name", "page template set",
+			duplicateLayoutPageTemplateCollectionException.getMessage(),
 			duplicateLayoutPageTemplateCollectionException);
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/ProblemUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/ProblemUtil.java
@@ -5,14 +5,141 @@
 
 package com.liferay.headless.admin.site.internal.vulcan.problem;
 
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.problem.Problem;
 
 import java.util.Locale;
 
 /**
  * @author Lourdes Fernández Besada
+ * @author Javier Moral
  */
 public class ProblemUtil {
+
+	public static <T extends Throwable> Problem getCannotCreateInSiteProblem(
+		String entity, T throwable) {
+
+		String message = "A " + entity + " cannot be created in this site";
+
+		String type = StringUtil.toLowerCase(
+			StringUtil.replace(entity, CharPool.SPACE, CharPool.DASH) +
+				"-cannot-be-created-in-this-site");
+
+		return _getProblem(
+			type, message, message, Problem.Status.BAD_REQUEST, throwable);
+	}
+
+	public static <T extends Throwable> Problem getDuplicateProblem(
+		String attribute, String entity, String value, T throwable) {
+
+		String title = StringBundler.concat(
+			"A ", entity, " with the same ", attribute, " already exists");
+
+		String detail = title;
+
+		if (Validator.isNotNull(value)) {
+			detail = StringBundler.concat(
+				"A ", entity, " with ", attribute, " ", value,
+				" already exists");
+		}
+
+		String type = StringUtil.toLowerCase(
+			StringBundler.concat(
+				StringUtil.replace(entity, CharPool.SPACE, CharPool.DASH),
+				"-with-the-same-",
+				StringUtil.replace(attribute, CharPool.SPACE, CharPool.DASH),
+				"-already-exists"));
+
+		return _getProblem(
+			type, detail, title, Problem.Status.CONFLICT, throwable);
+	}
+
+	public static <T extends Throwable> Problem getInvalidCharacterProblem(
+		String character, String field, T throwable) {
+
+		String title = "The " + field + " contains an invalid character";
+
+		String detail = title;
+
+		if (Validator.isNotNull(character)) {
+			detail = StringBundler.concat(
+				"The ", field, " contains an invalid character: \"", character,
+				"\"");
+		}
+
+		String type = StringUtil.toLowerCase(
+			StringUtil.replace(field, CharPool.SPACE, CharPool.DASH) +
+				"-contains-an-invalid-character");
+
+		return _getProblem(
+			type, detail, title, Problem.Status.BAD_REQUEST, throwable);
+	}
+
+	public static <T extends Throwable> Problem getKeyInvalidCharacterProblem(
+		T throwable) {
+
+		String message =
+			"The key must contain only alphanumeric characters, dashes, and " +
+				"underscores";
+
+		return _getProblem(
+			"key-must-contain-only-alphanumeric-characters-dashes-and-" +
+				"underscores",
+			message, message, Problem.Status.BAD_REQUEST, throwable);
+	}
+
+	public static <T extends Throwable> Problem getKeyTooLongProblem(
+		int maxLength, T throwable) {
+
+		String title = "The key is too long";
+
+		String detail = title;
+
+		if (maxLength > 0) {
+			detail =
+				"The key exceeds the maximum length of " + maxLength +
+					" characters";
+		}
+
+		return _getProblem(
+			"key-is-too-long", detail, title, Problem.Status.BAD_REQUEST,
+			throwable);
+	}
+
+	public static <T extends Throwable> Problem getMustBePublishedFirstProblem(
+		String entity, T throwable) {
+
+		String message = "The default " + entity + " must be published first";
+
+		String type = StringUtil.toLowerCase(
+			"default-" +
+				StringUtil.replace(entity, CharPool.SPACE, CharPool.DASH) +
+					"-must-be-published-first");
+
+		return _getProblem(
+			type, message, message, Problem.Status.CONFLICT, throwable);
+	}
+
+	public static <T extends Throwable> Problem getNameTooLongProblem(
+		int maxLength, T throwable) {
+
+		String title = "The name is too long";
+
+		String detail = title;
+
+		if (maxLength > 0) {
+			detail =
+				"The name exceeds the maximum length of " + maxLength +
+					" characters";
+		}
+
+		return _getProblem(
+			"name-is-too-long", detail, title, Problem.Status.BAD_REQUEST,
+			throwable);
+	}
 
 	public static <T extends Throwable> Problem getProblem(
 		Problem.Status status, T throwable) {
@@ -21,13 +148,119 @@ public class ProblemUtil {
 	}
 
 	public static <T extends Throwable> Problem getProblem(
+		String detail, Problem.Status status, String title, String type,
+		T throwable) {
+
+		return _getProblem(type, detail, title, status, throwable);
+	}
+
+	public static <T extends Throwable> Problem getProblem(
+		String message, Problem.Status status, String type, T throwable) {
+
+		return _getProblem(type, message, message, status, throwable);
+	}
+
+	public static <T extends Throwable> Problem getProblem(
 		String message, Problem.Status status, T throwable) {
+
+		return _getProblem(null, message, message, status, throwable);
+	}
+
+	public static <T extends Throwable> Problem getProblem(T throwable) {
+		return getProblem(Problem.Status.BAD_REQUEST, throwable);
+	}
+
+	public static <T extends Throwable> Problem getReferenceTypeMismatchProblem(
+		String entity, String externalReferenceCode, T throwable) {
+
+		String title =
+			"The external reference code does not point to a " + entity;
+
+		String detail = title;
+
+		if (Validator.isNotNull(externalReferenceCode)) {
+			detail = StringBundler.concat(
+				"The external reference code \"", externalReferenceCode,
+				"\" does not point to a ", entity);
+		}
+
+		String type = StringUtil.toLowerCase(
+			"external-reference-code-does-not-point-to-a-" +
+				StringUtil.replace(entity, CharPool.SPACE, CharPool.DASH));
+
+		return _getProblem(
+			type, detail, title, Problem.Status.BAD_REQUEST, throwable);
+	}
+
+	public static <T extends Throwable> Problem getRequiredFieldProblem(
+		String field, T throwable) {
+
+		String message = "A " + field + " is required";
+
+		String type = StringUtil.toLowerCase(
+			StringUtil.replace(field, CharPool.SPACE, CharPool.DASH) +
+				"-is-required");
+
+		return _getProblem(
+			type, message, message, Problem.Status.BAD_REQUEST, throwable);
+	}
+
+	public static <T extends Throwable> Problem getTypeMismatchProblem(
+		String actualType, String expectedType, T throwable) {
+
+		String message = StringBundler.concat(
+			"The ", actualType, " type does not match the ", expectedType,
+			" type");
+
+		String type = StringUtil.toLowerCase(
+			StringBundler.concat(
+				StringUtil.replace(actualType, CharPool.SPACE, CharPool.DASH),
+				"-type-does-not-match-the-",
+				StringUtil.replace(expectedType, CharPool.SPACE, CharPool.DASH),
+				"-type"));
+
+		return _getProblem(
+			type, message, message, Problem.Status.BAD_REQUEST, throwable);
+	}
+
+	public static <T extends Throwable> Problem getUnsupportedEnumProblem(
+		String enumType, String supportedTypes, String value, T throwable) {
+
+		String title = "The page type is not supported";
+
+		String detail = title;
+
+		if (Validator.isNotNull(value)) {
+			if (Validator.isNull(supportedTypes)) {
+				detail = StringBundler.concat(
+					"\"", value, "\" is not a supported ", enumType);
+			}
+			else {
+				detail = StringBundler.concat(
+					"\"", value, "\" is not a supported ", enumType,
+					". Supported types are: ", supportedTypes);
+			}
+		}
+
+		String type = StringUtil.toLowerCase(
+			StringUtil.replace(enumType, CharPool.SPACE, CharPool.DASH) +
+				"-not-supported");
+
+		return _getProblem(
+			type, detail, title, Problem.Status.BAD_REQUEST, throwable);
+	}
+
+	private static Problem _getProblem(
+		String type, String detail, String title, Problem.Status status,
+		Throwable throwable) {
+
+		String resolvedType = _resolveType(type, throwable);
 
 		return new Problem() {
 
 			@Override
 			public String getDetail(Locale locale) {
-				return message;
+				return detail;
 			}
 
 			@Override
@@ -37,22 +270,25 @@ public class ProblemUtil {
 
 			@Override
 			public String getTitle(Locale locale) {
-				return message;
+				return title;
 			}
 
 			@Override
 			public String getType() {
-				Class<? extends Throwable> throwableClass =
-					throwable.getClass();
-
-				return throwableClass.getName();
+				return resolvedType;
 			}
 
 		};
 	}
 
-	public static <T extends Throwable> Problem getProblem(T throwable) {
-		return getProblem(Problem.Status.BAD_REQUEST, throwable);
+	private static String _resolveType(String type, Throwable throwable) {
+		if (type != null) {
+			return type;
+		}
+
+		Class<? extends Throwable> throwableClass = throwable.getClass();
+
+		return throwableClass.getName();
 	}
 
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/SitePageLayoutTypeExceptionProblemMapper.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/SitePageLayoutTypeExceptionProblemMapper.java
@@ -30,7 +30,7 @@ public class SitePageLayoutTypeExceptionProblemMapper
 			_getLayoutTypeExceptionMessage(
 				layoutTypeException.getMessage(), layoutTypeException.getType(),
 				GetterUtil.getString(layoutTypeException.getLayoutType()),
-				LocaleUtil.getMostRelevantLocale()),
+				LocaleUtil.US),
 			Problem.Status.CONFLICT, layoutTypeException);
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateFolderResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateFolderResourceTest.java
@@ -20,8 +20,6 @@ import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -272,6 +270,30 @@ public class DisplayPageTemplateFolderResourceTest
 			StringBundler.concat(
 				"Key ", key, " must have fewer than 75 characters"));
 
+		DisplayPageTemplateFolder displayPageTemplateFolder =
+			randomDisplayPageTemplateFolder();
+
+		String parentExternalReferenceCode = RandomTestUtil.randomString();
+
+		displayPageTemplateFolder.
+			setParentDisplayPageTemplateFolderExternalReferenceCode(
+				parentExternalReferenceCode);
+
+		_assertProblemException(
+			StringBundler.concat(
+				"The external reference code \"", parentExternalReferenceCode,
+				"\" does not point to a display page template folder"),
+			"BAD_REQUEST",
+			"The external reference code does not point to a display page " +
+				"template folder",
+			"external-reference-code-does-not-point-to-a-display-page-" +
+				"template-folder",
+			() ->
+				displayPageTemplateFolderResource.
+					postSiteDisplayPageTemplateFolder(
+						testGroup.getExternalReferenceCode(),
+						displayPageTemplateFolder));
+
 		_enableLocalStaging();
 
 		_assertProblemException(
@@ -456,7 +478,7 @@ public class DisplayPageTemplateFolderResourceTest
 	}
 
 	private void _assertProblemException(
-			String status, String title,
+			String detail, String status, String title, String type,
 			UnsafeRunnable<Exception> unsafeRunnable)
 		throws Exception {
 
@@ -468,9 +490,28 @@ public class DisplayPageTemplateFolderResourceTest
 		catch (Problem.ProblemException problemException) {
 			Problem problem = problemException.getProblem();
 
+			if (Validator.isNotNull(detail)) {
+				Assert.assertEquals(detail, problem.getDetail());
+			}
+			else if (problem.getDetail() != null) {
+				Assert.assertEquals(title, problem.getDetail());
+			}
+
+			if (type != null) {
+				Assert.assertEquals(type, problem.getType());
+			}
+
 			Assert.assertEquals(status, problem.getStatus());
 			Assert.assertEquals(title, problem.getTitle());
 		}
+	}
+
+	private void _assertProblemException(
+			String status, String title,
+			UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		_assertProblemException(null, status, title, null, unsafeRunnable);
 	}
 
 	private void _enableLocalStaging() throws Exception {
@@ -700,11 +741,22 @@ public class DisplayPageTemplateFolderResourceTest
 	private void _testPutSiteDisplayPageTemplateFolderWithParentDisplayPageTemplateFolder()
 		throws Exception {
 
+		String invalidParentExternalReferenceCode =
+			RandomTestUtil.randomString();
+
 		_assertProblemException(
-			"BAD_REQUEST", null,
+			StringBundler.concat(
+				"The external reference code \"",
+				invalidParentExternalReferenceCode,
+				"\" does not point to a display page template folder"),
+			"BAD_REQUEST",
+			"The external reference code does not point to a display page " +
+				"template folder",
+			"external-reference-code-does-not-point-to-a-display-page-" +
+				"template-folder",
 			() -> _testPutSiteDisplayPageTemplateFolder(
 				randomDisplayPageTemplateFolder(),
-				RandomTestUtil.randomString()));
+				invalidParentExternalReferenceCode));
 
 		DisplayPageTemplateFolder parentDisplayPageTemplateFolder =
 			testPostSiteDisplayPageTemplateFolder_addDisplayPageTemplateFolder(
@@ -727,30 +779,32 @@ public class DisplayPageTemplateFolderResourceTest
 		parentDisplayPageTemplateFolder = _getParentDisplayPageTemplateFolder(
 			5);
 
+		String deeplyNestedParentExternalReferenceCode =
+			parentDisplayPageTemplateFolder.getExternalReferenceCode();
+
 		putDisplayPageTemplateFolder.setParentDisplayPageTemplateFolder(
 			parentDisplayPageTemplateFolder);
+
 		putDisplayPageTemplateFolder.
 			setParentDisplayPageTemplateFolderExternalReferenceCode(
-				parentDisplayPageTemplateFolder.getExternalReferenceCode());
+				deeplyNestedParentExternalReferenceCode);
 
-		try {
-			displayPageTemplateFolderResource.putSiteDisplayPageTemplateFolder(
-				testGroup.getExternalReferenceCode(),
-				putDisplayPageTemplateFolder.getExternalReferenceCode(),
-				putDisplayPageTemplateFolder);
-
-			Assert.fail();
-		}
-		catch (Problem.ProblemException problemException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(problemException);
-			}
-
-			Problem problem = problemException.getProblem();
-
-			Assert.assertEquals(
-				"UnsupportedOperationException", problem.getType());
-		}
+		_assertProblemException(
+			StringBundler.concat(
+				"The external reference code \"",
+				deeplyNestedParentExternalReferenceCode,
+				"\" does not point to a display page template folder"),
+			"BAD_REQUEST",
+			"The external reference code does not point to a display page " +
+				"template folder",
+			"external-reference-code-does-not-point-to-a-display-page-" +
+				"template-folder",
+			() ->
+				displayPageTemplateFolderResource.
+					putSiteDisplayPageTemplateFolder(
+						testGroup.getExternalReferenceCode(),
+						putDisplayPageTemplateFolder.getExternalReferenceCode(),
+						putDisplayPageTemplateFolder));
 
 		try (SafeCloseable safeCloseable =
 				LazyReferencingTestUtil.setLazyReferencingWithSafeCloseable(
@@ -784,10 +838,36 @@ public class DisplayPageTemplateFolderResourceTest
 						testGroup.getGroupId()),
 				parentLayoutPageTemplateCollections);
 		}
-	}
 
-	private static final Log _log = LogFactoryUtil.getLog(
-		DisplayPageTemplateFolderResourceTest.class);
+		try (SafeCloseable safeCloseable =
+				LazyReferencingTestUtil.setLazyReferencingWithSafeCloseable(
+					true)) {
+
+			DisplayPageTemplateFolder mismatchedDisplayPageTemplateFolder =
+				randomDisplayPageTemplateFolder();
+
+			mismatchedDisplayPageTemplateFolder.
+				setParentDisplayPageTemplateFolder(
+					randomDisplayPageTemplateFolder());
+			mismatchedDisplayPageTemplateFolder.
+				setParentDisplayPageTemplateFolderExternalReferenceCode(
+					RandomTestUtil.randomString());
+
+			_assertProblemException(
+				null, "BAD_REQUEST",
+				"The parent display page template folder external reference " +
+					"codes do not match",
+				"parent-display-page-template-folder-external-reference-" +
+					"codes-do-not-match",
+				() ->
+					displayPageTemplateFolderResource.
+						putSiteDisplayPageTemplateFolder(
+							testGroup.getExternalReferenceCode(),
+							mismatchedDisplayPageTemplateFolder.
+								getExternalReferenceCode(),
+							mismatchedDisplayPageTemplateFolder));
+		}
+	}
 
 	@Inject
 	private LayoutPageTemplateCollectionLocalService

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateFolderResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateFolderResourceTest.java
@@ -10,13 +10,12 @@ import com.liferay.exportimport.kernel.service.StagingLocalService;
 import com.liferay.exportimport.test.util.LazyReferencingTestUtil;
 import com.liferay.headless.admin.site.client.dto.v1_0.DisplayPageTemplateFolder;
 import com.liferay.headless.admin.site.client.pagination.Page;
-import com.liferay.headless.admin.site.client.problem.Problem;
+import com.liferay.headless.admin.site.resource.v1_0.test.util.ProblemExceptionTestUtil;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateCollectionTypeConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
 import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionService;
-import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -97,7 +96,7 @@ public class DisplayPageTemplateFolderResourceTest
 
 		_enableLocalStaging(irrelevantGroup);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", null,
 			() ->
 				displayPageTemplateFolderResource.
@@ -213,7 +212,7 @@ public class DisplayPageTemplateFolderResourceTest
 			displayPageTemplateFolder.getExternalReferenceCode(),
 			StringPool.BLANK);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"NOT_FOUND", null,
 			() ->
 				displayPageTemplateFolderResource.
@@ -224,7 +223,7 @@ public class DisplayPageTemplateFolderResourceTest
 
 		_enableLocalStaging();
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", null,
 			() ->
 				displayPageTemplateFolderResource.
@@ -279,7 +278,7 @@ public class DisplayPageTemplateFolderResourceTest
 			setParentDisplayPageTemplateFolderExternalReferenceCode(
 				parentExternalReferenceCode);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			StringBundler.concat(
 				"The external reference code \"", parentExternalReferenceCode,
 				"\" does not point to a display page template folder"),
@@ -296,7 +295,7 @@ public class DisplayPageTemplateFolderResourceTest
 
 		_enableLocalStaging();
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", null,
 			() ->
 				displayPageTemplateFolderResource.
@@ -326,7 +325,7 @@ public class DisplayPageTemplateFolderResourceTest
 
 		_enableLocalStaging();
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", null,
 			() ->
 				displayPageTemplateFolderResource.
@@ -475,43 +474,6 @@ public class DisplayPageTemplateFolderResourceTest
 		}
 
 		Assert.assertNull(parentDisplayPageTemplateFolder);
-	}
-
-	private void _assertProblemException(
-			String detail, String status, String title, String type,
-			UnsafeRunnable<Exception> unsafeRunnable)
-		throws Exception {
-
-		try {
-			unsafeRunnable.run();
-
-			Assert.fail();
-		}
-		catch (Problem.ProblemException problemException) {
-			Problem problem = problemException.getProblem();
-
-			if (Validator.isNotNull(detail)) {
-				Assert.assertEquals(detail, problem.getDetail());
-			}
-			else if (problem.getDetail() != null) {
-				Assert.assertEquals(title, problem.getDetail());
-			}
-
-			if (type != null) {
-				Assert.assertEquals(type, problem.getType());
-			}
-
-			Assert.assertEquals(status, problem.getStatus());
-			Assert.assertEquals(title, problem.getTitle());
-		}
-	}
-
-	private void _assertProblemException(
-			String status, String title,
-			UnsafeRunnable<Exception> unsafeRunnable)
-		throws Exception {
-
-		_assertProblemException(null, status, title, null, unsafeRunnable);
 	}
 
 	private void _enableLocalStaging() throws Exception {
@@ -701,7 +663,7 @@ public class DisplayPageTemplateFolderResourceTest
 
 		displayPageTemplateFolder.setKey(key);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"CONFLICT", title,
 			() ->
 				displayPageTemplateFolderResource.
@@ -744,7 +706,7 @@ public class DisplayPageTemplateFolderResourceTest
 		String invalidParentExternalReferenceCode =
 			RandomTestUtil.randomString();
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			StringBundler.concat(
 				"The external reference code \"",
 				invalidParentExternalReferenceCode,
@@ -789,7 +751,7 @@ public class DisplayPageTemplateFolderResourceTest
 			setParentDisplayPageTemplateFolderExternalReferenceCode(
 				deeplyNestedParentExternalReferenceCode);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			StringBundler.concat(
 				"The external reference code \"",
 				deeplyNestedParentExternalReferenceCode,
@@ -853,7 +815,7 @@ public class DisplayPageTemplateFolderResourceTest
 				setParentDisplayPageTemplateFolderExternalReferenceCode(
 					RandomTestUtil.randomString());
 
-			_assertProblemException(
+			ProblemExceptionTestUtil.assertProblemException(
 				null, "BAD_REQUEST",
 				"The parent display page template folder external reference " +
 					"codes do not match",

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateResourceTest.java
@@ -35,6 +35,7 @@ import com.liferay.headless.admin.site.resource.v1_0.test.util.LayoutPageTemplat
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageElementsTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageExperiencesTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageSpecificationsTestUtil;
+import com.liferay.headless.admin.site.resource.v1_0.test.util.ProblemExceptionTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.SettingsTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.ThumbnailHttpServer;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.ThumbnailURLReferenceUtil;
@@ -201,7 +202,7 @@ public class DisplayPageTemplateResourceTest
 					postDisplayPageTemplate.getExternalReferenceCode(),
 					testGroup.getGroupId()));
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"NOT_FOUND", null,
 			() -> displayPageTemplateResource.deleteSiteDisplayPageTemplate(
 				testGroup.getExternalReferenceCode(),
@@ -214,7 +215,7 @@ public class DisplayPageTemplateResourceTest
 
 		_enableLocalStaging(irrelevantGroup);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", null,
 			() -> displayPageTemplateResource.deleteSiteDisplayPageTemplate(
 				irrelevantGroup.getExternalReferenceCode(),
@@ -253,7 +254,7 @@ public class DisplayPageTemplateResourceTest
 
 		_testGetSiteDisplayPageTemplateWithNestedFields(displayPageTemplate);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"NOT_FOUND", null,
 			() -> displayPageTemplateResource.getSiteDisplayPageTemplate(
 				testGroup.getExternalReferenceCode(),
@@ -421,7 +422,7 @@ public class DisplayPageTemplateResourceTest
 		_testPatchSiteDisplayPageTemplateWithPageSpecifications();
 		_testPatchSiteDisplayPageTemplateWithThumbnail();
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"NOT_FOUND", null,
 			() -> displayPageTemplateResource.patchSiteDisplayPageTemplate(
 				testGroup.getExternalReferenceCode(),
@@ -429,7 +430,7 @@ public class DisplayPageTemplateResourceTest
 
 		_enableLocalStaging();
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", null,
 			() -> displayPageTemplateResource.patchSiteDisplayPageTemplate(
 				testGroup.getExternalReferenceCode(),
@@ -556,7 +557,7 @@ public class DisplayPageTemplateResourceTest
 		_assertStagingGroupDisplayPageTemplateThumbnail(
 			displayPageTemplate, fileEntry);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", null,
 			() -> displayPageTemplateResource.putSiteDisplayPageTemplate(
 				testGroup.getExternalReferenceCode(),
@@ -705,7 +706,7 @@ public class DisplayPageTemplateResourceTest
 				LayoutPageTemplateEntry layoutPageTemplateEntry)
 		throws Exception {
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", expectedTitle,
 			() ->
 				displayPageTemplateResource.
@@ -717,28 +718,6 @@ public class DisplayPageTemplateResourceTest
 								setType(() -> Type.CONTENT_PAGE_SPECIFICATION);
 							}
 						}));
-	}
-
-	private void _assertProblemException(
-			String expectedStatus, String expectedTitle,
-			UnsafeRunnable<Exception> unsafeRunnable)
-		throws Exception {
-
-		try {
-			unsafeRunnable.run();
-
-			Assert.fail();
-		}
-		catch (Problem.ProblemException problemException) {
-			Problem problem = problemException.getProblem();
-
-			if (problem.getDetail() != null) {
-				Assert.assertEquals(expectedTitle, problem.getDetail());
-			}
-
-			Assert.assertEquals(expectedStatus, problem.getStatus());
-			Assert.assertEquals(expectedTitle, problem.getTitle());
-		}
 	}
 
 	private void _assertStagingGroupDisplayPageTemplateThumbnail(
@@ -1787,7 +1766,7 @@ public class DisplayPageTemplateResourceTest
 
 		Assert.assertTrue(postDisplayPageTemplate.getMarkedAsDefault());
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"CONFLICT",
 			"The default display page template must be published first",
 			() -> displayPageTemplateResource.postSiteDisplayPageTemplate(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateResourceTest.java
@@ -732,6 +732,10 @@ public class DisplayPageTemplateResourceTest
 		catch (Problem.ProblemException problemException) {
 			Problem problem = problemException.getProblem();
 
+			if (problem.getDetail() != null) {
+				Assert.assertEquals(expectedTitle, problem.getDetail());
+			}
+
 			Assert.assertEquals(expectedStatus, problem.getStatus());
 			Assert.assertEquals(expectedTitle, problem.getTitle());
 		}
@@ -1785,7 +1789,7 @@ public class DisplayPageTemplateResourceTest
 
 		_assertProblemException(
 			"CONFLICT",
-			"The default display page template must be published first.",
+			"The default display page template must be published first",
 			() -> displayPageTemplateResource.postSiteDisplayPageTemplate(
 				testGroup.getExternalReferenceCode(),
 				_randomDisplayPageTemplate(Boolean.TRUE)));

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
@@ -68,6 +68,7 @@ import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.segments.constants.SegmentsExperienceConstants;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
 import com.liferay.sites.kernel.util.Sites;
 
@@ -368,6 +369,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 		Assert.assertNull(postMasterPage.getThumbnailURLReference());
 
 		_testPostSiteMasterPageWithDropZonePageElement();
+		_testPostSiteMasterPageWithInvalidPageSpecifications();
 		_testPostSiteMasterPageWithPageSpecifications();
 		_testPostSiteMasterPageWithSiteTemplatePageSpecification();
 		_testPostSiteMasterPageWithThumbnail();
@@ -418,6 +420,8 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 			"The external reference code does not point to a master page",
 			LayoutPageTemplateEntryTestUtil.
 				getDisplayPageLayoutPageTemplateEntry(serviceContext));
+
+		_testPostSiteMasterPagePageSpecificationWithInvalidPageExperiences();
 	}
 
 	@Override
@@ -606,8 +610,8 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 	}
 
 	private void _assertProblemException(
-			String expectedStatus, String expectedTitle,
-			UnsafeRunnable<Exception> unsafeRunnable)
+			String expectedDetail, String expectedStatus, String expectedTitle,
+			String expectedType, UnsafeRunnable<Exception> unsafeRunnable)
 		throws Exception {
 
 		try {
@@ -618,9 +622,29 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 		catch (Problem.ProblemException problemException) {
 			Problem problem = problemException.getProblem();
 
+			if (Validator.isNotNull(expectedDetail)) {
+				Assert.assertEquals(expectedDetail, problem.getDetail());
+			}
+			else if (problem.getDetail() != null) {
+				Assert.assertEquals(expectedTitle, problem.getDetail());
+			}
+
+			if (expectedType != null) {
+				Assert.assertEquals(expectedType, problem.getType());
+			}
+
 			Assert.assertEquals(expectedStatus, problem.getStatus());
 			Assert.assertEquals(expectedTitle, problem.getTitle());
 		}
+	}
+
+	private void _assertProblemException(
+			String expectedStatus, String expectedTitle,
+			UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		_assertProblemException(
+			null, expectedStatus, expectedTitle, null, unsafeRunnable);
 	}
 
 	private void _assertStagingGroupMasterPageThumbnail(
@@ -1273,6 +1297,64 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 		}
 	}
 
+	private void _testPostSiteMasterPagePageSpecificationWithInvalidPageExperiences()
+		throws Exception {
+
+		MasterPageResource masterPageResource = _getMasterPageResource();
+
+		MasterPage masterPage = masterPageResource.postSiteMasterPage(
+			testGroup.getExternalReferenceCode(), randomMasterPage());
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.
+				getLayoutPageTemplateEntryByExternalReferenceCode(
+					masterPage.getExternalReferenceCode(),
+					testGroup.getGroupId());
+
+		Layout layout = _layoutLocalService.getLayout(
+			layoutPageTemplateEntry.getPlid());
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		_assertProblemException(
+			"A page experience with key DEFAULT already exists", "CONFLICT",
+			"A page experience with the same key already exists",
+			"page-experience-with-the-same-key-already-exists",
+			() -> masterPageResource.postSiteMasterPagePageSpecification(
+				testGroup.getExternalReferenceCode(),
+				masterPage.getExternalReferenceCode(),
+				PageSpecificationsTestUtil.getContentPageSpecification(
+					draftLayout.getExternalReferenceCode(), null, null,
+					new PageExperience[] {
+						PageExperiencesTestUtil.getPageExperience(
+							RandomTestUtil.randomString(),
+							SegmentsExperienceConstants.KEY_DEFAULT, 0,
+							RandomTestUtil.randomString()),
+						PageExperiencesTestUtil.getPageExperience(
+							RandomTestUtil.randomString(),
+							SegmentsExperienceConstants.KEY_DEFAULT, 0,
+							RandomTestUtil.randomString())
+					},
+					testGroup.getGroupId(), PageSpecification.Status.DRAFT)));
+
+		_assertProblemException(
+			null, "BAD_REQUEST",
+			"The default page experience must have a priority of 0",
+			"default-page-experience-must-have-a-priority-of-0",
+			() -> masterPageResource.postSiteMasterPagePageSpecification(
+				testGroup.getExternalReferenceCode(),
+				masterPage.getExternalReferenceCode(),
+				PageSpecificationsTestUtil.getContentPageSpecification(
+					draftLayout.getExternalReferenceCode(), null, null,
+					new PageExperience[] {
+						PageExperiencesTestUtil.getPageExperience(
+							RandomTestUtil.randomString(),
+							SegmentsExperienceConstants.KEY_DEFAULT, 1,
+							RandomTestUtil.randomString())
+					},
+					testGroup.getGroupId(), PageSpecification.Status.DRAFT)));
+	}
+
 	private void _testPostSiteMasterPageWithDropZonePageElement()
 		throws Exception {
 
@@ -1289,6 +1371,49 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 			pageElements,
 			masterPageResource.postSiteMasterPage(
 				testGroup.getExternalReferenceCode(), masterPage));
+	}
+
+	private void _testPostSiteMasterPageWithInvalidPageSpecifications()
+		throws Exception {
+
+		MasterPage masterPage = randomMasterPage();
+
+		masterPage.setPageSpecifications(
+			() -> new PageSpecification[] {
+				PageSpecificationsTestUtil.getContentPageSpecification(
+					null, testGroup.getGroupId(),
+					PageSpecification.Status.APPROVED)
+			});
+
+		_assertProblemException(
+			"Exactly two page specifications are required", "BAD_REQUEST",
+			"The number of page specifications does not match the page type " +
+				"requirements",
+			"number-of-page-specifications-does-not-match-the-page-type-" +
+				"requirements",
+			() -> _getMasterPageResource().postSiteMasterPage(
+				testGroup.getExternalReferenceCode(), masterPage));
+
+		MasterPage mismatchedMasterPage = randomMasterPage();
+
+		mismatchedMasterPage.setPageSpecifications(
+			() -> new PageSpecification[] {
+				PageSpecificationsTestUtil.getContentPageSpecification(
+					RandomTestUtil.randomString(), testGroup.getGroupId(),
+					PageSpecification.Status.APPROVED),
+				PageSpecificationsTestUtil.getContentPageSpecification(
+					null, testGroup.getGroupId(),
+					PageSpecification.Status.DRAFT)
+			});
+
+		_assertProblemException(
+			null, "BAD_REQUEST",
+			"The draft and published page specifications have mismatched " +
+				"external reference codes",
+			"draft-and-published-page-specifications-have-mismatched-" +
+				"external-reference-codes",
+			() -> _getMasterPageResource().postSiteMasterPage(
+				testGroup.getExternalReferenceCode(), mismatchedMasterPage));
 	}
 
 	private void _testPostSiteMasterPageWithPageSpecifications()
@@ -1580,7 +1705,9 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 		masterPage.setMarkedAsDefault(Boolean.TRUE);
 
 		_assertProblemException(
-			"CONFLICT", "The default master page must be published first.",
+			"The default master page must be published first", "CONFLICT",
+			"The default master page must be published first",
+			"default-master-page-must-be-published-first",
 			() -> masterPageResource.putSiteMasterPage(
 				testGroup.getExternalReferenceCode(),
 				masterPage.getExternalReferenceCode(), masterPage));

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/MasterPageResourceTest.java
@@ -28,13 +28,13 @@ import com.liferay.headless.admin.site.resource.v1_0.test.util.LayoutPageTemplat
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageElementsTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageExperiencesTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageSpecificationsTestUtil;
+import com.liferay.headless.admin.site.resource.v1_0.test.util.ProblemExceptionTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.ThumbnailHttpServer;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.ThumbnailURLReferenceUtil;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
-import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.string.StringPool;
@@ -159,7 +159,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 					postMasterPage.getExternalReferenceCode(),
 					testGroup.getGroupId()));
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"NOT_FOUND", null,
 			() -> masterPageResource.deleteSiteMasterPage(
 				testGroup.getExternalReferenceCode(),
@@ -172,7 +172,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 
 		_enableLocalStaging(irrelevantGroup);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", null,
 			() -> masterPageResource.deleteSiteMasterPage(
 				irrelevantGroup.getExternalReferenceCode(),
@@ -191,7 +191,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 
 		_testGetSiteMasterPageWithNestedFieldsAndMissingFragmentEntryLink();
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"NOT_FOUND", null,
 			() -> masterPageResource.getSiteMasterPage(
 				testGroup.getExternalReferenceCode(),
@@ -330,7 +330,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 		_testPatchSiteMasterPageWithPageSpecifications();
 		_testPatchSiteMasterPageWithThumbnail();
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"NOT_FOUND", null,
 			() -> masterPageResource.patchSiteMasterPage(
 				testGroup.getExternalReferenceCode(),
@@ -341,7 +341,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 
 		_enableLocalStaging();
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", null,
 			() -> masterPageResource.patchSiteMasterPage(
 				testGroup.getExternalReferenceCode(),
@@ -454,7 +454,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 
 		_assertStagingGroupMasterPageThumbnail(fileEntry, masterPage);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", null,
 			() -> masterPageResource.putSiteMasterPage(
 				testGroup.getExternalReferenceCode(),
@@ -597,7 +597,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 			LayoutPageTemplateEntry layoutPageTemplateEntry)
 		throws Exception {
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", expectedTitle,
 			() -> masterPageResource.postSiteMasterPagePageSpecification(
 				testGroup.getExternalReferenceCode(),
@@ -607,44 +607,6 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 						setType(() -> Type.CONTENT_PAGE_SPECIFICATION);
 					}
 				}));
-	}
-
-	private void _assertProblemException(
-			String expectedDetail, String expectedStatus, String expectedTitle,
-			String expectedType, UnsafeRunnable<Exception> unsafeRunnable)
-		throws Exception {
-
-		try {
-			unsafeRunnable.run();
-
-			Assert.fail();
-		}
-		catch (Problem.ProblemException problemException) {
-			Problem problem = problemException.getProblem();
-
-			if (Validator.isNotNull(expectedDetail)) {
-				Assert.assertEquals(expectedDetail, problem.getDetail());
-			}
-			else if (problem.getDetail() != null) {
-				Assert.assertEquals(expectedTitle, problem.getDetail());
-			}
-
-			if (expectedType != null) {
-				Assert.assertEquals(expectedType, problem.getType());
-			}
-
-			Assert.assertEquals(expectedStatus, problem.getStatus());
-			Assert.assertEquals(expectedTitle, problem.getTitle());
-		}
-	}
-
-	private void _assertProblemException(
-			String expectedStatus, String expectedTitle,
-			UnsafeRunnable<Exception> unsafeRunnable)
-		throws Exception {
-
-		_assertProblemException(
-			null, expectedStatus, expectedTitle, null, unsafeRunnable);
 	}
 
 	private void _assertStagingGroupMasterPageThumbnail(
@@ -1316,7 +1278,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 
 		Layout draftLayout = layout.fetchDraftLayout();
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"A page experience with key DEFAULT already exists", "CONFLICT",
 			"A page experience with the same key already exists",
 			"page-experience-with-the-same-key-already-exists",
@@ -1337,7 +1299,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 					},
 					testGroup.getGroupId(), PageSpecification.Status.DRAFT)));
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			null, "BAD_REQUEST",
 			"The default page experience must have a priority of 0",
 			"default-page-experience-must-have-a-priority-of-0",
@@ -1385,7 +1347,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 					PageSpecification.Status.APPROVED)
 			});
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"Exactly two page specifications are required", "BAD_REQUEST",
 			"The number of page specifications does not match the page type " +
 				"requirements",
@@ -1406,7 +1368,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 					PageSpecification.Status.DRAFT)
 			});
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			null, "BAD_REQUEST",
 			"The draft and published page specifications have mismatched " +
 				"external reference codes",
@@ -1704,7 +1666,7 @@ public class MasterPageResourceTest extends BaseMasterPageResourceTestCase {
 
 		masterPage.setMarkedAsDefault(Boolean.TRUE);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"The default master page must be published first", "CONFLICT",
 			"The default master page must be published first",
 			"default-master-page-must-be-published-first",

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
@@ -269,7 +269,9 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 			Problem problem = problemException.getProblem();
 
 			Assert.assertEquals("NOT_FOUND", problem.getStatus());
-			Assert.assertNull(problem.getTitle());
+			Assert.assertEquals(
+				"The page element could not be found", problem.getTitle());
+			Assert.assertEquals("page-element-not-found", problem.getType());
 		}
 	}
 
@@ -312,7 +314,9 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 			Problem problem = problemException.getProblem();
 
 			Assert.assertEquals("NOT_FOUND", problem.getStatus());
-			Assert.assertNull(problem.getTitle());
+			Assert.assertEquals(
+				"The page element could not be found", problem.getTitle());
+			Assert.assertEquals("page-element-not-found", problem.getType());
 		}
 	}
 
@@ -356,7 +360,9 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 			Problem problem = problemException.getProblem();
 
 			Assert.assertEquals("NOT_FOUND", problem.getStatus());
-			Assert.assertNull(problem.getTitle());
+			Assert.assertEquals(
+				"The page element could not be found", problem.getTitle());
+			Assert.assertEquals("page-element-not-found", problem.getType());
 		}
 	}
 
@@ -838,6 +844,10 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		}
 		catch (Problem.ProblemException problemException) {
 			Problem problem = problemException.getProblem();
+
+			if (problem.getDetail() != null) {
+				Assert.assertEquals(title, problem.getDetail());
+			}
 
 			Assert.assertEquals(status, problem.getStatus());
 			Assert.assertEquals(title, problem.getTitle());

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageElementResourceTest.java
@@ -113,6 +113,7 @@ import com.liferay.headless.admin.site.resource.v1_0.test.util.FragmentViewportS
 import com.liferay.headless.admin.site.resource.v1_0.test.util.FragmentViewportTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.ImageValueTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageElementsTestUtil;
+import com.liferay.headless.admin.site.resource.v1_0.test.util.ProblemExceptionTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.ReferencesTestUtil;
 import com.liferay.journal.constants.JournalContentPortletKeys;
 import com.liferay.journal.constants.JournalFolderConstants;
@@ -830,28 +831,6 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		Assert.assertTrue(
 			scopeExternalReferenceCode,
 			Validator.isNull(scopeExternalReferenceCode));
-	}
-
-	private void _assertProblemException(
-			String status, String title,
-			UnsafeRunnable<Exception> unsafeRunnable)
-		throws Exception {
-
-		try {
-			unsafeRunnable.run();
-
-			Assert.fail();
-		}
-		catch (Problem.ProblemException problemException) {
-			Problem problem = problemException.getProblem();
-
-			if (problem.getDetail() != null) {
-				Assert.assertEquals(title, problem.getDetail());
-			}
-
-			Assert.assertEquals(status, problem.getStatus());
-			Assert.assertEquals(title, problem.getTitle());
-		}
 	}
 
 	private void _assertStyledLayoutStructureItemBackgroundImage(
@@ -2414,7 +2393,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 		collectionItemPageElement.setExternalReferenceCode(
 			pageElements[0].getExternalReferenceCode());
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", null,
 			() -> _testPostSitePageSpecificationPageExperiencePageElement(
 				collectionItemPageElement));
@@ -2554,7 +2533,7 @@ public class PageElementResourceTest extends BasePageElementResourceTestCase {
 				RandomTestUtil.randomString(),
 				formContainerExternalReferenceCode, false));
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST",
 			"Form relationship can only be added inside of a form",
 			() -> _testPostSitePageSpecificationPageExperiencePageElement(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
@@ -11,6 +11,7 @@ import com.liferay.headless.admin.site.client.problem.Problem;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.LayoutPageTemplateEntryTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageElementsTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageExperiencesTestUtil;
+import com.liferay.headless.admin.site.resource.v1_0.test.util.ProblemExceptionTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.ReferencesTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.function.UnsafeRunnable;
@@ -423,30 +424,6 @@ public class PageExperienceResourceTest
 			Integer.valueOf(expectedPriority), pageExperience.getPriority());
 	}
 
-	private void _assertProblemException(
-			String expectedTitle, String expectedType,
-			UnsafeRunnable<Exception> unsafeRunnable)
-		throws Exception {
-
-		try {
-			unsafeRunnable.run();
-
-			Assert.fail();
-		}
-		catch (Problem.ProblemException problemException) {
-			Problem problem = problemException.getProblem();
-
-			Assert.assertEquals("BAD_REQUEST", problem.getStatus());
-			Assert.assertEquals(expectedTitle, problem.getTitle());
-
-			if (problem.getDetail() != null) {
-				Assert.assertEquals(expectedTitle, problem.getDetail());
-			}
-
-			Assert.assertEquals(expectedType, problem.getType());
-		}
-	}
-
 	private PageExperience _getPageExperience() throws Exception {
 		PageExperience pageExperience = super.randomPageExperience();
 
@@ -553,7 +530,8 @@ public class PageExperienceResourceTest
 
 		Layout draftLayout = layout.fetchDraftLayout();
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
+			null, "BAD_REQUEST",
 			"Only site pages can define additional page experiences",
 			"only-site-pages-can-define-additional-page-experiences",
 			() ->
@@ -603,7 +581,8 @@ public class PageExperienceResourceTest
 
 		Layout draftLayout = layout.fetchDraftLayout();
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
+			null, "BAD_REQUEST",
 			"Only site pages can define additional page experiences",
 			"only-site-pages-can-define-additional-page-experiences",
 			() ->
@@ -679,7 +658,8 @@ public class PageExperienceResourceTest
 
 		Layout draftLayout = layout.fetchDraftLayout();
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
+			null, "BAD_REQUEST",
 			"Only site pages can define additional page experiences",
 			"only-site-pages-can-define-additional-page-experiences",
 			() -> pageExperienceResource.putSitePageExperience(
@@ -699,7 +679,8 @@ public class PageExperienceResourceTest
 
 		Layout draftLayout = layout.fetchDraftLayout();
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
+			null, "BAD_REQUEST",
 			"Only site pages can define additional page experiences",
 			"only-site-pages-can-define-additional-page-experiences",
 			() -> pageExperienceResource.putSitePageExperience(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageExperienceResourceTest.java
@@ -8,6 +8,7 @@ package com.liferay.headless.admin.site.resource.v1_0.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageExperience;
 import com.liferay.headless.admin.site.client.problem.Problem;
+import com.liferay.headless.admin.site.resource.v1_0.test.util.LayoutPageTemplateEntryTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageElementsTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageExperiencesTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.ReferencesTestUtil;
@@ -19,6 +20,8 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
@@ -215,6 +218,9 @@ public class PageExperienceResourceTest
 					null)));
 
 		_testPostSitePageSpecificationPageExperienceWithPriority();
+
+		_testPostSitePageSpecificationPageExperienceWithDisplayPageTemplate();
+		_testPostSitePageSpecificationPageExperienceWithPageTemplate();
 	}
 
 	@Override
@@ -246,6 +252,8 @@ public class PageExperienceResourceTest
 			testGroup.getExternalReferenceCode(),
 			pageExperience.getExternalReferenceCode());
 
+		_testPutSitePageExperienceWithDisplayPageTemplate();
+		_testPutSitePageExperienceWithPageTemplate();
 		_testPutSitePageExperienceWithPriority();
 	}
 
@@ -415,6 +423,30 @@ public class PageExperienceResourceTest
 			Integer.valueOf(expectedPriority), pageExperience.getPriority());
 	}
 
+	private void _assertProblemException(
+			String expectedTitle, String expectedType,
+			UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		try {
+			unsafeRunnable.run();
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("BAD_REQUEST", problem.getStatus());
+			Assert.assertEquals(expectedTitle, problem.getTitle());
+
+			if (problem.getDetail() != null) {
+				Assert.assertEquals(expectedTitle, problem.getDetail());
+			}
+
+			Assert.assertEquals(expectedType, problem.getType());
+		}
+	}
+
 	private PageExperience _getPageExperience() throws Exception {
 		PageExperience pageExperience = super.randomPageExperience();
 
@@ -510,6 +542,29 @@ public class PageExperienceResourceTest
 		assertValid(postPageExperience);
 	}
 
+	private void _testPostSitePageSpecificationPageExperienceWithDisplayPageTemplate()
+		throws Exception {
+
+		Layout layout =
+			LayoutPageTemplateEntryTestUtil.
+				getDisplayPageLayoutPageTemplateEntryLayout(
+					ServiceContextTestUtil.getServiceContext(
+						testGroup.getGroupId(), TestPropsValues.getUserId()));
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		_assertProblemException(
+			"Only site pages can define additional page experiences",
+			"only-site-pages-can-define-additional-page-experiences",
+			() ->
+				pageExperienceResource.postSitePageSpecificationPageExperience(
+					testGroup.getExternalReferenceCode(),
+					draftLayout.getExternalReferenceCode(),
+					PageExperiencesTestUtil.getPageExperience(
+						draftLayout.getExternalReferenceCode(), 1,
+						testGroup.getGroupId(), null)));
+	}
+
 	private void
 			_testPostSitePageSpecificationPageExperienceWithMissingOptionalReference(
 				int count, UnsafeRunnable<Exception> unsafeRunnable)
@@ -535,6 +590,29 @@ public class PageExperienceResourceTest
 						"Optional reference generated for missing"));
 			}
 		}
+	}
+
+	private void _testPostSitePageSpecificationPageExperienceWithPageTemplate()
+		throws Exception {
+
+		Layout layout =
+			LayoutPageTemplateEntryTestUtil.
+				getBasicLayoutPageTemplateEntryLayout(
+					ServiceContextTestUtil.getServiceContext(
+						testGroup.getGroupId(), TestPropsValues.getUserId()));
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		_assertProblemException(
+			"Only site pages can define additional page experiences",
+			"only-site-pages-can-define-additional-page-experiences",
+			() ->
+				pageExperienceResource.postSitePageSpecificationPageExperience(
+					testGroup.getExternalReferenceCode(),
+					draftLayout.getExternalReferenceCode(),
+					PageExperiencesTestUtil.getPageExperience(
+						draftLayout.getExternalReferenceCode(), 1,
+						testGroup.getGroupId(), null)));
 	}
 
 	private void _testPostSitePageSpecificationPageExperienceWithPriority()
@@ -588,6 +666,48 @@ public class PageExperienceResourceTest
 		assertValid(putSitePageExperience);
 
 		return putSitePageExperience;
+	}
+
+	private void _testPutSitePageExperienceWithDisplayPageTemplate()
+		throws Exception {
+
+		Layout layout =
+			LayoutPageTemplateEntryTestUtil.
+				getDisplayPageLayoutPageTemplateEntryLayout(
+					ServiceContextTestUtil.getServiceContext(
+						testGroup.getGroupId(), TestPropsValues.getUserId()));
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		_assertProblemException(
+			"Only site pages can define additional page experiences",
+			"only-site-pages-can-define-additional-page-experiences",
+			() -> pageExperienceResource.putSitePageExperience(
+				testGroup.getExternalReferenceCode(),
+				RandomTestUtil.randomString(),
+				PageExperiencesTestUtil.getPageExperience(
+					draftLayout.getExternalReferenceCode(), 1,
+					testGroup.getGroupId(), null)));
+	}
+
+	private void _testPutSitePageExperienceWithPageTemplate() throws Exception {
+		Layout layout =
+			LayoutPageTemplateEntryTestUtil.
+				getBasicLayoutPageTemplateEntryLayout(
+					ServiceContextTestUtil.getServiceContext(
+						testGroup.getGroupId(), TestPropsValues.getUserId()));
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		_assertProblemException(
+			"Only site pages can define additional page experiences",
+			"only-site-pages-can-define-additional-page-experiences",
+			() -> pageExperienceResource.putSitePageExperience(
+				testGroup.getExternalReferenceCode(),
+				RandomTestUtil.randomString(),
+				PageExperiencesTestUtil.getPageExperience(
+					draftLayout.getExternalReferenceCode(), 1,
+					testGroup.getGroupId(), null)));
 	}
 
 	private void _testPutSitePageExperienceWithPriority() throws Exception {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
@@ -16,18 +16,17 @@ import com.liferay.headless.admin.site.client.dto.v1_0.PageSpecification;
 import com.liferay.headless.admin.site.client.dto.v1_0.Settings;
 import com.liferay.headless.admin.site.client.dto.v1_0.WidgetPageSpecification;
 import com.liferay.headless.admin.site.client.pagination.Page;
-import com.liferay.headless.admin.site.client.problem.Problem;
 import com.liferay.headless.admin.site.client.scope.Scope;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.LayoutPageTemplateEntryTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.LayoutUtilityPageEntryTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageExperiencesTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageSpecificationsTestUtil;
+import com.liferay.headless.admin.site.resource.v1_0.test.util.ProblemExceptionTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.SettingsTestUtil;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
-import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Layout;
@@ -42,7 +41,6 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
@@ -103,7 +101,7 @@ public class PageSpecificationResourceTest
 		Layout layout = _addLayout(
 			LayoutConstants.TYPE_PORTLET, serviceContext);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", "The page status is not valid",
 			() -> pageSpecificationResource.deleteSitePageSpecification(
 				testGroup.getExternalReferenceCode(),
@@ -136,13 +134,13 @@ public class PageSpecificationResourceTest
 		Layout layoutPageTemplateEntryLayout = _layoutLocalService.getLayout(
 			layoutPageTemplateEntry.getPlid());
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"NOT_FOUND", null,
 			() -> pageSpecificationResource.deleteSitePageSpecification(
 				testGroup.getExternalReferenceCode(),
 				layoutPageTemplateEntryLayout.getExternalReferenceCode()));
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", "The page status is not valid",
 			() -> pageSpecificationResource.deleteSitePageSpecification(
 				testGroup.getExternalReferenceCode(),
@@ -637,43 +635,6 @@ public class PageSpecificationResourceTest
 			layout.fetchDraftLayout(), pageSpecifications.get(1));
 	}
 
-	private void _assertProblemException(
-			String expectedDetail, String expectedStatus, String expectedTitle,
-			String expectedType, UnsafeRunnable<Exception> unsafeRunnable)
-		throws Exception {
-
-		try {
-			unsafeRunnable.run();
-			Assert.fail();
-		}
-		catch (Problem.ProblemException problemException) {
-			Problem problem = problemException.getProblem();
-
-			if (Validator.isNotNull(expectedDetail)) {
-				Assert.assertEquals(expectedDetail, problem.getDetail());
-			}
-			else if (problem.getDetail() != null) {
-				Assert.assertEquals(expectedTitle, problem.getDetail());
-			}
-
-			if (expectedType != null) {
-				Assert.assertEquals(expectedType, problem.getType());
-			}
-
-			Assert.assertEquals(expectedStatus, problem.getStatus());
-			Assert.assertEquals(expectedTitle, problem.getTitle());
-		}
-	}
-
-	private void _assertProblemException(
-			String expectedStatus, String expectedTitle,
-			UnsafeRunnable<Exception> unsafeRunnable)
-		throws Exception {
-
-		_assertProblemException(
-			null, expectedStatus, expectedTitle, null, unsafeRunnable);
-	}
-
 	private void _assertPutSiteContentPageSpecification(
 			Layout layout, ServiceContext serviceContext)
 		throws Exception {
@@ -860,7 +821,7 @@ public class PageSpecificationResourceTest
 			Layout layout, ServiceContext serviceContext)
 		throws Exception {
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", "The page status is not valid",
 			() -> pageSpecificationResource.deleteSitePageSpecification(
 				testGroup.getExternalReferenceCode(),
@@ -872,13 +833,13 @@ public class PageSpecificationResourceTest
 
 		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", "The page status is not valid",
 			() -> pageSpecificationResource.deleteSitePageSpecification(
 				testGroup.getExternalReferenceCode(),
 				layout.getExternalReferenceCode()));
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", "The page status is not valid",
 			() -> pageSpecificationResource.deleteSitePageSpecification(
 				testGroup.getExternalReferenceCode(),
@@ -1075,7 +1036,7 @@ public class PageSpecificationResourceTest
 
 		widgetPageSpecification.setStatus(PageSpecification.Status.DRAFT);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST",
 			"The page specification must be widget and be in approved status",
 			() -> pageSpecificationResource.patchSitePageSpecification(
@@ -1137,7 +1098,7 @@ public class PageSpecificationResourceTest
 
 		contentPageSpecification.setStatus(PageSpecification.Status.APPROVED);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST",
 			"The page specification must be in draft status for content pages",
 			() -> pageSpecificationResource.patchSitePageSpecification(
@@ -1180,7 +1141,7 @@ public class PageSpecificationResourceTest
 
 		Layout draftLayout = layout.fetchDraftLayout();
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"A page experience with key DEFAULT already exists", "CONFLICT",
 			"A page experience with the same key already exists",
 			"page-experience-with-the-same-key-already-exists",
@@ -1201,7 +1162,7 @@ public class PageSpecificationResourceTest
 					},
 					testGroup.getGroupId(), PageSpecification.Status.DRAFT)));
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"The default page experience must have a priority of 0",
 			"BAD_REQUEST",
 			"The default page experience must have a priority of 0",
@@ -1234,13 +1195,13 @@ public class PageSpecificationResourceTest
 
 		pageSpecification.setStatus(PageSpecification.Status.APPROVED);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST",
 			"The page specification must be in draft status for content pages",
 			() -> pageSpecificationResource.putSitePageSpecification(
 				testGroup.getExternalReferenceCode(),
 				draftLayout.getExternalReferenceCode(), pageSpecification));
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST",
 			"The page specification must be in draft status for content pages",
 			() -> pageSpecificationResource.putSitePageSpecification(
@@ -1249,7 +1210,7 @@ public class PageSpecificationResourceTest
 
 		pageSpecification.setStatus(PageSpecification.Status.DRAFT);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST",
 			"The page specification must be in draft status for content pages",
 			() -> pageSpecificationResource.putSitePageSpecification(
@@ -1262,7 +1223,7 @@ public class PageSpecificationResourceTest
 
 		pageSpecification.setStatus(PageSpecification.Status.APPROVED);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST",
 			"The page specification must be in draft status for content pages",
 			() -> pageSpecificationResource.putSitePageSpecification(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageSpecificationResourceTest.java
@@ -42,12 +42,14 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.segments.constants.SegmentsExperienceConstants;
 import com.liferay.segments.service.SegmentsExperienceService;
 import com.liferay.style.book.model.StyleBookEntry;
 import com.liferay.style.book.service.StyleBookEntryLocalService;
@@ -379,6 +381,8 @@ public class PageSpecificationResourceTest
 			layoutPageTemplateEntry.getExternalReferenceCode(), serviceContext);
 
 		_testPutSitePageSpecificationWithStyleBookEntryScopeERC(serviceContext);
+
+		_testPutSitePageSpecificationWithInvalidPageExperiences(serviceContext);
 	}
 
 	@Override
@@ -634,8 +638,8 @@ public class PageSpecificationResourceTest
 	}
 
 	private void _assertProblemException(
-			String expectedStatus, String expectedTitle,
-			UnsafeRunnable<Exception> unsafeRunnable)
+			String expectedDetail, String expectedStatus, String expectedTitle,
+			String expectedType, UnsafeRunnable<Exception> unsafeRunnable)
 		throws Exception {
 
 		try {
@@ -645,9 +649,29 @@ public class PageSpecificationResourceTest
 		catch (Problem.ProblemException problemException) {
 			Problem problem = problemException.getProblem();
 
+			if (Validator.isNotNull(expectedDetail)) {
+				Assert.assertEquals(expectedDetail, problem.getDetail());
+			}
+			else if (problem.getDetail() != null) {
+				Assert.assertEquals(expectedTitle, problem.getDetail());
+			}
+
+			if (expectedType != null) {
+				Assert.assertEquals(expectedType, problem.getType());
+			}
+
 			Assert.assertEquals(expectedStatus, problem.getStatus());
 			Assert.assertEquals(expectedTitle, problem.getTitle());
 		}
+	}
+
+	private void _assertProblemException(
+			String expectedStatus, String expectedTitle,
+			UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		_assertProblemException(
+			null, expectedStatus, expectedTitle, null, unsafeRunnable);
 	}
 
 	private void _assertPutSiteContentPageSpecification(
@@ -1145,6 +1169,55 @@ public class PageSpecificationResourceTest
 				pageSpecificationExternalReferenceCode, pageSpecification);
 
 		assertEquals(pageSpecification, putPageSpecification);
+	}
+
+	private void _testPutSitePageSpecificationWithInvalidPageExperiences(
+			ServiceContext serviceContext)
+		throws Exception {
+
+		Layout layout = _addLayout(
+			LayoutConstants.TYPE_CONTENT, serviceContext);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		_assertProblemException(
+			"A page experience with key DEFAULT already exists", "CONFLICT",
+			"A page experience with the same key already exists",
+			"page-experience-with-the-same-key-already-exists",
+			() -> pageSpecificationResource.putSitePageSpecification(
+				testGroup.getExternalReferenceCode(),
+				draftLayout.getExternalReferenceCode(),
+				PageSpecificationsTestUtil.getContentPageSpecification(
+					draftLayout.getExternalReferenceCode(), null, null,
+					new PageExperience[] {
+						PageExperiencesTestUtil.getPageExperience(
+							RandomTestUtil.randomString(),
+							SegmentsExperienceConstants.KEY_DEFAULT, 0,
+							RandomTestUtil.randomString()),
+						PageExperiencesTestUtil.getPageExperience(
+							RandomTestUtil.randomString(),
+							SegmentsExperienceConstants.KEY_DEFAULT, 0,
+							RandomTestUtil.randomString())
+					},
+					testGroup.getGroupId(), PageSpecification.Status.DRAFT)));
+
+		_assertProblemException(
+			"The default page experience must have a priority of 0",
+			"BAD_REQUEST",
+			"The default page experience must have a priority of 0",
+			"default-page-experience-must-have-a-priority-of-0",
+			() -> pageSpecificationResource.putSitePageSpecification(
+				testGroup.getExternalReferenceCode(),
+				draftLayout.getExternalReferenceCode(),
+				PageSpecificationsTestUtil.getContentPageSpecification(
+					draftLayout.getExternalReferenceCode(), null, null,
+					new PageExperience[] {
+						PageExperiencesTestUtil.getPageExperience(
+							RandomTestUtil.randomString(),
+							SegmentsExperienceConstants.KEY_DEFAULT, 1,
+							RandomTestUtil.randomString())
+					},
+					testGroup.getGroupId(), PageSpecification.Status.DRAFT)));
 	}
 
 	private void _testPutSitePageSpecificationWithLayoutWithDraftLayout(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
@@ -768,8 +768,8 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 	}
 
 	private void _assertProblemException(
-			String expectedStatus, String expectedTitle,
-			UnsafeRunnable<Exception> unsafeRunnable)
+			String expectedDetail, String expectedStatus, String expectedTitle,
+			String expectedType, UnsafeRunnable<Exception> unsafeRunnable)
 		throws Exception {
 
 		try {
@@ -780,9 +780,29 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 		catch (Problem.ProblemException problemException) {
 			Problem problem = problemException.getProblem();
 
+			if (Validator.isNotNull(expectedDetail)) {
+				Assert.assertEquals(expectedDetail, problem.getDetail());
+			}
+			else if (problem.getDetail() != null) {
+				Assert.assertEquals(expectedTitle, problem.getDetail());
+			}
+
+			if (expectedType != null) {
+				Assert.assertEquals(expectedType, problem.getType());
+			}
+
 			Assert.assertEquals(expectedStatus, problem.getStatus());
 			Assert.assertEquals(expectedTitle, problem.getTitle());
 		}
+	}
+
+	private void _assertProblemException(
+			String expectedStatus, String expectedTitle,
+			UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		_assertProblemException(
+			null, expectedStatus, expectedTitle, null, unsafeRunnable);
 	}
 
 	private void _assertStagingGroupPageTemplateThumbnail(
@@ -1630,7 +1650,9 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 		}
 
 		_assertProblemException(
-			"BAD_REQUEST", null,
+			"The page template set does not belong to this site", "BAD_REQUEST",
+			"The page template set does not belong to this site",
+			"page-template-set-does-not-belong-to-this-site",
 			() -> pageTemplateResource.patchSitePageTemplate(
 				testGroup.getExternalReferenceCode(),
 				pageTemplate.getExternalReferenceCode(), patchPageTemplate));
@@ -1796,7 +1818,8 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 			});
 
 		_assertProblemException(
-			"BAD_REQUEST", null,
+			"BAD_REQUEST",
+			"The page specification is invalid or has not been approved",
 			() -> _postSitePageTemplate(
 				pageTemplate, testGroup.getExternalReferenceCode()));
 
@@ -1816,7 +1839,11 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 			});
 
 		_assertProblemException(
-			"BAD_REQUEST", null,
+			"Exactly one page specification is required", "BAD_REQUEST",
+			"The number of page specifications does not match the page type " +
+				"requirements",
+			"number-of-page-specifications-does-not-match-the-page-type-" +
+				"requirements",
 			() -> _postSitePageTemplate(
 				pageTemplate, testGroup.getExternalReferenceCode()));
 
@@ -1826,7 +1853,8 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 			() -> new PageSpecification[] {widgetPageSpecification});
 
 		_assertProblemException(
-			"BAD_REQUEST", null,
+			"BAD_REQUEST",
+			"The page specification is invalid or has not been approved",
 			() -> _postSitePageTemplate(
 				pageTemplate, testGroup.getExternalReferenceCode()));
 
@@ -1885,7 +1913,9 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 		pageTemplate.setPageTemplateSet(() -> null);
 
 		_assertProblemException(
-			"BAD_REQUEST", null,
+			"The page template set does not belong to this site", "BAD_REQUEST",
+			"The page template set does not belong to this site",
+			"page-template-set-does-not-belong-to-this-site",
 			() -> _postSitePageTemplate(
 				pageTemplate, testGroup.getExternalReferenceCode()));
 
@@ -1897,7 +1927,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 			});
 
 		_assertProblemException(
-			"BAD_REQUEST", null,
+			"BAD_REQUEST", "The page template set does not belong to this site",
 			() -> _postSitePageTemplate(
 				pageTemplate, testGroup.getExternalReferenceCode()));
 
@@ -2256,7 +2286,9 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 		pageTemplate.setPageTemplateSet(() -> null);
 
 		_assertProblemException(
-			"BAD_REQUEST", null,
+			"The page template set does not belong to this site", "BAD_REQUEST",
+			"The page template set does not belong to this site",
+			"page-template-set-does-not-belong-to-this-site",
 			() -> pageTemplateResource.putSitePageTemplate(
 				testGroup.getExternalReferenceCode(),
 				pageTemplate.getExternalReferenceCode(), pageTemplate));
@@ -2269,7 +2301,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 			});
 
 		_assertProblemException(
-			"BAD_REQUEST", null,
+			"BAD_REQUEST", "The page template set does not belong to this site",
 			() -> pageTemplateResource.putSitePageTemplate(
 				testGroup.getExternalReferenceCode(),
 				pageTemplate.getExternalReferenceCode(), pageTemplate));

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
@@ -32,6 +32,7 @@ import com.liferay.headless.admin.site.resource.v1_0.test.util.AssetTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.FileEntryTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.LayoutPageTemplateEntryTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageSpecificationsTestUtil;
+import com.liferay.headless.admin.site.resource.v1_0.test.util.ProblemExceptionTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.SettingsTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.ThumbnailHttpServer;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.ThumbnailURLReferenceUtil;
@@ -45,7 +46,6 @@ import com.liferay.layout.page.template.service.LayoutPageTemplateEntryService;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
-import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.lang.SafeCloseable;
@@ -163,7 +163,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 
 		_enableLocalStaging(irrelevantGroup);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", null,
 			() -> pageTemplateResource.deleteSitePageTemplate(
 				irrelevantGroup.getExternalReferenceCode(),
@@ -179,7 +179,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 			});
 
 		_withDepotEntry(
-			group -> _assertProblemException(
+			group -> ProblemExceptionTestUtil.assertProblemException(
 				"BAD_REQUEST", null,
 				() -> pageTemplateResource.deleteSitePageTemplate(
 					group.getExternalReferenceCode(),
@@ -200,7 +200,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 		_testGetSitePageTemplateWithNestedFields(
 			_getWidgetPageTemplate(testGroup));
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"NOT_FOUND", null,
 			() -> pageTemplateResource.getSitePageTemplate(
 				testGroup.getExternalReferenceCode(),
@@ -215,7 +215,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 				widgetPageTemplate, group.getExternalReferenceCode()));
 
 		_withDepotEntry(
-			group -> _assertProblemException(
+			group -> ProblemExceptionTestUtil.assertProblemException(
 				"BAD_REQUEST", null,
 				() -> pageTemplateResource.getSitePageTemplate(
 					group.getExternalReferenceCode(),
@@ -260,7 +260,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 			});
 
 		_withDepotEntry(
-			group -> _assertProblemException(
+			group -> ProblemExceptionTestUtil.assertProblemException(
 				"BAD_REQUEST", null,
 				() -> _getSitePageTemplatesPageTotalCount(
 					group.getExternalReferenceCode())));
@@ -316,12 +316,12 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 
 		_enableLocalStaging();
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", null,
 			() -> _testPatchSitePageTemplate(
 				contentPageTemplate, testGroup.getExternalReferenceCode()));
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", null,
 			() -> _testPatchSitePageTemplate(
 				widgetPageTemplate, testGroup.getExternalReferenceCode()));
@@ -337,7 +337,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 						curWidgetPageTemplate.getExternalReferenceCode()),
 					group.getExternalReferenceCode());
 
-				_assertProblemException(
+				ProblemExceptionTestUtil.assertProblemException(
 					"BAD_REQUEST", null,
 					() -> {
 						ContentPageTemplate curContentPageTemplate =
@@ -351,7 +351,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 			});
 
 		_withDepotEntry(
-			group -> _assertProblemException(
+			group -> ProblemExceptionTestUtil.assertProblemException(
 				"BAD_REQUEST", null,
 				() -> {
 					PageTemplate pageTemplate = _getPageTemplate(group);
@@ -411,7 +411,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 
 		_enableLocalStaging();
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", null,
 			() -> _postSitePageTemplate(
 				_getPageTemplate(testGroup),
@@ -423,7 +423,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 					companyGroupWidgetPageTemplate,
 					group.getExternalReferenceCode());
 
-				_assertProblemException(
+				ProblemExceptionTestUtil.assertProblemException(
 					"BAD_REQUEST", null,
 					() -> pageTemplateResource.postSitePageTemplate(
 						group.getExternalReferenceCode(),
@@ -431,7 +431,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 			});
 
 		_withDepotEntry(
-			group -> _assertProblemException(
+			group -> ProblemExceptionTestUtil.assertProblemException(
 				"BAD_REQUEST", null,
 				() -> pageTemplateResource.postSitePageTemplate(
 					group.getExternalReferenceCode(),
@@ -577,12 +577,12 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 		_assertStagingGroupPageTemplateThumbnail(
 			fileEntry, contentPageTemplate);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", null,
 			() -> _testPutSitePageTemplate(
 				contentPageTemplate, testGroup.getExternalReferenceCode()));
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", null,
 			() -> _testPutSitePageTemplate(
 				widgetPageTemplate, testGroup.getExternalReferenceCode()));
@@ -598,7 +598,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 						curWidgetPageTemplate.getExternalReferenceCode()),
 					group.getExternalReferenceCode());
 
-				_assertProblemException(
+				ProblemExceptionTestUtil.assertProblemException(
 					"BAD_REQUEST", null,
 					() -> {
 						ContentPageTemplate curContentPageTemplate =
@@ -612,7 +612,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 			});
 
 		_withDepotEntry(
-			group -> _assertProblemException(
+			group -> ProblemExceptionTestUtil.assertProblemException(
 				"BAD_REQUEST", null,
 				() -> {
 					PageTemplate pageTemplate = _getPageTemplate(group);
@@ -755,7 +755,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 			String pageTemplateExternalReferenceCode)
 		throws Exception {
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", "The page template must be of type basic",
 			() -> pageTemplateResource.postSitePageTemplatePageSpecification(
 				testGroup.getExternalReferenceCode(),
@@ -765,44 +765,6 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 						setType(() -> Type.CONTENT_PAGE_SPECIFICATION);
 					}
 				}));
-	}
-
-	private void _assertProblemException(
-			String expectedDetail, String expectedStatus, String expectedTitle,
-			String expectedType, UnsafeRunnable<Exception> unsafeRunnable)
-		throws Exception {
-
-		try {
-			unsafeRunnable.run();
-
-			Assert.fail();
-		}
-		catch (Problem.ProblemException problemException) {
-			Problem problem = problemException.getProblem();
-
-			if (Validator.isNotNull(expectedDetail)) {
-				Assert.assertEquals(expectedDetail, problem.getDetail());
-			}
-			else if (problem.getDetail() != null) {
-				Assert.assertEquals(expectedTitle, problem.getDetail());
-			}
-
-			if (expectedType != null) {
-				Assert.assertEquals(expectedType, problem.getType());
-			}
-
-			Assert.assertEquals(expectedStatus, problem.getStatus());
-			Assert.assertEquals(expectedTitle, problem.getTitle());
-		}
-	}
-
-	private void _assertProblemException(
-			String expectedStatus, String expectedTitle,
-			UnsafeRunnable<Exception> unsafeRunnable)
-		throws Exception {
-
-		_assertProblemException(
-			null, expectedStatus, expectedTitle, null, unsafeRunnable);
 	}
 
 	private void _assertStagingGroupPageTemplateThumbnail(
@@ -1323,7 +1285,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 				fetchLayoutPageTemplateEntryByExternalReferenceCode(
 					pageTemplateExternalReferenceCode, group.getGroupId()));
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"NOT_FOUND", null,
 			() -> pageTemplateResource.deleteSitePageTemplate(
 				group.getExternalReferenceCode(),
@@ -1649,7 +1611,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 			};
 		}
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"The page template set does not belong to this site", "BAD_REQUEST",
 			"The page template set does not belong to this site",
 			"page-template-set-does-not-belong-to-this-site",
@@ -1817,7 +1779,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 					PageSpecification.Status.APPROVED)
 			});
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST",
 			"The page specification is invalid or has not been approved",
 			() -> _postSitePageTemplate(
@@ -1838,7 +1800,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 				widgetPageSpecification, widgetPageSpecification
 			});
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"Exactly one page specification is required", "BAD_REQUEST",
 			"The number of page specifications does not match the page type " +
 				"requirements",
@@ -1852,7 +1814,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 		pageTemplate.setPageSpecifications(
 			() -> new PageSpecification[] {widgetPageSpecification});
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST",
 			"The page specification is invalid or has not been approved",
 			() -> _postSitePageTemplate(
@@ -1862,7 +1824,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 			RandomTestUtil::randomString);
 		widgetPageSpecification.setStatus(PageSpecification.Status.APPROVED);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST",
 			"The provided external reference code does not point to a widget " +
 				"page specification",
@@ -1912,7 +1874,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 
 		pageTemplate.setPageTemplateSet(() -> null);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"The page template set does not belong to this site", "BAD_REQUEST",
 			"The page template set does not belong to this site",
 			"page-template-set-does-not-belong-to-this-site",
@@ -1926,7 +1888,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 				}
 			});
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", "The page template set does not belong to this site",
 			() -> _postSitePageTemplate(
 				pageTemplate, testGroup.getExternalReferenceCode()));
@@ -2285,7 +2247,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 
 		pageTemplate.setPageTemplateSet(() -> null);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"The page template set does not belong to this site", "BAD_REQUEST",
 			"The page template set does not belong to this site",
 			"page-template-set-does-not-belong-to-this-site",
@@ -2300,7 +2262,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 				}
 			});
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", "The page template set does not belong to this site",
 			() -> pageTemplateResource.putSitePageTemplate(
 				testGroup.getExternalReferenceCode(),

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateSetResourceTest.java
@@ -9,9 +9,8 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.kernel.service.StagingLocalService;
 import com.liferay.headless.admin.site.client.dto.v1_0.PageTemplateSet;
 import com.liferay.headless.admin.site.client.pagination.Page;
-import com.liferay.headless.admin.site.client.problem.Problem;
+import com.liferay.headless.admin.site.resource.v1_0.test.util.ProblemExceptionTestUtil;
 import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionLocalService;
-import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
@@ -85,7 +84,7 @@ public class PageTemplateSetResourceTest
 
 		_enableLocalStaging(irrelevantGroup);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", null,
 			() -> pageTemplateSetResource.deleteSitePageTemplateSet(
 				irrelevantGroup.getExternalReferenceCode(),
@@ -222,7 +221,7 @@ public class PageTemplateSetResourceTest
 
 		_enableLocalStaging();
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", null,
 			() -> pageTemplateSetResource.patchSitePageTemplateSet(
 				testGroup.getExternalReferenceCode(),
@@ -292,7 +291,7 @@ public class PageTemplateSetResourceTest
 
 		_enableLocalStaging();
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST", null,
 			() -> pageTemplateSetResource.putSitePageTemplateSet(
 				testGroup.getExternalReferenceCode(),
@@ -331,43 +330,6 @@ public class PageTemplateSetResourceTest
 			testGroup.getExternalReferenceCode(), pageTemplateSet);
 	}
 
-	private void _assertProblemException(
-			String expectedDetail, String expectedStatus, String expectedTitle,
-			String expectedType, UnsafeRunnable<Exception> unsafeRunnable)
-		throws Exception {
-
-		try {
-			unsafeRunnable.run();
-
-			Assert.fail();
-		}
-		catch (Problem.ProblemException problemException) {
-			Problem problem = problemException.getProblem();
-
-			if (Validator.isNotNull(expectedDetail)) {
-				Assert.assertEquals(expectedDetail, problem.getDetail());
-			}
-			else if (problem.getDetail() != null) {
-				Assert.assertEquals(expectedTitle, problem.getDetail());
-			}
-
-			if (expectedType != null) {
-				Assert.assertEquals(expectedType, problem.getType());
-			}
-
-			Assert.assertEquals(expectedStatus, problem.getStatus());
-			Assert.assertEquals(expectedTitle, problem.getTitle());
-		}
-	}
-
-	private void _assertProblemException(
-			String status, String title,
-			UnsafeRunnable<Exception> unsafeRunnable)
-		throws Exception {
-
-		_assertProblemException(null, status, title, null, unsafeRunnable);
-	}
-
 	private void _enableLocalStaging() throws Exception {
 		_enableLocalStaging(testGroup);
 	}
@@ -395,7 +357,7 @@ public class PageTemplateSetResourceTest
 
 		pageTemplateSet.setKey(key);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"CONFLICT", title,
 			() -> pageTemplateSetResource.postSitePageTemplateSet(
 				testGroup.getExternalReferenceCode(), pageTemplateSet));
@@ -436,7 +398,7 @@ public class PageTemplateSetResourceTest
 
 		pageTemplateSet2.setName(pageTemplateSet1.getName());
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			StringBundler.concat(
 				"A page template set with name ", pageTemplateSet1.getName(),
 				" already exists"),

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateSetResourceTest.java
@@ -273,6 +273,8 @@ public class PageTemplateSetResourceTest
 			key,
 			StringBundler.concat(
 				"Key ", key, " must have fewer than 75 characters"));
+
+		_testPostSitePageTemplateSetWithDuplicateName();
 	}
 
 	@Override
@@ -330,8 +332,8 @@ public class PageTemplateSetResourceTest
 	}
 
 	private void _assertProblemException(
-			String status, String title,
-			UnsafeRunnable<Exception> unsafeRunnable)
+			String expectedDetail, String expectedStatus, String expectedTitle,
+			String expectedType, UnsafeRunnable<Exception> unsafeRunnable)
 		throws Exception {
 
 		try {
@@ -342,9 +344,28 @@ public class PageTemplateSetResourceTest
 		catch (Problem.ProblemException problemException) {
 			Problem problem = problemException.getProblem();
 
-			Assert.assertEquals(status, problem.getStatus());
-			Assert.assertEquals(title, problem.getTitle());
+			if (Validator.isNotNull(expectedDetail)) {
+				Assert.assertEquals(expectedDetail, problem.getDetail());
+			}
+			else if (problem.getDetail() != null) {
+				Assert.assertEquals(expectedTitle, problem.getDetail());
+			}
+
+			if (expectedType != null) {
+				Assert.assertEquals(expectedType, problem.getType());
+			}
+
+			Assert.assertEquals(expectedStatus, problem.getStatus());
+			Assert.assertEquals(expectedTitle, problem.getTitle());
 		}
+	}
+
+	private void _assertProblemException(
+			String status, String title,
+			UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		_assertProblemException(null, status, title, null, unsafeRunnable);
 	}
 
 	private void _enableLocalStaging() throws Exception {
@@ -403,6 +424,26 @@ public class PageTemplateSetResourceTest
 		assertValid(postPageTemplateSet);
 
 		return postPageTemplateSet;
+	}
+
+	private void _testPostSitePageTemplateSetWithDuplicateName()
+		throws Exception {
+
+		PageTemplateSet pageTemplateSet1 = _testPostSitePageTemplateSet(
+			randomPageTemplateSet());
+
+		PageTemplateSet pageTemplateSet2 = randomPageTemplateSet();
+
+		pageTemplateSet2.setName(pageTemplateSet1.getName());
+
+		_assertProblemException(
+			StringBundler.concat(
+				"A page template set with name ", pageTemplateSet1.getName(),
+				" already exists"),
+			"CONFLICT", "A page template set with the same name already exists",
+			"page-template-set-with-the-same-name-already-exists",
+			() -> pageTemplateSetResource.postSitePageTemplateSet(
+				testGroup.getExternalReferenceCode(), pageTemplateSet2));
 	}
 
 	@Inject

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -62,7 +62,6 @@ import com.liferay.headless.admin.site.client.dto.v1_0.WidgetPageSpecification;
 import com.liferay.headless.admin.site.client.http.HttpInvoker;
 import com.liferay.headless.admin.site.client.pagination.Page;
 import com.liferay.headless.admin.site.client.pagination.Pagination;
-import com.liferay.headless.admin.site.client.problem.Problem;
 import com.liferay.headless.admin.site.client.resource.v1_0.SitePageResource;
 import com.liferay.headless.admin.site.client.scope.Scope;
 import com.liferay.headless.admin.site.client.serdes.v1_0.FragmentImageValueSerDes;
@@ -73,6 +72,7 @@ import com.liferay.headless.admin.site.resource.v1_0.test.util.LayoutUtilityPage
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageElementsTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageExperiencesTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageSpecificationsTestUtil;
+import com.liferay.headless.admin.site.resource.v1_0.test.util.ProblemExceptionTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.SettingsTestUtil;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.type.InfoFieldType;
@@ -101,7 +101,6 @@ import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.function.UnsafeFunction;
-import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.lang.SafeCloseable;
@@ -462,7 +461,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		_testPutSiteSitePageWithInvalidPageExperiences();
 		LazyReferencingTestUtil.executeWithLazyReferencingSafeCloseable(
 			this::_testPutSiteSitePageWithMissingTaxonomyCategories);
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"NOT_FOUND", null,
 			this::_testPutSiteSitePageWithMissingTaxonomyCategories);
 		_testPutSiteSitePageWithPageElements();
@@ -758,8 +757,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		throws Exception {
 
 		for (Layout layout : layouts) {
-			_assertProblemException(
-				expectedTitle,
+			ProblemExceptionTestUtil.assertProblemException(
+				"BAD_REQUEST", expectedTitle,
 				() -> sitePageResource.deleteSiteSitePage(
 					testGroup.getExternalReferenceCode(),
 					layout.getExternalReferenceCode()));
@@ -1062,8 +1061,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			String expectedTitle, SitePage sitePage)
 		throws Exception {
 
-		_assertProblemException(
-			expectedTitle,
+		ProblemExceptionTestUtil.assertProblemException(
+			"BAD_REQUEST", expectedTitle,
 			() -> sitePageResource.patchSiteSitePage(
 				testGroup.getExternalReferenceCode(),
 				sitePage.getExternalReferenceCode(), false, sitePage));
@@ -1073,8 +1072,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			String expectedTitle, Layout layout)
 		throws Exception {
 
-		_assertProblemException(
-			expectedTitle,
+		ProblemExceptionTestUtil.assertProblemException(
+			"BAD_REQUEST", expectedTitle,
 			() -> sitePageResource.postSiteSitePagePageSpecification(
 				testGroup.getExternalReferenceCode(),
 				layout.getExternalReferenceCode(),
@@ -1124,64 +1123,10 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 		sitePage.setPageSpecifications(pageSpecifications);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			expectedTitle, "BAD_REQUEST", expectedTitle, expectedType,
 			() -> sitePageResource.postSiteSitePage(
 				testGroup.getExternalReferenceCode(), false, sitePage));
-	}
-
-	private void _assertProblemException(
-			String expectedDetail, String expectedStatus, String expectedTitle,
-			String expectedType, UnsafeRunnable<Exception> unsafeRunnable)
-		throws Exception {
-
-		try {
-			unsafeRunnable.run();
-			Assert.fail();
-		}
-		catch (Problem.ProblemException problemException) {
-			Problem problem = problemException.getProblem();
-
-			if (Validator.isNotNull(expectedDetail)) {
-				Assert.assertEquals(expectedDetail, problem.getDetail());
-			}
-			else if (problem.getDetail() != null) {
-				Assert.assertEquals(expectedTitle, problem.getDetail());
-			}
-
-			if (expectedType != null) {
-				Assert.assertEquals(expectedType, problem.getType());
-			}
-
-			Assert.assertEquals(expectedStatus, problem.getStatus());
-			Assert.assertEquals(expectedTitle, problem.getTitle());
-		}
-	}
-
-	private void _assertProblemException(
-			String expectedDetail, String expectedStatus, String expectedTitle,
-			UnsafeRunnable<Exception> unsafeRunnable)
-		throws Exception {
-
-		_assertProblemException(
-			expectedDetail, expectedStatus, expectedTitle, null,
-			unsafeRunnable);
-	}
-
-	private void _assertProblemException(
-			String expectedStatus, String expectedTitle,
-			UnsafeRunnable<Exception> unsafeRunnable)
-		throws Exception {
-
-		_assertProblemException(
-			null, expectedStatus, expectedTitle, null, unsafeRunnable);
-	}
-
-	private void _assertProblemException(
-			String expectedTitle, UnsafeRunnable<Exception> unsafeRunnable)
-		throws Exception {
-
-		_assertProblemException("BAD_REQUEST", expectedTitle, unsafeRunnable);
 	}
 
 	private void _assertPutSiteSitePageProblemException(
@@ -1202,8 +1147,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			String expectedTitle, SitePage sitePage)
 		throws Exception {
 
-		_assertProblemException(
-			expectedTitle,
+		ProblemExceptionTestUtil.assertProblemException(
+			"BAD_REQUEST", expectedTitle,
 			() -> sitePageResource.putSiteSitePage(
 				testGroup.getExternalReferenceCode(),
 				sitePage.getExternalReferenceCode(), false, sitePage));
@@ -1246,7 +1191,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			detail = expectedTitle;
 		}
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			detail, expectedStatus, expectedTitle, expectedType,
 			() -> sitePageResource.putSiteSitePage(
 				testGroup.getExternalReferenceCode(),
@@ -2379,7 +2324,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		SitePageResource sitePageResource = _getSitePageResource(
 			"pageSpecifications");
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
+			"BAD_REQUEST",
 			"A single content page specification cannot be applied to an " +
 				"existing page",
 			() -> sitePageResource.patchSiteSitePage(
@@ -2905,7 +2851,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 				SitePage.Type.CONTENT_PAGE,
 				StringUtil.toLowerCase(RandomTestUtil.randomString())));
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
+			"BAD_REQUEST",
 			"The private page setting does not match the target page's privacy",
 			() -> sitePageResource.postSiteSitePage(
 				testGroup.getExternalReferenceCode(), !privateLayout,
@@ -2945,7 +2892,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		SitePageResource sitePageResource = _getSitePageResource(
 			"pageSpecifications");
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"A page experience with key DEFAULT already exists", "CONFLICT",
 			"A page experience with the same key already exists",
 			"page-experience-with-the-same-key-already-exists",
@@ -2966,7 +2913,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 					},
 					testGroup.getGroupId(), PageSpecification.Status.DRAFT)));
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"The default page experience must have a priority of 0",
 			"BAD_REQUEST",
 			"The default page experience must have a priority of 0",
@@ -3211,7 +3158,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 					RandomTestUtil.randomString())[0]
 			});
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"Exactly one page specification is required", "BAD_REQUEST",
 			"The number of page specifications does not match the page type " +
 				"requirements",
@@ -3230,7 +3177,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 		invalidWidgetSitePage.setPageSpecifications(widgetPageSpecifications);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"The page specification is invalid or has not been approved",
 			"BAD_REQUEST",
 			"The page specification is invalid or has not been approved",
@@ -3252,7 +3199,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 					PageSpecification.Status.DRAFT)
 			});
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"BAD_REQUEST",
 			"The draft and published page specifications have mismatched " +
 				"external reference codes",
@@ -3315,7 +3262,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 				publishedContentPageSpecification, draftContentPageSpecification
 			});
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
+			"BAD_REQUEST",
 			StringBundler.concat(
 				"Site page external reference code ",
 				sitePage.getExternalReferenceCode(),
@@ -3741,7 +3689,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		getSitePage.setPageSpecifications(
 			() -> new PageSpecification[] {pageSpecifications[0]});
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
+			"BAD_REQUEST",
 			"A single content page specification cannot be applied to an " +
 				"existing page",
 			() -> sitePageResource.putSiteSitePage(
@@ -3906,7 +3855,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 		pageSettings.setPriority(0);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"CONFLICT",
 			_language.format(
 				LocaleUtil.getDefault(), "the-first-page-cannot-be-of-type-x",

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -160,6 +160,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
+import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -376,6 +377,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		_testPostSiteSitePageWithPageElements();
 		_testPostSiteSitePageWithPageSpecifications();
 		_testPostSiteSitePageWithContentPageSpecification();
+		_testPostSiteSitePageWithInvalidPageExperiences();
+		_testPostSiteSitePageWithInvalidPageSpecifications();
 		_testPostSiteSitePageWithWidgetPageSettings();
 		_testPostSiteSitePageWithWidgetPageSettingsWithWidgetPageTemplate();
 		_testPostSiteSitePageWithWidgetPageTypeIsDeprecated();
@@ -419,6 +422,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 				getMasterLayoutPageTemplateEntryLayout(serviceContext),
 			LayoutUtilityPageEntryTestUtil.getLayoutUtilityPageEntryLayout(
 				serviceContext));
+
+		_testPostSiteSitePagePageSpecificationWithInvalidPageExperiences();
 	}
 
 	@FeatureFlag("LPD-38869")
@@ -454,6 +459,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		_testPutSiteSitePageWithExportedSitePage();
 		_testPutSiteSitePageWithExportedSitePageWithLayoutIdFriendlyURL();
 		_testPutSiteSitePageWithFormFragmentPageElements();
+		_testPutSiteSitePageWithInvalidPageExperiences();
 		LazyReferencingTestUtil.executeWithLazyReferencingSafeCloseable(
 			this::_testPutSiteSitePageWithMissingTaxonomyCategories);
 		_assertProblemException(
@@ -1092,9 +1098,41 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		}
 	}
 
+	private void _assertPostSiteSitePageWithPageExperiencesProblemException(
+			String expectedTitle, String expectedType,
+			UnsafeFunction<PageExperience[], PageExperience[], Exception>
+				pageExperiencesUnsafeFunction)
+		throws Exception {
+
+		SitePageResource sitePageResource = _getSitePageResource(
+			"pageSpecifications");
+
+		SitePage sitePage = _getRandomSitePage(SitePage.Type.CONTENT_PAGE);
+
+		PageSpecification[] pageSpecifications =
+			PageSpecificationsTestUtil.getContentPageSpecifications(
+				sitePage.getExternalReferenceCode(), testGroup.getGroupId());
+
+		for (PageSpecification pageSpecification : pageSpecifications) {
+			ContentPageSpecification contentPageSpecification =
+				(ContentPageSpecification)pageSpecification;
+
+			contentPageSpecification.setPageExperiences(
+				pageExperiencesUnsafeFunction.apply(
+					contentPageSpecification.getPageExperiences()));
+		}
+
+		sitePage.setPageSpecifications(pageSpecifications);
+
+		_assertProblemException(
+			expectedTitle, "BAD_REQUEST", expectedTitle, expectedType,
+			() -> sitePageResource.postSiteSitePage(
+				testGroup.getExternalReferenceCode(), false, sitePage));
+	}
+
 	private void _assertProblemException(
-			String expectedStatus, String expectedTitle,
-			UnsafeRunnable<Exception> unsafeRunnable)
+			String expectedDetail, String expectedStatus, String expectedTitle,
+			String expectedType, UnsafeRunnable<Exception> unsafeRunnable)
 		throws Exception {
 
 		try {
@@ -1104,9 +1142,39 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		catch (Problem.ProblemException problemException) {
 			Problem problem = problemException.getProblem();
 
+			if (Validator.isNotNull(expectedDetail)) {
+				Assert.assertEquals(expectedDetail, problem.getDetail());
+			}
+			else if (problem.getDetail() != null) {
+				Assert.assertEquals(expectedTitle, problem.getDetail());
+			}
+
+			if (expectedType != null) {
+				Assert.assertEquals(expectedType, problem.getType());
+			}
+
 			Assert.assertEquals(expectedStatus, problem.getStatus());
 			Assert.assertEquals(expectedTitle, problem.getTitle());
 		}
+	}
+
+	private void _assertProblemException(
+			String expectedDetail, String expectedStatus, String expectedTitle,
+			UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		_assertProblemException(
+			expectedDetail, expectedStatus, expectedTitle, null,
+			unsafeRunnable);
+	}
+
+	private void _assertProblemException(
+			String expectedStatus, String expectedTitle,
+			UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		_assertProblemException(
+			null, expectedStatus, expectedTitle, null, unsafeRunnable);
 	}
 
 	private void _assertProblemException(
@@ -1139,6 +1207,50 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			() -> sitePageResource.putSiteSitePage(
 				testGroup.getExternalReferenceCode(),
 				sitePage.getExternalReferenceCode(), false, sitePage));
+	}
+
+	private void _assertPutSiteSitePageWithPageExperiencesProblemException(
+			String expectedStatus, String expectedTitle, String expectedDetail,
+			String expectedType,
+			UnsafeFunction<PageExperience[], PageExperience[], Exception>
+				pageExperiencesUnsafeFunction)
+		throws Exception {
+
+		SitePageResource sitePageResource = _getSitePageResource(
+			"pageSpecifications");
+
+		SitePage sitePage = _getSitePageWithPageElements(
+			PageElementsTestUtil.getPageElements(testGroup.getGroupId()));
+
+		sitePageResource.postSiteSitePage(
+			testGroup.getExternalReferenceCode(), false, sitePage);
+
+		SitePage getSitePage = sitePageResource.getSiteSitePage(
+			testGroup.getExternalReferenceCode(),
+			sitePage.getExternalReferenceCode());
+
+		for (PageSpecification pageSpecification :
+				getSitePage.getPageSpecifications()) {
+
+			ContentPageSpecification contentPageSpecification =
+				(ContentPageSpecification)pageSpecification;
+
+			contentPageSpecification.setPageExperiences(
+				pageExperiencesUnsafeFunction.apply(
+					contentPageSpecification.getPageExperiences()));
+		}
+
+		String detail = expectedDetail;
+
+		if (detail == null) {
+			detail = expectedTitle;
+		}
+
+		_assertProblemException(
+			detail, expectedStatus, expectedTitle, expectedType,
+			() -> sitePageResource.putSiteSitePage(
+				testGroup.getExternalReferenceCode(),
+				sitePage.getExternalReferenceCode(), false, getSitePage));
 	}
 
 	private void _assertSitePage(Layout layout, SitePage sitePage)
@@ -2823,6 +2935,56 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			postSitePage);
 	}
 
+	private void _testPostSiteSitePagePageSpecificationWithInvalidPageExperiences()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(testGroup);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		SitePageResource sitePageResource = _getSitePageResource(
+			"pageSpecifications");
+
+		_assertProblemException(
+			"A page experience with key DEFAULT already exists", "CONFLICT",
+			"A page experience with the same key already exists",
+			"page-experience-with-the-same-key-already-exists",
+			() -> sitePageResource.postSiteSitePagePageSpecification(
+				testGroup.getExternalReferenceCode(),
+				layout.getExternalReferenceCode(),
+				PageSpecificationsTestUtil.getContentPageSpecification(
+					draftLayout.getExternalReferenceCode(), null, null,
+					new PageExperience[] {
+						PageExperiencesTestUtil.getPageExperience(
+							RandomTestUtil.randomString(),
+							SegmentsExperienceConstants.KEY_DEFAULT, 0,
+							RandomTestUtil.randomString()),
+						PageExperiencesTestUtil.getPageExperience(
+							RandomTestUtil.randomString(),
+							SegmentsExperienceConstants.KEY_DEFAULT, 0,
+							RandomTestUtil.randomString())
+					},
+					testGroup.getGroupId(), PageSpecification.Status.DRAFT)));
+
+		_assertProblemException(
+			"The default page experience must have a priority of 0",
+			"BAD_REQUEST",
+			"The default page experience must have a priority of 0",
+			"default-page-experience-must-have-a-priority-of-0",
+			() -> sitePageResource.postSiteSitePagePageSpecification(
+				testGroup.getExternalReferenceCode(),
+				layout.getExternalReferenceCode(),
+				PageSpecificationsTestUtil.getContentPageSpecification(
+					draftLayout.getExternalReferenceCode(), null, null,
+					new PageExperience[] {
+						PageExperiencesTestUtil.getPageExperience(
+							RandomTestUtil.randomString(),
+							SegmentsExperienceConstants.KEY_DEFAULT, 1,
+							RandomTestUtil.randomString())
+					},
+					testGroup.getGroupId(), PageSpecification.Status.DRAFT)));
+	}
+
 	private void _testPostSiteSitePageWithContentPageSpecification()
 		throws Exception {
 
@@ -3014,6 +3176,89 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			true, draftContentPageSpecification,
 			draftContentPageSpecificationExternalReferenceCode, true,
 			sitePageExternalReferenceCode, status);
+	}
+
+	private void _testPostSiteSitePageWithInvalidPageExperiences()
+		throws Exception {
+
+		_assertPostSiteSitePageWithPageExperiencesProblemException(
+			"A page experience is required", "page-experience-is-required",
+			pageExperiences -> new PageExperience[0]);
+
+		_assertPostSiteSitePageWithPageExperiencesProblemException(
+			"A default page experience is required",
+			"default-page-experience-is-required",
+			pageExperiences -> new PageExperience[] {
+				PageExperiencesTestUtil.getPageExperience()
+			});
+	}
+
+	private void _testPostSiteSitePageWithInvalidPageSpecifications()
+		throws Exception {
+
+		SitePageResource sitePageResource = _getSitePageResource(
+			"pageSpecifications");
+
+		SitePage widgetSitePage = _getRandomSitePage(SitePage.Type.WIDGET_PAGE);
+
+		widgetSitePage.setPageSpecifications(
+			new PageSpecification[] {
+				PageSpecificationsTestUtil.getWidgetPageSpecifications(
+					PageSpecificationsTestUtil.getCustomFields(), "1_column",
+					widgetSitePage.getExternalReferenceCode())[0],
+				PageSpecificationsTestUtil.getWidgetPageSpecifications(
+					PageSpecificationsTestUtil.getCustomFields(), "1_column",
+					RandomTestUtil.randomString())[0]
+			});
+
+		_assertProblemException(
+			"Exactly one page specification is required", "BAD_REQUEST",
+			"The number of page specifications does not match the page type " +
+				"requirements",
+			() -> sitePageResource.postSiteSitePage(
+				testGroup.getExternalReferenceCode(), false, widgetSitePage));
+
+		SitePage invalidWidgetSitePage = _getRandomSitePage(
+			SitePage.Type.WIDGET_PAGE);
+
+		PageSpecification[] widgetPageSpecifications =
+			PageSpecificationsTestUtil.getWidgetPageSpecifications(
+				PageSpecificationsTestUtil.getCustomFields(), "1_column",
+				invalidWidgetSitePage.getExternalReferenceCode());
+
+		widgetPageSpecifications[0].setStatus(PageSpecification.Status.DRAFT);
+
+		invalidWidgetSitePage.setPageSpecifications(widgetPageSpecifications);
+
+		_assertProblemException(
+			"The page specification is invalid or has not been approved",
+			"BAD_REQUEST",
+			"The page specification is invalid or has not been approved",
+			"page-specification-is-invalid-or-has-not-been-approved",
+			() -> sitePageResource.postSiteSitePage(
+				testGroup.getExternalReferenceCode(), false,
+				invalidWidgetSitePage));
+
+		SitePage mismatchedContentSitePage = _getRandomSitePage(
+			SitePage.Type.CONTENT_PAGE);
+
+		mismatchedContentSitePage.setPageSpecifications(
+			new PageSpecification[] {
+				PageSpecificationsTestUtil.getContentPageSpecification(
+					RandomTestUtil.randomString(), testGroup.getGroupId(),
+					PageSpecification.Status.APPROVED),
+				PageSpecificationsTestUtil.getContentPageSpecification(
+					null, testGroup.getGroupId(),
+					PageSpecification.Status.DRAFT)
+			});
+
+		_assertProblemException(
+			"BAD_REQUEST",
+			"The draft and published page specifications have mismatched " +
+				"external reference codes",
+			() -> sitePageResource.postSiteSitePage(
+				testGroup.getExternalReferenceCode(), false,
+				mismatchedContentSitePage));
 	}
 
 	private void _testPostSiteSitePageWithPageElements() throws Exception {
@@ -3918,6 +4163,81 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			fragmentEntryLinks, infoForm, expectedInfoForm,
 			_layoutLocalService.getLayoutByExternalReferenceCode(
 				layout.getExternalReferenceCode(), testGroup.getGroupId()));
+	}
+
+	private void _testPutSiteSitePageWithInvalidPageExperiences()
+		throws Exception {
+
+		_assertPutSiteSitePageWithPageExperiencesProblemException(
+			"CONFLICT", "A page experience with the same key already exists",
+			"A page experience with key DEFAULT already exists",
+			"page-experience-with-the-same-key-already-exists",
+			pageExperiences -> {
+				PageExperience defaultPageExperience =
+					PageExperiencesTestUtil.getDefaultPageExperience(
+						pageExperiences);
+
+				return new PageExperience[] {
+					defaultPageExperience,
+					PageExperiencesTestUtil.getPageExperience(
+						RandomTestUtil.randomString(),
+						defaultPageExperience.getKey(), 0,
+						RandomTestUtil.randomString())
+				};
+			});
+
+		_assertPutSiteSitePageWithPageExperiencesProblemException(
+			"BAD_REQUEST",
+			"The default page experience must have a priority of 0", null,
+			"default-page-experience-must-have-a-priority-of-0",
+			pageExperiences -> {
+				PageExperience defaultPageExperience =
+					PageExperiencesTestUtil.getDefaultPageExperience(
+						pageExperiences);
+
+				defaultPageExperience.setPriority(1);
+
+				return pageExperiences;
+			});
+
+		_assertPutSiteSitePageWithPageExperiencesProblemException(
+			"BAD_REQUEST",
+			"The external reference code does not match the target page's " +
+				"experience external reference code",
+			null,
+			"external-reference-code-does-not-match-the-target-pages-" +
+				"experience-external-reference-code",
+			pageExperiences -> {
+				PageExperience defaultPageExperience =
+					PageExperiencesTestUtil.getDefaultPageExperience(
+						pageExperiences);
+
+				defaultPageExperience.setExternalReferenceCode(
+					RandomTestUtil.randomString());
+
+				return pageExperiences;
+			});
+
+		_assertPutSiteSitePageWithPageExperiencesProblemException(
+			"BAD_REQUEST",
+			"The default page experience cannot reference a segment", null,
+			"default-page-experience-cannot-reference-a-segment",
+			pageExperiences -> {
+				PageExperience defaultPageExperience =
+					PageExperiencesTestUtil.getDefaultPageExperience(
+						pageExperiences);
+
+				defaultPageExperience.setSegmentItemExternalReference(
+					() -> new ItemExternalReference() {
+						{
+							setClassName(SegmentsEntry.class.getName());
+							setExternalReferenceCode(
+								RandomTestUtil.randomString());
+						}
+					});
+
+				return pageExperiences;
+			});
 	}
 
 	private void _testPutSiteSitePageWithMissingTaxonomyCategories()

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
@@ -51,6 +51,7 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.test.util.IdempotentRetryAssert;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
@@ -392,9 +393,12 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 		Assert.assertFalse(layout.isPublished());
 
 		_assertProblemException(
-			"BAD_REQUEST", null,
-			() -> _testPutSiteUtilityPage(
-				Boolean.TRUE,
+			null, "CONFLICT",
+			"The default utility page must be published first",
+			"default-utility-page-must-be-published-first",
+			() -> utilityPageResource.putSiteUtilityPage(
+				testGroup.getExternalReferenceCode(),
+				layoutUtilityPageEntry.getExternalReferenceCode(),
 				_getUtilityPage(
 					null, Boolean.TRUE,
 					layoutUtilityPageEntry.getExternalReferenceCode())));
@@ -569,8 +573,8 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 	}
 
 	private void _assertProblemException(
-			String expectedStatus, String expectedTitle,
-			UnsafeRunnable<Exception> unsafeRunnable)
+			String expectedDetail, String expectedStatus, String expectedTitle,
+			String expectedType, UnsafeRunnable<Exception> unsafeRunnable)
 		throws Exception {
 
 		try {
@@ -581,9 +585,29 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 		catch (Problem.ProblemException problemException) {
 			Problem problem = problemException.getProblem();
 
+			if (Validator.isNotNull(expectedDetail)) {
+				Assert.assertEquals(expectedDetail, problem.getDetail());
+			}
+			else if (problem.getDetail() != null) {
+				Assert.assertEquals(expectedTitle, problem.getDetail());
+			}
+
+			if (expectedType != null) {
+				Assert.assertEquals(expectedType, problem.getType());
+			}
+
 			Assert.assertEquals(expectedStatus, problem.getStatus());
 			Assert.assertEquals(expectedTitle, problem.getTitle());
 		}
+	}
+
+	private void _assertProblemException(
+			String expectedStatus, String expectedTitle,
+			UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		_assertProblemException(
+			null, expectedStatus, expectedTitle, null, unsafeRunnable);
 	}
 
 	private void _assertThumbnailFileEntryId(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/UtilityPageResourceTest.java
@@ -19,12 +19,12 @@ import com.liferay.headless.admin.site.client.resource.v1_0.UtilityPageResource;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.FileEntryTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.LayoutUtilityPageEntryTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.PageSpecificationsTestUtil;
+import com.liferay.headless.admin.site.resource.v1_0.test.util.ProblemExceptionTestUtil;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.ThumbnailHttpServer;
 import com.liferay.headless.admin.site.resource.v1_0.test.util.ThumbnailURLReferenceUtil;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
-import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.io.StreamUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -51,7 +51,6 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.test.util.IdempotentRetryAssert;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
@@ -148,7 +147,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 					postUtilityPage.getExternalReferenceCode(),
 					testGroup.getGroupId()));
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"NOT_FOUND", null,
 			() -> utilityPageResource.deleteSiteUtilityPage(
 				testGroup.getExternalReferenceCode(),
@@ -172,7 +171,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 		assertEquals(postUtilityPage, getUtilityPage);
 		assertValid(getUtilityPage);
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"NOT_FOUND", null,
 			() -> utilityPageResource.getSiteUtilityPage(
 				testGroup.getExternalReferenceCode(),
@@ -321,7 +320,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 		_testPatchSiteUtilityPageWithPageSpecifications();
 		_testPatchSiteUtilityPageWithThumbnail();
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			"NOT_FOUND", null,
 			() -> utilityPageResource.patchSiteUtilityPage(
 				testGroup.getExternalReferenceCode(),
@@ -392,7 +391,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 
 		Assert.assertFalse(layout.isPublished());
 
-		_assertProblemException(
+		ProblemExceptionTestUtil.assertProblemException(
 			null, "CONFLICT",
 			"The default utility page must be published first",
 			"default-utility-page-must-be-published-first",
@@ -570,44 +569,6 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 		PageSpecificationsTestUtil.assertPageSpecifications(
 			draftContentPageSpecification, publishedContentPageSpecification,
 			utilityPage.getPageSpecifications(), layout, status);
-	}
-
-	private void _assertProblemException(
-			String expectedDetail, String expectedStatus, String expectedTitle,
-			String expectedType, UnsafeRunnable<Exception> unsafeRunnable)
-		throws Exception {
-
-		try {
-			unsafeRunnable.run();
-
-			Assert.fail();
-		}
-		catch (Problem.ProblemException problemException) {
-			Problem problem = problemException.getProblem();
-
-			if (Validator.isNotNull(expectedDetail)) {
-				Assert.assertEquals(expectedDetail, problem.getDetail());
-			}
-			else if (problem.getDetail() != null) {
-				Assert.assertEquals(expectedTitle, problem.getDetail());
-			}
-
-			if (expectedType != null) {
-				Assert.assertEquals(expectedType, problem.getType());
-			}
-
-			Assert.assertEquals(expectedStatus, problem.getStatus());
-			Assert.assertEquals(expectedTitle, problem.getTitle());
-		}
-	}
-
-	private void _assertProblemException(
-			String expectedStatus, String expectedTitle,
-			UnsafeRunnable<Exception> unsafeRunnable)
-		throws Exception {
-
-		_assertProblemException(
-			null, expectedStatus, expectedTitle, null, unsafeRunnable);
 	}
 
 	private void _assertThumbnailFileEntryId(
@@ -966,7 +927,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 
 			PageSpecification pageSpecification = pageSpecifications[0];
 
-			_assertProblemException(
+			ProblemExceptionTestUtil.assertProblemException(
 				"BAD_REQUEST", "Utility pages do not support custom fields",
 				() -> utilityPageResource.patchSiteUtilityPage(
 					testGroup.getExternalReferenceCode(),
@@ -1123,7 +1084,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 				() -> PageSpecificationsTestUtil.getContentPageSpecifications(
 					RandomTestUtil.randomString(), testGroup.getGroupId()));
 
-			_assertProblemException(
+			ProblemExceptionTestUtil.assertProblemException(
 				"BAD_REQUEST", "Utility pages do not support custom fields",
 				() -> utilityPageResource.postSiteUtilityPage(
 					testGroup.getExternalReferenceCode(), utilityPage));
@@ -1409,7 +1370,7 @@ public class UtilityPageResourceTest extends BaseUtilityPageResourceTestCase {
 					pageSpecification.getExternalReferenceCode(),
 					testGroup.getGroupId()));
 
-			_assertProblemException(
+			ProblemExceptionTestUtil.assertProblemException(
 				"BAD_REQUEST", "Utility pages do not support custom fields",
 				() -> utilityPageResource.patchSiteUtilityPage(
 					testGroup.getExternalReferenceCode(),

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/ProblemExceptionTestUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/ProblemExceptionTestUtil.java
@@ -1,0 +1,67 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.resource.v1_0.test.util;
+
+import com.liferay.headless.admin.site.client.problem.Problem;
+import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.portal.kernel.util.Validator;
+
+import org.junit.Assert;
+
+/**
+ * @author Javier Moral
+ */
+public class ProblemExceptionTestUtil {
+
+	public static void assertProblemException(
+			String expectedDetail, String expectedStatus, String expectedTitle,
+			String expectedType, UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		try {
+			unsafeRunnable.run();
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			if (Validator.isNotNull(expectedDetail)) {
+				Assert.assertEquals(expectedDetail, problem.getDetail());
+			}
+			else if (problem.getDetail() != null) {
+				Assert.assertEquals(expectedTitle, problem.getDetail());
+			}
+
+			if (expectedType != null) {
+				Assert.assertEquals(expectedType, problem.getType());
+			}
+
+			Assert.assertEquals(expectedStatus, problem.getStatus());
+			Assert.assertEquals(expectedTitle, problem.getTitle());
+		}
+	}
+
+	public static void assertProblemException(
+			String expectedDetail, String expectedStatus, String expectedTitle,
+			UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		assertProblemException(
+			expectedDetail, expectedStatus, expectedTitle, null,
+			unsafeRunnable);
+	}
+
+	public static void assertProblemException(
+			String expectedStatus, String expectedTitle,
+			UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		assertProblemException(
+			null, expectedStatus, expectedTitle, null, unsafeRunnable);
+	}
+
+}


### PR DESCRIPTION
- For context see the Confluence article result of the Spike: [LPD-76005 Backend validations & error handling](https://liferay.atlassian.net/wiki/spaces/~752084159/pages/4977360976/LPD-76005+Backend+validations+error+handling) (This PR contains tasks XC-02 and XC-03)

- And the [message inventory](https://docs.google.com/spreadsheets/d/1vh4bafZTadnXRCWSRhHWdp2vLdGwkM1dz0JUOQxUP-0/edit?gid=1692302960#gid=1692302960)

https://liferay.atlassian.net/browse/LPD-95038
https://liferay.atlassian.net/browse/LPD-95007

## What Is Being Fixed

Several resource methods in headless-admin-site were throwing `UnsupportedOperationException` with opaque error messages when encountering invalid inputs (duplicate page experience keys, mismatched external reference codes, unsupported page types, etc.). These errors were not mapped to structured HTTP problem responses, so clients received unhelpful 500-class errors instead of descriptive 400/409 responses.

## How It Is Being Fixed

LPD-95038 adds canonical error builders to `ProblemUtil` — a shared utility that constructs RFC 9457-compliant `Problem` objects with consistent `type`, `title`, `detail`, and `status` fields for cross-entity error families.

LPD-95007 replaces the bare `UnsupportedOperationException` throws with typed exceptions (`PageExperienceException`, `PageSpecificationException`, `NoSuchPageElementException`, and several ERC mismatch exceptions), adds corresponding `ProblemMapper` OSGi components that translate each typed exception into a structured HTTP response, documents the new error responses in the OpenAPI contract, and covers the error paths with integration test assertions. A shared `ProblemExceptionTestUtil` is extracted to avoid duplicating the assertion helper across ten resource test classes.

## Design Notes

1. The error responses use the `Problem` members as defined by [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457):

   - **`title`** — a human-readable summary that does not change between occurrences of the same error and contains no user input.
   - **`detail`** — a human-readable explanation of the specific occurrence; it may include the concrete values supplied in the request.
   - **`type`** — the machine-readable, primary identifier of the error.

   The prevailing pattern in the product is to derive it from the throwing exception's fully-qualified class name ([see `ProblemUtil` behavior](https://github.com/liferay/liferay-portal/blob/c083b39572e369eabfe2baec1d45857701c69802/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/ProblemUtil.java#L44-L49)). This PR instead assigns each error a stable identifier that is independent of the exception class, for two reasons. First, it decouples the API contract from the exception's fully-qualified name, so the exceptions can be renamed, merged, or split without a breaking change for clients. Second, a single exception is sometimes reused for several distinct errors — see [`SitePageLayoutTypeExceptionProblemMapper`](https://github.com/liferay-page-management/liferay-portal/blob/c52390c0f3d5510f369d4fe9a5a01de3513bb5a3/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/SitePageLayoutTypeExceptionProblemMapper.java), which maps the four `LayoutTypeException` conditions — so the class name does not identify the concrete error; independent identifiers let us keep sharing exceptions without losing specificity.

2. Per the Headless team's standard — [agreed with the Product team](https://liferay.slack.com/archives/C08T3K4T1UP/p1782209883034239) — API error messages are not localized. The canonical `ProblemUtil` builders return fixed English strings rather than resolving Language keys, so there is no `buildLang` step and no module-local `Language.properties`.

3. In `rest-openapi.yaml` we document the possible response statuses but omit the response body. The body is omitted because REST Builder already generates the `Problem` type that the `ProblemMapper` responses rely on, so declaring one in the contract is unnecessary. Documenting the statuses has no user-facing effect today because REST Builder does not yet support it ([Slack thread](https://liferay.slack.com/archives/C5E1CRLJY/p1780912994888869)); it still serves as internal documentation and would already be in place if REST Builder ever adds support.

## PR Check

**pr-check: PASS** — tested on `c52390c0f3d5510f369d4fe9a5a01de3513bb5a3`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c52390c0f3d5510f369d4fe9a5a01de3513bb5a3"} -->
