### PR TITLE
LPD-78161 Use the time icon for the Friendly URL history button

### DIFF
--- a/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/META-INF/resources/js/FriendlyURLHistory.js
+++ b/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/META-INF/resources/js/FriendlyURLHistory.js
@@ -77,7 +77,7 @@ export default function FriendlyURLHistory({
 				}}
 				outline
 				small
-				symbol="restore"
+				symbol="time"
 				title={Liferay.Language.get('history')}
 			/>
 			{showModal && (

--- a/modules/apps/friendly-url/friendly-url-taglib/test/js/FriendlyURLHistory.js
+++ b/modules/apps/friendly-url/friendly-url-taglib/test/js/FriendlyURLHistory.js
@@ -95,11 +95,11 @@ describe('FriendlyURLHistory', () => {
 		expect(historyButton.className).toContain('btn-url-history');
 	});
 
-	it('renders a restore icon inside the button', () => {
+	it('renders a time icon inside the button', () => {
 		renderComponent(defaultProps);
 
 		expect(historyButton.querySelector('svg').classList).toContain(
-			'lexicon-icon-restore'
+			'lexicon-icon-time'
 		);
 	});
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-78161

## What Is Being Fixed

On the page configuration screen, the action button that opens the Friendly URL history used the "restore" icon (a counter-clockwise arrow). That icon reads as "revert/undo" rather than "view history", so it misrepresented the button's purpose and was inconsistent with the rest of the UI.

## How It Is Being Fixed

The button's Clay icon symbol is changed from `restore` to `time` (a clock) in the `FriendlyURLHistory` React component. The ticket asked for a dedicated "history" icon, but the Clay version bundled in the repo (clay-css 3.165.0) ships no `history` icon; `time` is the closest standard icon in the runtime sprite — visually it is the `restore` clock without the rewind arrow. The existing Jest test that asserts the rendered icon was updated to expect `lexicon-icon-time`.

## PR Check

**pr-check: SKIPPED** — Trivial two-file JS icon swap (icon symbol + matching test assertion); Source Format already verified clean via `gradlew formatSource` and the module compiled and deployed successfully; the JavaScript unit-test runner (node-scripts test) is a no-op in this checkout, so the suite cannot be executed locally.

<!-- pr-check {"reason": "Trivial two-file JS icon swap (icon symbol + matching test assertion); Source Format verified clean and the module compiled and deployed successfully; the JavaScript unit-test runner is a no-op in this checkout.", "result": "skipped", "sha": "1f3eaa2f49b1621808c5145c7cd755da6fc8ea93"} -->
