### PR TITLE
LPD-94450 Add keyboard navigation and dnd

### DIFF
--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/AudienceBuilder.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/AudienceBuilder.tsx
@@ -116,6 +116,8 @@ export default function AudienceBuilder({
 						<div className="audience-builder-sidebar border-right d-flex flex-column flex-shrink-0 px-4">
 							<AttributesSidebar
 								audiencesCriteriaTypes={audiencesCriteriaTypes}
+								dispatch={dispatch}
+								rules={state.rules}
 							/>
 						</div>
 

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/AudienceBuilder.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/AudienceBuilder.tsx
@@ -10,8 +10,8 @@ import ClayLayout from '@clayui/layout';
 import ClayLink from '@clayui/link';
 import ClayToolbar from '@clayui/toolbar';
 import {
+	DragAndDropContextProvider,
 	DragPreview,
-	ScreenReaderAnnouncerContextProvider,
 } from '@liferay/layout-js-components-web';
 import React, {useReducer} from 'react';
 import {DndProvider} from 'react-dnd';
@@ -54,7 +54,7 @@ export default function AudienceBuilder({
 	);
 
 	return (
-		<ScreenReaderAnnouncerContextProvider>
+		<DragAndDropContextProvider>
 			<DragAndDropProvider backend={HTML5Backend}>
 				<DragPreview />
 
@@ -168,6 +168,6 @@ export default function AudienceBuilder({
 					</div>
 				</div>
 			</DragAndDropProvider>
-		</ScreenReaderAnnouncerContextProvider>
+		</DragAndDropContextProvider>
 	);
 }

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/AttributeListItem.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/AttributeListItem.tsx
@@ -7,18 +7,12 @@ import ClayIcon from '@clayui/icon';
 import {RovingItemProps} from '@liferay/layout-js-components-web';
 import classNames from 'classnames';
 import {sub} from 'frontend-js-web';
-import React, {useEffect} from 'react';
-import {useDrag} from 'react-dnd';
-import {getEmptyImage} from 'react-dnd-html5-backend';
+import React from 'react';
 
-import {DRAG_TYPES} from '../constants/dragTypes';
-import useKeyboardInsert from '../hooks/useKeyboardInsert';
+import {DragItem} from '../dnd/types';
+import useAttributeDrag from '../dnd/useAttributeDrag';
+import useKeyboardInsert from '../dnd/useKeyboardInsert';
 import {AudiencesCriteria} from '../types';
-
-interface DragItem {
-	id: string;
-	name: string;
-}
 
 interface IProps {
 	audiencesCriteria: AudiencesCriteria;
@@ -35,27 +29,13 @@ export default function AttributeListItem({
 	onInsert,
 	rovingProps,
 }: IProps) {
-	const [{isDragging}, handlerRef, previewRef] = useDrag({
-		collect: (monitor) => ({
-			isDragging: monitor.isDragging(),
-		}),
-		item: {
-			audiencesCriteria,
-			icon: audiencesCriteria.icon,
-			name: audiencesCriteria.label,
-			type: DRAG_TYPES.ATTRIBUTE,
-		},
-	});
+	const {handlerRef, isDragging} = useAttributeDrag(audiencesCriteria);
 
 	const {handleKeyboardInsert, isPlacing} = useKeyboardInsert({
 		item: {id: audiencesCriteria.key, name: audiencesCriteria.label},
 		items,
 		onInsert: (index) => onInsert(audiencesCriteria, index),
 	});
-
-	useEffect(() => {
-		previewRef(getEmptyImage(), {captureDraggingState: true});
-	}, [previewRef]);
 
 	const setRefs = (node: HTMLDivElement | null) => {
 		handlerRef(node);

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/AttributeListItem.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/AttributeListItem.tsx
@@ -4,22 +4,36 @@
  */
 
 import ClayIcon from '@clayui/icon';
+import {RovingItemProps} from '@liferay/layout-js-components-web';
 import classNames from 'classnames';
+import {sub} from 'frontend-js-web';
 import React, {useEffect} from 'react';
 import {useDrag} from 'react-dnd';
 import {getEmptyImage} from 'react-dnd-html5-backend';
 
 import {DRAG_TYPES} from '../constants/dragTypes';
+import useKeyboardInsert from '../hooks/useKeyboardInsert';
 import {AudiencesCriteria} from '../types';
+
+interface DragItem {
+	id: string;
+	name: string;
+}
 
 interface IProps {
 	audiencesCriteria: AudiencesCriteria;
 	iconColor: string;
+	items: DragItem[];
+	onInsert: (audiencesCriteria: AudiencesCriteria, index: number) => void;
+	rovingProps: RovingItemProps;
 }
 
 export default function AttributeListItem({
 	audiencesCriteria,
 	iconColor,
+	items,
+	onInsert,
+	rovingProps,
 }: IProps) {
 	const [{isDragging}, handlerRef, previewRef] = useDrag({
 		collect: (monitor) => ({
@@ -33,19 +47,46 @@ export default function AttributeListItem({
 		},
 	});
 
+	const {handleKeyboardInsert, isPlacing} = useKeyboardInsert({
+		item: {id: audiencesCriteria.key, name: audiencesCriteria.label},
+		items,
+		onInsert: (index) => onInsert(audiencesCriteria, index),
+	});
+
 	useEffect(() => {
 		previewRef(getEmptyImage(), {captureDraggingState: true});
 	}, [previewRef]);
 
+	const setRefs = (node: HTMLDivElement | null) => {
+		handlerRef(node);
+
+		rovingProps.ref(node);
+	};
+
 	return (
 		<div
+			aria-label={sub(
+				Liferay.Language.get('add-x'),
+				audiencesCriteria.label
+			)}
 			className={classNames(
 				'align-items-center audience-builder-attribute c-gap-3 d-flex px-2 rounded',
 				{
-					'audience-builder-attribute--dragging': isDragging,
+					'audience-builder-attribute--dragging':
+						isDragging || isPlacing,
 				}
 			)}
-			ref={handlerRef}
+			onFocus={rovingProps.onFocus}
+			onKeyDown={(event) => {
+				handleKeyboardInsert(event);
+
+				if (!event.defaultPrevented) {
+					rovingProps.onKeyDown(event);
+				}
+			}}
+			ref={setRefs}
+			role="button"
+			tabIndex={rovingProps.tabIndex}
 		>
 			<ClayIcon
 				className="audience-builder-attribute__grip text-secondary"

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/AttributesSidebar.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/AttributesSidebar.tsx
@@ -12,6 +12,7 @@ import {
 	CATEGORY_ICON_COLORS,
 	DEFAULT_ICON_COLOR,
 } from '../constants/categoryIconColors';
+import buildDndItems from '../dnd/buildDndItems';
 import {Action} from '../reducer';
 import {AudiencesCriteria, AudiencesCriteriaType, Rule} from '../types';
 import AttributeListItem from './AttributeListItem';
@@ -58,10 +59,7 @@ export default function AttributesSidebar({
 				])
 		);
 
-	const dndItems = rules.map((rule) => ({
-		id: rule.id,
-		name: audiencesCriteriasByKey[rule.attribute]?.label ?? rule.attribute,
-	}));
+	const dndItems = buildDndItems(rules, audiencesCriteriasByKey);
 
 	const handleInsert = (
 		audiencesCriteria: AudiencesCriteria,

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/AttributesSidebar.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/AttributesSidebar.tsx
@@ -5,21 +5,28 @@
 
 import ClayEmptyState from '@clayui/empty-state';
 import ClayForm, {ClaySelectWithOption} from '@clayui/form';
-import {SearchForm} from '@liferay/layout-js-components-web';
-import React, {useState} from 'react';
+import {SearchForm, useRovingFocus} from '@liferay/layout-js-components-web';
+import React, {Dispatch, useState} from 'react';
 
 import {
 	CATEGORY_ICON_COLORS,
 	DEFAULT_ICON_COLOR,
 } from '../constants/categoryIconColors';
-import {AudiencesCriteriaType} from '../types';
+import {Action} from '../reducer';
+import {AudiencesCriteria, AudiencesCriteriaType, Rule} from '../types';
 import AttributeListItem from './AttributeListItem';
 
 interface IProps {
 	audiencesCriteriaTypes: AudiencesCriteriaType[];
+	dispatch: Dispatch<Action>;
+	rules: Rule[];
 }
 
-export default function AttributesSidebar({audiencesCriteriaTypes}: IProps) {
+export default function AttributesSidebar({
+	audiencesCriteriaTypes,
+	dispatch,
+	rules,
+}: IProps) {
 	const [selectedIndex, setSelectedIndex] = useState(0);
 	const [query, setQuery] = useState('');
 
@@ -32,6 +39,34 @@ export default function AttributesSidebar({audiencesCriteriaTypes}: IProps) {
 			(audiencesCriteria) =>
 				audiencesCriteria.label.toLowerCase().includes(normalizedQuery)
 		) ?? [];
+
+	const {getItemProps} = useRovingFocus({
+		itemCount: audiencesCriterias.length,
+		loop: true,
+	});
+
+	const audiencesCriteriasByKey: Record<string, AudiencesCriteria> =
+		Object.fromEntries(
+			audiencesCriteriaTypes
+				.flatMap(
+					(audiencesCriteriaType) =>
+						audiencesCriteriaType.audiencesCriterias
+				)
+				.map((audiencesCriteria) => [
+					audiencesCriteria.key,
+					audiencesCriteria,
+				])
+		);
+
+	const dndItems = rules.map((rule) => ({
+		id: rule.id,
+		name: audiencesCriteriasByKey[rule.attribute]?.label ?? rule.attribute,
+	}));
+
+	const handleInsert = (
+		audiencesCriteria: AudiencesCriteria,
+		index: number
+	) => dispatch({audiencesCriteria, index, type: 'ADD_RULE'});
 
 	return (
 		<div className="d-flex flex-column flex-grow-0 h-100">
@@ -64,15 +99,23 @@ export default function AttributesSidebar({audiencesCriteriaTypes}: IProps) {
 			/>
 
 			{audiencesCriterias.length ? (
-				<div className="overflow-auto">
-					{audiencesCriterias.map((audiencesCriteria) => (
+				<div
+					aria-label={Liferay.Language.get('attributes')}
+					aria-orientation="vertical"
+					className="overflow-auto"
+					role="toolbar"
+				>
+					{audiencesCriterias.map((audiencesCriteria, index) => (
 						<AttributeListItem
 							audiencesCriteria={audiencesCriteria}
 							iconColor={
 								CATEGORY_ICON_COLORS[selectedKey] ??
 								DEFAULT_ICON_COLOR
 							}
+							items={dndItems}
 							key={audiencesCriteria.key}
+							onInsert={handleInsert}
+							rovingProps={getItemProps(index)}
 						/>
 					))}
 				</div>

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/ConditionsPanel.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/ConditionsPanel.tsx
@@ -11,13 +11,13 @@ import {
 } from '@liferay/layout-js-components-web';
 import classNames from 'classnames';
 import React, {Dispatch, Fragment} from 'react';
-import {useDrop} from 'react-dnd';
 
 import {
 	CATEGORY_ICON_COLORS,
 	DEFAULT_ICON_COLOR,
 } from '../constants/categoryIconColors';
-import {DRAG_TYPES} from '../constants/dragTypes';
+import buildDndItems from '../dnd/buildDndItems';
+import useAttributeDrop from '../dnd/useAttributeDrop';
 import {Action} from '../reducer';
 import {AudiencesCriteria, AudiencesCriteriaType, Rule} from '../types';
 import RuleRow from './RuleRow';
@@ -27,11 +27,6 @@ interface IProps {
 	conjunction: string;
 	dispatch: Dispatch<Action>;
 	rules: Rule[];
-}
-
-interface AttributeDragItem {
-	audiencesCriteria: AudiencesCriteria;
-	type: string;
 }
 
 export default function ConditionsPanel({
@@ -71,27 +66,10 @@ export default function ConditionsPanel({
 		loop: true,
 	});
 
-	const dndItems = rules.map((rule) => {
-		const audiencesCriteria = audiencesCriteriasByKey[rule.attribute];
+	const dndItems = buildDndItems(rules, audiencesCriteriasByKey);
 
-		return {
-			icon: audiencesCriteria?.icon ?? '',
-			id: rule.id,
-			name: audiencesCriteria?.label ?? rule.attribute,
-		};
-	});
-
-	const [{canDrop, isOver}, drop] = useDrop<
-		AttributeDragItem,
-		void,
-		{canDrop: boolean; isOver: boolean}
-	>({
-		accept: DRAG_TYPES.ATTRIBUTE,
-		collect: (monitor) => ({
-			canDrop: monitor.canDrop(),
-			isOver: monitor.isOver(),
-		}),
-		drop: (item) => handleAddRule(item.audiencesCriteria),
+	const {canDrop, dropRef, isOver} = useAttributeDrop({
+		onAddRule: handleAddRule,
 	});
 
 	function handleAddRule(
@@ -253,7 +231,7 @@ export default function ConditionsPanel({
 							'audience-builder-drop-zone--over': isOver,
 						}
 					)}
-					ref={drop}
+					ref={dropRef}
 				>
 					{!canDrop && (
 						<ClayEmptyState

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/ConditionsPanel.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/ConditionsPanel.tsx
@@ -5,7 +5,10 @@
 
 import {Option, Picker} from '@clayui/core';
 import ClayEmptyState from '@clayui/empty-state';
-import {useScreenReaderAnnounce} from '@liferay/layout-js-components-web';
+import {
+	useRovingFocus,
+	useScreenReaderAnnounce,
+} from '@liferay/layout-js-components-web';
 import classNames from 'classnames';
 import React, {Dispatch, Fragment} from 'react';
 import {useDrop} from 'react-dnd';
@@ -62,6 +65,11 @@ export default function ConditionsPanel({
 	);
 
 	const announce = useScreenReaderAnnounce();
+
+	const {focusItem, getItemProps} = useRovingFocus({
+		itemCount: rules.length,
+		loop: true,
+	});
 
 	const dndItems = rules.map((rule) => {
 		const audiencesCriteria = audiencesCriteriasByKey[rule.attribute];
@@ -167,7 +175,12 @@ export default function ConditionsPanel({
 						</span>
 					</div>
 
-					<div className="px-3 py-2">
+					<div
+						aria-label={Liferay.Language.get('conditions')}
+						aria-orientation="vertical"
+						className="px-3 py-2"
+						role="menu"
+					>
 						{rules.map((rule, index) => (
 							<Fragment key={rule.id}>
 								{index > 0 ? (
@@ -217,7 +230,14 @@ export default function ConditionsPanel({
 											)
 										);
 									}}
+									onNavigate={(delta) =>
+										focusItem(
+											(index + delta + rules.length) %
+												rules.length
+										)
+									}
 									onReorder={handleReorder}
+									rovingProps={getItemProps(index)}
 									rule={rule}
 								/>
 							</Fragment>

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
@@ -6,7 +6,6 @@
 import {ClayButtonWithIcon} from '@clayui/button';
 import {Option, Picker} from '@clayui/core';
 import {ClayInput} from '@clayui/form';
-import ClayIcon from '@clayui/icon';
 import {useDragAndDrop} from '@liferay/layout-js-components-web';
 import classNames from 'classnames';
 import {sub} from 'frontend-js-web';
@@ -71,20 +70,24 @@ export default function RuleRow({
 	onReorder,
 	rule,
 }: IProps) {
-	const dragHandlerRef = useRef<HTMLSpanElement>(null);
+	const dragHandlerRef = useRef<HTMLButtonElement>(null);
 	const dropItemRef = useRef<HTMLDivElement | null>(null);
 
 	const [dropPosition, setDropPosition] = useState<DropPosition>(null);
 
-	const {isDragging, isDropBottomPosition, isDropTopPosition} =
-		useDragAndDrop<DragItem>({
-			dragHandlerRef,
-			dropItemRef,
-			item: items[index],
-			itemIndex: index,
-			items,
-			onDrop: onReorder,
-		});
+	const {
+		handleKeyboardDragAndDrop,
+		isDragging,
+		isDropBottomPosition,
+		isDropTopPosition,
+	} = useDragAndDrop<DragItem>({
+		dragHandlerRef,
+		dropItemRef,
+		item: items[index],
+		itemIndex: index,
+		items,
+		onDrop: onReorder,
+	});
 
 	const [{isOver}, attributeDrop] = useDrop<
 		AttributeDragItem,
@@ -170,20 +173,17 @@ export default function RuleRow({
 				ref={dropItemRef}
 			>
 				<div className="align-items-center c-gap-3 d-flex">
-					<span
-						aria-label={sub(
-							Liferay.Language.get('drag-x'),
-							Liferay.Language.get('condition')
-						)}
+					<ClayButtonWithIcon
+						aria-label={sub(Liferay.Language.get('move-x'), label)}
+						borderless
 						className="audience-builder-grip text-secondary"
+						displayType="secondary"
+						onKeyDown={handleKeyboardDragAndDrop}
 						ref={dragHandlerRef}
-						title={sub(
-							Liferay.Language.get('drag-x'),
-							Liferay.Language.get('condition')
-						)}
-					>
-						<ClayIcon symbol="drag" />
-					</span>
+						size="sm"
+						symbol="drag"
+						title={sub(Liferay.Language.get('move-x'), label)}
+					/>
 
 					<span className="font-weight-semi-bold text-4 text-nowrap">
 						{label}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
@@ -13,25 +13,12 @@ import {
 } from '@liferay/layout-js-components-web';
 import classNames from 'classnames';
 import {sub} from 'frontend-js-web';
-import React, {useEffect, useRef, useState} from 'react';
-import {DropTargetMonitor, useDrop} from 'react-dnd';
+import React, {useEffect, useRef} from 'react';
 
-import {DRAG_TYPES} from '../constants/dragTypes';
 import {getOperatorLabel, getOperators} from '../constants/operators';
+import {DragItem} from '../dnd/types';
+import useAttributeDrop from '../dnd/useAttributeDrop';
 import {AudiencesCriteria, Rule} from '../types';
-
-type DropPosition = 'bottom' | 'top' | null;
-
-interface DragItem {
-	icon: string;
-	id: string;
-	name: string;
-}
-
-interface AttributeDragItem {
-	audiencesCriteria: AudiencesCriteria;
-	type: string;
-}
 
 interface IProps {
 	audiencesCriteria?: AudiencesCriteria;
@@ -47,22 +34,6 @@ interface IProps {
 	rovingProps: RovingItemProps;
 	rule: Rule;
 }
-
-const getDropPosition = (
-	ref: React.RefObject<HTMLElement>,
-	monitor: DropTargetMonitor
-): DropPosition => {
-	const clientOffset = monitor.getClientOffset();
-
-	if (!ref.current || !clientOffset) {
-		return null;
-	}
-
-	const dropItemBoundingRect = ref.current.getBoundingClientRect();
-	const hoverClientY = clientOffset.y - dropItemBoundingRect.top;
-
-	return hoverClientY < dropItemBoundingRect.height / 2 ? 'top' : 'bottom';
-};
 
 export default function RuleRow({
 	audiencesCriteria,
@@ -87,8 +58,6 @@ export default function RuleRow({
 		rovingProps.ref(node);
 	};
 
-	const [dropPosition, setDropPosition] = useState<DropPosition>(null);
-
 	const {
 		handleKeyboardDragAndDrop,
 		isDragging,
@@ -104,30 +73,10 @@ export default function RuleRow({
 		onDrop: onReorder,
 	});
 
-	const [{isOver}, attributeDrop] = useDrop<
-		AttributeDragItem,
-		void,
-		{isOver: boolean}
-	>({
-		accept: DRAG_TYPES.ATTRIBUTE,
-		collect: (monitor) => ({isOver: !!monitor.isOver()}),
-		drop: (item, monitor) => {
-			const dropPosition = getDropPosition(dropItemRef, monitor);
-
-			onAddRule(
-				item.audiencesCriteria,
-				dropPosition === 'bottom' ? index + 1 : index
-			);
-		},
-		hover: (item, monitor) => {
-			let dropPosition: DropPosition = null;
-
-			if (isOver) {
-				dropPosition = getDropPosition(dropItemRef, monitor);
-			}
-
-			setDropPosition(dropPosition);
-		},
+	const {dropPosition, dropRef, isOver} = useAttributeDrop({
+		dropItemRef,
+		index,
+		onAddRule,
 	});
 
 	const isNavigationTarget = rovingProps.tabIndex === 0;
@@ -218,7 +167,7 @@ export default function RuleRow({
 	const operators = getOperators(inputType, type);
 
 	return (
-		<div ref={attributeDrop}>
+		<div ref={dropRef}>
 			<div
 				aria-label={label}
 				className={classNames(

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
@@ -173,7 +173,14 @@ export default function RuleRow({
 				aria-label={Liferay.Language.get(
 					'the-criteria-is-no-longer-available'
 				)}
-				className="align-items-center audience-builder-rule audience-builder-rule--error d-flex justify-content-between p-3"
+				className={classNames(
+					'align-items-center audience-builder-rule audience-builder-rule--error d-flex justify-content-between p-3',
+					{
+						'audience-builder-rule--drop-bottom':
+							isDropBottomPosition,
+						'audience-builder-rule--drop-top': isDropTopPosition,
+					}
+				)}
 				onFocus={rovingProps.onFocus}
 				onKeyDownCapture={handleArrowNavigation}
 				ref={setRowRef}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
@@ -6,10 +6,13 @@
 import {ClayButtonWithIcon} from '@clayui/button';
 import {Option, Picker} from '@clayui/core';
 import {ClayInput} from '@clayui/form';
-import {useDragAndDrop} from '@liferay/layout-js-components-web';
+import {
+	RovingItemProps,
+	useDragAndDrop,
+} from '@liferay/layout-js-components-web';
 import classNames from 'classnames';
 import {sub} from 'frontend-js-web';
-import React, {useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {DropTargetMonitor, useDrop} from 'react-dnd';
 
 import {DRAG_TYPES} from '../constants/dragTypes';
@@ -38,7 +41,9 @@ interface IProps {
 	onChange: (rule: Rule) => void;
 	onDelete: () => void;
 	onDuplicate: () => void;
+	onNavigate: (delta: number) => void;
 	onReorder: (items: DragItem[]) => void;
+	rovingProps: RovingItemProps;
 	rule: Rule;
 }
 
@@ -67,11 +72,19 @@ export default function RuleRow({
 	onChange,
 	onDelete,
 	onDuplicate,
+	onNavigate,
 	onReorder,
+	rovingProps,
 	rule,
 }: IProps) {
 	const dragHandlerRef = useRef<HTMLButtonElement>(null);
 	const dropItemRef = useRef<HTMLDivElement | null>(null);
+
+	const setRowRef = (node: HTMLDivElement | null) => {
+		dropItemRef.current = node;
+
+		rovingProps.ref(node);
+	};
 
 	const [dropPosition, setDropPosition] = useState<DropPosition>(null);
 
@@ -80,6 +93,7 @@ export default function RuleRow({
 		isDragging,
 		isDropBottomPosition,
 		isDropTopPosition,
+		isKeyboardDragging,
 	} = useDragAndDrop<DragItem>({
 		dragHandlerRef,
 		dropItemRef,
@@ -114,6 +128,43 @@ export default function RuleRow({
 			setDropPosition(dropPosition);
 		},
 	});
+
+	const isNavigationTarget = rovingProps.tabIndex === 0;
+
+	useEffect(() => {
+		dropItemRef.current
+			?.querySelectorAll<HTMLElement>(
+				'a, button, input, select, textarea, [role="combobox"]'
+			)
+			.forEach((element) => {
+				element.tabIndex = isNavigationTarget ? 0 : -1;
+			});
+	}, [isNavigationTarget]);
+
+	const handleArrowNavigation = (
+		event: React.KeyboardEvent<HTMLDivElement>
+	) => {
+		if (
+			isKeyboardDragging ||
+			(event.key !== 'ArrowDown' && event.key !== 'ArrowUp')
+		) {
+			return;
+		}
+
+		const target = event.target as HTMLElement;
+
+		if (
+			target.getAttribute('role') === 'combobox' ||
+			target.tagName === 'INPUT'
+		) {
+			return;
+		}
+
+		event.preventDefault();
+		event.stopPropagation();
+
+		onNavigate(event.key === 'ArrowDown' ? 1 : -1);
+	};
 
 	if (!audiencesCriteria) {
 		return (
@@ -157,6 +208,7 @@ export default function RuleRow({
 	return (
 		<div ref={attributeDrop}>
 			<div
+				aria-label={label}
 				className={classNames(
 					'align-items-center audience-builder-rule d-flex justify-content-between p-3',
 					`audience-builder-rule--${iconColor}`,
@@ -170,7 +222,11 @@ export default function RuleRow({
 							(isOver && dropPosition === 'top'),
 					}
 				)}
-				ref={dropItemRef}
+				onFocus={rovingProps.onFocus}
+				onKeyDownCapture={handleArrowNavigation}
+				ref={setRowRef}
+				role="menuitem"
+				tabIndex={rovingProps.tabIndex}
 			>
 				<div className="align-items-center c-gap-3 d-flex">
 					<ClayButtonWithIcon

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
@@ -6,6 +6,7 @@
 import {ClayButtonWithIcon} from '@clayui/button';
 import {Option, Picker} from '@clayui/core';
 import {ClayInput} from '@clayui/form';
+import ClayIcon from '@clayui/icon';
 import {
 	RovingItemProps,
 	useDragAndDrop,
@@ -173,7 +174,11 @@ export default function RuleRow({
 					'the-criteria-is-no-longer-available'
 				)}
 				className="align-items-center audience-builder-rule audience-builder-rule--error d-flex justify-content-between p-3"
-				ref={dropItemRef}
+				onFocus={rovingProps.onFocus}
+				onKeyDownCapture={handleArrowNavigation}
+				ref={setRowRef}
+				role="menuitem"
+				tabIndex={rovingProps.tabIndex}
 			>
 				<div className="align-items-center c-gap-3 d-flex">
 					<ClayIcon

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/dnd/buildDndItems.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/dnd/buildDndItems.ts
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Rule} from '../types';
+import {DragItem} from './types';
+
+export default function buildDndItems(
+	rules: Rule[],
+	audiencesCriteriasByKey: Record<string, {icon?: string; label: string}>
+): DragItem[] {
+	return rules.map((rule) => {
+		const audiencesCriteria = audiencesCriteriasByKey[rule.attribute];
+
+		return {
+			icon: audiencesCriteria?.icon ?? '',
+			id: rule.id,
+			name: audiencesCriteria?.label ?? rule.attribute,
+		};
+	});
+}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/dnd/getDropPosition.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/dnd/getDropPosition.ts
@@ -1,0 +1,25 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React from 'react';
+import {DropTargetMonitor} from 'react-dnd';
+
+import {DropPosition} from './types';
+
+export default function getDropPosition(
+	ref: React.RefObject<HTMLElement>,
+	monitor: DropTargetMonitor
+): DropPosition {
+	const clientOffset = monitor.getClientOffset();
+
+	if (!ref.current || !clientOffset) {
+		return null;
+	}
+
+	const dropItemBoundingRect = ref.current.getBoundingClientRect();
+	const hoverClientY = clientOffset.y - dropItemBoundingRect.top;
+
+	return hoverClientY < dropItemBoundingRect.height / 2 ? 'top' : 'bottom';
+}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/dnd/types.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/dnd/types.ts
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {AudiencesCriteria} from '../types';
+
+export type DropPosition = 'bottom' | 'top' | null;
+
+export interface DragItem {
+	icon?: string;
+	id: string;
+	name: string;
+}
+
+export interface AttributeDragItem {
+	audiencesCriteria: AudiencesCriteria;
+	type: string;
+}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/dnd/useAttributeDrag.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/dnd/useAttributeDrag.ts
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {useEffect} from 'react';
+import {useDrag} from 'react-dnd';
+import {getEmptyImage} from 'react-dnd-html5-backend';
+
+import {DRAG_TYPES} from '../constants/dragTypes';
+import {AudiencesCriteria} from '../types';
+
+export default function useAttributeDrag(audiencesCriteria: AudiencesCriteria) {
+	const [{isDragging}, handlerRef, previewRef] = useDrag({
+		collect: (monitor) => ({
+			isDragging: monitor.isDragging(),
+		}),
+		item: {
+			audiencesCriteria,
+			icon: audiencesCriteria.icon,
+			name: audiencesCriteria.label,
+			type: DRAG_TYPES.ATTRIBUTE,
+		},
+	});
+
+	useEffect(() => {
+		previewRef(getEmptyImage(), {captureDraggingState: true});
+	}, [previewRef]);
+
+	return {handlerRef, isDragging};
+}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/dnd/useAttributeDrop.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/dnd/useAttributeDrop.ts
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React, {useState} from 'react';
+import {useDrop} from 'react-dnd';
+
+import {DRAG_TYPES} from '../constants/dragTypes';
+import {AudiencesCriteria} from '../types';
+import getDropPosition from './getDropPosition';
+import {AttributeDragItem, DropPosition} from './types';
+
+interface Options {
+	dropItemRef?: React.RefObject<HTMLElement>;
+	index?: number;
+	onAddRule: (audiencesCriteria: AudiencesCriteria, index?: number) => void;
+}
+
+export default function useAttributeDrop({
+	dropItemRef,
+	index,
+	onAddRule,
+}: Options) {
+	const [dropPosition, setDropPosition] = useState<DropPosition>(null);
+
+	const [{canDrop, isOver}, dropRef] = useDrop<
+		AttributeDragItem,
+		void,
+		{canDrop: boolean; isOver: boolean}
+	>({
+		accept: DRAG_TYPES.ATTRIBUTE,
+		collect: (monitor) => ({
+			canDrop: monitor.canDrop(),
+			isOver: monitor.isOver(),
+		}),
+		drop: (item, monitor) => {
+			if (dropItemRef && index !== undefined) {
+				const position = getDropPosition(dropItemRef, monitor);
+
+				onAddRule(
+					item.audiencesCriteria,
+					position === 'bottom' ? index + 1 : index
+				);
+			}
+			else {
+				onAddRule(item.audiencesCriteria);
+			}
+		},
+		hover: (item, monitor) => {
+			if (dropItemRef) {
+				setDropPosition(
+					monitor.isOver()
+						? getDropPosition(dropItemRef, monitor)
+						: null
+				);
+			}
+		},
+	});
+
+	return {canDrop, dropPosition, dropRef, isOver};
+}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/dnd/useKeyboardInsert.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/dnd/useKeyboardInsert.ts
@@ -12,10 +12,7 @@ import {
 import {sub} from 'frontend-js-web';
 import React, {useCallback, useState} from 'react';
 
-interface DragItem {
-	id: string;
-	name: string;
-}
+import {DragItem} from './types';
 
 interface Props {
 	item: DragItem;

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/hooks/useKeyboardInsert.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/hooks/useKeyboardInsert.ts
@@ -1,0 +1,144 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {
+	useKeyboardItem,
+	useScreenReaderAnnounce,
+	useUpdateKeyboardItem,
+} from '@liferay/layout-js-components-web';
+import {sub} from 'frontend-js-web';
+import React, {useCallback, useState} from 'react';
+
+interface DragItem {
+	id: string;
+	name: string;
+}
+
+interface Props {
+	item: DragItem;
+	items: DragItem[];
+	onInsert: (index: number) => void;
+}
+
+export default function useKeyboardInsert({item, items, onInsert}: Props) {
+	const [isPlacing, setIsPlacing] = useState(false);
+
+	const announce = useScreenReaderAnnounce();
+	const keyboardItem = useKeyboardItem();
+	const updateKeyboardItem = useUpdateKeyboardItem();
+
+	const finishPlacement = useCallback(() => {
+		updateKeyboardItem({index: null, position: null});
+
+		setIsPlacing(false);
+	}, [updateKeyboardItem]);
+
+	const handleKeyboardInsert = useCallback(
+		(event: React.KeyboardEvent<HTMLElement>) => {
+			const {key} = event;
+
+			if (isPlacing && (key === 'ArrowDown' || key === 'ArrowUp')) {
+				event.preventDefault();
+				event.stopPropagation();
+
+				let nextIndex = keyboardItem.index ?? 0;
+				let nextPosition = keyboardItem.position;
+
+				if (key === 'ArrowDown') {
+					if (nextPosition === 'top') {
+						nextPosition = 'bottom';
+					}
+					else if (nextIndex < items.length - 1) {
+						nextIndex = nextIndex + 1;
+					}
+				}
+				else if (nextPosition === 'bottom') {
+					nextPosition = 'top';
+				}
+				else if (nextIndex > 0) {
+					nextIndex = nextIndex - 1;
+				}
+
+				announce(
+					sub(Liferay.Language.get('move-x-at-the-x-of-x'), [
+						item.name,
+						nextPosition,
+						items[nextIndex].name,
+					])
+				);
+
+				updateKeyboardItem({index: nextIndex, position: nextPosition});
+
+				return;
+			}
+
+			if (key === 'Enter' || key === ' ') {
+				event.preventDefault();
+				event.stopPropagation();
+
+				if (!isPlacing) {
+					if (!items.length) {
+						onInsert(0);
+
+						announce(Liferay.Language.get('a-condition-was-added'));
+
+						return;
+					}
+
+					setIsPlacing(true);
+
+					updateKeyboardItem({
+						index: items.length - 1,
+						name: item.name,
+						position: 'bottom',
+					});
+
+					announce(
+						Liferay.Language.get(
+							'use-arrows-to-move-it-and-press-enter-to-select-the-new-position-press-esc-to-cancel'
+						)
+					);
+
+					return;
+				}
+
+				if (keyboardItem.index === null) {
+					return;
+				}
+
+				onInsert(
+					keyboardItem.position === 'bottom'
+						? keyboardItem.index + 1
+						: keyboardItem.index
+				);
+
+				announce(Liferay.Language.get('a-condition-was-added'));
+
+				finishPlacement();
+
+				return;
+			}
+
+			if (key === 'Escape' && isPlacing) {
+				event.preventDefault();
+				event.stopPropagation();
+
+				finishPlacement();
+			}
+		},
+		[
+			announce,
+			finishPlacement,
+			isPlacing,
+			item,
+			items,
+			keyboardItem,
+			onInsert,
+			updateKeyboardItem,
+		]
+	);
+
+	return {handleKeyboardInsert, isPlacing};
+}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/hooks/useKeyboardInsert.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/hooks/useKeyboardInsert.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+	getNextKeyboardPosition,
 	useKeyboardItem,
 	useScreenReaderAnnounce,
 	useUpdateKeyboardItem,
@@ -43,23 +44,15 @@ export default function useKeyboardInsert({item, items, onInsert}: Props) {
 				event.preventDefault();
 				event.stopPropagation();
 
-				let nextIndex = keyboardItem.index ?? 0;
-				let nextPosition = keyboardItem.position;
-
-				if (key === 'ArrowDown') {
-					if (nextPosition === 'top') {
-						nextPosition = 'bottom';
-					}
-					else if (nextIndex < items.length - 1) {
-						nextIndex = nextIndex + 1;
-					}
-				}
-				else if (nextPosition === 'bottom') {
-					nextPosition = 'top';
-				}
-				else if (nextIndex > 0) {
-					nextIndex = nextIndex - 1;
-				}
+				const {index: nextIndex, position: nextPosition} =
+					getNextKeyboardPosition(
+						{
+							index: keyboardItem.index ?? 0,
+							position: keyboardItem.position,
+						},
+						key,
+						items.length
+					);
 
 				announce(
 					sub(Liferay.Language.get('move-x-at-the-x-of-x'), [

--- a/modules/apps/audiences/audiences-web/test/js/components/AttributesSidebar.test.tsx
+++ b/modules/apps/audiences/audiences-web/test/js/components/AttributesSidebar.test.tsx
@@ -3,13 +3,15 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {render, screen, waitFor} from '@testing-library/react';
+import {DragAndDropContextProvider} from '@liferay/layout-js-components-web';
+import {render, screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
+import React, {useReducer} from 'react';
 import {DndProvider} from 'react-dnd';
 import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import AttributesSidebar from '../../../src/main/resources/META-INF/resources/js/components/AttributesSidebar';
+import {reducer} from '../../../src/main/resources/META-INF/resources/js/reducer';
 import {AudiencesCriteriaType} from '../../../src/main/resources/META-INF/resources/js/types';
 
 const DragAndDropProvider = DndProvider as unknown as React.FC<
@@ -55,15 +57,46 @@ const AUDIENCES_CRITERIA_TYPES: AudiencesCriteriaType[] = [
 	},
 ];
 
+function renderSidebar() {
+	const dispatch = jest.fn();
+
+	function Sidebar() {
+		const [state, reducerDispatch] = useReducer(reducer, {
+			conjunction: 'AND',
+			name: '',
+			rules: [],
+		});
+
+		return (
+			<AttributesSidebar
+				audiencesCriteriaTypes={AUDIENCES_CRITERIA_TYPES}
+				dispatch={(action) => {
+					dispatch(action);
+					reducerDispatch(action);
+				}}
+				rules={state.rules}
+			/>
+		);
+	}
+
+	render(
+		<DragAndDropProvider backend={HTML5Backend}>
+			<DragAndDropContextProvider>
+				<Sidebar />
+			</DragAndDropContextProvider>
+		</DragAndDropProvider>
+	);
+
+	return {dispatch};
+}
+
+function getAttributeItems() {
+	return within(screen.getByRole('toolbar')).getAllByRole('button');
+}
+
 describe('AttributesSidebar', () => {
 	it('lists and filters the attributes', async () => {
-		render(
-			<DragAndDropProvider backend={HTML5Backend}>
-				<AttributesSidebar
-					audiencesCriteriaTypes={AUDIENCES_CRITERIA_TYPES}
-				/>
-			</DragAndDropProvider>
-		);
+		renderSidebar();
 
 		expect(screen.getByText('Age')).toBeTruthy();
 		expect(screen.getByText('City')).toBeTruthy();
@@ -94,5 +127,39 @@ describe('AttributesSidebar', () => {
 		await waitFor(() =>
 			expect(screen.getByText('no-attributes-were-found')).toBeTruthy()
 		);
+	});
+
+	it('navigates, adds, and inserts conditions with the keyboard', async () => {
+		const {dispatch} = renderSidebar();
+
+		const items = getAttributeItems();
+
+		items[0].focus();
+
+		await userEvent.keyboard('{ArrowDown}');
+
+		expect(document.activeElement).toBe(items[1]);
+
+		await userEvent.keyboard('{ArrowUp}');
+
+		expect(document.activeElement).toBe(items[0]);
+
+		await userEvent.keyboard('{Enter}');
+
+		expect(dispatch).toHaveBeenCalledWith({
+			audiencesCriteria: expect.objectContaining({key: 'age'}),
+			index: 0,
+			type: 'ADD_RULE',
+		});
+
+		getAttributeItems()[1].focus();
+
+		await userEvent.keyboard('{Enter}{ArrowUp}{Enter}');
+
+		expect(dispatch).toHaveBeenCalledWith({
+			audiencesCriteria: expect.objectContaining({key: 'city'}),
+			index: 0,
+			type: 'ADD_RULE',
+		});
 	});
 });

--- a/modules/apps/audiences/audiences-web/test/js/components/ConditionsPanel.test.tsx
+++ b/modules/apps/audiences/audiences-web/test/js/components/ConditionsPanel.test.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {ScreenReaderAnnouncerContextProvider} from '@liferay/layout-js-components-web';
+import {DragAndDropContextProvider} from '@liferay/layout-js-components-web';
 
 import '@testing-library/jest-dom';
 import {render, screen} from '@testing-library/react';
@@ -33,6 +33,14 @@ const AUDIENCES_CRITERIA_TYPES: AudiencesCriteriaType[] = [
 				options: [],
 				type: 'number',
 			},
+			{
+				icon: 'globe',
+				inputType: 'text',
+				key: 'country',
+				label: 'Country',
+				options: [],
+				type: 'string',
+			},
 		],
 		key: 'user',
 		label: 'User',
@@ -43,8 +51,14 @@ const RULES: Rule[] = [
 	{attribute: 'age', id: 'rule-age', operator: 'gt', value: '18'},
 ];
 
+const TWO_RULES: Rule[] = [
+	{attribute: 'age', id: 'rule-age', operator: 'gt', value: '18'},
+	{attribute: 'country', id: 'rule-country', operator: 'eq', value: 'us'},
+];
+
 const RULES_WITH_REMOVED: Rule[] = [
 	{attribute: 'removed', id: 'rule-removed', operator: 'eq', value: ''},
+	{attribute: 'age', id: 'rule-age', operator: 'gt', value: '18'},
 ];
 
 function renderConditionsPanel({
@@ -53,14 +67,14 @@ function renderConditionsPanel({
 } = {}) {
 	render(
 		<DragAndDropProvider backend={HTML5Backend}>
-			<ScreenReaderAnnouncerContextProvider>
+			<DragAndDropContextProvider>
 				<ConditionsPanel
 					audiencesCriteriaTypes={AUDIENCES_CRITERIA_TYPES}
 					conjunction="AND"
 					dispatch={dispatch}
 					rules={rules}
 				/>
-			</ScreenReaderAnnouncerContextProvider>
+			</DragAndDropContextProvider>
 		</DragAndDropProvider>
 	);
 
@@ -108,11 +122,72 @@ describe('ConditionsPanel', () => {
 		});
 	});
 
-	it('shows an error state for a removed criteria', () => {
-		renderConditionsPanel({rules: RULES_WITH_REMOVED});
+	it('shows an error state for a removed criteria and deletes it', async () => {
+		const {dispatch} = renderConditionsPanel({rules: RULES_WITH_REMOVED});
 
 		expect(
 			screen.getByText('the-criteria-is-no-longer-available')
 		).toBeTruthy();
+
+		const rows = screen.getAllByRole('menuitem');
+
+		rows[0].focus();
+
+		await userEvent.keyboard('{ArrowDown}');
+
+		expect(document.activeElement).toBe(rows[1]);
+
+		screen.getByLabelText('move-x').focus();
+
+		await userEvent.keyboard('{Enter}{ArrowUp}');
+
+		expect(rows[0]).toHaveClass('audience-builder-rule--drop-top');
+
+		await userEvent.keyboard('{Escape}');
+
+		await userEvent.click(screen.getAllByLabelText('delete')[0]);
+
+		expect(dispatch).toHaveBeenCalledWith({index: 0, type: 'DELETE_RULE'});
+	});
+
+	it('navigates and reorders the rows with the keyboard', async () => {
+		const {dispatch} = renderConditionsPanel({rules: TWO_RULES});
+
+		const rows = screen.getAllByRole('menuitem');
+
+		expect(rows[0].tabIndex).toBe(0);
+		expect(rows[1].tabIndex).toBe(-1);
+		expect(screen.getAllByLabelText('move-x')[0].tabIndex).toBe(0);
+
+		rows[0].focus();
+
+		await userEvent.keyboard('{ArrowDown}');
+
+		expect(document.activeElement).toBe(rows[1]);
+		expect(rows[0].tabIndex).toBe(-1);
+		expect(rows[1].tabIndex).toBe(0);
+
+		await userEvent.keyboard('{ArrowUp}');
+
+		expect(document.activeElement).toBe(rows[0]);
+
+		screen.getAllByLabelText('move-x')[0].focus();
+
+		await userEvent.keyboard('{ArrowDown}');
+
+		expect(document.activeElement).toBe(rows[1]);
+
+		await userEvent.keyboard('{ArrowUp}');
+
+		expect(document.activeElement).toBe(rows[0]);
+
+		screen.getAllByLabelText('move-x')[0].focus();
+
+		await userEvent.keyboard('{Enter}{ArrowDown}{Enter}');
+
+		expect(dispatch).toHaveBeenCalledWith({
+			rules: [TWO_RULES[1], TWO_RULES[0]],
+			type: 'REORDER_RULES',
+		});
 	});
 });

--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/hooks/drag_and_drop/getNextKeyboardPosition.ts
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/hooks/drag_and_drop/getNextKeyboardPosition.ts
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {DropPosition} from './useDragAndDrop';
+
+export default function getNextKeyboardPosition(
+	{index, position}: {index: number; position: DropPosition},
+	key: string,
+	itemsLength: number
+): {index: number; position: DropPosition} {
+	let nextIndex = index;
+	let nextPosition = position;
+
+	if (key === 'ArrowDown') {
+		if (nextPosition === 'top') {
+			nextPosition = 'bottom';
+		}
+		else if (nextIndex < itemsLength - 1) {
+			nextIndex = nextIndex + 1;
+		}
+	}
+	else if (key === 'ArrowUp') {
+		if (nextPosition === 'bottom') {
+			nextPosition = 'top';
+		}
+		else if (nextIndex > 0) {
+			nextIndex = nextIndex - 1;
+		}
+	}
+
+	return {index: nextIndex, position: nextPosition};
+}

--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/hooks/drag_and_drop/useDragAndDrop.ts
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/hooks/drag_and_drop/useDragAndDrop.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {useEffect} from 'react';
+
 import useKeyboardDragAndDrop from './useKeyboardDragAndDrop';
 import usePointerDragAndDrop from './usePointerDragAndDrop';
 
@@ -43,6 +45,7 @@ export default function useDragAndDrop<T extends {id: string; name: string}>({
 		handleKeyboardDragAndDrop,
 		isKeyboardDragging,
 		isKeyboardDropBottomPosition,
+		isKeyboardDropTarget,
 		isKeyboardDropTopPosition,
 	} = useKeyboardDragAndDrop<T>({
 		draggedItem: item,
@@ -50,6 +53,15 @@ export default function useDragAndDrop<T extends {id: string; name: string}>({
 		items,
 		onDrop,
 	});
+
+	useEffect(() => {
+		if (isKeyboardDropTarget) {
+			dropItemRef.current?.scrollIntoView?.({
+				behavior: 'smooth',
+				block: 'center',
+			});
+		}
+	}, [dropItemRef, isKeyboardDropTarget]);
 
 	return {
 		handleKeyboardDragAndDrop,

--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/hooks/drag_and_drop/useKeyboardDragAndDrop.ts
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/hooks/drag_and_drop/useKeyboardDragAndDrop.ts
@@ -11,6 +11,7 @@ import {
 	useUpdateKeyboardItem,
 } from '../../contexts/DragAndDropContext';
 import {useScreenReaderAnnounce} from '../../contexts/ScreenReaderContext';
+import getNextKeyboardPosition from './getNextKeyboardPosition';
 
 interface Props<T extends {id: string}> {
 	draggedItem: T;
@@ -102,25 +103,15 @@ export default function useKeyboardDragAndDrop<
 				return;
 			}
 
-			let nextIndex = keyboardItem.index!;
-			let nextPosition = keyboardItem.position;
-
-			if (key === 'ArrowDown' && nextIndex <= items.length - 1) {
-				if (nextPosition === 'top') {
-					nextPosition = 'bottom';
-				}
-				else if (nextIndex < items.length - 1) {
-					nextIndex = nextIndex + 1;
-				}
-			}
-			else if (key === 'ArrowUp' && nextIndex >= 0) {
-				if (nextPosition === 'bottom') {
-					nextPosition = 'top';
-				}
-				else if (nextIndex > 0) {
-					nextIndex = nextIndex - 1;
-				}
-			}
+			const {index: nextIndex, position: nextPosition} =
+				getNextKeyboardPosition(
+					{
+						index: keyboardItem.index!,
+						position: keyboardItem.position,
+					},
+					key,
+					items.length
+				);
 
 			announce(
 				sub(Liferay.Language.get('move-x-at-the-x-of-x'), [

--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/hooks/useRovingFocus.ts
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/hooks/useRovingFocus.ts
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React, {useRef, useState} from 'react';
+
+export interface RovingItemProps {
+	onFocus: () => void;
+	onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
+	ref: (node: HTMLElement | null) => void;
+	tabIndex: number;
+}
+
+interface Props {
+	itemCount: number;
+	loop?: boolean;
+}
+
+export default function useRovingFocus({itemCount, loop = false}: Props) {
+	const [activeIndex, setActiveIndex] = useState(0);
+
+	const itemRefs = useRef<Array<HTMLElement | null>>([]);
+
+	const activeItemIndex = Math.min(activeIndex, Math.max(0, itemCount - 1));
+
+	const focusItem = (index: number) => {
+		const nextIndex = Math.max(0, Math.min(index, itemCount - 1));
+
+		setActiveIndex(nextIndex);
+
+		itemRefs.current[nextIndex]?.focus();
+	};
+
+	const getItemProps = (index: number): RovingItemProps => ({
+		onFocus: () => setActiveIndex(index),
+		onKeyDown: (event) => {
+			if (event.target !== event.currentTarget || !itemCount) {
+				return;
+			}
+
+			let nextIndex;
+
+			if (event.key === 'ArrowDown') {
+				nextIndex = loop
+					? (index + 1) % itemCount
+					: Math.min(index + 1, itemCount - 1);
+			}
+			else if (event.key === 'ArrowUp') {
+				nextIndex = loop
+					? (index - 1 + itemCount) % itemCount
+					: Math.max(index - 1, 0);
+			}
+			else if (event.key === 'Home') {
+				nextIndex = 0;
+			}
+			else if (event.key === 'End') {
+				nextIndex = itemCount - 1;
+			}
+			else {
+				return;
+			}
+
+			event.preventDefault();
+
+			focusItem(nextIndex);
+		},
+		ref: (node) => {
+			itemRefs.current[index] = node;
+		},
+		tabIndex: index === activeItemIndex ? 0 : -1,
+	});
+
+	return {focusItem, getItemProps};
+}

--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/index.ts
@@ -46,6 +46,7 @@ export {
 	StyleErrorsContextProvider,
 	useHasStyleErrors,
 } from './contexts/StyleErrorsContext';
+export {default as getNextKeyboardPosition} from './hooks/drag_and_drop/getNextKeyboardPosition';
 export {default as useDragAndDrop} from './hooks/drag_and_drop/useDragAndDrop';
 export {default as useControlledState} from './hooks/useControlledState';
 export {default as useMediaQuery} from './hooks/useMediaQuery';

--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/index.ts
@@ -33,6 +33,8 @@ export {default as SearchResultsMessage} from './components/search_results_messa
 export {
 	DragAndDropContextProvider,
 	useKeyboardDragPreviewProps,
+	useKeyboardItem,
+	useUpdateKeyboardItem,
 } from './contexts/DragAndDropContext';
 export {
 	ScreenReaderAnnouncerContext,
@@ -47,6 +49,10 @@ export {
 export {default as useDragAndDrop} from './hooks/drag_and_drop/useDragAndDrop';
 export {default as useControlledState} from './hooks/useControlledState';
 export {default as useMediaQuery} from './hooks/useMediaQuery';
+export {
+	default as useRovingFocus,
+	RovingItemProps,
+} from './hooks/useRovingFocus';
 export type {default as ConfigurationCustomComponentProps} from './types/ConfigurationCustomComponentProps';
 export {default as SegmentExperience} from './types/SegmentExperience';
 export {default as convertRGBtoHex} from './utils/convertRGBtoHex';


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94450

## What Is Being Fixed

The Audience Builder conditions could only be reordered with a mouse, leaving keyboard and screen reader users unable to build or rearrange an audience. The UI had also drifted from the latest design: the criteria icons had no category coloring, the operator dropdown rendered raw language keys, the conditions summary had grammar and casing issues, set-type criteria used the wrong icon, and there was no feedback while dragging or when a rule referenced a criterion that no longer exists.

## How It Is Being Fixed

Keyboard drag-and-drop is added on top of the shared layout hooks. A roving focus hook drives arrow-key navigation across the attributes sidebar and the conditions list, attributes can be inserted and rules reordered from the keyboard, and the active drag target scrolls into view. Screen reader announcements report additions, removals, and duplications.

The design is aligned with Figma. Criteria icons get category-based colored badges and rule rows carry a matching left accent. Rows are restyled as bordered cards with a primary focus highlight, the conjunction selector is uppercased, and the between-row divider is reduced to the AND/OR text. Set-type criteria use the braces icon, the back button shows a tooltip, and the conditions summary grammar and casing are fixed with a singular and plural criterion key. The empty drop zone shows a dashed border while dragging and a tint on dragover, and a rule whose criterion has been removed renders an accessible error state with a delete action. The operator labels are fixed to resolve from literal language keys so the build extracts them.

## Screenshot

<!-- drag the screenshot in here -->

## PR Check

**pr-check: PASS** — tested on `9a21a2a0beaf13a3d9c7b36429e22268bad99a6f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "9a21a2a0beaf13a3d9c7b36429e22268bad99a6f"} -->

<img width="1662" height="823" alt="Screenshot from 2026-07-03 11-31-06" src="https://github.com/user-attachments/assets/3a644a02-8609-4caa-8d0d-d68785872b41" />

