### PR TITLE
LPD-97413 Stop breadcrumb bar intercepting fragment Options click

### DIFF
--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -795,14 +795,20 @@ export class PageEditorPage {
 	) {
 		await this.selectFragment(fragmentId, isDesktop);
 
+		const optionsButton = this.page
+			.locator('.page-editor__topper__item')
+			.getByRole('button', {name: 'Options'});
+
+		await optionsButton.evaluate((element) =>
+			element.scrollIntoView({block: 'center', inline: 'center'})
+		);
+
 		await clickAndExpectToBeVisible({
 			autoClick: true,
 			target: this.page
 				.locator('.dropdown-menu.show')
 				.getByText(name, {exact: true}),
-			trigger: this.page
-				.locator('.page-editor__topper__item')
-				.getByRole('button', {name: 'Options'}),
+			trigger: optionsButton,
 		});
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97413

## What Is Being Fixed

The Playwright tests "Two Custom Elements share one FDS subscription until one is reconfigured away" and "Custom Element reconfiguration switches the active FDS subscription" in clientExtensions.spec.ts were intermittently failing in CI (not reproducible locally). Both failed inside setCustomElementProperties, which calls goToWidgetConfiguration -> clickFragmentOption to click a fragment's Options button.

The failure was a click-interception deadlock: Playwright's built-in "scroll into view if needed" only scrolls the Options button to the nearest edge, wedging it directly under the page's fixed breadcrumb bar, which then intercepts every click. Because the clickAndExpectToBeVisible retry loop never re-scrolls, the button stayed pinned under the bar and the retries spun until the 90s test timeout fired. It only surfaced in CI because the post-navigation scroll position that triggers the overlap is timing-dependent.

## How It Is Being Fixed

clickFragmentOption now scrolls the Options button to the center of the viewport before entering the retry-click loop. Centering clears the button of the top-fixed breadcrumb bar, and because the button is then fully visible Playwright's subsequent "scroll if needed" is a no-op, so it can no longer re-wedge it under the bar. The fix lives in the shared helper rather than the two specs because any page-editor test targeting a widget near the top of the page is exposed to the same interception.

## Why Are There No Tests?

This change modifies test-framework code (the shared clickFragmentOption Playwright Page helper) to stabilize existing tests. The coverage is the existing clientExtensions.spec.ts tests it de-flakes; no new product behavior is introduced.

## PR Check

**pr-check: PASS** — tested on `042e0d3a8ebd9ba9ff537f31889cf97c0f781fb3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "042e0d3a8ebd9ba9ff537f31889cf97c0f781fb3"} -->
