### PR TITLE
LPD-97432 Include the external reference code in the audiences definition

### DIFF
--- a/modules/apps/audiences/audiences-test/build.gradle
+++ b/modules/apps/audiences/audiences-test/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	testIntegrationImplementation group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.18.6"
 	testIntegrationImplementation project(":apps:audiences:audiences-api")
 	testIntegrationImplementation project(":apps:client-extension:client-extension-api")
 	testIntegrationImplementation project(":apps:frontend-js:frontend-js-audiences-api")

--- a/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/frontend/js/audiences/test/AudiencesDefinitionProviderTest.java
+++ b/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/frontend/js/audiences/test/AudiencesDefinitionProviderTest.java
@@ -5,14 +5,18 @@
 
 package com.liferay.audiences.frontend.js.audiences.test;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.audiences.model.AudiencesEntry;
 import com.liferay.audiences.service.AudiencesEntryLocalService;
 import com.liferay.frontend.js.audiences.AudiencesDefinition;
 import com.liferay.frontend.js.audiences.AudiencesDefinitionProvider;
 import com.liferay.portal.kernel.frontend.hashed.files.HashedFilesUtil;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -20,9 +24,6 @@ import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -44,13 +45,13 @@ public class AudiencesDefinitionProviderTest {
 	@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-93951"))
 	@Test
 	public void testGetAudiencesDefinition() throws Exception {
-		String name = RandomTestUtil.randomString();
-
-		_audiencesEntries.add(
+		AudiencesEntry audiencesEntry =
 			_audiencesEntryLocalService.addAudiencesEntry(
-				null, "{\"conjunction\": \"AND\", \"rules\": []}", name,
+				RandomTestUtil.randomString(),
+				"{\"conjunction\": \"AND\", \"rules\": []}",
+				RandomTestUtil.randomString(),
 				ServiceContextTestUtil.getServiceContext(
-					TestPropsValues.getGroupId())));
+					TestPropsValues.getGroupId()));
 
 		AudiencesDefinition audiencesDefinition =
 			_audiencesDefinitionProvider.getAudiencesDefinition(
@@ -58,7 +59,21 @@ public class AudiencesDefinitionProviderTest {
 
 		String content = audiencesDefinition.getContent();
 
-		Assert.assertTrue(content.contains(name));
+		JSONObject audiencesEntryJSONObject = JSONFactoryUtil.createJSONObject(
+			audiencesEntry.getJSON());
+
+		JSONObject expectedContentJSONObject = JSONUtil.put(
+			"audiences",
+			JSONUtil.putAll(
+				audiencesEntryJSONObject.put(
+					"id", audiencesEntry.getExternalReferenceCode())));
+
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		Assert.assertEquals(
+			objectMapper.readTree(expectedContentJSONObject.toString()),
+			objectMapper.readTree(content));
+
 		Assert.assertEquals(
 			HashedFilesUtil.computeHash(content),
 			audiencesDefinition.getHash());
@@ -66,9 +81,6 @@ public class AudiencesDefinitionProviderTest {
 
 	@Inject
 	private AudiencesDefinitionProvider _audiencesDefinitionProvider;
-
-	@DeleteAfterTestRun
-	private final List<AudiencesEntry> _audiencesEntries = new ArrayList<>();
 
 	@Inject
 	private AudiencesEntryLocalService _audiencesEntryLocalService;

--- a/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/frontend/js/audiences/AudiencesDefinitionProviderImpl.java
+++ b/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/frontend/js/audiences/AudiencesDefinitionProviderImpl.java
@@ -12,11 +12,15 @@ import com.liferay.frontend.js.audiences.AudiencesDefinitionProvider;
 import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.frontend.hashed.files.HashedFilesUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 
 import java.util.List;
 
@@ -51,7 +55,12 @@ public class AudiencesDefinitionProviderImpl
 				companyId, QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
 
 		for (AudiencesEntry audiencesEntry : audiencesEntries) {
-			audiencesJSONArray.put(audiencesEntry);
+			JSONObject jsonObject = _getAudiencesEntryJSONObject(
+				audiencesEntry);
+
+			audiencesJSONArray.put(
+				jsonObject.put(
+					"id", audiencesEntry.getExternalReferenceCode()));
 		}
 
 		String json = JSONUtil.put(
@@ -77,6 +86,24 @@ public class AudiencesDefinitionProviderImpl
 	protected void deactivate() {
 		_multiVMPool.removePortalCache(AudiencesEntry.class.getName());
 	}
+
+	private JSONObject _getAudiencesEntryJSONObject(
+		AudiencesEntry audiencesEntry) {
+
+		try {
+			return _jsonFactory.createJSONObject(audiencesEntry.getJSON());
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+
+		return _jsonFactory.createJSONObject();
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AudiencesDefinitionProviderImpl.class);
 
 	@Reference
 	private AudiencesEntryLocalService _audiencesEntryLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97432

## What Is Being Fixed

The audiences definition served to the front end serialized each audience entry as the raw model object and exposed no stable identifier, so consumers (such as element variations) had no way to reference an audience by its external reference code.

## How It Is Being Fixed

Each audience entry is now serialized from its own criteria JSON with an added id field set to the entry's external reference code. A helper parses the stored entry JSON and falls back to an empty object when it cannot be parsed.

## PR Check

**pr-check: PASS** — tested on 

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |

<!-- pr-check {result: success, sha: 2f49d2c91afac44552867ecd25648f63fa5b7858} -->