### PR TITLE
LPD-97270 Fix the form container translation Playwright tests

### DIFF
--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -2098,9 +2098,7 @@ export class PageEditorPage {
 			target: iframe.locator('.card', {
 				hasText: fragmentName,
 			}),
-			trigger: iframe.locator('.card', {
-				hasText: folder,
-			}),
+			trigger: iframe.getByRole('link', {name: folder}),
 		});
 
 		await clickAndExpectToBeHidden({

--- a/modules/test/playwright/tests/layout-content-page-editor-web/form-container/formWithTranslation.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/form-container/formWithTranslation.spec.ts
@@ -2047,7 +2047,7 @@ test(
 					},
 					{
 						DBType: 'String',
-						businessType: 'Text',
+						businessType: 'EmailAddress',
 						externalReferenceCode: 'plantEmailERC',
 						indexed: true,
 						indexedAsKeyword: false,
@@ -2245,14 +2245,6 @@ test(
 
 		await pageEditorPage.mapFormFragment(formId, 'Plant', 'all', {
 			addLocalizationSelect: true,
-		});
-
-		// Swap the Text fragment mapped to the Email field to the Email fragment
-
-		await pageEditorPage.swapFragment({
-			folder: 'Form Components',
-			fragmentId: await pageEditorPage.getFragmentId('Text', 1),
-			fragmentName: 'Email',
 		});
 
 		// Swap to Multiselector Checkbox fragment


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97270
https://liferay.atlassian.net/browse/LPD-97224

## What Is Being Fixed

The form container translation test "Set unlocalized fields to disabled or readonly when changing language" times out, for two independent reasons. First, the shared `swapFragment` helper clicks the center of the item selector directory card, but that card is now a wide horizontal card whose only clickable target is its title link, so the folder never opens and every swap-based test times out. Second, the test maps the object's email field as a plain `Text` field and swaps that Text fragment to the Email fragment, but LPD-91039 restricted the email input fragment to `email` field types, so the Email fragment is no longer a valid swap target and never appears in the modal.

## How It Is Being Fixed

The `swapFragment` helper now clicks the fragment collection link with `getByRole('link', {name: folder})` instead of the card body, matching how every other item selector interaction in the suite navigates and staying robust to card layout changes. The object's email field is declared with the `EmailAddress` business type so the form maps it to the email input fragment natively, which renders the Email combobox the test asserts on and lets the now-invalid Text to Email swap be removed.

## Why Are There No Tests?

This change only repairs existing Playwright tests and the shared page object helper they use. It introduces no product code, so no new test coverage applies.

## PR Check

**pr-check: SKIPPED** — The only applicable validation, Source Format, cannot run locally: the JS/TS formatter (`node-scripts format --current-branch`) crashes on Windows with `ERR_UNSUPPORTED_ESM_URL_SCHEME`. The two-file Playwright TypeScript diff is prettier-conformant; CI pr-check will validate formatting.

<!-- pr-check {"reason": "Source Format (node-scripts format --current-branch) crashes locally on Windows with ERR_UNSUPPORTED_ESM_URL_SCHEME; Playwright TypeScript diff is prettier-conformant and CI will validate", "result": "skipped", "sha": "f7d859975fefae07fad849ba1f8565af0b6e92a4"} -->
