### PR TITLE
LPD-96538 Disambiguate the Import menuitem in page template admin tests

### DIFF
--- a/modules/test/playwright/tests/layout-page-template-admin-web/main/masterPagesAdmin.spec.ts
+++ b/modules/test/playwright/tests/layout-page-template-admin-web/main/masterPagesAdmin.spec.ts
@@ -400,7 +400,7 @@ test(
 			autoClick: true,
 			target: page
 				.locator('.dropdown-menu')
-				.getByRole('menuitem', {name: 'Import'}),
+				.getByRole('menuitem', {exact: true, name: 'Import'}),
 			trigger: page
 				.locator('.control-menu-nav-item')
 				.getByLabel('Options', {exact: true}),
@@ -485,7 +485,7 @@ test(
 			autoClick: true,
 			target: page
 				.locator('.dropdown-menu')
-				.getByRole('menuitem', {name: 'Import'}),
+				.getByRole('menuitem', {exact: true, name: 'Import'}),
 			trigger: page
 				.locator('.control-menu-nav-item')
 				.getByLabel('Options', {exact: true}),
@@ -545,7 +545,7 @@ test(
 			autoClick: true,
 			target: page
 				.locator('.dropdown-menu')
-				.getByRole('menuitem', {name: 'Import'}),
+				.getByRole('menuitem', {exact: true, name: 'Import'}),
 			trigger: page
 				.locator('.control-menu-nav-item')
 				.getByLabel('Options', {exact: true}),

--- a/modules/test/playwright/tests/layout-page-template-admin-web/main/pageTemplatesAdmin.spec.ts
+++ b/modules/test/playwright/tests/layout-page-template-admin-web/main/pageTemplatesAdmin.spec.ts
@@ -502,7 +502,7 @@ test.describe('Import page templates', () => {
 				autoClick: true,
 				target: page
 					.locator('.dropdown-menu')
-					.getByRole('menuitem', {name: 'Import'}),
+					.getByRole('menuitem', {exact: true, name: 'Import'}),
 				trigger: page
 					.locator('.control-menu-nav-item')
 					.getByLabel('Options', {exact: true}),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96538

## What Is Being Fixed

Three Playwright tests in the layout-page-template-admin-web module fail intermittently when opening the import view from the Options dropdown: masterPagesAdmin.spec.ts "Importing master page templates" (LPS-173150), masterPagesAdmin.spec.ts "Importing master page templates with overwrite existing entries" (LPS-102207), and pageTemplatesAdmin.spec.ts "Import content page templates works when success and error occurs" (LPS-173150). They locate the import action with getByRole('menuitem', {name: 'Import'}), which is a non-exact match. The Options dropdown also contains an "Export / Import" item whose accessible name contains "Import", so the locator matches two elements and the import menuitem never resolves. This surfaces as a strict mode violation or, through the clickAndExpectToBeVisible retry loop, an "element(s) not found" timeout.

## How It Is Being Fixed

Add exact: true to the menuitem locator at all four call sites (three in masterPagesAdmin.spec.ts, one in pageTemplatesAdmin.spec.ts) so it matches only the "Import" item, not "Export / Import". Verified on a local bundle: the three tests fail before the change and pass after.

## Why Are There No Tests?

The change is itself a fix to existing Playwright tests, correcting their locators. No product code changed and no new test is warranted.

## PR Check

**pr-check: PASS** — tested on `50ea75afec861c17d76ed909229884ff020ffcbe`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "50ea75afec861c17d76ed909229884ff020ffcbe"} -->
