### PR TITLE
LPD-96674 Fix ordering in Static Pages search and Utility Pages

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContext.java
@@ -20,6 +20,8 @@ import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.OrderByComparatorFactoryUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -31,6 +33,7 @@ import jakarta.portlet.RenderResponse;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Jürgen Kappler
@@ -83,6 +86,8 @@ public class LayoutUtilityPageEntryDisplayContext {
 				"there-are-no-utility-pages");
 
 		layoutUtilityPageEntrySearchContainer.setOrderByCol(getOrderByCol());
+		layoutUtilityPageEntrySearchContainer.setOrderByComparator(
+			_getOrderByComparator());
 		layoutUtilityPageEntrySearchContainer.setOrderByType(getOrderByType());
 
 		String[] types = TransformUtil.transformToArray(
@@ -99,7 +104,8 @@ public class LayoutUtilityPageEntryDisplayContext {
 							types,
 							layoutUtilityPageEntrySearchContainer.getStart(),
 							layoutUtilityPageEntrySearchContainer.getEnd(),
-							null),
+							layoutUtilityPageEntrySearchContainer.
+								getOrderByComparator()),
 				LayoutUtilityPageEntryServiceUtil.
 					getLayoutUtilityPageEntriesCount(
 						_themeDisplay.getScopeGroupId(), _getKeywords(),
@@ -113,7 +119,8 @@ public class LayoutUtilityPageEntryDisplayContext {
 							_themeDisplay.getScopeGroupId(), types,
 							layoutUtilityPageEntrySearchContainer.getStart(),
 							layoutUtilityPageEntrySearchContainer.getEnd(),
-							null),
+							layoutUtilityPageEntrySearchContainer.
+								getOrderByComparator()),
 				LayoutUtilityPageEntryServiceUtil.
 					getLayoutUtilityPageEntriesCount(
 						_themeDisplay.getScopeGroupId(), types));
@@ -159,6 +166,26 @@ public class LayoutUtilityPageEntryDisplayContext {
 		_keywords = ParamUtil.getString(_renderRequest, "keywords");
 
 		return _keywords;
+	}
+
+	private OrderByComparator<LayoutUtilityPageEntry> _getOrderByComparator() {
+		boolean orderByAsc = false;
+
+		if (Objects.equals(getOrderByType(), "asc")) {
+			orderByAsc = true;
+		}
+
+		if (Objects.equals(getOrderByCol(), "create-date")) {
+			return OrderByComparatorFactoryUtil.create(
+				"LayoutUtilityPageEntry", "createDate", orderByAsc);
+		}
+
+		if (Objects.equals(getOrderByCol(), "name")) {
+			return OrderByComparatorFactoryUtil.create(
+				"LayoutUtilityPageEntry", "name", orderByAsc);
+		}
+
+		return null;
 	}
 
 	private PortletURL _getPortletURL() {

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContext.java
@@ -142,7 +142,7 @@ public class LayoutUtilityPageEntryDisplayContext {
 
 		_orderByCol = ParamUtil.getString(
 			_renderRequest, SearchContainer.DEFAULT_ORDER_BY_COL_PARAM,
-			"modified-date");
+			"create-date");
 
 		return _orderByCol;
 	}

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContext.java
@@ -85,9 +85,12 @@ public class LayoutUtilityPageEntryDisplayContext {
 				_renderRequest, _getPortletURL(), null,
 				"there-are-no-utility-pages");
 
+		OrderByComparator<LayoutUtilityPageEntry> orderByComparator =
+			_getOrderByComparator();
+
 		layoutUtilityPageEntrySearchContainer.setOrderByCol(getOrderByCol());
 		layoutUtilityPageEntrySearchContainer.setOrderByComparator(
-			_getOrderByComparator());
+			orderByComparator);
 		layoutUtilityPageEntrySearchContainer.setOrderByType(getOrderByType());
 
 		String[] types = TransformUtil.transformToArray(
@@ -104,8 +107,7 @@ public class LayoutUtilityPageEntryDisplayContext {
 							types,
 							layoutUtilityPageEntrySearchContainer.getStart(),
 							layoutUtilityPageEntrySearchContainer.getEnd(),
-							layoutUtilityPageEntrySearchContainer.
-								getOrderByComparator()),
+							orderByComparator),
 				LayoutUtilityPageEntryServiceUtil.
 					getLayoutUtilityPageEntriesCount(
 						_themeDisplay.getScopeGroupId(), _getKeywords(),
@@ -119,8 +121,7 @@ public class LayoutUtilityPageEntryDisplayContext {
 							_themeDisplay.getScopeGroupId(), types,
 							layoutUtilityPageEntrySearchContainer.getStart(),
 							layoutUtilityPageEntrySearchContainer.getEnd(),
-							layoutUtilityPageEntrySearchContainer.
-								getOrderByComparator()),
+							orderByComparator),
 				LayoutUtilityPageEntryServiceUtil.
 					getLayoutUtilityPageEntriesCount(
 						_themeDisplay.getScopeGroupId(), types));

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminManagementToolbarDisplayContext.java
@@ -236,6 +236,16 @@ public class LayoutsAdminManagementToolbarDisplayContext
 
 	@Override
 	public String getSortingURL() {
+		if (_layoutsAdminDisplayContext.isFirstColumn() ||
+			Objects.equals(getOrderByCol(), "relevance")) {
+
+			return null;
+		}
+
+		if (_layoutsAdminDisplayContext.isSearch()) {
+			return super.getSortingURL();
+		}
+
 		return null;
 	}
 

--- a/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContextTest.java
+++ b/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContextTest.java
@@ -42,13 +42,6 @@ public class LayoutUtilityPageEntryDisplayContextTest {
 
 	@Before
 	public void setUp() {
-		_layoutUtilityPageEntryServiceUtilMockedStatic = Mockito.mockStatic(
-			LayoutUtilityPageEntryServiceUtil.class);
-
-		_layoutUtilityPageEntryViewRendererRegistryUtilMockedStatic =
-			Mockito.mockStatic(
-				LayoutUtilityPageEntryViewRendererRegistryUtil.class);
-
 		_layoutUtilityPageEntryViewRendererRegistryUtilMockedStatic.when(
 			LayoutUtilityPageEntryViewRendererRegistryUtil::
 				getLayoutUtilityPageEntryViewRenderers
@@ -155,9 +148,12 @@ public class LayoutUtilityPageEntryDisplayContextTest {
 				RandomTestUtil.randomString(), "asc"));
 	}
 
-	private MockedStatic<LayoutUtilityPageEntryServiceUtil>
-		_layoutUtilityPageEntryServiceUtilMockedStatic;
-	private MockedStatic<LayoutUtilityPageEntryViewRendererRegistryUtil>
-		_layoutUtilityPageEntryViewRendererRegistryUtilMockedStatic;
+	private final MockedStatic<LayoutUtilityPageEntryServiceUtil>
+		_layoutUtilityPageEntryServiceUtilMockedStatic = Mockito.mockStatic(
+			LayoutUtilityPageEntryServiceUtil.class);
+	private final MockedStatic<LayoutUtilityPageEntryViewRendererRegistryUtil>
+		_layoutUtilityPageEntryViewRendererRegistryUtilMockedStatic =
+			Mockito.mockStatic(
+				LayoutUtilityPageEntryViewRendererRegistryUtil.class);
 
 }

--- a/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContextTest.java
+++ b/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContextTest.java
@@ -122,19 +122,20 @@ public class LayoutUtilityPageEntryDisplayContextTest {
 	}
 
 	private void _testGetLayoutUtilityPageEntrySearchContainerOrderByCreateDate() {
+		OrderByComparator<LayoutUtilityPageEntry> orderByComparator =
+			_getOrderByComparator("create-date", "asc");
+
 		Assert.assertEquals(
 			"LayoutUtilityPageEntry.createDate ASC",
-			_getOrderByComparator(
-				"create-date", "asc"
-			).getOrderBy());
+			orderByComparator.getOrderBy());
 	}
 
 	private void _testGetLayoutUtilityPageEntrySearchContainerOrderByName() {
+		OrderByComparator<LayoutUtilityPageEntry> orderByComparator =
+			_getOrderByComparator("name", "desc");
+
 		Assert.assertEquals(
-			"LayoutUtilityPageEntry.name DESC",
-			_getOrderByComparator(
-				"name", "desc"
-			).getOrderBy());
+			"LayoutUtilityPageEntry.name DESC", orderByComparator.getOrderBy());
 	}
 
 	private void _testGetLayoutUtilityPageEntrySearchContainerWithoutOrderByComparator() {

--- a/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContextTest.java
+++ b/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContextTest.java
@@ -86,7 +86,7 @@ public class LayoutUtilityPageEntryDisplayContextTest {
 	public void testGetLayoutUtilityPageEntrySearchContainer() {
 		_testGetLayoutUtilityPageEntrySearchContainerOrderByCreateDate();
 		_testGetLayoutUtilityPageEntrySearchContainerOrderByName();
-		_testGetLayoutUtilityPageEntrySearchContainerWithoutOrderByComparator();
+		_testGetLayoutUtilityPageEntrySearchContainerUnknownOrderByCol();
 	}
 
 	private OrderByComparator<LayoutUtilityPageEntry>
@@ -139,7 +139,7 @@ public class LayoutUtilityPageEntryDisplayContextTest {
 			"LayoutUtilityPageEntry.name DESC", orderByComparator.getOrderBy());
 	}
 
-	private void _testGetLayoutUtilityPageEntrySearchContainerWithoutOrderByComparator() {
+	private void _testGetLayoutUtilityPageEntrySearchContainerUnknownOrderByCol() {
 		Assert.assertNull(
 			_getSearchContainerOrderByComparator(
 				RandomTestUtil.randomString(), "asc"));

--- a/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContextTest.java
+++ b/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContextTest.java
@@ -145,7 +145,7 @@ public class LayoutUtilityPageEntryDisplayContextTest {
 	private void _testGetLayoutUtilityPageEntrySearchContainerUnknownOrderByCol() {
 		Assert.assertNull(
 			_getSearchContainerOrderByComparator(
-				RandomTestUtil.randomString(), "asc"));
+				RandomTestUtil.randomString(), RandomTestUtil.randomString()));
 	}
 
 	private final MockedStatic<LayoutUtilityPageEntryServiceUtil>

--- a/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContextTest.java
+++ b/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContextTest.java
@@ -42,13 +42,6 @@ public class LayoutUtilityPageEntryDisplayContextTest {
 
 	@Before
 	public void setUp() {
-		_layoutUtilityPageEntryViewRendererRegistryUtilMockedStatic.when(
-			LayoutUtilityPageEntryViewRendererRegistryUtil::
-				getLayoutUtilityPageEntryViewRenderers
-		).thenReturn(
-			Collections.emptyList()
-		);
-
 		_layoutUtilityPageEntryServiceUtilMockedStatic.when(
 			() -> LayoutUtilityPageEntryServiceUtil.getLayoutUtilityPageEntries(
 				Mockito.anyLong(), Mockito.any(String[].class),
@@ -65,6 +58,13 @@ public class LayoutUtilityPageEntryDisplayContextTest {
 						Mockito.anyLong(), Mockito.any(String[].class))
 		).thenReturn(
 			0
+		);
+
+		_layoutUtilityPageEntryViewRendererRegistryUtilMockedStatic.when(
+			LayoutUtilityPageEntryViewRendererRegistryUtil::
+				getLayoutUtilityPageEntryViewRenderers
+		).thenReturn(
+			Collections.emptyList()
 		);
 	}
 

--- a/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContextTest.java
+++ b/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContextTest.java
@@ -84,6 +84,7 @@ public class LayoutUtilityPageEntryDisplayContextTest {
 	@Test
 	@TestInfo("LPD-96674")
 	public void testGetLayoutUtilityPageEntrySearchContainer() {
+		_testGetLayoutUtilityPageEntrySearchContainerDefaultOrderByComparator();
 		_testGetLayoutUtilityPageEntrySearchContainerOrderByCreateDate();
 		_testGetLayoutUtilityPageEntrySearchContainerOrderByName();
 		_testGetLayoutUtilityPageEntrySearchContainerUnknownOrderByCol();
@@ -120,6 +121,15 @@ public class LayoutUtilityPageEntryDisplayContextTest {
 				getLayoutUtilityPageEntrySearchContainer();
 
 		return searchContainer.getOrderByComparator();
+	}
+
+	private void _testGetLayoutUtilityPageEntrySearchContainerDefaultOrderByComparator() {
+		OrderByComparator<LayoutUtilityPageEntry> orderByComparator =
+			_getSearchContainerOrderByComparator(null, null);
+
+		Assert.assertEquals(
+			"LayoutUtilityPageEntry.createDate ASC",
+			orderByComparator.getOrderBy());
 	}
 
 	private void _testGetLayoutUtilityPageEntrySearchContainerOrderByCreateDate() {

--- a/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContextTest.java
+++ b/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContextTest.java
@@ -1,0 +1,150 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.admin.web.internal.display.context;
+
+import com.liferay.layout.utility.page.kernel.LayoutUtilityPageEntryViewRendererRegistryUtil;
+import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
+import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryServiceUtil;
+import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Collections;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Balázs Sáfrány-Kovalik
+ */
+public class LayoutUtilityPageEntryDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_layoutUtilityPageEntryServiceUtilMockedStatic = Mockito.mockStatic(
+			LayoutUtilityPageEntryServiceUtil.class);
+
+		_layoutUtilityPageEntryViewRendererRegistryUtilMockedStatic =
+			Mockito.mockStatic(
+				LayoutUtilityPageEntryViewRendererRegistryUtil.class);
+
+		_layoutUtilityPageEntryViewRendererRegistryUtilMockedStatic.when(
+			LayoutUtilityPageEntryViewRendererRegistryUtil::
+				getLayoutUtilityPageEntryViewRenderers
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		_layoutUtilityPageEntryServiceUtilMockedStatic.when(
+			() -> LayoutUtilityPageEntryServiceUtil.getLayoutUtilityPageEntries(
+				Mockito.anyLong(), Mockito.any(String[].class),
+				Mockito.anyInt(), Mockito.anyInt(),
+				Mockito.<OrderByComparator<LayoutUtilityPageEntry>>any())
+		).thenReturn(
+			Collections.<LayoutUtilityPageEntry>emptyList()
+		);
+
+		_layoutUtilityPageEntryServiceUtilMockedStatic.when(
+			() ->
+				LayoutUtilityPageEntryServiceUtil.
+					getLayoutUtilityPageEntriesCount(
+						Mockito.anyLong(), Mockito.any(String[].class))
+		).thenReturn(
+			0
+		);
+	}
+
+	@After
+	public void tearDown() {
+		_layoutUtilityPageEntryServiceUtilMockedStatic.close();
+		_layoutUtilityPageEntryViewRendererRegistryUtilMockedStatic.close();
+	}
+
+	@Test
+	@TestInfo("LPD-96674")
+	public void testGetLayoutUtilityPageEntrySearchContainer() {
+		_testGetLayoutUtilityPageEntrySearchContainerOrderByCreateDate();
+		_testGetLayoutUtilityPageEntrySearchContainerOrderByName();
+		_testGetLayoutUtilityPageEntrySearchContainerWithoutOrderByComparator();
+	}
+
+	private OrderByComparator<LayoutUtilityPageEntry> _getOrderByComparator(
+		String orderByCol, String orderByType) {
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			new MockLiferayPortletRenderRequest();
+
+		mockLiferayPortletRenderRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, new ThemeDisplay());
+
+		if (orderByCol != null) {
+			mockLiferayPortletRenderRequest.setParameter(
+				"orderByCol", orderByCol);
+		}
+
+		if (orderByType != null) {
+			mockLiferayPortletRenderRequest.setParameter(
+				"orderByType", orderByType);
+		}
+
+		LayoutUtilityPageEntryDisplayContext
+			layoutUtilityPageEntryDisplayContext =
+				new LayoutUtilityPageEntryDisplayContext(
+					mockLiferayPortletRenderRequest,
+					new MockLiferayPortletRenderResponse());
+
+		SearchContainer<LayoutUtilityPageEntry> searchContainer =
+			layoutUtilityPageEntryDisplayContext.
+				getLayoutUtilityPageEntrySearchContainer();
+
+		return searchContainer.getOrderByComparator();
+	}
+
+	private void _testGetLayoutUtilityPageEntrySearchContainerOrderByCreateDate() {
+		Assert.assertEquals(
+			"LayoutUtilityPageEntry.createDate ASC",
+			_getOrderByComparator(
+				"create-date", "asc"
+			).getOrderBy());
+	}
+
+	private void _testGetLayoutUtilityPageEntrySearchContainerOrderByName() {
+		Assert.assertEquals(
+			"LayoutUtilityPageEntry.name DESC",
+			_getOrderByComparator(
+				"name", "desc"
+			).getOrderBy());
+	}
+
+	private void _testGetLayoutUtilityPageEntrySearchContainerWithoutOrderByComparator() {
+		Assert.assertNull(
+			_getOrderByComparator(RandomTestUtil.randomString(), "asc"));
+	}
+
+	private MockedStatic<LayoutUtilityPageEntryServiceUtil>
+		_layoutUtilityPageEntryServiceUtilMockedStatic;
+	private MockedStatic<LayoutUtilityPageEntryViewRendererRegistryUtil>
+		_layoutUtilityPageEntryViewRendererRegistryUtilMockedStatic;
+
+}

--- a/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContextTest.java
+++ b/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryDisplayContextTest.java
@@ -89,8 +89,9 @@ public class LayoutUtilityPageEntryDisplayContextTest {
 		_testGetLayoutUtilityPageEntrySearchContainerWithoutOrderByComparator();
 	}
 
-	private OrderByComparator<LayoutUtilityPageEntry> _getOrderByComparator(
-		String orderByCol, String orderByType) {
+	private OrderByComparator<LayoutUtilityPageEntry>
+		_getSearchContainerOrderByComparator(
+			String orderByCol, String orderByType) {
 
 		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
 			new MockLiferayPortletRenderRequest();
@@ -123,7 +124,7 @@ public class LayoutUtilityPageEntryDisplayContextTest {
 
 	private void _testGetLayoutUtilityPageEntrySearchContainerOrderByCreateDate() {
 		OrderByComparator<LayoutUtilityPageEntry> orderByComparator =
-			_getOrderByComparator("create-date", "asc");
+			_getSearchContainerOrderByComparator("create-date", "asc");
 
 		Assert.assertEquals(
 			"LayoutUtilityPageEntry.createDate ASC",
@@ -132,7 +133,7 @@ public class LayoutUtilityPageEntryDisplayContextTest {
 
 	private void _testGetLayoutUtilityPageEntrySearchContainerOrderByName() {
 		OrderByComparator<LayoutUtilityPageEntry> orderByComparator =
-			_getOrderByComparator("name", "desc");
+			_getSearchContainerOrderByComparator("name", "desc");
 
 		Assert.assertEquals(
 			"LayoutUtilityPageEntry.name DESC", orderByComparator.getOrderBy());
@@ -140,7 +141,8 @@ public class LayoutUtilityPageEntryDisplayContextTest {
 
 	private void _testGetLayoutUtilityPageEntrySearchContainerWithoutOrderByComparator() {
 		Assert.assertNull(
-			_getOrderByComparator(RandomTestUtil.randomString(), "asc"));
+			_getSearchContainerOrderByComparator(
+				RandomTestUtil.randomString(), "asc"));
 	}
 
 	private MockedStatic<LayoutUtilityPageEntryServiceUtil>

--- a/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminManagementToolbarDisplayContextTest.java
+++ b/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminManagementToolbarDisplayContextTest.java
@@ -17,7 +17,7 @@ import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import jakarta.portlet.PortletURL;
 
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -39,11 +39,6 @@ public class LayoutsAdminManagementToolbarDisplayContextTest {
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
 
-	@AfterClass
-	public static void tearDownClass() {
-		_portletURLUtilMockedStatic.close();
-	}
-
 	@Before
 	public void setUp() throws Exception {
 		_portletURLUtilMockedStatic.when(
@@ -61,6 +56,11 @@ public class LayoutsAdminManagementToolbarDisplayContextTest {
 		).thenReturn(
 			new MockLiferayPortletURL()
 		);
+	}
+
+	@After
+	public void tearDown() {
+		_portletURLUtilMockedStatic.close();
 	}
 
 	@Test
@@ -176,7 +176,7 @@ public class LayoutsAdminManagementToolbarDisplayContextTest {
 			layoutsAdminManagementToolbarDisplayContext.getSortingURL());
 	}
 
-	private static final MockedStatic<PortletURLUtil>
-		_portletURLUtilMockedStatic = Mockito.mockStatic(PortletURLUtil.class);
+	private final MockedStatic<PortletURLUtil> _portletURLUtilMockedStatic =
+		Mockito.mockStatic(PortletURLUtil.class);
 
 }

--- a/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminManagementToolbarDisplayContextTest.java
+++ b/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminManagementToolbarDisplayContextTest.java
@@ -157,10 +157,13 @@ public class LayoutsAdminManagementToolbarDisplayContextTest {
 		LayoutsAdminManagementToolbarDisplayContext
 			layoutsAdminManagementToolbarDisplayContext =
 				_createLayoutsAdminManagementToolbarDisplayContext(
-					false, RandomTestUtil.randomString(), true);
+					false, "create-date", true);
 
-		Assert.assertNotNull(
-			layoutsAdminManagementToolbarDisplayContext.getSortingURL());
+		String sortingURL =
+			layoutsAdminManagementToolbarDisplayContext.getSortingURL();
+
+		Assert.assertTrue(sortingURL.contains("=create-date"));
+		Assert.assertTrue(sortingURL.contains("=asc"));
 	}
 
 	private void _testGetSortingURLWhenSearchingFirstColumn() throws Exception {

--- a/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminManagementToolbarDisplayContextTest.java
+++ b/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminManagementToolbarDisplayContextTest.java
@@ -1,0 +1,179 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.admin.web.internal.display.context;
+
+import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
+import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.PortletURLUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletURL;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.PortletURL;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Balázs Sáfrány-Kovalik
+ */
+public class LayoutsAdminManagementToolbarDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@AfterClass
+	public static void tearDownClass() {
+		_portletURLUtilMockedStatic.close();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_portletURLUtilMockedStatic.when(
+			() -> PortletURLUtil.clone(
+				Mockito.any(PortletURL.class),
+				Mockito.any(LiferayPortletResponse.class))
+		).thenReturn(
+			new MockLiferayPortletURL()
+		);
+
+		_portletURLUtilMockedStatic.when(
+			() -> PortletURLUtil.getCurrent(
+				Mockito.any(LiferayPortletRequest.class),
+				Mockito.any(LiferayPortletResponse.class))
+		).thenReturn(
+			new MockLiferayPortletURL()
+		);
+	}
+
+	@Test
+	@TestInfo("LPD-96674")
+	public void testGetSortingURL() throws Exception {
+		_testGetSortingURLWhenNotSearching();
+		_testGetSortingURLWhenOrderByRelevance();
+		_testGetSortingURLWhenSearching();
+		_testGetSortingURLWhenSearchingFirstColumn();
+	}
+
+	private LayoutsAdminManagementToolbarDisplayContext
+			_createLayoutsAdminManagementToolbarDisplayContext(
+				boolean firstColumn, String orderByCol, boolean search)
+		throws Exception {
+
+		LayoutsAdminDisplayContext layoutsAdminDisplayContext = Mockito.mock(
+			LayoutsAdminDisplayContext.class);
+
+		SearchContainer<Layout> searchContainer = _createSearchContainer(
+			orderByCol);
+
+		Mockito.when(
+			layoutsAdminDisplayContext.getLayoutsSearchContainer()
+		).thenReturn(
+			searchContainer
+		);
+
+		Mockito.when(
+			layoutsAdminDisplayContext.isFirstColumn()
+		).thenReturn(
+			firstColumn
+		);
+
+		Mockito.when(
+			layoutsAdminDisplayContext.isSearch()
+		).thenReturn(
+			search
+		);
+
+		return new LayoutsAdminManagementToolbarDisplayContext(
+			new MockHttpServletRequest(),
+			Mockito.mock(LiferayPortletRequest.class),
+			Mockito.mock(LiferayPortletResponse.class),
+			layoutsAdminDisplayContext);
+	}
+
+	private SearchContainer<Layout> _createSearchContainer(String orderByCol) {
+		SearchContainer<Layout> searchContainer =
+			(SearchContainer<Layout>)Mockito.mock(SearchContainer.class);
+
+		Mockito.when(
+			searchContainer.getOrderByCol()
+		).thenReturn(
+			orderByCol
+		);
+
+		Mockito.when(
+			searchContainer.getOrderByColParam()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		Mockito.when(
+			searchContainer.getOrderByTypeParam()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		return searchContainer;
+	}
+
+	private void _testGetSortingURLWhenNotSearching() throws Exception {
+		LayoutsAdminManagementToolbarDisplayContext
+			layoutsAdminManagementToolbarDisplayContext =
+				_createLayoutsAdminManagementToolbarDisplayContext(
+					false, RandomTestUtil.randomString(), false);
+
+		Assert.assertNull(
+			layoutsAdminManagementToolbarDisplayContext.getSortingURL());
+	}
+
+	private void _testGetSortingURLWhenOrderByRelevance() throws Exception {
+		LayoutsAdminManagementToolbarDisplayContext
+			layoutsAdminManagementToolbarDisplayContext =
+				_createLayoutsAdminManagementToolbarDisplayContext(
+					false, "relevance", true);
+
+		Assert.assertNull(
+			layoutsAdminManagementToolbarDisplayContext.getSortingURL());
+	}
+
+	private void _testGetSortingURLWhenSearching() throws Exception {
+		LayoutsAdminManagementToolbarDisplayContext
+			layoutsAdminManagementToolbarDisplayContext =
+				_createLayoutsAdminManagementToolbarDisplayContext(
+					false, RandomTestUtil.randomString(), true);
+
+		Assert.assertNotNull(
+			layoutsAdminManagementToolbarDisplayContext.getSortingURL());
+	}
+
+	private void _testGetSortingURLWhenSearchingFirstColumn() throws Exception {
+		LayoutsAdminManagementToolbarDisplayContext
+			layoutsAdminManagementToolbarDisplayContext =
+				_createLayoutsAdminManagementToolbarDisplayContext(
+					true, RandomTestUtil.randomString(), true);
+
+		Assert.assertNull(
+			layoutsAdminManagementToolbarDisplayContext.getSortingURL());
+	}
+
+	private static final MockedStatic<PortletURLUtil>
+		_portletURLUtilMockedStatic = Mockito.mockStatic(PortletURLUtil.class);
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96674

## What Is Being Fixed

In the Pages admin, sorting was inoperative in two flows. When searching Static Pages, the sorting arrow on the columns did nothing because `LayoutsAdminManagementToolbarDisplayContext.getSortingURL()` always returned `null`. In the Utility Pages listing, selecting a sort column on the management toolbar had no effect either, since the display context set `orderByCol` on the `SearchContainer` but passed a `null` `OrderByComparator` to the service. On top of that, the default `orderByCol` for Utility Pages was `modified-date`, which was not offered by the toolbar (only `name` and `create-date` were), producing a UI/state mismatch on first load.

## How It Is Being Fixed

For Static Pages, `getSortingURL()` now delegates to the base management toolbar when in search mode (skipping the first column and `relevance` cases). For Utility Pages, the display context builds an `OrderByComparator` from the current `orderByCol`/`orderByType` and passes it to `LayoutUtilityPageEntryServiceUtil`, and the default column is aligned with the toolbar to `create-date`. Unit tests cover the new URL sorting, the order comparator branches, and the default column.

## PR Check

**pr-check: PASS** — tested on `89a03bd8cd47fdb96e22270b0446c95331894562`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "89a03bd8cd47fdb96e22270b0446c95331894562"} -->
