### PR TITLE
LPD-95291 Persist and validate the audience external reference code

### DIFF
--- a/modules/apps/audiences/audiences-api/src/main/java/com/liferay/audiences/service/AudiencesEntryLocalService.java
+++ b/modules/apps/audiences/audiences-api/src/main/java/com/liferay/audiences/service/AudiencesEntryLocalService.java
@@ -291,8 +291,9 @@ public interface AudiencesEntryLocalService
 	public AudiencesEntry updateAudiencesEntry(AudiencesEntry audiencesEntry);
 
 	public AudiencesEntry updateAudiencesEntry(
-			long audiencesEntryId, String json, String name)
+			long audiencesEntryId, String externalReferenceCode, String json,
+			String name)
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1109827201
+// LIFERAY-SERVICE-BUILDER-HASH:-306389058

--- a/modules/apps/audiences/audiences-api/src/main/java/com/liferay/audiences/service/AudiencesEntryLocalServiceUtil.java
+++ b/modules/apps/audiences/audiences-api/src/main/java/com/liferay/audiences/service/AudiencesEntryLocalServiceUtil.java
@@ -339,10 +339,12 @@ public class AudiencesEntryLocalServiceUtil {
 	}
 
 	public static AudiencesEntry updateAudiencesEntry(
-			long audiencesEntryId, String json, String name)
+			long audiencesEntryId, String externalReferenceCode, String json,
+			String name)
 		throws PortalException {
 
-		return getService().updateAudiencesEntry(audiencesEntryId, json, name);
+		return getService().updateAudiencesEntry(
+			audiencesEntryId, externalReferenceCode, json, name);
 	}
 
 	public static AudiencesEntryLocalService getService() {
@@ -355,4 +357,4 @@ public class AudiencesEntryLocalServiceUtil {
 			AudiencesEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-724476987
+// LIFERAY-SERVICE-BUILDER-HASH:2035146410

--- a/modules/apps/audiences/audiences-api/src/main/java/com/liferay/audiences/service/AudiencesEntryLocalServiceWrapper.java
+++ b/modules/apps/audiences/audiences-api/src/main/java/com/liferay/audiences/service/AudiencesEntryLocalServiceWrapper.java
@@ -394,11 +394,12 @@ public class AudiencesEntryLocalServiceWrapper
 
 	@Override
 	public com.liferay.audiences.model.AudiencesEntry updateAudiencesEntry(
-			long audiencesEntryId, String json, String name)
+			long audiencesEntryId, String externalReferenceCode, String json,
+			String name)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _audiencesEntryLocalService.updateAudiencesEntry(
-			audiencesEntryId, json, name);
+			audiencesEntryId, externalReferenceCode, json, name);
 	}
 
 	@Override
@@ -421,4 +422,4 @@ public class AudiencesEntryLocalServiceWrapper
 	private AudiencesEntryLocalService _audiencesEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:711059145
+// LIFERAY-SERVICE-BUILDER-HASH:-593247208

--- a/modules/apps/audiences/audiences-api/src/main/java/com/liferay/audiences/service/AudiencesEntryService.java
+++ b/modules/apps/audiences/audiences-api/src/main/java/com/liferay/audiences/service/AudiencesEntryService.java
@@ -83,8 +83,9 @@ public interface AudiencesEntryService extends BaseService {
 	public String getOSGiServiceIdentifier();
 
 	public AudiencesEntry updateAudiencesEntry(
-			long audiencesEntryId, String json, String name)
+			long audiencesEntryId, String externalReferenceCode, String json,
+			String name)
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-927578154
+// LIFERAY-SERVICE-BUILDER-HASH:430037065

--- a/modules/apps/audiences/audiences-api/src/main/java/com/liferay/audiences/service/AudiencesEntryServiceUtil.java
+++ b/modules/apps/audiences/audiences-api/src/main/java/com/liferay/audiences/service/AudiencesEntryServiceUtil.java
@@ -92,10 +92,12 @@ public class AudiencesEntryServiceUtil {
 	}
 
 	public static AudiencesEntry updateAudiencesEntry(
-			long audiencesEntryId, String json, String name)
+			long audiencesEntryId, String externalReferenceCode, String json,
+			String name)
 		throws PortalException {
 
-		return getService().updateAudiencesEntry(audiencesEntryId, json, name);
+		return getService().updateAudiencesEntry(
+			audiencesEntryId, externalReferenceCode, json, name);
 	}
 
 	public static AudiencesEntryService getService() {
@@ -107,4 +109,4 @@ public class AudiencesEntryServiceUtil {
 			AudiencesEntryServiceUtil.class, AudiencesEntryService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1016925610
+// LIFERAY-SERVICE-BUILDER-HASH:1816943745

--- a/modules/apps/audiences/audiences-api/src/main/java/com/liferay/audiences/service/AudiencesEntryServiceWrapper.java
+++ b/modules/apps/audiences/audiences-api/src/main/java/com/liferay/audiences/service/AudiencesEntryServiceWrapper.java
@@ -105,11 +105,12 @@ public class AudiencesEntryServiceWrapper
 
 	@Override
 	public com.liferay.audiences.model.AudiencesEntry updateAudiencesEntry(
-			long audiencesEntryId, String json, String name)
+			long audiencesEntryId, String externalReferenceCode, String json,
+			String name)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _audiencesEntryService.updateAudiencesEntry(
-			audiencesEntryId, json, name);
+			audiencesEntryId, externalReferenceCode, json, name);
 	}
 
 	@Override
@@ -125,4 +126,4 @@ public class AudiencesEntryServiceWrapper
 	private AudiencesEntryService _audiencesEntryService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1148478342
+// LIFERAY-SERVICE-BUILDER-HASH:-1546322937

--- a/modules/apps/audiences/audiences-api/src/main/resources/com/liferay/audiences/service/packageinfo
+++ b/modules/apps/audiences/audiences-api/src/main/resources/com/liferay/audiences/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/modules/apps/audiences/audiences-service/src/main/java/com/liferay/audiences/service/http/AudiencesEntryServiceHttp.java
+++ b/modules/apps/audiences/audiences-service/src/main/java/com/liferay/audiences/service/http/AudiencesEntryServiceHttp.java
@@ -337,8 +337,8 @@ public class AudiencesEntryServiceHttp {
 
 	public static com.liferay.audiences.model.AudiencesEntry
 			updateAudiencesEntry(
-				HttpPrincipal httpPrincipal, long audiencesEntryId, String json,
-				String name)
+				HttpPrincipal httpPrincipal, long audiencesEntryId,
+				String externalReferenceCode, String json, String name)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -347,7 +347,7 @@ public class AudiencesEntryServiceHttp {
 				_updateAudiencesEntryParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, audiencesEntryId, json, name);
+				methodKey, audiencesEntryId, externalReferenceCode, json, name);
 
 			Object returnObj = null;
 
@@ -404,7 +404,7 @@ public class AudiencesEntryServiceHttp {
 	private static final Class<?>[] _getAudiencesEntryParameterTypes6 =
 		new Class[] {long.class};
 	private static final Class<?>[] _updateAudiencesEntryParameterTypes7 =
-		new Class[] {long.class, String.class, String.class};
+		new Class[] {long.class, String.class, String.class, String.class};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1830899090
+// LIFERAY-SERVICE-BUILDER-HASH:968614239

--- a/modules/apps/audiences/audiences-service/src/main/java/com/liferay/audiences/service/impl/AudiencesEntryLocalServiceImpl.java
+++ b/modules/apps/audiences/audiences-service/src/main/java/com/liferay/audiences/service/impl/AudiencesEntryLocalServiceImpl.java
@@ -106,7 +106,8 @@ public class AudiencesEntryLocalServiceImpl
 
 	@Override
 	public AudiencesEntry updateAudiencesEntry(
-			long audiencesEntryId, String json, String name)
+			long audiencesEntryId, String externalReferenceCode, String json,
+			String name)
 		throws PortalException {
 
 		_validate(json, name);
@@ -114,6 +115,7 @@ public class AudiencesEntryLocalServiceImpl
 		AudiencesEntry audiencesEntry =
 			audiencesEntryPersistence.findByPrimaryKey(audiencesEntryId);
 
+		audiencesEntry.setExternalReferenceCode(externalReferenceCode);
 		audiencesEntry.setJSON(json);
 		audiencesEntry.setName(name);
 

--- a/modules/apps/audiences/audiences-service/src/main/java/com/liferay/audiences/service/impl/AudiencesEntryServiceImpl.java
+++ b/modules/apps/audiences/audiences-service/src/main/java/com/liferay/audiences/service/impl/AudiencesEntryServiceImpl.java
@@ -125,7 +125,8 @@ public class AudiencesEntryServiceImpl extends AudiencesEntryServiceBaseImpl {
 
 	@Override
 	public AudiencesEntry updateAudiencesEntry(
-			long audiencesEntryId, String json, String name)
+			long audiencesEntryId, String externalReferenceCode, String json,
+			String name)
 		throws PortalException {
 
 		_portletResourcePermission.check(
@@ -133,7 +134,7 @@ public class AudiencesEntryServiceImpl extends AudiencesEntryServiceBaseImpl {
 			AudiencesActionKeys.MANAGE_AUDIENCES_ENTRIES);
 
 		return audiencesEntryLocalService.updateAudiencesEntry(
-			audiencesEntryId, json, name);
+			audiencesEntryId, externalReferenceCode, json, name);
 	}
 
 	@Reference

--- a/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/service/test/AudiencesEntryLocalServiceTest.java
+++ b/modules/apps/audiences/audiences-test/src/testIntegration/java/com/liferay/audiences/service/test/AudiencesEntryLocalServiceTest.java
@@ -8,12 +8,14 @@ package com.liferay.audiences.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.audiences.exception.AudiencesEntryJSONException;
 import com.liferay.audiences.exception.AudiencesEntryNameException;
+import com.liferay.audiences.exception.DuplicateAudiencesEntryExternalReferenceCodeException;
 import com.liferay.audiences.model.AudiencesEntry;
 import com.liferay.audiences.service.AudiencesEntryLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.AssertUtils;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -50,35 +52,57 @@ public class AudiencesEntryLocalServiceTest {
 	}
 
 	@Test
+	@TestInfo("LPD-95291")
 	public void testAddAudiencesEntry() throws Exception {
+		String externalReferenceCode = RandomTestUtil.randomString();
 		String name = RandomTestUtil.randomString();
 
 		AudiencesEntry audiencesEntry = _addAudiencesEntry(
+			externalReferenceCode,
 			StringBundler.concat(
 				"{\"conjunction\": \"AND\", \"rules\": [{\"attribute\": ",
 				"\"url\", \"operator\": \"eq\", \"value\": \"",
 				RandomTestUtil.randomString(), "\"}]}"),
 			name);
 
+		Assert.assertEquals(
+			externalReferenceCode, audiencesEntry.getExternalReferenceCode());
 		Assert.assertNotNull(audiencesEntry.getJSON());
 		Assert.assertEquals(name, audiencesEntry.getName());
 
 		AssertUtils.assertFailure(
 			AudiencesEntryNameException.class, null,
-			() -> _addAudiencesEntry(StringPool.BLANK));
+			() -> _addAudiencesEntry(null, StringPool.BLANK, StringPool.BLANK));
 		AssertUtils.assertFailure(
-			AudiencesEntryJSONException.class, null,
+			AudiencesEntryJSONException.class,
+			"/conjunction: INVALID is not a valid enum value",
 			() -> _addAudiencesEntry(
-				"{\"conjunction\": \"INVALID\", \"rules\": []}",
+				null, "{\"conjunction\": \"INVALID\", \"rules\": []}",
 				RandomTestUtil.randomString()));
 	}
 
+	@Test(
+		expected = DuplicateAudiencesEntryExternalReferenceCodeException.class
+	)
+	@TestInfo("LPD-95291")
+	public void testAddAudiencesEntryWithExistingExternalReferenceCode()
+		throws Exception {
+
+		AudiencesEntry audiencesEntry = _addAudiencesEntry(
+			null, StringPool.BLANK, RandomTestUtil.randomString());
+
+		_audiencesEntryLocalService.addAudiencesEntry(
+			audiencesEntry.getExternalReferenceCode(), StringPool.BLANK,
+			RandomTestUtil.randomString(), _serviceContext);
+	}
+
 	@Test
+	@TestInfo("LPD-95291")
 	public void testDeleteAudiencesEntry() throws Exception {
 		AudiencesEntry audiencesEntry =
 			_audiencesEntryLocalService.addAudiencesEntry(
-				null, RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), _serviceContext);
+				null, StringPool.BLANK, RandomTestUtil.randomString(),
+				_serviceContext);
 
 		long audiencesEntryId = audiencesEntry.getAudiencesEntryId();
 
@@ -89,16 +113,20 @@ public class AudiencesEntryLocalServiceTest {
 	}
 
 	@Test
+	@TestInfo("LPD-95291")
 	public void testUpdateAudiencesEntry() throws Exception {
 		AudiencesEntry audiencesEntry = _addAudiencesEntry(
-			RandomTestUtil.randomString());
+			null, StringPool.BLANK, RandomTestUtil.randomString());
 
+		String externalReferenceCode = RandomTestUtil.randomString();
 		String name = RandomTestUtil.randomString();
 
 		audiencesEntry = _audiencesEntryLocalService.updateAudiencesEntry(
-			audiencesEntry.getAudiencesEntryId(), audiencesEntry.getJSON(),
-			name);
+			audiencesEntry.getAudiencesEntryId(), externalReferenceCode,
+			audiencesEntry.getJSON(), name);
 
+		Assert.assertEquals(
+			externalReferenceCode, audiencesEntry.getExternalReferenceCode());
 		Assert.assertEquals(name, audiencesEntry.getName());
 
 		AudiencesEntry updatedAudiencesEntry = audiencesEntry;
@@ -107,24 +135,44 @@ public class AudiencesEntryLocalServiceTest {
 			AudiencesEntryNameException.class, null,
 			() -> _audiencesEntryLocalService.updateAudiencesEntry(
 				updatedAudiencesEntry.getAudiencesEntryId(),
+				updatedAudiencesEntry.getExternalReferenceCode(),
 				updatedAudiencesEntry.getJSON(), StringPool.BLANK));
 		AssertUtils.assertFailure(
-			AudiencesEntryJSONException.class, null,
+			AudiencesEntryJSONException.class,
+			"/conjunction: INVALID is not a valid enum value",
 			() -> _audiencesEntryLocalService.updateAudiencesEntry(
-				updatedAudiencesEntry.getAudiencesEntryId(), StringPool.BLANK,
+				updatedAudiencesEntry.getAudiencesEntryId(),
+				updatedAudiencesEntry.getExternalReferenceCode(),
+				"{\"conjunction\": \"INVALID\", \"rules\": []}",
 				updatedAudiencesEntry.getName()));
 	}
 
-	private AudiencesEntry _addAudiencesEntry(String name) throws Exception {
-		return _addAudiencesEntry(StringPool.BLANK, name);
+	@Test(
+		expected = DuplicateAudiencesEntryExternalReferenceCodeException.class
+	)
+	@TestInfo("LPD-95291")
+	public void testUpdateAudiencesEntryWithExistingExternalReferenceCode()
+		throws Exception {
+
+		AudiencesEntry audiencesEntry1 = _addAudiencesEntry(
+			null, StringPool.BLANK, RandomTestUtil.randomString());
+
+		AudiencesEntry audiencesEntry2 = _addAudiencesEntry(
+			null, StringPool.BLANK, RandomTestUtil.randomString());
+
+		_audiencesEntryLocalService.updateAudiencesEntry(
+			audiencesEntry2.getAudiencesEntryId(),
+			audiencesEntry1.getExternalReferenceCode(),
+			audiencesEntry2.getJSON(), audiencesEntry2.getName());
 	}
 
-	private AudiencesEntry _addAudiencesEntry(String json, String name)
+	private AudiencesEntry _addAudiencesEntry(
+			String externalReferenceCode, String json, String name)
 		throws Exception {
 
 		AudiencesEntry audiencesEntry =
 			_audiencesEntryLocalService.addAudiencesEntry(
-				null, json, name, _serviceContext);
+				externalReferenceCode, json, name, _serviceContext);
 
 		_audiencesEntries.add(audiencesEntry);
 

--- a/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/display/context/EditAudiencesEntryDisplayContext.java
+++ b/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/display/context/EditAudiencesEntryDisplayContext.java
@@ -151,6 +151,8 @@ public class EditAudiencesEntryDisplayContext {
 		).put(
 			"backURLTitle", getBackURLTitle()
 		).put(
+			"externalReferenceCode", _getExternalReferenceCode()
+		).put(
 			"name", _getName()
 		).put(
 			"namespace", _renderResponse.getNamespace()
@@ -207,6 +209,23 @@ public class EditAudiencesEntryDisplayContext {
 		}
 
 		return null;
+	}
+
+	private String _getExternalReferenceCode() {
+		try {
+			AudiencesEntry audiencesEntry = _getAudiencesEntry();
+
+			if (audiencesEntry != null) {
+				return audiencesEntry.getExternalReferenceCode();
+			}
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+
+		return StringPool.BLANK;
 	}
 
 	private String _getName() {

--- a/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/portlet/action/UpdateAudiencesEntryMVCActionCommand.java
+++ b/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/portlet/action/UpdateAudiencesEntryMVCActionCommand.java
@@ -8,6 +8,7 @@ package com.liferay.audiences.web.internal.portlet.action;
 import com.liferay.audiences.constants.AudiencesPortletKeys;
 import com.liferay.audiences.exception.AudiencesEntryJSONException;
 import com.liferay.audiences.exception.AudiencesEntryNameException;
+import com.liferay.audiences.exception.DuplicateAudiencesEntryExternalReferenceCodeException;
 import com.liferay.audiences.exception.NoSuchAudiencesEntryException;
 import com.liferay.audiences.model.AudiencesEntry;
 import com.liferay.audiences.service.AudiencesEntryService;
@@ -52,6 +53,8 @@ public class UpdateAudiencesEntryMVCActionCommand extends BaseMVCActionCommand {
 		long audiencesEntryId = ParamUtil.getLong(
 			actionRequest, "audiencesEntryId");
 
+		String externalReferenceCode = ParamUtil.getString(
+			actionRequest, "externalReferenceCode");
 		String json = ParamUtil.getString(actionRequest, "json");
 		String name = ParamUtil.getString(actionRequest, "name");
 
@@ -63,11 +66,11 @@ public class UpdateAudiencesEntryMVCActionCommand extends BaseMVCActionCommand {
 
 			if (audiencesEntryId <= 0) {
 				audiencesEntry = _audiencesEntryService.addAudiencesEntry(
-					null, json, name, serviceContext);
+					externalReferenceCode, json, name, serviceContext);
 			}
 			else {
 				audiencesEntry = _audiencesEntryService.updateAudiencesEntry(
-					audiencesEntryId, json, name);
+					audiencesEntryId, externalReferenceCode, json, name);
 			}
 
 			String redirect = ParamUtil.getString(actionRequest, "redirect");
@@ -97,7 +100,9 @@ public class UpdateAudiencesEntryMVCActionCommand extends BaseMVCActionCommand {
 				actionResponse.setRenderParameter("mvcPath", "/error.jsp");
 			}
 			else if (exception instanceof AudiencesEntryJSONException ||
-					 exception instanceof AudiencesEntryNameException) {
+					 exception instanceof AudiencesEntryNameException ||
+					 exception instanceof
+						 DuplicateAudiencesEntryExternalReferenceCodeException) {
 
 				SessionErrors.add(
 					actionRequest, exception.getClass(), exception);

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/edit_audiences_entry.jsp
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/edit_audiences_entry.jsp
@@ -26,6 +26,8 @@ renderResponse.setTitle(editAudiencesEntryDisplayContext.getTitle());
 
 <liferay-ui:error embed="<%= false %>" exception="<%= AudiencesEntryNameException.class %>" message="please-enter-a-valid-name" />
 
+<liferay-ui:error embed="<%= false %>" exception="<%= DuplicateAudiencesEntryExternalReferenceCodeException.class %>" message="please-enter-a-unique-external-reference-code" />
+
 <portlet:actionURL name="/audiences/update_audiences_entry" var="updateAudiencesEntryActionURL" />
 
 <aui:form action="<%= updateAudiencesEntryActionURL %>" method="post" name="fm">

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/init.jsp
@@ -17,6 +17,7 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.audiences.exception.AudiencesEntryJSONException" %><%@
 page import="com.liferay.audiences.exception.AudiencesEntryNameException" %><%@
+page import="com.liferay.audiences.exception.DuplicateAudiencesEntryExternalReferenceCodeException" %><%@
 page import="com.liferay.audiences.exception.NoSuchAudiencesEntryException" %><%@
 page import="com.liferay.audiences.web.internal.constants.AudiencesFDSNames" %><%@
 page import="com.liferay.audiences.web.internal.display.context.AudiencesDisplayContext" %><%@


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95291

## What Is Being Fixed

The audiences editor could not set or persist an external reference code (ERC) for an audience, and the service layer neither stored nor validated one. An audience therefore had no stable, company-unique external key.

## How It Is Being Fixed

The AudiencesEntry add and update service methods now accept an external reference code, validate that it is unique within the company (throwing DuplicateAudiencesEntryExternalReferenceCodeException on a clash), and persist it. Service Builder regenerated the API for the new updateAudiencesEntry signature and synced the com.liferay.audiences.service package to 2.0.0 to match the already-bumped bundle version. The editor is wired end to end: EditAudiencesEntryDisplayContext exposes the current ERC to the client, UpdateAudiencesEntryMVCActionCommand reads the submitted value, and the edit JSP passes it through. An integration test covers the add, update, and duplicate-detection paths.

## PR Check

**pr-check: PASS** — tested on `ba46eb86fe0bc4b9e84bde02c8a2ac66eca663d0`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Baseline | PASS |
| Cross-Module Compile | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| JSP Compile | PASS |
| Java Unit Tests | N/A |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "ba46eb86fe0bc4b9e84bde02c8a2ac66eca663d0"} -->
