### PR TITLE
LPD-97524 Fix site page creation with a Menu Display fragment

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
@@ -466,6 +466,8 @@ public class SitePageResourceImpl
 
 			Layout draftLayout = _updateDraftLayout(layout);
 
+			layout = _layoutService.getLayout(layout.getPlid());
+
 			layout.setModifiedDate(draftLayout.getModifiedDate());
 
 			layout.setStatus(WorkflowConstants.STATUS_APPROVED);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97524

## Problem

Creating a site page whose definition contains a Menu Display fragment (`com.liferay.fragment.renderer.menu.display.internal.MenuDisplayFragmentRenderer`) failed with HTTP 500 and `org.hibernate.StaleObjectStateException`. Failing test: `layout-content-page-editor-web/fragments/fragmentsWithPrivatePages.spec.ts` > "Can configure sublevels, display style, selected item color and hovered item color".

## Cause

In `SitePageResourceImpl._addLayout` the head layout is read into a detached object, then a nested import step (`_importPageDefinition`) advances that same row's version via `updateStatus`. Merging the stale detached object back fails the optimistic lock check (`mvccVersion` is the Hibernate version column). This is a timing regression introduced by LPD-91662 (arrayable pagination finder delegation).

## Fix

Re-read the layout right before the final `updateLayout` call so the merge sees current state.

## Notes

This is a call-site workaround to get the failing test green. The systemic persistence fix is tracked in LPD-97519 (is caused by LPD-91662), which has a reproduction branch (`SitePageResourceFactoryImplTest` on `victorg1991/liferay-portal @ LPD-97519-repro`) that fails without any resource-side change.
