### PR TITLE
LPD-97461 Add a readable target element selector to element variations

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/EditElementVariationsDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/EditElementVariationsDisplayContext.java
@@ -6,8 +6,15 @@
 package com.liferay.layout.content.page.editor.web.internal.display.context;
 
 import com.liferay.audiences.service.AudiencesEntryService;
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
+import com.liferay.layout.content.page.editor.web.internal.util.layout.structure.LayoutStructureUtil;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationService;
+import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
+import com.liferay.layout.util.structure.LayoutStructure;
+import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -40,6 +47,7 @@ import jakarta.portlet.WindowState;
 import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -51,6 +59,7 @@ public class EditElementVariationsDisplayContext {
 
 	public EditElementVariationsDisplayContext(
 		AudiencesEntryService audiencesEntryService,
+		FragmentEntryLinkLocalService fragmentEntryLinkLocalService,
 		HttpServletRequest httpServletRequest,
 		LayoutLocalService layoutLocalService,
 		LayoutPageTemplateStructureRelElementVariationService
@@ -58,6 +67,7 @@ public class EditElementVariationsDisplayContext {
 		Portal portal, SegmentsExperienceService segmentsExperienceService) {
 
 		_audiencesEntryService = audiencesEntryService;
+		_fragmentEntryLinkLocalService = fragmentEntryLinkLocalService;
 		_httpServletRequest = httpServletRequest;
 		_layoutLocalService = layoutLocalService;
 		_layoutPageTemplateStructureRelElementVariationService =
@@ -92,6 +102,8 @@ public class EditElementVariationsDisplayContext {
 			_getLayoutPageTemplateStructureRelElementVariations()
 		).put(
 			"experiences", _getSegmentsExperiences()
+		).put(
+			"itemNames", _getLayoutStructureItemNamesMap()
 		).put(
 			"locales", _getAvailableLocalesJSONArray()
 		).put(
@@ -226,6 +238,59 @@ public class EditElementVariationsDisplayContext {
 		}
 	}
 
+	private Map<String, String> _getLayoutStructureItemNamesMap() {
+		try {
+			Map<String, String> layoutStructureItemNamesMap = new HashMap<>();
+
+			LayoutStructure layoutStructure =
+				LayoutStructureUtil.getLayoutStructure(
+					_themeDisplay.getScopeGroupId(), _getPlid(),
+					_getSegmentsExperienceId());
+
+			Map<Long, LayoutStructureItem> fragmentLayoutStructureItems =
+				layoutStructure.getFragmentLayoutStructureItems();
+
+			for (LayoutStructureItem layoutStructureItem :
+					fragmentLayoutStructureItems.values()) {
+
+				FragmentStyledLayoutStructureItem
+					fragmentStyledLayoutStructureItem =
+						(FragmentStyledLayoutStructureItem)layoutStructureItem;
+
+				String name = fragmentStyledLayoutStructureItem.getName();
+
+				if (Validator.isNull(name)) {
+					FragmentEntryLink fragmentEntryLink =
+						_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+							fragmentStyledLayoutStructureItem.
+								getFragmentEntryLinkId());
+
+					if (fragmentEntryLink != null) {
+						FragmentEntry fragmentEntry =
+							LayoutStructureUtil.getFragmentEntry(
+								fragmentEntryLink);
+
+						if (fragmentEntry != null) {
+							name = fragmentEntry.getName();
+						}
+					}
+				}
+
+				if (Validator.isNotNull(name)) {
+					layoutStructureItemNamesMap.put(
+						fragmentStyledLayoutStructureItem.getItemId(), name);
+				}
+			}
+
+			return layoutStructureItemNamesMap;
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+
+			return Collections.emptyMap();
+		}
+	}
+
 	private long _getPlid() {
 		if (_plid != null) {
 			return _plid;
@@ -303,6 +368,7 @@ public class EditElementVariationsDisplayContext {
 		EditElementVariationsDisplayContext.class);
 
 	private final AudiencesEntryService _audiencesEntryService;
+	private final FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
 	private final HttpServletRequest _httpServletRequest;
 	private final LayoutLocalService _layoutLocalService;
 	private final LayoutPageTemplateStructureRelElementVariationService

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/EditElementVariationsMVCRenderCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/EditElementVariationsMVCRenderCommand.java
@@ -6,6 +6,7 @@
 package com.liferay.layout.content.page.editor.web.internal.portlet.action;
 
 import com.liferay.audiences.service.AudiencesEntryService;
+import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.layout.content.page.editor.web.internal.display.context.EditElementVariationsDisplayContext;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationService;
@@ -39,7 +40,7 @@ public class EditElementVariationsMVCRenderCommand implements MVCRenderCommand {
 		renderRequest.setAttribute(
 			EditElementVariationsDisplayContext.class.getName(),
 			new EditElementVariationsDisplayContext(
-				_audiencesEntryService,
+				_audiencesEntryService, _fragmentEntryLinkLocalService,
 				_portal.getHttpServletRequest(renderRequest),
 				_layoutLocalService,
 				_layoutPageTemplateStructureRelElementVariationService, _portal,
@@ -50,6 +51,9 @@ public class EditElementVariationsMVCRenderCommand implements MVCRenderCommand {
 
 	@Reference
 	private AudiencesEntryService _audiencesEntryService;
+
+	@Reference
+	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/layout/structure/LayoutStructureUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/layout/structure/LayoutStructureUtil.java
@@ -74,6 +74,19 @@ public class LayoutStructureUtil {
 		}
 	}
 
+	public static FragmentEntry getFragmentEntry(
+		FragmentEntryLink fragmentEntryLink) {
+
+		FragmentEntry fragmentEntry = fragmentEntryLink.fetchFragmentEntry();
+
+		if (fragmentEntry == null) {
+			return FragmentCollectionContributorRegistryUtil.getFragmentEntry(
+				fragmentEntryLink.getRendererKey());
+		}
+
+		return fragmentEntry;
+	}
+
 	public static LayoutStructure getLayoutStructure(
 			long groupId, long plid, long segmentsExperienceId)
 		throws PortalException {
@@ -131,19 +144,6 @@ public class LayoutStructureUtil {
 		return dataJSONObject;
 	}
 
-	private static FragmentEntry _getFragmentEntry(
-		FragmentEntryLink fragmentEntryLink) {
-
-		FragmentEntry fragmentEntry = fragmentEntryLink.fetchFragmentEntry();
-
-		if (fragmentEntry == null) {
-			return FragmentCollectionContributorRegistryUtil.getFragmentEntry(
-				fragmentEntryLink.getRendererKey());
-		}
-
-		return fragmentEntry;
-	}
-
 	private static boolean _hasMissingFragmentEntryFragmentEntryLinks(
 		List<String> itemIds, LayoutStructure layoutStructure) {
 
@@ -172,7 +172,7 @@ public class LayoutStructureUtil {
 				FragmentEntryLinkLocalServiceUtil.fetchFragmentEntryLink(
 					fragmentStyledLayoutStructureItem.getFragmentEntryLinkId());
 
-			FragmentEntry fragmentEntry = _getFragmentEntry(fragmentEntryLink);
+			FragmentEntry fragmentEntry = getFragmentEntry(fragmentEntryLink);
 
 			if (fragmentEntry != null) {
 				continue;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
@@ -4,14 +4,15 @@
  */
 
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
-import {LanguagePicker} from '@clayui/core';
+import {LanguagePicker, Option, Picker} from '@clayui/core';
 import ClayForm, {ClayInput, ClayToggle} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayMultiSelect from '@clayui/multi-select';
 import {useId} from 'frontend-js-components-web';
 import React from 'react';
 
-import {ElementVariation} from './elementVariationsReducer';
+import {Action, ElementVariation} from './elementVariationsReducer';
+import {EditableElementOption} from './getEditableElementOptions';
 
 type ElementVariationFormData = Pick<
 	ElementVariation,
@@ -21,6 +22,8 @@ type ElementVariationFormData = Pick<
 interface Props {
 	audiences: Array<{label: string; value: string}>;
 	defaultLanguageId: string;
+	dispatch: React.Dispatch<Action>;
+	editableElementOptions: EditableElementOption[];
 	elementVariation: ElementVariationFormData;
 	languageId: string;
 	locales: Array<{id: string; label: string; symbol: string}>;
@@ -34,6 +37,8 @@ interface Props {
 export default function ElementVariationForm({
 	audiences,
 	defaultLanguageId,
+	dispatch,
+	editableElementOptions,
 	elementVariation,
 	languageId,
 	locales,
@@ -48,6 +53,19 @@ export default function ElementVariationForm({
 	const jsId = useId();
 	const nameId = useId();
 	const targetElementId = useId();
+
+	const targetElementItems = editableElementOptions.map(
+		(editableElementOption, index) => ({
+			key: String(index),
+			label: editableElementOption.label,
+			value: editableElementOption.value,
+		})
+	);
+
+	const selectedTargetElementItem = targetElementItems.find(
+		(targetElementItem) =>
+			targetElementItem.value === elementVariation.targetElement
+	);
 
 	return (
 		<>
@@ -121,14 +139,47 @@ export default function ElementVariationForm({
 						/>
 					</label>
 
-					<ClayInput
-						defaultValue={elementVariation.targetElement}
+					<Picker
+						aria-label={Liferay.Language.get('page-element')}
+						className="form-control-sm"
 						id={targetElementId}
-						onBlur={(event) =>
-							onChange({targetElement: event.target.value})
-						}
-						type="text"
-					/>
+						items={targetElementItems}
+						onSelectionChange={(selection) => {
+							const targetElementItem = targetElementItems.find(
+								(currentTargetElementItem) =>
+									currentTargetElementItem.key ===
+									String(selection)
+							);
+
+							onChange({
+								targetElement: targetElementItem?.value ?? '',
+							});
+						}}
+						selectedKey={selectedTargetElementItem?.key}
+					>
+						{(item) => (
+							<Option key={item.key} textValue={item.label}>
+								<span
+									className="d-block"
+									onMouseEnter={() =>
+										dispatch({
+											highlightedTargetElement:
+												item.value,
+											type: 'SET_HIGHLIGHTED_TARGET_ELEMENT',
+										})
+									}
+									onMouseLeave={() =>
+										dispatch({
+											highlightedTargetElement: null,
+											type: 'SET_HIGHLIGHTED_TARGET_ELEMENT',
+										})
+									}
+								>
+									{item.label}
+								</span>
+							</Option>
+						)}
+					</Picker>
 				</ClayForm.Group>
 
 				<ClayForm.Group small>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
@@ -7,7 +7,7 @@ import ClayButton from '@clayui/button';
 import {Option, Picker} from '@clayui/core';
 import ClayEmptyState from '@clayui/empty-state';
 import {useId} from 'frontend-js-components-web';
-import React, {useReducer, useRef, useState} from 'react';
+import React, {useReducer, useRef} from 'react';
 
 import {initializeConfig} from '../../app/config/index';
 import {Config} from '../../types/config';
@@ -38,6 +38,7 @@ interface Props {
 		segmentsExperienceERC: string;
 		segmentsExperienceId: number;
 	}>;
+	itemNames: Record<string, string>;
 	locales: Array<{id: string; label: string; symbol: string}>;
 	plid: number;
 	portletNamespace: string;
@@ -58,6 +59,7 @@ function ElementVariations({
 	deleteElementVariationURL,
 	elementVariations: initialElementVariations = [],
 	experiences = [],
+	itemNames,
 	locales,
 	plid,
 	previewURL,
@@ -65,28 +67,26 @@ function ElementVariations({
 }: Props) {
 	const experienceId = useId();
 
-	const [experienceKey, setExperienceKey] = useState(() => {
-		const selectedExperience = experiences.find(
-			(experience) =>
-				experience.segmentsExperienceId === selectedSegmentsExperienceId
-		);
-
-		return (
-			selectedExperience?.segmentsExperienceERC ??
-			experiences[0]?.segmentsExperienceERC ??
-			''
-		);
-	});
-
-	const [{draftElementVariation, elementVariations, languageId}, dispatch] =
-		useReducer(
-			reducer,
-			{
-				defaultLanguageId,
-				elementVariations: initialElementVariations,
-			},
-			createInitialState
-		);
+	const [
+		{
+			draftElementVariation,
+			editableElementOptions,
+			elementVariations,
+			experienceKey,
+			highlightedTargetElement,
+			languageId,
+		},
+		dispatch,
+	] = useReducer(
+		reducer,
+		{
+			defaultLanguageId,
+			elementVariations: initialElementVariations,
+			experiences,
+			selectedSegmentsExperienceId,
+		},
+		createInitialState
+	);
 
 	const experienceElementVariations = elementVariations.filter(
 		(elementVariation) =>
@@ -104,6 +104,8 @@ function ElementVariations({
 						<ElementVariationForm
 							audiences={audiences}
 							defaultLanguageId={defaultLanguageId}
+							dispatch={dispatch}
+							editableElementOptions={editableElementOptions}
 							elementVariation={draftElementVariation}
 							key={draftElementVariation.key}
 							languageId={languageId}
@@ -162,7 +164,11 @@ function ElementVariations({
 										id={experienceId}
 										items={experiences}
 										onSelectionChange={(selection) =>
-											setExperienceKey(String(selection))
+											dispatch({
+												experienceKey:
+													String(selection),
+												type: 'SET_EXPERIENCE_KEY',
+											})
 										}
 										selectedKey={experienceKey}
 									>
@@ -181,6 +187,9 @@ function ElementVariations({
 								{experienceElementVariations.length ? (
 									<ElementVariationsList
 										audiences={audiences}
+										editableElementOptions={
+											editableElementOptions
+										}
 										elementVariations={
 											experienceElementVariations
 										}
@@ -246,7 +255,10 @@ function ElementVariations({
 
 				<ElementVariationsPreview
 					defaultLanguageId={defaultLanguageId}
+					dispatch={dispatch}
 					draftElementVariation={draftElementVariation}
+					highlightedTargetElement={highlightedTargetElement}
+					itemNames={itemNames}
 					languageId={languageId}
 					previewURL={previewURL}
 					ref={elementVariationsPreviewRef}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsList.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsList.tsx
@@ -8,9 +8,11 @@ import ClayList from '@clayui/list';
 import React from 'react';
 
 import {ElementVariation} from './elementVariationsReducer';
+import {EditableElementOption} from './getEditableElementOptions';
 
 interface Props {
 	audiences: Array<{label: string; value: string}>;
+	editableElementOptions: EditableElementOption[];
 	elementVariations: ElementVariation[];
 	onDeleteElementVariation: (elementVariation: ElementVariation) => void;
 	onEditElementVariation: (key: string) => void;
@@ -18,6 +20,7 @@ interface Props {
 
 export default function ElementVariationsList({
 	audiences,
+	editableElementOptions,
 	elementVariations,
 	onDeleteElementVariation,
 	onEditElementVariation,
@@ -44,7 +47,11 @@ export default function ElementVariationsList({
 					<ClayList className="mx-3" key={targetElement}>
 						{[
 							<ClayList.Header className="text-none" key="header">
-								{targetElement}
+								{editableElementOptions.find(
+									(editableElementOption) =>
+										editableElementOption.value ===
+										targetElement
+								)?.label ?? targetElement}
 							</ClayList.Header>,
 							...targetElementVariations.map(
 								(elementVariation) => (

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsPreview.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsPreview.tsx
@@ -13,8 +13,11 @@ import React, {
 	useState,
 } from 'react';
 
-import {ElementVariation} from './elementVariationsReducer';
+import {Action, ElementVariation} from './elementVariationsReducer';
+import getEditableElementOptions from './getEditableElementOptions';
 import getElementVariationScript from './getElementVariationScript';
+
+const HIGHLIGHT_STYLE_ELEMENT_ID = 'lfr-element-variation-highlight';
 
 export interface ElementVariationsPreviewRef {
 	reload: () => void;
@@ -22,7 +25,10 @@ export interface ElementVariationsPreviewRef {
 
 interface Props {
 	defaultLanguageId: string;
+	dispatch: React.Dispatch<Action>;
 	draftElementVariation: ElementVariation | null;
+	highlightedTargetElement: string | null;
+	itemNames: Record<string, string>;
 	languageId: string;
 	previewURL: string;
 }
@@ -31,7 +37,10 @@ const ElementVariationsPreview = forwardRef<ElementVariationsPreviewRef, Props>(
 	function ElementVariationsPreview(
 		{
 			defaultLanguageId,
+			dispatch,
 			draftElementVariation,
+			highlightedTargetElement,
+			itemNames,
 			languageId,
 			previewURL: initialPreviewURL,
 		},
@@ -139,9 +148,55 @@ const ElementVariationsPreview = forwardRef<ElementVariationsPreviewRef, Props>(
 			};
 		}, [defaultLanguageId, draftElementVariation, languageId]);
 
+		const highlightTargetElements = useCallback(() => {
+			const iframeDocument = iframeRef.current?.contentDocument;
+
+			if (!iframeDocument?.head) {
+				return;
+			}
+
+			let styleElement = iframeDocument.getElementById(
+				HIGHLIGHT_STYLE_ELEMENT_ID
+			) as HTMLStyleElement | null;
+
+			const rules = [];
+
+			if (highlightedTargetElement) {
+				rules.push(
+					`${highlightedTargetElement} { box-shadow: inset 0 0 0 2px var(--primary-l1, #4b93ff) !important; }`
+				);
+			}
+
+			if (draftElementVariation?.targetElement) {
+				rules.push(
+					`${draftElementVariation.targetElement} { box-shadow: inset 0 0 0 2px var(--primary, #0b5fff) !important; }`
+				);
+			}
+
+			if (!rules.length) {
+				styleElement?.remove();
+
+				return;
+			}
+
+			if (!styleElement) {
+				styleElement = iframeDocument.createElement('style');
+
+				styleElement.id = HIGHLIGHT_STYLE_ELEMENT_ID;
+
+				iframeDocument.head.appendChild(styleElement);
+			}
+
+			styleElement.textContent = rules.join(' ');
+		}, [draftElementVariation, highlightedTargetElement]);
+
 		useEffect(() => {
 			applyDraftElementVariation();
 		}, [applyDraftElementVariation]);
+
+		useEffect(() => {
+			highlightTargetElements();
+		}, [highlightTargetElements, previewReady]);
 
 		useEffect(() => {
 			setPreviewReady(false);
@@ -158,7 +213,23 @@ const ElementVariationsPreview = forwardRef<ElementVariationsPreviewRef, Props>(
 				<iframe
 					className="border-0 flex-grow-1 w-100"
 					onLoad={() => {
+						const iframeDocument =
+							iframeRef.current?.contentDocument;
+
+						if (iframeDocument) {
+							dispatch({
+								editableElementOptions:
+									getEditableElementOptions(
+										iframeDocument,
+										itemNames
+									),
+								type: 'SET_EDITABLE_ELEMENT_OPTIONS',
+							});
+						}
+
 						applyDraftElementVariation();
+
+						highlightTargetElements();
 
 						setPreviewReady(true);
 					}}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/elementVariationsReducer.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/elementVariationsReducer.ts
@@ -5,6 +5,8 @@
 
 import {v4 as uuidv4} from 'uuid';
 
+import {EditableElementOption} from './getEditableElementOptions';
+
 export interface ElementVariation {
 	audienceEntryERCs: string[];
 	externalReferenceCode: string;
@@ -20,17 +22,29 @@ export interface ElementVariation {
 export interface State {
 	defaultLanguageId: string;
 	draftElementVariation: ElementVariation | null;
+	editableElementOptions: EditableElementOption[];
 	elementVariations: ElementVariation[];
+	experienceKey: string;
+	highlightedTargetElement: string | null;
 	languageId: string;
 }
 
-type Action =
+export type Action =
 	| {
 			draftElementVariation: ElementVariation;
 			type: 'CREATE_ELEMENT_VARIATION_DRAFT';
 	  }
 	| {key: string; type: 'DELETE_ELEMENT_VARIATION'}
 	| {key: string; type: 'EDIT_ELEMENT_VARIATION'}
+	| {
+			editableElementOptions: EditableElementOption[];
+			type: 'SET_EDITABLE_ELEMENT_OPTIONS';
+	  }
+	| {experienceKey: string; type: 'SET_EXPERIENCE_KEY'}
+	| {
+			highlightedTargetElement: string | null;
+			type: 'SET_HIGHLIGHTED_TARGET_ELEMENT';
+	  }
 	| {languageId: string; type: 'SET_LANGUAGE_ID'}
 	| {
 			properties: Partial<ElementVariation>;
@@ -61,13 +75,27 @@ export type LoadedElementVariation = Omit<ElementVariation, 'hide' | 'key'> & {
 export function createInitialState({
 	defaultLanguageId,
 	elementVariations,
+	experiences,
+	selectedSegmentsExperienceId,
 }: {
 	defaultLanguageId: string;
 	elementVariations: LoadedElementVariation[];
+	experiences: Array<{
+		label: string;
+		segmentsExperienceERC: string;
+		segmentsExperienceId: number;
+	}>;
+	selectedSegmentsExperienceId: number;
 }): State {
+	const selectedExperience = experiences.find(
+		(experience) =>
+			experience.segmentsExperienceId === selectedSegmentsExperienceId
+	);
+
 	return {
 		defaultLanguageId,
 		draftElementVariation: null,
+		editableElementOptions: [],
 		elementVariations: elementVariations.map((elementVariation) => ({
 			...elementVariation,
 			hide: Object.fromEntries(
@@ -80,6 +108,11 @@ export function createInitialState({
 			),
 			key: uuidv4(),
 		})),
+		experienceKey:
+			selectedExperience?.segmentsExperienceERC ??
+			experiences[0]?.segmentsExperienceERC ??
+			'',
+		highlightedTargetElement: null,
 		languageId: defaultLanguageId,
 	};
 }
@@ -143,6 +176,21 @@ export function reducer(state: State, action: Action): State {
 			return {
 				...state,
 				draftElementVariation: action.draftElementVariation,
+			};
+
+		case 'SET_EDITABLE_ELEMENT_OPTIONS':
+			return {
+				...state,
+				editableElementOptions: action.editableElementOptions,
+			};
+
+		case 'SET_EXPERIENCE_KEY':
+			return {...state, experienceKey: action.experienceKey};
+
+		case 'SET_HIGHLIGHTED_TARGET_ELEMENT':
+			return {
+				...state,
+				highlightedTargetElement: action.highlightedTargetElement,
 			};
 
 		case 'SET_LANGUAGE_ID':

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/getEditableElementOptions.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/getEditableElementOptions.ts
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {LAYOUT_STRUCTURE_ITEM_CLASS_NAME_PREFIX} from '../../app/config/constants/layoutStructureItemClassNamePrefix';
+
+export interface EditableElementOption {
+	label: string;
+	value: string;
+}
+
+export default function getEditableElementOptions(
+	document: Document,
+	itemNames: Record<string, string>
+): EditableElementOption[] {
+	const editableElementOptions: EditableElementOption[] = [];
+	const values = new Set<string>();
+
+	Object.entries(itemNames).forEach(([layoutStructureItemId, name]) => {
+		document
+			.querySelectorAll(
+				`.${LAYOUT_STRUCTURE_ITEM_CLASS_NAME_PREFIX}${layoutStructureItemId} [data-lfr-editable-id]`
+			)
+			.forEach((editableElement) => {
+				const editableId = editableElement.getAttribute(
+					'data-lfr-editable-id'
+				);
+
+				if (!editableId) {
+					return;
+				}
+
+				const value = `.${LAYOUT_STRUCTURE_ITEM_CLASS_NAME_PREFIX}${layoutStructureItemId} [data-lfr-editable-id="${editableId}"]`;
+
+				if (values.has(value)) {
+					return;
+				}
+
+				values.add(value);
+
+				editableElementOptions.push({
+					label: `${name} (${editableId})`,
+					value,
+				});
+			});
+	});
+
+	return editableElementOptions;
+}

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/elementVariationsReducer.test.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/elementVariationsReducer.test.ts
@@ -32,7 +32,10 @@ function buildState(properties: Partial<State> = {}): State {
 	return {
 		defaultLanguageId: 'en_US',
 		draftElementVariation: null,
+		editableElementOptions: [],
 		elementVariations: [],
+		experienceKey: '',
+		highlightedTargetElement: null,
 		languageId: 'en_US',
 		...properties,
 	};
@@ -60,11 +63,16 @@ describe('elementVariationsReducer', () => {
 				createInitialState({
 					defaultLanguageId: 'en_US',
 					elementVariations: [],
+					experiences: [],
+					selectedSegmentsExperienceId: 0,
 				})
 			).toEqual({
 				defaultLanguageId: 'en_US',
 				draftElementVariation: null,
+				editableElementOptions: [],
 				elementVariations: [],
+				experienceKey: '',
+				highlightedTargetElement: null,
 				languageId: 'en_US',
 			});
 		});
@@ -85,6 +93,8 @@ describe('elementVariationsReducer', () => {
 							targetElement: '#main',
 						},
 					],
+					experiences: [],
+					selectedSegmentsExperienceId: 0,
 				});
 
 			expect(draftElementVariation).toBeNull();
@@ -127,6 +137,37 @@ describe('elementVariationsReducer', () => {
 			});
 
 			expect(state.languageId).toBe('es_ES');
+		});
+
+		it('sets the editable element options on SET_EDITABLE_ELEMENT_OPTIONS', () => {
+			const editableElementOptions = [
+				{label: 'Heading (element-text)', value: '.selector'},
+			];
+
+			const state = reducer(buildState(), {
+				editableElementOptions,
+				type: 'SET_EDITABLE_ELEMENT_OPTIONS',
+			});
+
+			expect(state.editableElementOptions).toBe(editableElementOptions);
+		});
+
+		it('sets the experience key on SET_EXPERIENCE_KEY', () => {
+			const state = reducer(buildState(), {
+				experienceKey: 'experience-2',
+				type: 'SET_EXPERIENCE_KEY',
+			});
+
+			expect(state.experienceKey).toBe('experience-2');
+		});
+
+		it('sets the highlighted target element on SET_HIGHLIGHTED_TARGET_ELEMENT', () => {
+			const state = reducer(buildState(), {
+				highlightedTargetElement: '.selector',
+				type: 'SET_HIGHLIGHTED_TARGET_ELEMENT',
+			});
+
+			expect(state.highlightedTargetElement).toBe('.selector');
 		});
 
 		it('appends a new draft and clears it on SAVE_ELEMENT_VARIATION_DRAFT', () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97461

## What Is Being Fixed

The element variations form required authors to type a raw CSS selector into a free-text field to designate the target element of a variation. This forced authors to know the internal layout structure selector syntax, offered no discoverability of which page elements were targetable, and let a typo silently produce a variation that matched nothing.

## How It Is Being Fixed

The target element field is now a picker populated from the editable elements present on the page. The display context exposes an itemNames map that resolves each layout structure item to a human-readable name, falling back to the fragment entry name when the item carries no explicit name. On the client, getEditableElementOptions walks those items, collects every data-lfr-editable-id element under each one, and builds a deduplicated option labeled with the item name and the editable id while keeping the underlying selector as the stored value. The form dispatches the selection through the reducer, so choosing an element writes the same selector the field previously accepted by hand.

## PR Check

**pr-check: PASS** — tested on `bbef1be94cc4966ec9d084eefc00648980bec69b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "bbef1be94cc4966ec9d084eefc00648980bec69b"} -->
