### PR TITLE
LPD-96674 Fix sort ordering on Static Pages and Utility Pages

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContext.java
@@ -20,6 +20,8 @@ import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.OrderByComparatorFactoryUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -31,6 +33,7 @@ import jakarta.portlet.RenderResponse;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Jürgen Kappler
@@ -83,6 +86,8 @@ public class LayoutUtilityPageEntryDisplayContext {
 				"there-are-no-utility-pages");
 
 		layoutUtilityPageEntrySearchContainer.setOrderByCol(getOrderByCol());
+		layoutUtilityPageEntrySearchContainer.setOrderByComparator(
+			_getOrderByComparator());
 		layoutUtilityPageEntrySearchContainer.setOrderByType(getOrderByType());
 
 		String[] types = TransformUtil.transformToArray(
@@ -99,7 +104,8 @@ public class LayoutUtilityPageEntryDisplayContext {
 							types,
 							layoutUtilityPageEntrySearchContainer.getStart(),
 							layoutUtilityPageEntrySearchContainer.getEnd(),
-							null),
+							layoutUtilityPageEntrySearchContainer.
+								getOrderByComparator()),
 				LayoutUtilityPageEntryServiceUtil.
 					getLayoutUtilityPageEntriesCount(
 						_themeDisplay.getScopeGroupId(), _getKeywords(),
@@ -113,7 +119,8 @@ public class LayoutUtilityPageEntryDisplayContext {
 							_themeDisplay.getScopeGroupId(), types,
 							layoutUtilityPageEntrySearchContainer.getStart(),
 							layoutUtilityPageEntrySearchContainer.getEnd(),
-							null),
+							layoutUtilityPageEntrySearchContainer.
+								getOrderByComparator()),
 				LayoutUtilityPageEntryServiceUtil.
 					getLayoutUtilityPageEntriesCount(
 						_themeDisplay.getScopeGroupId(), types));
@@ -159,6 +166,26 @@ public class LayoutUtilityPageEntryDisplayContext {
 		_keywords = ParamUtil.getString(_renderRequest, "keywords");
 
 		return _keywords;
+	}
+
+	private OrderByComparator<LayoutUtilityPageEntry> _getOrderByComparator() {
+		boolean orderByAsc = false;
+
+		if (Objects.equals(getOrderByType(), "asc")) {
+			orderByAsc = true;
+		}
+
+		if (Objects.equals(getOrderByCol(), "create-date")) {
+			return OrderByComparatorFactoryUtil.create(
+				"LayoutUtilityPageEntry", "createDate", orderByAsc);
+		}
+
+		if (Objects.equals(getOrderByCol(), "name")) {
+			return OrderByComparatorFactoryUtil.create(
+				"LayoutUtilityPageEntry", "name", orderByAsc);
+		}
+
+		return null;
 	}
 
 	private PortletURL _getPortletURL() {

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContext.java
@@ -142,7 +142,7 @@ public class LayoutUtilityPageEntryDisplayContext {
 
 		_orderByCol = ParamUtil.getString(
 			_renderRequest, SearchContainer.DEFAULT_ORDER_BY_COL_PARAM,
-			"modified-date");
+			"create-date");
 
 		return _orderByCol;
 	}

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminManagementToolbarDisplayContext.java
@@ -236,6 +236,16 @@ public class LayoutsAdminManagementToolbarDisplayContext
 
 	@Override
 	public String getSortingURL() {
+		if (_layoutsAdminDisplayContext.isFirstColumn() ||
+			Objects.equals(getOrderByCol(), "relevance")) {
+
+			return null;
+		}
+
+		if (_layoutsAdminDisplayContext.isSearch()) {
+			return super.getSortingURL();
+		}
+
 		return null;
 	}
 

--- a/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContextTest.java
+++ b/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContextTest.java
@@ -1,0 +1,150 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.admin.web.internal.display.context;
+
+import com.liferay.layout.utility.page.kernel.LayoutUtilityPageEntryViewRendererRegistryUtil;
+import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
+import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryServiceUtil;
+import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Collections;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Balázs Sáfrány-Kovalik
+ */
+public class LayoutUtilityPageEntryDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_layoutUtilityPageEntryServiceUtilMockedStatic = Mockito.mockStatic(
+			LayoutUtilityPageEntryServiceUtil.class);
+
+		_layoutUtilityPageEntryViewRendererRegistryUtilMockedStatic =
+			Mockito.mockStatic(
+				LayoutUtilityPageEntryViewRendererRegistryUtil.class);
+
+		_layoutUtilityPageEntryViewRendererRegistryUtilMockedStatic.when(
+			LayoutUtilityPageEntryViewRendererRegistryUtil::
+				getLayoutUtilityPageEntryViewRenderers
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		_layoutUtilityPageEntryServiceUtilMockedStatic.when(
+			() -> LayoutUtilityPageEntryServiceUtil.getLayoutUtilityPageEntries(
+				Mockito.anyLong(), Mockito.any(String[].class),
+				Mockito.anyInt(), Mockito.anyInt(),
+				Mockito.<OrderByComparator<LayoutUtilityPageEntry>>any())
+		).thenReturn(
+			Collections.<LayoutUtilityPageEntry>emptyList()
+		);
+
+		_layoutUtilityPageEntryServiceUtilMockedStatic.when(
+			() ->
+				LayoutUtilityPageEntryServiceUtil.
+					getLayoutUtilityPageEntriesCount(
+						Mockito.anyLong(), Mockito.any(String[].class))
+		).thenReturn(
+			0
+		);
+	}
+
+	@After
+	public void tearDown() {
+		_layoutUtilityPageEntryServiceUtilMockedStatic.close();
+		_layoutUtilityPageEntryViewRendererRegistryUtilMockedStatic.close();
+	}
+
+	@Test
+	@TestInfo("LPD-96674")
+	public void testGetLayoutUtilityPageEntrySearchContainer() {
+		_testGetLayoutUtilityPageEntrySearchContainerOrderByCreateDate();
+		_testGetLayoutUtilityPageEntrySearchContainerOrderByName();
+		_testGetLayoutUtilityPageEntrySearchContainerWithoutOrderByComparator();
+	}
+
+	private OrderByComparator<LayoutUtilityPageEntry> _getOrderByComparator(
+		String orderByCol, String orderByType) {
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			new MockLiferayPortletRenderRequest();
+
+		mockLiferayPortletRenderRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, new ThemeDisplay());
+
+		if (orderByCol != null) {
+			mockLiferayPortletRenderRequest.setParameter(
+				"orderByCol", orderByCol);
+		}
+
+		if (orderByType != null) {
+			mockLiferayPortletRenderRequest.setParameter(
+				"orderByType", orderByType);
+		}
+
+		LayoutUtilityPageEntryDisplayContext
+			layoutUtilityPageEntryDisplayContext =
+				new LayoutUtilityPageEntryDisplayContext(
+					mockLiferayPortletRenderRequest,
+					new MockLiferayPortletRenderResponse());
+
+		SearchContainer<LayoutUtilityPageEntry> searchContainer =
+			layoutUtilityPageEntryDisplayContext.
+				getLayoutUtilityPageEntrySearchContainer();
+
+		return searchContainer.getOrderByComparator();
+	}
+
+	private void _testGetLayoutUtilityPageEntrySearchContainerOrderByCreateDate() {
+		Assert.assertEquals(
+			"LayoutUtilityPageEntry.createDate ASC",
+			_getOrderByComparator(
+				"create-date", "asc"
+			).getOrderBy());
+	}
+
+	private void _testGetLayoutUtilityPageEntrySearchContainerOrderByName() {
+		Assert.assertEquals(
+			"LayoutUtilityPageEntry.name DESC",
+			_getOrderByComparator(
+				"name", "desc"
+			).getOrderBy());
+	}
+
+	private void _testGetLayoutUtilityPageEntrySearchContainerWithoutOrderByComparator() {
+		Assert.assertNull(
+			_getOrderByComparator(RandomTestUtil.randomString(), "asc"));
+	}
+
+	private MockedStatic<LayoutUtilityPageEntryServiceUtil>
+		_layoutUtilityPageEntryServiceUtilMockedStatic;
+	private MockedStatic<LayoutUtilityPageEntryViewRendererRegistryUtil>
+		_layoutUtilityPageEntryViewRendererRegistryUtilMockedStatic;
+
+}

--- a/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminManagementToolbarDisplayContextTest.java
+++ b/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminManagementToolbarDisplayContextTest.java
@@ -1,0 +1,179 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.admin.web.internal.display.context;
+
+import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.PortletURLUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletURL;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.PortletURL;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Balázs Sáfrány-Kovalik
+ */
+public class LayoutsAdminManagementToolbarDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@AfterClass
+	public static void tearDownClass() {
+		_portletURLUtilMockedStatic.close();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_portletURLUtilMockedStatic.when(
+			() -> PortletURLUtil.clone(
+				Mockito.any(PortletURL.class),
+				Mockito.any(LiferayPortletResponse.class))
+		).thenReturn(
+			new MockLiferayPortletURL()
+		);
+
+		_portletURLUtilMockedStatic.when(
+			() -> PortletURLUtil.getCurrent(
+				Mockito.any(LiferayPortletRequest.class),
+				Mockito.any(LiferayPortletResponse.class))
+		).thenReturn(
+			new MockLiferayPortletURL()
+		);
+	}
+
+	@Test
+	@TestInfo("LPD-96674")
+	public void testGetSortingURL() throws Exception {
+		_testGetSortingURLWhenNotSearching();
+		_testGetSortingURLWhenOrderByRelevance();
+		_testGetSortingURLWhenSearching();
+		_testGetSortingURLWhenSearchingFirstColumn();
+	}
+
+	private LayoutsAdminManagementToolbarDisplayContext
+			_createLayoutsAdminManagementToolbarDisplayContext(
+				boolean firstColumn, String orderByCol, boolean search)
+		throws Exception {
+
+		LayoutsAdminDisplayContext layoutsAdminDisplayContext = Mockito.mock(
+			LayoutsAdminDisplayContext.class);
+
+		SearchContainer<Layout> searchContainer = _createSearchContainer(
+			orderByCol);
+
+		Mockito.when(
+			layoutsAdminDisplayContext.getLayoutsSearchContainer()
+		).thenReturn(
+			searchContainer
+		);
+
+		Mockito.when(
+			layoutsAdminDisplayContext.isFirstColumn()
+		).thenReturn(
+			firstColumn
+		);
+
+		Mockito.when(
+			layoutsAdminDisplayContext.isSearch()
+		).thenReturn(
+			search
+		);
+
+		return new LayoutsAdminManagementToolbarDisplayContext(
+			new MockHttpServletRequest(),
+			Mockito.mock(LiferayPortletRequest.class),
+			Mockito.mock(LiferayPortletResponse.class),
+			layoutsAdminDisplayContext);
+	}
+
+	private SearchContainer<Layout> _createSearchContainer(String orderByCol) {
+		SearchContainer<Layout> searchContainer =
+			(SearchContainer<Layout>)Mockito.mock(SearchContainer.class);
+
+		Mockito.when(
+			searchContainer.getOrderByCol()
+		).thenReturn(
+			orderByCol
+		);
+
+		Mockito.when(
+			searchContainer.getOrderByColParam()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		Mockito.when(
+			searchContainer.getOrderByTypeParam()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		return searchContainer;
+	}
+
+	private void _testGetSortingURLWhenNotSearching() throws Exception {
+		LayoutsAdminManagementToolbarDisplayContext
+			layoutsAdminManagementToolbarDisplayContext =
+				_createLayoutsAdminManagementToolbarDisplayContext(
+					false, RandomTestUtil.randomString(), false);
+
+		Assert.assertNull(
+			layoutsAdminManagementToolbarDisplayContext.getSortingURL());
+	}
+
+	private void _testGetSortingURLWhenOrderByRelevance() throws Exception {
+		LayoutsAdminManagementToolbarDisplayContext
+			layoutsAdminManagementToolbarDisplayContext =
+				_createLayoutsAdminManagementToolbarDisplayContext(
+					false, "relevance", true);
+
+		Assert.assertNull(
+			layoutsAdminManagementToolbarDisplayContext.getSortingURL());
+	}
+
+	private void _testGetSortingURLWhenSearching() throws Exception {
+		LayoutsAdminManagementToolbarDisplayContext
+			layoutsAdminManagementToolbarDisplayContext =
+				_createLayoutsAdminManagementToolbarDisplayContext(
+					false, RandomTestUtil.randomString(), true);
+
+		Assert.assertNotNull(
+			layoutsAdminManagementToolbarDisplayContext.getSortingURL());
+	}
+
+	private void _testGetSortingURLWhenSearchingFirstColumn() throws Exception {
+		LayoutsAdminManagementToolbarDisplayContext
+			layoutsAdminManagementToolbarDisplayContext =
+				_createLayoutsAdminManagementToolbarDisplayContext(
+					true, RandomTestUtil.randomString(), true);
+
+		Assert.assertNull(
+			layoutsAdminManagementToolbarDisplayContext.getSortingURL());
+	}
+
+	private static final MockedStatic<PortletURLUtil>
+		_portletURLUtilMockedStatic = Mockito.mockStatic(PortletURLUtil.class);
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96674

## What Is Being Fixed

In Site Builder → Pages, two sort-ordering defects made the toolbar controls appear functional while doing nothing. On Static Pages, sorting by Creation Date showed the Ascending/Descending options but clicking them never reordered the list. On Utility Pages, the Name and Creation Date options and their direction toggle likewise had no effect on the listing.

## How It Is Being Fixed

For Static Pages, `LayoutsAdminManagementToolbarDisplayContext.getSortingURL()` returned `null` unconditionally, so the direction items in the management toolbar's Order dropdown had no href and were inert. It now mirrors the guard already used by `getSortingOrder()`, delegating to the base class to build a toggled sorting URL when searching a real column and returning `null` only for the first-column, relevance, and non-search cases.

For Utility Pages, `LayoutUtilityPageEntryDisplayContext` passed a `null` `OrderByComparator` to the service, so the persistence query never applied any ordering. It now builds a comparator from the selected column and direction — `create-date` and `name`, the two keys the toolbar offers — and returns `null` for anything else, matching the pattern in the Static Pages display context. The default order-by column was also corrected from the non-selectable `modified-date` to `create-date` so the initial listing matches an option the toolbar actually presents.

Each fix ships with a unit test.

## PR Check

**pr-check: PASS** — tested on `bfbd1abc22a0232c16006326b09d2301218c59c1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "bfbd1abc22a0232c16006326b09d2301218c59c1"} -->
