### PR TITLE
LPD-96948 Prevent the Page Editor from crashing at small resolutions

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/hooks/app_hooks/useApplySmallResolutionChanges.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/hooks/app_hooks/useApplySmallResolutionChanges.js
@@ -48,7 +48,7 @@ export default function useApplySmallResolutionChanges() {
 
 		const elements = ELEMENTS_SELECTORS.map((selector) =>
 			document.querySelector(selector)
-		);
+		).filter(Boolean);
 
 		const onResize = debounce(() => {
 			document.body.style.setProperty('--editor-height', '0px');


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96948

## What Is Being Fixed

The Content Page Editor crashed on load at small viewport widths (768px and below). At that width the editor closes its sidebar, so the `.page-editor__sidebar__content` and `.page-editor__item-configuration-sidebar` elements are not in the DOM. The `useApplySmallResolutionChanges` hook looked these elements up with `document.querySelector` and, without a null check, passed them to `ResizeObserver.observe` and called `getBoundingClientRect` on them. That threw three uncaught exceptions that stopped the editor's React app from mounting, leaving an empty toolbar and an unusable editor.

## How It Is Being Fixed

The hook now filters out the null results of `document.querySelector` before observing or measuring, so it only handles the elements that are actually present. When the sidebar is closed it measures the wrapper alone, and when no target elements exist the ResizeObserver observes nothing and the editor mounts normally.

## Why Are There No Tests?

The regression is already covered by the existing Playwright test `viewports.spec.ts` "Topper is properly aligned in small resolutions", which sets a 700px viewport and opens the editor. It timed out before this fix (the editor never mounted) and passes after it.

## PR Check

**pr-check: SKIPPED** — Local Source Format fails on 26 pre-existing react-compiler violations in unrelated files (the one-line diff is untouched by the formatter) and JavaScript unit tests are not runnable in this local environment; the fix is verified via the existing Playwright test viewports.spec.ts and CI will run the full checks.

<!-- pr-check {"reason": "Local Source Format fails on 26 pre-existing react-compiler violations in unrelated files; JavaScript unit tests are not runnable locally; fix verified via existing Playwright test viewports.spec.ts and CI will run full checks.", "result": "skipped", "sha": "8da39caa0a33553175f586ebaffdde37f1c1fa18"} -->
