### PR TITLE
LPD-96314 Fix flaky testMissingCtCollectionId date comparison

### DIFF
--- a/modules/apps/change-tracking/change-tracking-test-util/src/main/java/com/liferay/change/tracking/test/util/BaseCTUpgradeProcessTestCase.java
+++ b/modules/apps/change-tracking/change-tracking-test-util/src/main/java/com/liferay/change/tracking/test/util/BaseCTUpgradeProcessTestCase.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.Inject;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -61,7 +62,7 @@ public abstract class BaseCTUpgradeProcessTestCase {
 
 			modelAttributeDiffs.put(
 				productionEntry.getKey(),
-				Objects.equals(productionEntry.getValue(), publicationValue));
+				_equals(productionEntry.getValue(), publicationValue));
 		}
 
 		runUpgrade();
@@ -95,7 +96,7 @@ public abstract class BaseCTUpgradeProcessTestCase {
 
 			Assert.assertEquals(
 				modelAttributeDiffs.get(entry.getKey()),
-				Objects.equals(entry.getValue(), publicationValue));
+				_equals(entry.getValue(), publicationValue));
 		}
 
 		_ctCollectionService.deleteCTCollection(ctCollection);
@@ -125,6 +126,21 @@ public abstract class BaseCTUpgradeProcessTestCase {
 
 	protected abstract CTModel<?> updateCTModel(CTModel<?> ctModel)
 		throws Exception;
+
+	private boolean _equals(Object value1, Object value2) {
+		if ((value1 instanceof Date) && (value2 instanceof Date)) {
+			Date date1 = (Date)value1;
+			Date date2 = (Date)value2;
+
+			if (date1.getTime() == date2.getTime()) {
+				return true;
+			}
+
+			return false;
+		}
+
+		return Objects.equals(value1, value2);
+	}
 
 	@Inject
 	private CTCollectionService _ctCollectionService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96314

Previous pull: https://github.com/liferay-site-management/liferay-portal/pull/3520

Pull review request for site management team: https://liferay.slack.com/archives/CLUBRGT42/p1782729876956669

## What Is Being Fixed

BaseCTUpgradeProcessTestCase.testMissingCtCollectionId intermittently failed (~10% locally, occasionally on CI) with `expected:<true> but was:<false>`. The flipped attributes are the date columns `createDate` and `lastPropagationDate`: after the upgrade the production row is re-fetched from the database as a java.sql.Timestamp (millisecond precision) while the publication row is served from cache as a java.util.Date. The comparison used Objects.equals, and java.sql.Timestamp.equals returns false for any non-Timestamp argument, so an unchanged date intermittently read as modified and failed the assertion.

## How It Is Being Fixed

Compare date model attributes by their instant (Date.getTime()) instead of by equals, applied consistently to the before-upgrade diff and the after-upgrade check. Non-date attributes still use Objects.equals. This removes the Timestamp/Date type sensitivity for every test extending the base class.

## Why Are There No Tests

The change is itself a fix to test infrastructure (the comparison logic in a shared test base class), so it adds no new test. It was validated empirically: the failure reproduced ~10% on clean master, and 30/30 runs pass with the fix.

## Note on Repository and Reviewers

This change lives in `change-tracking-test-util`, owned by @liferay-site-management. It is opened against the liferay-page-management fork only because the liferay-site-management fork's master is ~4,200 commits behind upstream and I do not have write access to sync it, which made the PR base unusable (a 4,200-commit diff). The original PR was https://github.com/liferay-site-management/liferay-portal/pull/3520. @liferay-site-management — please review, since you own this file. Happy to re-target to your fork once its master is synced.

## PR Check

**pr-check: PASS** — tested on `c5682d28b935fd4de67ec1922d250e6466f2f68b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "c5682d28b935fd4de67ec1922d250e6466f2f68b"} -->
