### PR TITLE
LPD-97456 Click the folder card link when swapping fragments

### DIFF
--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -2098,9 +2098,7 @@ export class PageEditorPage {
 			target: iframe.locator('.card', {
 				hasText: fragmentName,
 			}),
-			trigger: iframe.locator('.card', {
-				hasText: folder,
-			}),
+			trigger: iframe.getByRole('link', {exact: true, name: folder}),
 		});
 
 		await clickAndExpectToBeHidden({


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97456

## What Is Being Fixed

`displayPagesEdition.spec.ts > Object Display page > Can edit values in display page` fails on the page-management routine since 2026-07-03, along with the form-container specs that swap fragments. The `swapFragment` page object clicks the center of the folder card in the Swap Fragment modal, but the only clickable element in that card is its title link. Since the LPD-88758 card revamp lays out the card page with CSS Grid (`minmax(296px, 1fr)` columns), the card is wide enough in the modal that the center click misses the link, so the collection never opens and the test times out.

## How It Is Being Fixed

The folder trigger now targets the card's link role instead of the card body, so the click always lands on the element that navigates into the collection regardless of card geometry. `displayPagesEdition.spec.ts` ("Can edit values in display page") and `form-container/swapFragment.spec.ts` were run locally and pass.

## Why Are There No Tests?

The change is itself test code — it fixes the shared Playwright page object consumed by the affected specs, which now pass.

## PR Check

**pr-check: PASS** — tested on `354f37d82d9dca5f1de0efe73302aeda99471920`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "354f37d82d9dca5f1de0efe73302aeda99471920"} -->
