### PR TITLE
LPD-97476 Restore alignment in the sample CKEditor 5 toolbar

### DIFF
--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-1/src/index.ts
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-1/src/index.ts
@@ -39,7 +39,14 @@ const editorConfigTransformer: EditorConfigTransformer<any> = (config) => {
 	if (config.editorType === 'ckeditor5') {
 		return {
 			...config,
-			toolbar: ['accessibilityHelp', '|', 'undo', 'redo', '|', 'alignment'],
+			toolbar: [
+				'accessibilityHelp',
+				'|',
+				'undo',
+				'redo',
+				'|',
+				'alignment',
+			],
 		};
 	}
 

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-1/src/index.ts
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor-1/src/index.ts
@@ -39,7 +39,7 @@ const editorConfigTransformer: EditorConfigTransformer<any> = (config) => {
 	if (config.editorType === 'ckeditor5') {
 		return {
 			...config,
-			toolbar: ['accessibilityHelp', '|', 'undo', 'redo'],
+			toolbar: ['accessibilityHelp', '|', 'undo', 'redo', '|', 'alignment'],
 		};
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97476

## What Is Being Fixed

`layout-content-page-editor-web/fragments/fragments.spec.ts > Paragraph Fragment > Can use CKEditor options when editing a rich text editable` fails on the page-management routine since 2026-06-24. The fragments Playwright project deploys the `liferay-sample-editor-config-contributor-1` client extension in CI (`env/client-extensions.list`), and LPD-95740 (#18649) restored that sample's CKEditor 5 branch with a short replacement toolbar — `accessibilityHelp`, `undo`, `redo` — that drops the alignment plugin. The fragment rich text editor loses its Text alignment button, so the spec times out waiting for it.

## How It Is Being Fixed

The sample's CKEditor 5 toolbar gets `alignment` back, matching what the original sample carried before the LPD-89734 refactor split it into numbered variants. This keeps the short custom toolbar the sample demonstrates (including the `accessibilityHelp` button the companion spec `Editor config contributor client extension is applied` asserts) while restoring the button the fragments spec exercises. Verified locally by hot-deploying the extension into a bundle: without the fix the CI failure reproduces exactly; with it, both specs pass.

## Why Are There No Tests?

The change is covered by the two existing Playwright specs above, which were run locally against the deployed extension; Playwright execution is out of pr-check scope.

## PR Check

**pr-check: PASS** — tested on `aaf2915b85a5fc5ea571bb9ac2db738574b07591`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "aaf2915b85a5fc5ea571bb9ac2db738574b07591"} -->
