### PR TITLE
LPD-96412 Persist multiple audience entries per element variation

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/DeleteLayoutPageTemplateStructureRelElementVariationMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/DeleteLayoutPageTemplateStructureRelElementVariationMVCActionCommandTest.java
@@ -59,7 +59,8 @@ public class
 		_layoutPageTemplateStructureRelElementVariationLocalService.
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				externalReferenceCode, TestPropsValues.getUserId(),
-				group.getGroupId(), RandomTestUtil.randomString(),
+				group.getGroupId(),
+				new String[] {RandomTestUtil.randomString()},
 				Collections.emptyMap(), Collections.emptyMap(),
 				Collections.emptyMap(), RandomTestUtil.randomString(),
 				layout.getPlid(), RandomTestUtil.randomString(),

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/SaveLayoutPageTemplateStructureRelElementVariationMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/SaveLayoutPageTemplateStructureRelElementVariationMVCActionCommandTest.java
@@ -25,7 +25,6 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/SaveLayoutPageTemplateStructureRelElementVariationMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/SaveLayoutPageTemplateStructureRelElementVariationMVCActionCommandTest.java
@@ -7,8 +7,11 @@ package com.liferay.layout.content.page.editor.web.internal.portlet.action.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariation;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariationAudienceEntryRel;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationLocalService;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -22,12 +25,15 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assert;
@@ -52,6 +58,8 @@ public class
 
 	@Test
 	public void testProcessAction() throws Exception {
+		String audienceEntryERC1 = RandomTestUtil.randomString();
+		String audienceEntryERC2 = RandomTestUtil.randomString();
 		String externalReferenceCode = RandomTestUtil.randomString();
 		String name = RandomTestUtil.randomString();
 		String targetElement = RandomTestUtil.randomString();
@@ -63,7 +71,8 @@ public class
 		_mvcActionCommand.processAction(
 			_getMockLiferayPortletActionRequest(
 				JSONUtil.put(
-					"audienceEntryERC", RandomTestUtil.randomString()
+					"audienceEntryERCs",
+					JSONUtil.putAll(audienceEntryERC1, audienceEntryERC2)
 				).put(
 					"externalReferenceCode", externalReferenceCode
 				).put(
@@ -99,6 +108,10 @@ public class
 			layoutPageTemplateStructureRelElementVariation =
 				layoutPageTemplateStructureRelElementVariations.get(0);
 
+		_assertAudienceEntryERCs(
+			externalReferenceCode,
+			Arrays.asList(audienceEntryERC1, audienceEntryERC2));
+
 		Assert.assertEquals(
 			externalReferenceCode,
 			layoutPageTemplateStructureRelElementVariation.
@@ -109,13 +122,15 @@ public class
 			targetElement,
 			layoutPageTemplateStructureRelElementVariation.getTargetElement());
 
+		String updatedAudienceEntryERC = RandomTestUtil.randomString();
 		String updatedName = RandomTestUtil.randomString();
 		String updatedTargetElement = RandomTestUtil.randomString();
 
 		_mvcActionCommand.processAction(
 			_getMockLiferayPortletActionRequest(
 				JSONUtil.put(
-					"audienceEntryERC", RandomTestUtil.randomString()
+					"audienceEntryERCs",
+					JSONUtil.putAll(updatedAudienceEntryERC)
 				).put(
 					"externalReferenceCode", externalReferenceCode
 				).put(
@@ -149,12 +164,32 @@ public class
 		layoutPageTemplateStructureRelElementVariation =
 			layoutPageTemplateStructureRelElementVariations.get(0);
 
+		_assertAudienceEntryERCs(
+			externalReferenceCode,
+			Collections.singletonList(updatedAudienceEntryERC));
+
 		Assert.assertEquals(
 			updatedName,
 			layoutPageTemplateStructureRelElementVariation.getName());
 		Assert.assertEquals(
 			updatedTargetElement,
 			layoutPageTemplateStructureRelElementVariation.getTargetElement());
+	}
+
+	private void _assertAudienceEntryERCs(
+		String externalReferenceCode, List<String> audienceEntryERCs) {
+
+		List<String> actualAudienceEntryERCs = TransformUtil.transform(
+			_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
+				getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+					externalReferenceCode),
+			LayoutPageTemplateStructureRelElementVariationAudienceEntryRel::
+				getAudienceEntryERC);
+
+		Collections.sort(audienceEntryERCs);
+		Collections.sort(actualAudienceEntryERCs);
+
+		Assert.assertEquals(audienceEntryERCs, actualAudienceEntryERCs);
 	}
 
 	private MockLiferayPortletActionRequest _getMockLiferayPortletActionRequest(
@@ -192,6 +227,11 @@ public class
 
 	@Inject
 	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private
+		LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService
+			_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService;
 
 	@Inject
 	private LayoutPageTemplateStructureRelElementVariationLocalService

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/EditElementVariationsDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/EditElementVariationsDisplayContext.java
@@ -184,9 +184,9 @@ public class EditElementVariationsDisplayContext {
 						_getPlid()),
 				layoutPageTemplateStructureRelElementVariation ->
 					HashMapBuilder.<String, Object>put(
-						"audienceEntryERC",
+						"audienceEntryERCs",
 						layoutPageTemplateStructureRelElementVariation.
-							getAudienceEntryERC()
+							getAudienceEntryERCs()
 					).put(
 						"externalReferenceCode",
 						layoutPageTemplateStructureRelElementVariation.

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/SaveLayoutPageTemplateStructureRelElementVariationMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/SaveLayoutPageTemplateStructureRelElementVariationMVCActionCommand.java
@@ -9,6 +9,7 @@ import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortlet
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationService;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -54,7 +55,8 @@ public class SaveLayoutPageTemplateStructureRelElementVariationMVCActionCommand
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				jsonObject.getString("externalReferenceCode"),
 				themeDisplay.getScopeGroupId(),
-				jsonObject.getString("audienceEntryERC"),
+				JSONUtil.toStringArray(
+					jsonObject.getJSONArray("audienceEntryERCs")),
 				_toLocalizedMap(jsonObject.getJSONObject("hideMap")),
 				_toLocalizedMap(jsonObject.getJSONObject("htmlMap")),
 				_toLocalizedMap(jsonObject.getJSONObject("jsMap")),

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
@@ -15,7 +15,7 @@ import {ElementVariation} from './elementVariationsReducer';
 
 type ElementVariationFormData = Pick<
 	ElementVariation,
-	'audienceEntryERC' | 'hide' | 'html' | 'js' | 'name' | 'targetElement'
+	'audienceEntryERCs' | 'hide' | 'html' | 'js' | 'name' | 'targetElement'
 >;
 
 interface Props {
@@ -143,10 +143,10 @@ export default function ElementVariationForm({
 
 					<ClayMultiSelect
 						id={audienceId}
-						items={audiences.filter(
-							(audience) =>
-								audience.value ===
-								elementVariation.audienceEntryERC
+						items={audiences.filter((audience) =>
+							elementVariation.audienceEntryERCs.includes(
+								audience.value
+							)
 						)}
 						onItemsChange={(
 							items: Array<{label: string; value: string}>
@@ -168,11 +168,9 @@ export default function ElementVariationForm({
 								);
 
 							onChange({
-								audienceEntryERC: existingAudiences.length
-									? existingAudiences[
-											existingAudiences.length - 1
-										].value
-									: '',
+								audienceEntryERCs: existingAudiences.map(
+									(audience) => audience.value
+								),
 							});
 						}}
 						sourceItems={audiences}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationService.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationService.ts
@@ -27,7 +27,7 @@ export default {
 		return serviceFetch<void>(addElementVariationURL, {
 			body: {
 				elementVariation: JSON.stringify({
-					audienceEntryERC: elementVariation.audienceEntryERC,
+					audienceEntryERCs: elementVariation.audienceEntryERCs,
 					externalReferenceCode:
 						elementVariation.externalReferenceCode,
 					hideMap: elementVariation.hide,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsList.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsList.tsx
@@ -58,11 +58,17 @@ export default function ElementVariationsList({
 											</ClayList.ItemTitle>
 
 											<ClayList.ItemText>
-												{audiences.find(
-													(audience) =>
-														audience.value ===
-														elementVariation.audienceEntryERC
-												)?.label ?? ''}
+												{elementVariation.audienceEntryERCs
+													.map(
+														(audienceEntryERC) =>
+															audiences.find(
+																(audience) =>
+																	audience.value ===
+																	audienceEntryERC
+															)?.label
+													)
+													.filter(Boolean)
+													.join(', ')}
 											</ClayList.ItemText>
 
 											<ClayList.ItemText>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/elementVariationsReducer.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/elementVariationsReducer.ts
@@ -6,7 +6,7 @@
 import {v4 as uuidv4} from 'uuid';
 
 export interface ElementVariation {
-	audienceEntryERC: string;
+	audienceEntryERCs: string[];
 	externalReferenceCode: string;
 	hide: Record<string, boolean>;
 	html: Record<string, string>;
@@ -42,7 +42,7 @@ export function createElementVariation(
 	segmentsExperienceERC: string
 ): ElementVariation {
 	return {
-		audienceEntryERC: '',
+		audienceEntryERCs: [],
 		externalReferenceCode: uuidv4(),
 		hide: {},
 		html: {},

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/elementVariationsReducer.test.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/elementVariationsReducer.test.ts
@@ -15,7 +15,7 @@ function buildElementVariation(
 	properties: Partial<ElementVariation> = {}
 ): ElementVariation {
 	return {
-		audienceEntryERC: '',
+		audienceEntryERCs: [],
 		externalReferenceCode: '',
 		hide: {},
 		html: {},
@@ -75,7 +75,7 @@ describe('elementVariationsReducer', () => {
 					defaultLanguageId: 'en_US',
 					elementVariations: [
 						{
-							audienceEntryERC: '',
+							audienceEntryERCs: [],
 							externalReferenceCode: 'erc-1',
 							hide: {en_US: 'true'},
 							html: {},

--- a/modules/apps/layout/layout-page-template-api/bnd.bnd
+++ b/modules/apps/layout/layout-page-template-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout Page Template API
 Bundle-SymbolicName: com.liferay.layout.page.template.api
-Bundle-Version: 36.2.0
+Bundle-Version: 37.0.0
 Export-Package:\
 	com.liferay.layout.page.template.constants,\
 	com.liferay.layout.page.template.exception,\

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/exception/LayoutPageTemplateStructureRelElementVariationAudienceEntryERCsException.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/exception/LayoutPageTemplateStructureRelElementVariationAudienceEntryERCsException.java
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class
+	LayoutPageTemplateStructureRelElementVariationAudienceEntryERCsException
+		extends PortalException {
+
+	public LayoutPageTemplateStructureRelElementVariationAudienceEntryERCsException() {
+	}
+
+	public LayoutPageTemplateStructureRelElementVariationAudienceEntryERCsException(
+		String msg) {
+
+		super(msg);
+	}
+
+	public LayoutPageTemplateStructureRelElementVariationAudienceEntryERCsException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public LayoutPageTemplateStructureRelElementVariationAudienceEntryERCsException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/exception/LayoutPageTemplateStructureRelElementVariationNameException.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/exception/LayoutPageTemplateStructureRelElementVariationNameException.java
@@ -1,0 +1,37 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class LayoutPageTemplateStructureRelElementVariationNameException
+	extends PortalException {
+
+	public LayoutPageTemplateStructureRelElementVariationNameException() {
+	}
+
+	public LayoutPageTemplateStructureRelElementVariationNameException(
+		String msg) {
+
+		super(msg);
+	}
+
+	public LayoutPageTemplateStructureRelElementVariationNameException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public LayoutPageTemplateStructureRelElementVariationNameException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/exception/LayoutPageTemplateStructureRelElementVariationTargetElementException.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/exception/LayoutPageTemplateStructureRelElementVariationTargetElementException.java
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class
+	LayoutPageTemplateStructureRelElementVariationTargetElementException
+		extends PortalException {
+
+	public LayoutPageTemplateStructureRelElementVariationTargetElementException() {
+	}
+
+	public LayoutPageTemplateStructureRelElementVariationTargetElementException(
+		String msg) {
+
+		super(msg);
+	}
+
+	public LayoutPageTemplateStructureRelElementVariationTargetElementException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public LayoutPageTemplateStructureRelElementVariationTargetElementException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateStructureRelElementVariation.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateStructureRelElementVariation.java
@@ -61,5 +61,7 @@ public interface LayoutPageTemplateStructureRelElementVariation
 
 				};
 
+	public java.util.List<String> getAudienceEntryERCs();
+
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-203147207
+// LIFERAY-SERVICE-BUILDER-HASH:1213896382

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateStructureRelElementVariationModel.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateStructureRelElementVariationModel.java
@@ -257,21 +257,6 @@ public interface LayoutPageTemplateStructureRelElementVariationModel
 	public void setModifiedDate(Date modifiedDate);
 
 	/**
-	 * Returns the audience entry erc of this layout page template structure rel element variation.
-	 *
-	 * @return the audience entry erc of this layout page template structure rel element variation
-	 */
-	@AutoEscape
-	public String getAudienceEntryERC();
-
-	/**
-	 * Sets the audience entry erc of this layout page template structure rel element variation.
-	 *
-	 * @param audienceEntryERC the audience entry erc of this layout page template structure rel element variation
-	 */
-	public void setAudienceEntryERC(String audienceEntryERC);
-
-	/**
 	 * Returns the hide of this layout page template structure rel element variation.
 	 *
 	 * @return the hide of this layout page template structure rel element variation
@@ -649,4 +634,4 @@ public interface LayoutPageTemplateStructureRelElementVariationModel
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1461842433
+// LIFERAY-SERVICE-BUILDER-HASH:-1774816791

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateStructureRelElementVariationTable.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateStructureRelElementVariationTable.java
@@ -74,11 +74,6 @@ public class LayoutPageTemplateStructureRelElementVariationTable
 				"modifiedDate", Date.class, Types.TIMESTAMP,
 				Column.FLAG_DEFAULT);
 	public final Column
-		<LayoutPageTemplateStructureRelElementVariationTable, String>
-			audienceEntryERC = createColumn(
-				"audienceEntryERC", String.class, Types.VARCHAR,
-				Column.FLAG_DEFAULT);
-	public final Column
 		<LayoutPageTemplateStructureRelElementVariationTable, String> hide =
 			createColumn(
 				"hide", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
@@ -115,4 +110,4 @@ public class LayoutPageTemplateStructureRelElementVariationTable
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1881588054
+// LIFERAY-SERVICE-BUILDER-HASH:647063486

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateStructureRelElementVariationWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateStructureRelElementVariationWrapper.java
@@ -53,7 +53,6 @@ public class LayoutPageTemplateStructureRelElementVariationWrapper
 		attributes.put("userName", getUserName());
 		attributes.put("createDate", getCreateDate());
 		attributes.put("modifiedDate", getModifiedDate());
-		attributes.put("audienceEntryERC", getAudienceEntryERC());
 		attributes.put("hide", getHide());
 		attributes.put("html", getHtml());
 		attributes.put("js", getJs());
@@ -137,12 +136,6 @@ public class LayoutPageTemplateStructureRelElementVariationWrapper
 			setModifiedDate(modifiedDate);
 		}
 
-		String audienceEntryERC = (String)attributes.get("audienceEntryERC");
-
-		if (audienceEntryERC != null) {
-			setAudienceEntryERC(audienceEntryERC);
-		}
-
 		String hide = (String)attributes.get("hide");
 
 		if (hide != null) {
@@ -192,16 +185,6 @@ public class LayoutPageTemplateStructureRelElementVariationWrapper
 		cloneWithOriginalValues() {
 
 		return wrap(model.cloneWithOriginalValues());
-	}
-
-	/**
-	 * Returns the audience entry erc of this layout page template structure rel element variation.
-	 *
-	 * @return the audience entry erc of this layout page template structure rel element variation
-	 */
-	@Override
-	public String getAudienceEntryERC() {
-		return model.getAudienceEntryERC();
 	}
 
 	@Override
@@ -633,16 +616,6 @@ public class LayoutPageTemplateStructureRelElementVariationWrapper
 	}
 
 	/**
-	 * Sets the audience entry erc of this layout page template structure rel element variation.
-	 *
-	 * @param audienceEntryERC the audience entry erc of this layout page template structure rel element variation
-	 */
-	@Override
-	public void setAudienceEntryERC(String audienceEntryERC) {
-		model.setAudienceEntryERC(audienceEntryERC);
-	}
-
-	/**
 	 * Sets the company ID of this layout page template structure rel element variation.
 	 *
 	 * @param companyId the company ID of this layout page template structure rel element variation
@@ -1042,4 +1015,4 @@ public class LayoutPageTemplateStructureRelElementVariationWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1318191918
+// LIFERAY-SERVICE-BUILDER-HASH:360827116

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateStructureRelElementVariationWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateStructureRelElementVariationWrapper.java
@@ -188,6 +188,11 @@ public class LayoutPageTemplateStructureRelElementVariationWrapper
 	}
 
 	@Override
+	public java.util.List<String> getAudienceEntryERCs() {
+		return model.getAudienceEntryERCs();
+	}
+
+	@Override
 	public String[] getAvailableLanguageIds() {
 		return model.getAvailableLanguageIds();
 	}
@@ -1015,4 +1020,4 @@ public class LayoutPageTemplateStructureRelElementVariationWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:360827116
+// LIFERAY-SERVICE-BUILDER-HASH:387626618

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.service.BaseLocalService;
 import com.liferay.portal.kernel.service.PersistedModelLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.change.tracking.CTService;
 import com.liferay.portal.kernel.service.persistence.change.tracking.CTPersistence;
 import com.liferay.portal.kernel.transaction.Isolation;
@@ -80,6 +81,13 @@ public interface
 			LayoutPageTemplateStructureRelElementVariationAudienceEntryRel
 				layoutPageTemplateStructureRelElementVariationAudienceEntryRel);
 
+	public LayoutPageTemplateStructureRelElementVariationAudienceEntryRel
+			addLayoutPageTemplateStructureRelElementVariationAudienceEntryRel(
+				long userId, long groupId, String audienceEntryERC,
+				String layoutPageTemplateStructureRelElementVariationERC,
+				ServiceContext serviceContext)
+		throws PortalException;
+
 	/**
 	 * Creates a new layout page template structure rel element variation audience entry rel with the primary key. Does not add the layout page template structure rel element variation audience entry rel to the database.
 	 *
@@ -131,6 +139,10 @@ public interface
 				long
 					layoutPageTemplateStructureRelElementVariationAudienceEntryRelId)
 		throws PortalException;
+
+	public void
+		deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+			String layoutPageTemplateStructureRelElementVariationERC);
 
 	/**
 	 * @throws PortalException
@@ -294,6 +306,11 @@ public interface
 		getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
 			int start, int end);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+		getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+			String layoutPageTemplateStructureRelElementVariationERC);
+
 	/**
 	 * Returns all the layout page template structure rel element variation audience entry rels matching the UUID and company.
 	 *
@@ -385,4 +402,4 @@ public interface
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2006019107
+// LIFERAY-SERVICE-BUILDER-HASH:-651643994

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceUtil.java
@@ -58,6 +58,20 @@ public class
 				layoutPageTemplateStructureRelElementVariationAudienceEntryRel);
 	}
 
+	public static LayoutPageTemplateStructureRelElementVariationAudienceEntryRel
+			addLayoutPageTemplateStructureRelElementVariationAudienceEntryRel(
+				long userId, long groupId, String audienceEntryERC,
+				String layoutPageTemplateStructureRelElementVariationERC,
+				com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().
+			addLayoutPageTemplateStructureRelElementVariationAudienceEntryRel(
+				userId, groupId, audienceEntryERC,
+				layoutPageTemplateStructureRelElementVariationERC,
+				serviceContext);
+	}
+
 	/**
 	 * Creates a new layout page template structure rel element variation audience entry rel with the primary key. Does not add the layout page template structure rel element variation audience entry rel to the database.
 	 *
@@ -124,6 +138,15 @@ public class
 		return getService().
 			deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRel(
 				layoutPageTemplateStructureRelElementVariationAudienceEntryRelId);
+	}
+
+	public static void
+		deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+			String layoutPageTemplateStructureRelElementVariationERC) {
+
+		getService().
+			deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+				layoutPageTemplateStructureRelElementVariationERC);
 	}
 
 	/**
@@ -344,6 +367,16 @@ public class
 				start, end);
 	}
 
+	public static List
+		<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+			getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+				String layoutPageTemplateStructureRelElementVariationERC) {
+
+		return getService().
+			getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+				layoutPageTemplateStructureRelElementVariationERC);
+	}
+
 	/**
 	 * Returns all the layout page template structure rel element variation audience entry rels matching the UUID and company.
 	 *
@@ -448,4 +481,4 @@ public class
 				LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1523546470
+// LIFERAY-SERVICE-BUILDER-HASH:2034933066

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceWrapper.java
@@ -57,6 +57,21 @@ public class
 				layoutPageTemplateStructureRelElementVariationAudienceEntryRel);
 	}
 
+	@Override
+	public LayoutPageTemplateStructureRelElementVariationAudienceEntryRel
+			addLayoutPageTemplateStructureRelElementVariationAudienceEntryRel(
+				long userId, long groupId, String audienceEntryERC,
+				String layoutPageTemplateStructureRelElementVariationERC,
+				com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
+			addLayoutPageTemplateStructureRelElementVariationAudienceEntryRel(
+				userId, groupId, audienceEntryERC,
+				layoutPageTemplateStructureRelElementVariationERC,
+				serviceContext);
+	}
+
 	/**
 	 * Creates a new layout page template structure rel element variation audience entry rel with the primary key. Does not add the layout page template structure rel element variation audience entry rel to the database.
 	 *
@@ -128,6 +143,16 @@ public class
 		return _layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
 			deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRel(
 				layoutPageTemplateStructureRelElementVariationAudienceEntryRelId);
+	}
+
+	@Override
+	public void
+		deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+			String layoutPageTemplateStructureRelElementVariationERC) {
+
+		_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
+			deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+				layoutPageTemplateStructureRelElementVariationERC);
 	}
 
 	/**
@@ -385,6 +410,17 @@ public class
 				start, end);
 	}
 
+	@Override
+	public java.util.List
+		<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+			getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+				String layoutPageTemplateStructureRelElementVariationERC) {
+
+		return _layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
+			getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+				layoutPageTemplateStructureRelElementVariationERC);
+	}
+
 	/**
 	 * Returns all the layout page template structure rel element variation audience entry rels matching the UUID and company.
 	 *
@@ -541,4 +577,4 @@ public class
 			_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-489171970
+// LIFERAY-SERVICE-BUILDER-HASH:1708431927

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalService.java
@@ -84,7 +84,7 @@ public interface LayoutPageTemplateStructureRelElementVariationLocalService
 	public LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long userId, long groupId,
-				String audienceEntryERC, Map<Locale, String> hideMap,
+				String[] audienceEntryERCs, Map<Locale, String> hideMap,
 				Map<Locale, String> htmlMap, Map<Locale, String> jsMap,
 				String name, long plid, String segmentsExperienceERC,
 				String targetElement, ServiceContext serviceContext)
@@ -393,4 +393,4 @@ public interface LayoutPageTemplateStructureRelElementVariationLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:302590000
+// LIFERAY-SERVICE-BUILDER-HASH:-734232431

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceUtil.java
@@ -60,7 +60,8 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceUtil {
 	public static LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long userId, long groupId,
-				String audienceEntryERC, Map<java.util.Locale, String> hideMap,
+				String[] audienceEntryERCs,
+				Map<java.util.Locale, String> hideMap,
 				Map<java.util.Locale, String> htmlMap,
 				Map<java.util.Locale, String> jsMap, String name, long plid,
 				String segmentsExperienceERC, String targetElement,
@@ -69,7 +70,7 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceUtil {
 
 		return getService().
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
-				externalReferenceCode, userId, groupId, audienceEntryERC,
+				externalReferenceCode, userId, groupId, audienceEntryERCs,
 				hideMap, htmlMap, jsMap, name, plid, segmentsExperienceERC,
 				targetElement, serviceContext);
 	}
@@ -467,4 +468,4 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceUtil {
 					class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1346441991
+// LIFERAY-SERVICE-BUILDER-HASH:-1606851615

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper.java
@@ -60,7 +60,7 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper
 	public LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long userId, long groupId,
-				String audienceEntryERC,
+				String[] audienceEntryERCs,
 				java.util.Map<java.util.Locale, String> hideMap,
 				java.util.Map<java.util.Locale, String> htmlMap,
 				java.util.Map<java.util.Locale, String> jsMap, String name,
@@ -70,7 +70,7 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper
 
 		return _layoutPageTemplateStructureRelElementVariationLocalService.
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
-				externalReferenceCode, userId, groupId, audienceEntryERC,
+				externalReferenceCode, userId, groupId, audienceEntryERCs,
 				hideMap, htmlMap, jsMap, name, plid, segmentsExperienceERC,
 				targetElement, serviceContext);
 	}
@@ -561,4 +561,4 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper
 		_layoutPageTemplateStructureRelElementVariationLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1728596920
+// LIFERAY-SERVICE-BUILDER-HASH:-247877782

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationService.java
@@ -51,7 +51,7 @@ public interface LayoutPageTemplateStructureRelElementVariationService
 	public LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long groupId,
-				String audienceEntryERC, Map<Locale, String> hideMap,
+				String[] audienceEntryERCs, Map<Locale, String> hideMap,
 				Map<Locale, String> htmlMap, Map<Locale, String> jsMap,
 				String name, long plid, String segmentsExperienceERC,
 				String targetElement, ServiceContext serviceContext)
@@ -74,4 +74,4 @@ public interface LayoutPageTemplateStructureRelElementVariationService
 	public String getOSGiServiceIdentifier();
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1818296790
+// LIFERAY-SERVICE-BUILDER-HASH:1465290773

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationServiceUtil.java
@@ -34,7 +34,8 @@ public class LayoutPageTemplateStructureRelElementVariationServiceUtil {
 	public static LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long groupId,
-				String audienceEntryERC, Map<java.util.Locale, String> hideMap,
+				String[] audienceEntryERCs,
+				Map<java.util.Locale, String> hideMap,
 				Map<java.util.Locale, String> htmlMap,
 				Map<java.util.Locale, String> jsMap, String name, long plid,
 				String segmentsExperienceERC, String targetElement,
@@ -43,7 +44,7 @@ public class LayoutPageTemplateStructureRelElementVariationServiceUtil {
 
 		return getService().
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
-				externalReferenceCode, groupId, audienceEntryERC, hideMap,
+				externalReferenceCode, groupId, audienceEntryERCs, hideMap,
 				htmlMap, jsMap, name, plid, segmentsExperienceERC,
 				targetElement, serviceContext);
 	}
@@ -86,4 +87,4 @@ public class LayoutPageTemplateStructureRelElementVariationServiceUtil {
 				LayoutPageTemplateStructureRelElementVariationService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1077885661
+// LIFERAY-SERVICE-BUILDER-HASH:2068769419

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationServiceWrapper.java
@@ -36,7 +36,7 @@ public class LayoutPageTemplateStructureRelElementVariationServiceWrapper
 	public LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long groupId,
-				String audienceEntryERC,
+				String[] audienceEntryERCs,
 				java.util.Map<java.util.Locale, String> hideMap,
 				java.util.Map<java.util.Locale, String> htmlMap,
 				java.util.Map<java.util.Locale, String> jsMap, String name,
@@ -46,7 +46,7 @@ public class LayoutPageTemplateStructureRelElementVariationServiceWrapper
 
 		return _layoutPageTemplateStructureRelElementVariationService.
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
-				externalReferenceCode, groupId, audienceEntryERC, hideMap,
+				externalReferenceCode, groupId, audienceEntryERCs, hideMap,
 				htmlMap, jsMap, name, plid, segmentsExperienceERC,
 				targetElement, serviceContext);
 	}
@@ -101,4 +101,4 @@ public class LayoutPageTemplateStructureRelElementVariationServiceWrapper
 		_layoutPageTemplateStructureRelElementVariationService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-569638205
+// LIFERAY-SERVICE-BUILDER-HASH:-1714054147

--- a/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/model/packageinfo
+++ b/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/model/packageinfo
@@ -1,1 +1,1 @@
-version 7.8.0
+version 8.0.0

--- a/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/packageinfo
+++ b/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/packageinfo
@@ -1,1 +1,1 @@
-version 17.2.0
+version 18.0.0

--- a/modules/apps/layout/layout-page-template-service/service.xml
+++ b/modules/apps/layout/layout-page-template-service/service.xml
@@ -346,7 +346,6 @@
 
 		<!-- Other fields -->
 
-		<column name="audienceEntryERC" type="String" />
 		<column localized="true" name="hide" type="String" />
 		<column localized="true" name="html" type="String" />
 		<column localized="true" name="js" type="String" />

--- a/modules/apps/layout/layout-page-template-service/service.xml
+++ b/modules/apps/layout/layout-page-template-service/service.xml
@@ -408,6 +408,9 @@
 		<exception>LayoutPageTemplateEntryLayoutPageTemplateCollectionId</exception>
 		<exception>LayoutPageTemplateEntryLayoutPageTemplateEntryKey</exception>
 		<exception>LayoutPageTemplateEntryName</exception>
+		<exception>LayoutPageTemplateStructureRelElementVariationAudienceEntryERCs</exception>
+		<exception>LayoutPageTemplateStructureRelElementVariationName</exception>
+		<exception>LayoutPageTemplateStructureRelElementVariationTargetElement</exception>
 		<exception>RequiredLayoutPageTemplateEntry</exception>
 	</exceptions>
 </service-builder>

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v6_1_0/util/LayoutPageTemplateStructureRelElementVariationTable.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v6_1_0/util/LayoutPageTemplateStructureRelElementVariationTable.java
@@ -30,6 +30,6 @@ public class LayoutPageTemplateStructureRelElementVariationTable {
 	private static final String _TABLE_NAME = "LPTSRelElementVariation";
 
 	private static final String _TABLE_SQL_CREATE =
-		"create table LPTSRelElementVariation (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,lptsRelElementVariationId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,audienceEntryERC VARCHAR(75) null,hide STRING null,html STRING null,js STRING null,name VARCHAR(75) null,plid LONG,segmentsExperienceERC VARCHAR(75) null,targetElement VARCHAR(1000) null,primary key (lptsRelElementVariationId, ctCollectionId))";
+		"create table LPTSRelElementVariation (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,lptsRelElementVariationId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,hide STRING null,html STRING null,js STRING null,name VARCHAR(75) null,plid LONG,segmentsExperienceERC VARCHAR(75) null,targetElement VARCHAR(1000) null,primary key (lptsRelElementVariationId, ctCollectionId))";
 
 }

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureRelElementVariationCacheModel.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureRelElementVariationCacheModel.java
@@ -7,6 +7,7 @@ package com.liferay.layout.page.template.model.impl;
 
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariation;
 import com.liferay.petra.lang.HashUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.CacheModel;
 import com.liferay.portal.kernel.model.MVCCModel;
@@ -15,6 +16,9 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 
 import java.util.Date;
 
@@ -233,11 +237,22 @@ public class LayoutPageTemplateStructureRelElementVariationCacheModel
 		layoutPageTemplateStructureRelElementVariationImpl.
 			resetOriginalValues();
 
+		try {
+			_audienceEntryERCsMethodHandle.invokeExact(
+				layoutPageTemplateStructureRelElementVariationImpl,
+				audienceEntryERCs);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
+		}
+
 		return layoutPageTemplateStructureRelElementVariationImpl;
 	}
 
 	@Override
-	public void readExternal(ObjectInput objectInput) throws IOException {
+	public void readExternal(ObjectInput objectInput)
+		throws ClassNotFoundException, IOException {
+
 		mvccVersion = objectInput.readLong();
 
 		ctCollectionId = objectInput.readLong();
@@ -263,6 +278,8 @@ public class LayoutPageTemplateStructureRelElementVariationCacheModel
 		plid = objectInput.readLong();
 		segmentsExperienceERC = objectInput.readUTF();
 		targetElement = objectInput.readUTF();
+
+		audienceEntryERCs = (java.util.List)objectInput.readObject();
 	}
 
 	@Override
@@ -347,6 +364,8 @@ public class LayoutPageTemplateStructureRelElementVariationCacheModel
 		else {
 			objectOutput.writeUTF(targetElement);
 		}
+
+		objectOutput.writeObject(audienceEntryERCs);
 	}
 
 	public long mvccVersion;
@@ -367,6 +386,22 @@ public class LayoutPageTemplateStructureRelElementVariationCacheModel
 	public long plid;
 	public String segmentsExperienceERC;
 	public String targetElement;
+	public volatile java.util.List audienceEntryERCs;
+
+	private static final MethodHandle _audienceEntryERCsMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_audienceEntryERCsMethodHandle = lookup.findSetter(
+				LayoutPageTemplateStructureRelElementVariationImpl.class,
+				"_audienceEntryERCs", java.util.List.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2003123989
+// LIFERAY-SERVICE-BUILDER-HASH:-2108233286

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureRelElementVariationCacheModel.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureRelElementVariationCacheModel.java
@@ -78,7 +78,7 @@ public class LayoutPageTemplateStructureRelElementVariationCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(39);
+		StringBundler sb = new StringBundler(37);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -102,8 +102,6 @@ public class LayoutPageTemplateStructureRelElementVariationCacheModel
 		sb.append(createDate);
 		sb.append(", modifiedDate=");
 		sb.append(modifiedDate);
-		sb.append(", audienceEntryERC=");
-		sb.append(audienceEntryERC);
 		sb.append(", hide=");
 		sb.append(hide);
 		sb.append(", html=");
@@ -184,15 +182,6 @@ public class LayoutPageTemplateStructureRelElementVariationCacheModel
 				new Date(modifiedDate));
 		}
 
-		if (audienceEntryERC == null) {
-			layoutPageTemplateStructureRelElementVariationImpl.
-				setAudienceEntryERC("");
-		}
-		else {
-			layoutPageTemplateStructureRelElementVariationImpl.
-				setAudienceEntryERC(audienceEntryERC);
-		}
-
 		if (hide == null) {
 			layoutPageTemplateStructureRelElementVariationImpl.setHide("");
 		}
@@ -266,7 +255,6 @@ public class LayoutPageTemplateStructureRelElementVariationCacheModel
 		userName = objectInput.readUTF();
 		createDate = objectInput.readLong();
 		modifiedDate = objectInput.readLong();
-		audienceEntryERC = objectInput.readUTF();
 		hide = objectInput.readUTF();
 		html = objectInput.readUTF();
 		js = objectInput.readUTF();
@@ -315,13 +303,6 @@ public class LayoutPageTemplateStructureRelElementVariationCacheModel
 
 		objectOutput.writeLong(createDate);
 		objectOutput.writeLong(modifiedDate);
-
-		if (audienceEntryERC == null) {
-			objectOutput.writeUTF("");
-		}
-		else {
-			objectOutput.writeUTF(audienceEntryERC);
-		}
 
 		if (hide == null) {
 			objectOutput.writeUTF("");
@@ -379,7 +360,6 @@ public class LayoutPageTemplateStructureRelElementVariationCacheModel
 	public String userName;
 	public long createDate;
 	public long modifiedDate;
-	public String audienceEntryERC;
 	public String hide;
 	public String html;
 	public String js;
@@ -389,4 +369,4 @@ public class LayoutPageTemplateStructureRelElementVariationCacheModel
 	public String targetElement;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1657957509
+// LIFERAY-SERVICE-BUILDER-HASH:-2003123989

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureRelElementVariationImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureRelElementVariationImpl.java
@@ -5,9 +5,34 @@
 
 package com.liferay.layout.page.template.model.impl;
 
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariationAudienceEntryRel;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceUtil;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.model.cache.CacheField;
+
+import java.util.List;
+
 /**
  * @author Brian Wing Shun Chan
  */
 public class LayoutPageTemplateStructureRelElementVariationImpl
 	extends LayoutPageTemplateStructureRelElementVariationBaseImpl {
+
+	@Override
+	public List<String> getAudienceEntryERCs() {
+		if (_audienceEntryERCs == null) {
+			_audienceEntryERCs = TransformUtil.transform(
+				LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceUtil.
+					getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+						getExternalReferenceCode()),
+				LayoutPageTemplateStructureRelElementVariationAudienceEntryRel::
+					getAudienceEntryERC);
+		}
+
+		return _audienceEntryERCs;
+	}
+
+	@CacheField(permanent = true, propagateToInterface = true)
+	private transient List<String> _audienceEntryERCs;
+
 }

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureRelElementVariationImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureRelElementVariationImpl.java
@@ -27,6 +27,9 @@ public class LayoutPageTemplateStructureRelElementVariationImpl
 						getExternalReferenceCode()),
 				LayoutPageTemplateStructureRelElementVariationAudienceEntryRel::
 					getAudienceEntryERC);
+
+			audienceEntryERCsUpdateEntityCacheBiConsumer.accept(
+				this, _audienceEntryERCs);
 		}
 
 		return _audienceEntryERCs;

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureRelElementVariationModelImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureRelElementVariationModelImpl.java
@@ -10,8 +10,10 @@ import com.liferay.expando.kernel.util.ExpandoBridgeFactoryUtil;
 import com.liferay.exportimport.kernel.lar.StagedModelType;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariation;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariationModel;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.bean.AutoEscapeBeanHandler;
+import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.exception.LocaleException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSON;
@@ -31,6 +33,8 @@ import com.liferay.portal.kernel.util.Validator;
 
 import java.io.Serializable;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationHandler;
 
 import java.sql.Blob;
@@ -40,6 +44,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -1156,6 +1161,13 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 		_targetElement = targetElement;
 	}
 
+	public List<String> getAudienceEntryERCs() {
+		return null;
+	}
+
+	public void setAudienceEntryERCs(List<String> audienceEntryERCs) {
+	}
+
 	@Override
 	public StagedModelType getStagedModelType() {
 		return new StagedModelType(
@@ -1441,6 +1453,17 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 	}
 
 	@Override
+	public void copyCacheFields(
+		LayoutPageTemplateStructureRelElementVariation source) {
+
+		LayoutPageTemplateStructureRelElementVariationModelImpl
+			sourceModelImpl =
+				(LayoutPageTemplateStructureRelElementVariationModelImpl)source;
+
+		setAudienceEntryERCs(sourceModelImpl.getAudienceEntryERCs());
+	}
+
+	@Override
 	public boolean equals(Object object) {
 		if (this == object) {
 			return true;
@@ -1652,6 +1675,17 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 		if ((targetElement != null) && (targetElement.length() == 0)) {
 			layoutPageTemplateStructureRelElementVariationCacheModel.
 				targetElement = null;
+		}
+
+		try {
+			layoutPageTemplateStructureRelElementVariationCacheModel.
+				audienceEntryERCs =
+					(List<String>)_audienceEntryERCsMethodHandle.invokeExact(
+						(LayoutPageTemplateStructureRelElementVariationImpl)
+							this);
+		}
+		catch (Throwable throwable) {
+			ReflectionUtil.throwException(throwable);
 		}
 
 		return layoutPageTemplateStructureRelElementVariationCacheModel;
@@ -1866,7 +1900,49 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 	}
 
 	private long _columnBitmask;
+
+	protected static final BiConsumer
+		<LayoutPageTemplateStructureRelElementVariation, List<String>>
+			audienceEntryERCsUpdateEntityCacheBiConsumer =
+				(layoutPageTemplateStructureRelElementVariation,
+				 audienceEntryERCs) -> {
+
+					LayoutPageTemplateStructureRelElementVariationCacheModel
+						layoutPageTemplateStructureRelElementVariationCacheModel =
+							EntityCacheUtil.fetchCacheModel(
+								LayoutPageTemplateStructureRelElementVariationImpl.class,
+								layoutPageTemplateStructureRelElementVariation.
+									getPrimaryKey(),
+								LayoutPageTemplateStructureRelElementVariationCacheModel.class);
+
+					if ((layoutPageTemplateStructureRelElementVariationCacheModel !=
+							null) &&
+						(layoutPageTemplateStructureRelElementVariationCacheModel.
+							getMvccVersion() ==
+								layoutPageTemplateStructureRelElementVariation.
+									getMvccVersion())) {
+
+						layoutPageTemplateStructureRelElementVariationCacheModel.audienceEntryERCs =
+							audienceEntryERCs;
+					}
+				};
+
+	private static final MethodHandle _audienceEntryERCsMethodHandle;
+
+	static {
+		MethodHandles.Lookup lookup = ReflectionUtil.getImplLookup();
+
+		try {
+			_audienceEntryERCsMethodHandle = lookup.findGetter(
+				LayoutPageTemplateStructureRelElementVariationImpl.class,
+				"_audienceEntryERCs", List.class);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ExceptionInInitializerError(reflectiveOperationException);
+		}
+	}
+
 	private LayoutPageTemplateStructureRelElementVariation _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1030817281
+// LIFERAY-SERVICE-BUILDER-HASH:1763412238

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureRelElementVariationModelImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateStructureRelElementVariationModelImpl.java
@@ -77,10 +77,9 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 		{"lptsRelElementVariationId", Types.BIGINT}, {"groupId", Types.BIGINT},
 		{"companyId", Types.BIGINT}, {"userId", Types.BIGINT},
 		{"userName", Types.VARCHAR}, {"createDate", Types.TIMESTAMP},
-		{"modifiedDate", Types.TIMESTAMP}, {"audienceEntryERC", Types.VARCHAR},
-		{"hide", Types.VARCHAR}, {"html", Types.VARCHAR}, {"js", Types.VARCHAR},
-		{"name", Types.VARCHAR}, {"plid", Types.BIGINT},
-		{"segmentsExperienceERC", Types.VARCHAR},
+		{"modifiedDate", Types.TIMESTAMP}, {"hide", Types.VARCHAR},
+		{"html", Types.VARCHAR}, {"js", Types.VARCHAR}, {"name", Types.VARCHAR},
+		{"plid", Types.BIGINT}, {"segmentsExperienceERC", Types.VARCHAR},
 		{"targetElement", Types.VARCHAR}
 	};
 
@@ -99,7 +98,6 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 		TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
 		TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
-		TABLE_COLUMNS_MAP.put("audienceEntryERC", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("hide", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("html", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("js", Types.VARCHAR);
@@ -110,7 +108,7 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table LPTSRelElementVariation (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,lptsRelElementVariationId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,audienceEntryERC VARCHAR(75) null,hide STRING null,html STRING null,js STRING null,name VARCHAR(75) null,plid LONG,segmentsExperienceERC VARCHAR(75) null,targetElement VARCHAR(1000) null,primary key (lptsRelElementVariationId, ctCollectionId))";
+		"create table LPTSRelElementVariation (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,lptsRelElementVariationId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,hide STRING null,html STRING null,js STRING null,name VARCHAR(75) null,plid LONG,segmentsExperienceERC VARCHAR(75) null,targetElement VARCHAR(1000) null,primary key (lptsRelElementVariationId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP =
 		"drop table LPTSRelElementVariation";
@@ -344,10 +342,6 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 				LayoutPageTemplateStructureRelElementVariation::
 					getModifiedDate);
 			attributeGetterFunctions.put(
-				"audienceEntryERC",
-				LayoutPageTemplateStructureRelElementVariation::
-					getAudienceEntryERC);
-			attributeGetterFunctions.put(
 				"hide",
 				LayoutPageTemplateStructureRelElementVariation::getHide);
 			attributeGetterFunctions.put(
@@ -460,12 +454,6 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 					<LayoutPageTemplateStructureRelElementVariation, Date>)
 						LayoutPageTemplateStructureRelElementVariation::
 							setModifiedDate);
-			attributeSetterBiConsumers.put(
-				"audienceEntryERC",
-				(BiConsumer
-					<LayoutPageTemplateStructureRelElementVariation, String>)
-						LayoutPageTemplateStructureRelElementVariation::
-							setAudienceEntryERC);
 			attributeSetterBiConsumers.put(
 				"hide",
 				(BiConsumer
@@ -754,26 +742,6 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 		}
 
 		_modifiedDate = modifiedDate;
-	}
-
-	@JSON
-	@Override
-	public String getAudienceEntryERC() {
-		if (_audienceEntryERC == null) {
-			return "";
-		}
-		else {
-			return _audienceEntryERC;
-		}
-	}
-
-	@Override
-	public void setAudienceEntryERC(String audienceEntryERC) {
-		if (_columnOriginalValues == Collections.EMPTY_MAP) {
-			_setColumnOriginalValues();
-		}
-
-		_audienceEntryERC = audienceEntryERC;
 	}
 
 	@JSON
@@ -1386,8 +1354,6 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 			getCreateDate());
 		layoutPageTemplateStructureRelElementVariationImpl.setModifiedDate(
 			getModifiedDate());
-		layoutPageTemplateStructureRelElementVariationImpl.setAudienceEntryERC(
-			getAudienceEntryERC());
 		layoutPageTemplateStructureRelElementVariationImpl.setHide(getHide());
 		layoutPageTemplateStructureRelElementVariationImpl.setHtml(getHtml());
 		layoutPageTemplateStructureRelElementVariationImpl.setJs(getJs());
@@ -1436,8 +1402,6 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 			this.<Date>getColumnOriginalValue("createDate"));
 		layoutPageTemplateStructureRelElementVariationImpl.setModifiedDate(
 			this.<Date>getColumnOriginalValue("modifiedDate"));
-		layoutPageTemplateStructureRelElementVariationImpl.setAudienceEntryERC(
-			this.<String>getColumnOriginalValue("audienceEntryERC"));
 		layoutPageTemplateStructureRelElementVariationImpl.setHide(
 			this.<String>getColumnOriginalValue("hide"));
 		layoutPageTemplateStructureRelElementVariationImpl.setHtml(
@@ -1620,18 +1584,6 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 				modifiedDate = Long.MIN_VALUE;
 		}
 
-		layoutPageTemplateStructureRelElementVariationCacheModel.
-			audienceEntryERC = getAudienceEntryERC();
-
-		String audienceEntryERC =
-			layoutPageTemplateStructureRelElementVariationCacheModel.
-				audienceEntryERC;
-
-		if ((audienceEntryERC != null) && (audienceEntryERC.length() == 0)) {
-			layoutPageTemplateStructureRelElementVariationCacheModel.
-				audienceEntryERC = null;
-		}
-
 		layoutPageTemplateStructureRelElementVariationCacheModel.hide =
 			getHide();
 
@@ -1783,7 +1735,6 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 	private Date _createDate;
 	private Date _modifiedDate;
 	private boolean _setModifiedDate;
-	private String _audienceEntryERC;
 	private String _hide;
 	private String _hideCurrentLanguageId;
 	private String _html;
@@ -1841,7 +1792,6 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 		_columnOriginalValues.put("userName", _userName);
 		_columnOriginalValues.put("createDate", _createDate);
 		_columnOriginalValues.put("modifiedDate", _modifiedDate);
-		_columnOriginalValues.put("audienceEntryERC", _audienceEntryERC);
 		_columnOriginalValues.put("hide", _hide);
 		_columnOriginalValues.put("html", _html);
 		_columnOriginalValues.put("js", _js);
@@ -1898,21 +1848,19 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 
 		columnBitmasks.put("modifiedDate", 1024L);
 
-		columnBitmasks.put("audienceEntryERC", 2048L);
+		columnBitmasks.put("hide", 2048L);
 
-		columnBitmasks.put("hide", 4096L);
+		columnBitmasks.put("html", 4096L);
 
-		columnBitmasks.put("html", 8192L);
+		columnBitmasks.put("js", 8192L);
 
-		columnBitmasks.put("js", 16384L);
+		columnBitmasks.put("name", 16384L);
 
-		columnBitmasks.put("name", 32768L);
+		columnBitmasks.put("plid", 32768L);
 
-		columnBitmasks.put("plid", 65536L);
+		columnBitmasks.put("segmentsExperienceERC", 65536L);
 
-		columnBitmasks.put("segmentsExperienceERC", 131072L);
-
-		columnBitmasks.put("targetElement", 262144L);
+		columnBitmasks.put("targetElement", 131072L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}
@@ -1921,4 +1869,4 @@ public class LayoutPageTemplateStructureRelElementVariationModelImpl
 	private LayoutPageTemplateStructureRelElementVariation _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:709803567
+// LIFERAY-SERVICE-BUILDER-HASH:1030817281

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/http/LayoutPageTemplateStructureRelElementVariationServiceHttp.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/http/LayoutPageTemplateStructureRelElementVariationServiceHttp.java
@@ -45,7 +45,7 @@ public class LayoutPageTemplateStructureRelElementVariationServiceHttp {
 		LayoutPageTemplateStructureRelElementVariation
 				addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 					HttpPrincipal httpPrincipal, String externalReferenceCode,
-					long groupId, String audienceEntryERC,
+					long groupId, String[] audienceEntryERCs,
 					java.util.Map<java.util.Locale, String> hideMap,
 					java.util.Map<java.util.Locale, String> htmlMap,
 					java.util.Map<java.util.Locale, String> jsMap, String name,
@@ -62,7 +62,7 @@ public class LayoutPageTemplateStructureRelElementVariationServiceHttp {
 				_addOrUpdateLayoutPageTemplateStructureRelElementVariationParameterTypes0);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, groupId, audienceEntryERC,
+				methodKey, externalReferenceCode, groupId, audienceEntryERCs,
 				hideMap, htmlMap, jsMap, name, plid, segmentsExperienceERC,
 				targetElement, serviceContext);
 
@@ -184,7 +184,7 @@ public class LayoutPageTemplateStructureRelElementVariationServiceHttp {
 	private static final Class<?>[]
 		_addOrUpdateLayoutPageTemplateStructureRelElementVariationParameterTypes0 =
 			new Class[] {
-				String.class, long.class, String.class, java.util.Map.class,
+				String.class, long.class, String[].class, java.util.Map.class,
 				java.util.Map.class, java.util.Map.class, String.class,
 				long.class, String.class, String.class,
 				com.liferay.portal.kernel.service.ServiceContext.class
@@ -197,4 +197,4 @@ public class LayoutPageTemplateStructureRelElementVariationServiceHttp {
 			new Class[] {long.class};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1637411577
+// LIFERAY-SERVICE-BUILDER-HASH:-1984029539

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceImpl.java
@@ -5,10 +5,19 @@
 
 package com.liferay.layout.page.template.service.impl;
 
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariationAudienceEntryRel;
 import com.liferay.layout.page.template.service.base.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceBaseImpl;
 import com.liferay.portal.aop.AopService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+
+import java.util.Date;
+import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Brian Wing Shun Chan
@@ -20,4 +29,65 @@ import org.osgi.service.component.annotations.Component;
 public class
 	LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceImpl
 		extends LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalServiceBaseImpl {
+
+	public LayoutPageTemplateStructureRelElementVariationAudienceEntryRel
+			addLayoutPageTemplateStructureRelElementVariationAudienceEntryRel(
+				long userId, long groupId, String audienceEntryERC,
+				String layoutPageTemplateStructureRelElementVariationERC,
+				ServiceContext serviceContext)
+		throws PortalException {
+
+		User user = _userLocalService.getUser(userId);
+
+		LayoutPageTemplateStructureRelElementVariationAudienceEntryRel
+			layoutPageTemplateStructureRelElementVariationAudienceEntryRel =
+				layoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistence.
+					create(counterLocalService.increment());
+
+		layoutPageTemplateStructureRelElementVariationAudienceEntryRel.setUuid(
+			serviceContext.getUuid());
+		layoutPageTemplateStructureRelElementVariationAudienceEntryRel.
+			setGroupId(groupId);
+		layoutPageTemplateStructureRelElementVariationAudienceEntryRel.
+			setCompanyId(user.getCompanyId());
+		layoutPageTemplateStructureRelElementVariationAudienceEntryRel.
+			setUserId(user.getUserId());
+		layoutPageTemplateStructureRelElementVariationAudienceEntryRel.
+			setUserName(user.getFullName());
+		layoutPageTemplateStructureRelElementVariationAudienceEntryRel.
+			setCreateDate(serviceContext.getCreateDate(new Date()));
+		layoutPageTemplateStructureRelElementVariationAudienceEntryRel.
+			setModifiedDate(serviceContext.getModifiedDate(new Date()));
+		layoutPageTemplateStructureRelElementVariationAudienceEntryRel.
+			setAudienceEntryERC(audienceEntryERC);
+		layoutPageTemplateStructureRelElementVariationAudienceEntryRel.
+			setLayoutPageTemplateStructureRelElementVariationERC(
+				layoutPageTemplateStructureRelElementVariationERC);
+
+		return layoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistence.
+			update(
+				layoutPageTemplateStructureRelElementVariationAudienceEntryRel);
+	}
+
+	public void
+		deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+			String layoutPageTemplateStructureRelElementVariationERC) {
+
+		layoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistence.
+			removeByLayoutPageTemplateStructureRelElementVariationERC(
+				layoutPageTemplateStructureRelElementVariationERC);
+	}
+
+	public List<LayoutPageTemplateStructureRelElementVariationAudienceEntryRel>
+		getLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+			String layoutPageTemplateStructureRelElementVariationERC) {
+
+		return layoutPageTemplateStructureRelElementVariationAudienceEntryRelPersistence.
+			findByLayoutPageTemplateStructureRelElementVariationERC(
+				layoutPageTemplateStructureRelElementVariationERC);
+	}
+
+	@Reference
+	private UserLocalService _userLocalService;
+
 }

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationLocalServiceImpl.java
@@ -6,12 +6,14 @@
 package com.liferay.layout.page.template.service.impl;
 
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariation;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService;
 import com.liferay.layout.page.template.service.base.LayoutPageTemplateStructureRelElementVariationLocalServiceBaseImpl;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Date;
 import java.util.List;
@@ -34,7 +36,7 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 	public LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long userId, long groupId,
-				String audienceEntryERC, Map<Locale, String> hideMap,
+				String[] audienceEntryERCs, Map<Locale, String> hideMap,
 				Map<Locale, String> htmlMap, Map<Locale, String> jsMap,
 				String name, long plid, String segmentsExperienceERC,
 				String targetElement, ServiceContext serviceContext)
@@ -69,8 +71,6 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 
 		layoutPageTemplateStructureRelElementVariation.setModifiedDate(
 			serviceContext.getModifiedDate(new Date()));
-		layoutPageTemplateStructureRelElementVariation.setAudienceEntryERC(
-			audienceEntryERC);
 		layoutPageTemplateStructureRelElementVariation.setHideMap(hideMap);
 		layoutPageTemplateStructureRelElementVariation.setHtmlMap(htmlMap);
 		layoutPageTemplateStructureRelElementVariation.setJsMap(jsMap);
@@ -81,8 +81,26 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 		layoutPageTemplateStructureRelElementVariation.setTargetElement(
 			targetElement);
 
-		return layoutPageTemplateStructureRelElementVariationPersistence.update(
-			layoutPageTemplateStructureRelElementVariation);
+		layoutPageTemplateStructureRelElementVariation =
+			layoutPageTemplateStructureRelElementVariationPersistence.update(
+				layoutPageTemplateStructureRelElementVariation);
+
+		_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
+			deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+				externalReferenceCode);
+
+		for (String audienceEntryERC : audienceEntryERCs) {
+			if (Validator.isNull(audienceEntryERC)) {
+				continue;
+			}
+
+			_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
+				addLayoutPageTemplateStructureRelElementVariationAudienceEntryRel(
+					userId, groupId, audienceEntryERC, externalReferenceCode,
+					serviceContext);
+		}
+
+		return layoutPageTemplateStructureRelElementVariation;
 	}
 
 	public void deleteLayoutPageTemplateStructureRelElementVariation(
@@ -96,6 +114,10 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 		if (layoutPageTemplateStructureRelElementVariation != null) {
 			layoutPageTemplateStructureRelElementVariationPersistence.remove(
 				layoutPageTemplateStructureRelElementVariation);
+
+			_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
+				deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRels(
+					externalReferenceCode);
 		}
 	}
 
@@ -105,6 +127,11 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 		return layoutPageTemplateStructureRelElementVariationPersistence.
 			findByPlid(plid);
 	}
+
+	@Reference
+	private
+		LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService
+			_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationLocalServiceImpl.java
@@ -5,6 +5,9 @@
 
 package com.liferay.layout.page.template.service.impl;
 
+import com.liferay.layout.page.template.exception.LayoutPageTemplateStructureRelElementVariationAudienceEntryERCsException;
+import com.liferay.layout.page.template.exception.LayoutPageTemplateStructureRelElementVariationNameException;
+import com.liferay.layout.page.template.exception.LayoutPageTemplateStructureRelElementVariationTargetElementException;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariation;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService;
 import com.liferay.layout.page.template.service.base.LayoutPageTemplateStructureRelElementVariationLocalServiceBaseImpl;
@@ -13,6 +16,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Date;
@@ -41,6 +45,8 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 				String name, long plid, String segmentsExperienceERC,
 				String targetElement, ServiceContext serviceContext)
 		throws PortalException {
+
+		_validate(audienceEntryERCs, name, targetElement);
 
 		LayoutPageTemplateStructureRelElementVariation
 			layoutPageTemplateStructureRelElementVariation =
@@ -126,6 +132,26 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 
 		return layoutPageTemplateStructureRelElementVariationPersistence.
 			findByPlid(plid);
+	}
+
+	private void _validate(
+			String[] audienceEntryERCs, String name, String targetElement)
+		throws PortalException {
+
+		if (ArrayUtil.isEmpty(audienceEntryERCs)) {
+			throw new LayoutPageTemplateStructureRelElementVariationAudienceEntryERCsException(
+				"Audience entry external reference codes must not be empty");
+		}
+
+		if (Validator.isNull(name)) {
+			throw new LayoutPageTemplateStructureRelElementVariationNameException(
+				"Name must not be null");
+		}
+
+		if (Validator.isNull(targetElement)) {
+			throw new LayoutPageTemplateStructureRelElementVariationTargetElementException(
+				"Target element must not be null");
+		}
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationServiceImpl.java
@@ -34,7 +34,7 @@ public class LayoutPageTemplateStructureRelElementVariationServiceImpl
 	public LayoutPageTemplateStructureRelElementVariation
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
 				String externalReferenceCode, long groupId,
-				String audienceEntryERC, Map<Locale, String> hideMap,
+				String[] audienceEntryERCs, Map<Locale, String> hideMap,
 				Map<Locale, String> htmlMap, Map<Locale, String> jsMap,
 				String name, long plid, String segmentsExperienceERC,
 				String targetElement, ServiceContext serviceContext)
@@ -45,7 +45,7 @@ public class LayoutPageTemplateStructureRelElementVariationServiceImpl
 
 		return layoutPageTemplateStructureRelElementVariationLocalService.
 			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
-				externalReferenceCode, getUserId(), groupId, audienceEntryERC,
+				externalReferenceCode, getUserId(), groupId, audienceEntryERCs,
 				hideMap, htmlMap, jsMap, name, plid, segmentsExperienceERC,
 				targetElement, serviceContext);
 	}

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/persistence/impl/LayoutPageTemplateStructureRelElementVariationPersistenceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/persistence/impl/LayoutPageTemplateStructureRelElementVariationPersistenceImpl.java
@@ -1132,7 +1132,6 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceImpl
 		ctStrictColumnNames.add("userName");
 		ctStrictColumnNames.add("createDate");
 		ctIgnoreColumnNames.add("modifiedDate");
-		ctMergeColumnNames.add("audienceEntryERC");
 		ctMergeColumnNames.add("hide");
 		ctMergeColumnNames.add("html");
 		ctMergeColumnNames.add("js");
@@ -1438,4 +1437,4 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-941394124
+// LIFERAY-SERVICE-BUILDER-HASH:867617760

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/persistence/impl/LayoutPageTemplateStructureRelElementVariationPersistenceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/persistence/impl/LayoutPageTemplateStructureRelElementVariationPersistenceImpl.java
@@ -1437,4 +1437,4 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:867617760
+// LIFERAY-SERVICE-BUILDER-HASH:886004683

--- a/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/module-hbm.xml
@@ -111,7 +111,6 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="userName" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="createDate" type="timestamp" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="modifiedDate" type="timestamp" />
-		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="audienceEntryERC" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="hide" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="html" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="js" type="com.liferay.portal.dao.orm.hibernate.StringType" />

--- a/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -100,7 +100,6 @@
 		<field name="userName" type="String" />
 		<field name="createDate" type="Date" />
 		<field name="modifiedDate" type="Date" />
-		<field name="audienceEntryERC" type="String" />
 		<field localized="true" name="hide" type="String" />
 		<field localized="true" name="html" type="String" />
 		<field localized="true" name="js" type="String" />

--- a/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/layout/layout-page-template-service/src/main/resources/META-INF/sql/tables.sql
@@ -27,7 +27,6 @@ create table LPTSRelElementVariation (
 	userName VARCHAR(75) null,
 	createDate DATE null,
 	modifiedDate DATE null,
-	audienceEntryERC VARCHAR(75) null,
 	hide STRING null,
 	html STRING null,
 	js STRING null,

--- a/modules/apps/layout/layout-page-template-service/src/main/resources/service.properties
+++ b/modules/apps/layout/layout-page-template-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.layout.page.template.service
-    build.number=9
-    build.date=1782774473043
+    build.number=10
+    build.date=1782890218648

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructureRelElementVariationPersistenceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/persistence/test/LayoutPageTemplateStructureRelElementVariationPersistenceTest.java
@@ -155,9 +155,6 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceTest {
 		newLayoutPageTemplateStructureRelElementVariation.setModifiedDate(
 			RandomTestUtil.nextDate());
 
-		newLayoutPageTemplateStructureRelElementVariation.setAudienceEntryERC(
-			RandomTestUtil.randomString());
-
 		newLayoutPageTemplateStructureRelElementVariation.setHide(
 			RandomTestUtil.randomString());
 
@@ -241,11 +238,6 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceTest {
 			Time.getShortTimestamp(
 				newLayoutPageTemplateStructureRelElementVariation.
 					getModifiedDate()));
-		Assert.assertEquals(
-			existingLayoutPageTemplateStructureRelElementVariation.
-				getAudienceEntryERC(),
-			newLayoutPageTemplateStructureRelElementVariation.
-				getAudienceEntryERC());
 		Assert.assertEquals(
 			existingLayoutPageTemplateStructureRelElementVariation.getHide(),
 			newLayoutPageTemplateStructureRelElementVariation.getHide());
@@ -404,8 +396,8 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceTest {
 			true, "uuid", true, "externalReferenceCode", true,
 			"layoutPageTemplateStructureRelElementVariationId", true, "groupId",
 			true, "companyId", true, "userId", true, "userName", true,
-			"createDate", true, "modifiedDate", true, "audienceEntryERC", true,
-			"hide", true, "html", true, "js", true, "name", true, "plid", true,
+			"createDate", true, "modifiedDate", true, "hide", true, "html",
+			true, "js", true, "name", true, "plid", true,
 			"segmentsExperienceERC", true, "targetElement", true);
 	}
 
@@ -824,9 +816,6 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceTest {
 		layoutPageTemplateStructureRelElementVariation.setModifiedDate(
 			RandomTestUtil.nextDate());
 
-		layoutPageTemplateStructureRelElementVariation.setAudienceEntryERC(
-			RandomTestUtil.randomString());
-
 		layoutPageTemplateStructureRelElementVariation.setHide(
 			RandomTestUtil.randomString());
 
@@ -863,4 +852,4 @@ public class LayoutPageTemplateStructureRelElementVariationPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-389629694
+// LIFERAY-SERVICE-BUILDER-HASH:-1881622989


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96412

## What Is Being Fixed

An element variation could only be associated with a single audience entry, stored directly as the audienceEntryERC column on the element variation. This prevented targeting the same element variation at more than one audience.

## How It Is Being Fixed

The single audienceEntryERC column is removed from the element variation and replaced by a new LayoutPageTemplateStructureRelElementVariationAudienceEntryRel relation entity, so an element variation can reference multiple audience entries. The element variation model exposes them through getAudienceEntryERCs(), which lazily loads from the relation and propagates the result to the entity cache. The addOrUpdate service persists the audience entries by clearing the existing relations and recreating one per external reference code, and validates that the name, target element, and audience entries are provided, with new Service Builder exceptions for those checks.

## PR Check

**pr-check: PASS** — tested on `32d5ef50e12b0c284e3e728d3dfe964799bfa539`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "32d5ef50e12b0c284e3e728d3dfe964799bfa539"} -->
