### PR TITLE
LPD-97574 Disable jsoup pretty printing on rendered page HTML

### DIFF
--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/struts/RenderFragmentEntryStrutsAction.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/struts/RenderFragmentEntryStrutsAction.java
@@ -100,7 +100,7 @@ public class RenderFragmentEntryStrutsAction implements StrutsAction {
 			return null;
 		}
 
-		Document document = Jsoup.parse(content);
+		Document document = _getDocument(content);
 
 		Element bodyElement = document.body();
 
@@ -116,6 +116,18 @@ public class RenderFragmentEntryStrutsAction implements StrutsAction {
 				SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_SUCCESS_MESSAGE);
 
 		return null;
+	}
+
+	private Document _getDocument(String html) {
+		Document document = Jsoup.parse(html);
+
+		Document.OutputSettings outputSettings = new Document.OutputSettings();
+
+		outputSettings.prettyPrint(false);
+
+		document.outputSettings(outputSettings);
+
+		return document;
 	}
 
 	@Reference

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/PageDefinitionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/PageDefinitionResourceImpl.java
@@ -185,7 +185,7 @@ public class PageDefinitionResourceImpl extends BasePageDefinitionResourceImpl {
 
 		LayoutSet layoutSet = layout.getLayoutSet();
 
-		Document document = Jsoup.parse(
+		Document document = _getDocument(
 			ThemeUtil.include(
 				ServletContextPool.get(StringPool.BLANK),
 				contextHttpServletRequest, contextHttpServletResponse,
@@ -200,6 +200,18 @@ public class PageDefinitionResourceImpl extends BasePageDefinitionResourceImpl {
 		return Response.ok(
 			document.html()
 		).build();
+	}
+
+	private Document _getDocument(String html) {
+		Document document = Jsoup.parse(html);
+
+		Document.OutputSettings outputSettings = new Document.OutputSettings();
+
+		outputSettings.prettyPrint(false);
+
+		document.outputSettings(outputSettings);
+
+		return document;
 	}
 
 	private ThemeDisplay _getThemeDisplay(Layout layout) throws Exception {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/DisplayPageRendererUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/DisplayPageRendererUtil.java
@@ -168,7 +168,7 @@ public class DisplayPageRendererUtil {
 
 		LayoutSet layoutSet = layout.getLayoutSet();
 
-		Document document = Jsoup.parse(
+		Document document = _getDocument(
 			ThemeUtil.include(
 				ServletContextPool.get(StringPool.BLANK), httpServletRequest,
 				httpServletResponse, "portal_normal.ftl", layoutSet.getTheme(),
@@ -179,6 +179,18 @@ public class DisplayPageRendererUtil {
 		bodyElement.html(sb.toString());
 
 		return document.html();
+	}
+
+	private static Document _getDocument(String html) {
+		Document document = Jsoup.parse(html);
+
+		Document.OutputSettings outputSettings = new Document.OutputSettings();
+
+		outputSettings.prettyPrint(false);
+
+		document.outputSettings(outputSettings);
+
+		return document;
 	}
 
 	private static LayoutDisplayPageObjectProvider<?>

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
@@ -549,6 +549,18 @@ public class SitePageResourceImpl
 		).build();
 	}
 
+	private Document _getDocument(String html) {
+		Document document = Jsoup.parse(html);
+
+		Document.OutputSettings outputSettings = new Document.OutputSettings();
+
+		outputSettings.prettyPrint(false);
+
+		document.outputSettings(outputSettings);
+
+		return document;
+	}
+
 	private Map<String, Map<String, String>> _getExperienceActions(
 		Layout layout) {
 
@@ -790,7 +802,7 @@ public class SitePageResourceImpl
 
 			LayoutSet layoutSet = layout.getLayoutSet();
 
-			Document document = Jsoup.parse(
+			Document document = _getDocument(
 				ThemeUtil.include(
 					ServletContextPool.get(StringPool.BLANK),
 					httpServletRequest, contextHttpServletResponse,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/adaptive/media/LayoutAdaptiveMediaProcessorImpl.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/adaptive/media/LayoutAdaptiveMediaProcessorImpl.java
@@ -57,7 +57,7 @@ public class LayoutAdaptiveMediaProcessorImpl
 			return processedContent;
 		}
 
-		Document document = Jsoup.parse(processedContent);
+		Document document = _getDocument(processedContent);
 
 		try {
 			for (Map.Entry<ViewportSize, String> entry :
@@ -154,6 +154,18 @@ public class LayoutAdaptiveMediaProcessorImpl
 		sourceElement.attr("srcset", uri.toString());
 
 		parentElement.prependChild(sourceElement);
+	}
+
+	private Document _getDocument(String html) {
+		Document document = Jsoup.parse(html);
+
+		Document.OutputSettings outputSettings = new Document.OutputSettings();
+
+		outputSettings.prettyPrint(false);
+
+		document.outputSettings(outputSettings);
+
+		return document;
 	}
 
 	private String _getMediaQuery(String elementId, long fileEntryId)

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/struts/GetPagePreviewStrutsAction.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/struts/GetPagePreviewStrutsAction.java
@@ -181,7 +181,7 @@ public class GetPagePreviewStrutsAction implements StrutsAction {
 			layout.includeLayoutContent(
 				httpServletRequest, httpServletResponse);
 
-			Document document = Jsoup.parse(
+			Document document = _getDocument(
 				ThemeUtil.include(
 					ServletContextPool.get(_portal.getServletContextName()),
 					httpServletRequest, httpServletResponse,
@@ -293,6 +293,18 @@ public class GetPagePreviewStrutsAction implements StrutsAction {
 		return _layoutLocalService.fetchLayoutByUuidAndGroupId(
 			layout.getUuid(), stagingGroup.getGroupId(),
 			layout.isPrivateLayout());
+	}
+
+	private Document _getDocument(String html) {
+		Document document = Jsoup.parse(html);
+
+		Document.OutputSettings outputSettings = new Document.OutputSettings();
+
+		outputSettings.prettyPrint(false);
+
+		document.outputSettings(outputSettings);
+
+		return document;
 	}
 
 	private void _includeInfoItemObjects(

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/struts/StatusStrutsAction.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/struts/StatusStrutsAction.java
@@ -82,7 +82,7 @@ public class StatusStrutsAction implements StrutsAction {
 		try {
 			PrincipalThreadLocal.setName(themeDisplay.getUserId());
 
-			document = Jsoup.parse(
+			document = _getDocument(
 				ThemeUtil.include(
 					httpServletRequest.getServletContext(), httpServletRequest,
 					httpServletResponse, "portal_normal.ftl",
@@ -113,6 +113,18 @@ public class StatusStrutsAction implements StrutsAction {
 		ServletResponseUtil.write(httpServletResponse, document.html());
 
 		return null;
+	}
+
+	private Document _getDocument(String html) {
+		Document document = Jsoup.parse(html);
+
+		Document.OutputSettings outputSettings = new Document.OutputSettings();
+
+		outputSettings.prettyPrint(false);
+
+		document.outputSettings(outputSettings);
+
+		return document;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/test/java/com/liferay/layout/utility/page/status/internal/struts/StatusStrutsActionTest.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/test/java/com/liferay/layout/utility/page/status/internal/struts/StatusStrutsActionTest.java
@@ -76,8 +76,8 @@ public class StatusStrutsActionTest {
 		String htmlEnd = RandomTestUtil.randomString() + _HTML_END;
 
 		String expected = StringBundler.concat(
-			htmlStart, "\n  <div id=\"content\">\n   ", _STATUS_PAGE_CONTENT,
-			"\n  </div>", htmlEnd);
+			htmlStart, "<div id=\"content\">", _STATUS_PAGE_CONTENT, "</div>",
+			htmlEnd);
 		String html = StringBundler.concat(
 			htmlStart, "<div id=\"content\">", RandomTestUtil.randomString(),
 			"</div>", htmlEnd);
@@ -121,8 +121,8 @@ public class StatusStrutsActionTest {
 
 		_testExecute(
 			StringBundler.concat(
-				htmlStart, "\n  <div id=\"content\">\n   ",
-				_STATUS_PAGE_CONTENT, "\n  </div>", htmlEnd),
+				htmlStart, "<div id=\"content\">", _STATUS_PAGE_CONTENT,
+				"</div>", htmlEnd),
 			StringBundler.concat(
 				htmlStart, "<div id=\"content\">",
 				RandomTestUtil.randomString(), "</div>", htmlEnd));
@@ -213,7 +213,7 @@ public class StatusStrutsActionTest {
 
 				PrintWriter printWriter = pipingServletResponse.getWriter();
 
-				printWriter.println(_STATUS_PAGE_CONTENT);
+				printWriter.print(_STATUS_PAGE_CONTENT);
 
 				return null;
 			}
@@ -263,11 +263,11 @@ public class StatusStrutsActionTest {
 		Assert.assertEquals(expected, argumentCaptor.getValue());
 	}
 
-	private static final String _HTML_END = "\n </body>\n</html>";
+	private static final String _HTML_END = "</body>\n</html>";
 
 	private static final String _HTML_START = StringBundler.concat(
 		"<html>\n <head>\n  <script>var ", RandomTestUtil.randomString(), " = ",
-		RandomTestUtil.randomString(), ";</script>\n </head>\n <body>\n  ");
+		RandomTestUtil.randomString(), ";</script>\n </head>\n <body>");
 
 	private static final String _STATUS_PAGE_CONTENT =
 		RandomTestUtil.randomString();

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/src/main/java/com/liferay/layout/utility/page/terms/of/use/internal/struts/TermsOfUseStrutsAction.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/src/main/java/com/liferay/layout/utility/page/terms/of/use/internal/struts/TermsOfUseStrutsAction.java
@@ -69,7 +69,7 @@ public class TermsOfUseStrutsAction implements StrutsAction {
 
 		requestDispatcher.include(httpServletRequest, pipingServletResponse);
 
-		Document document = Jsoup.parse(
+		Document document = _getDocument(
 			ThemeUtil.include(
 				httpServletRequest.getServletContext(), httpServletRequest,
 				httpServletResponse, "portal_normal.ftl", layoutSet.getTheme(),
@@ -93,6 +93,18 @@ public class TermsOfUseStrutsAction implements StrutsAction {
 		ServletResponseUtil.write(httpServletResponse, document.html());
 
 		return null;
+	}
+
+	private Document _getDocument(String html) {
+		Document document = Jsoup.parse(html);
+
+		Document.OutputSettings outputSettings = new Document.OutputSettings();
+
+		outputSettings.prettyPrint(false);
+
+		document.outputSettings(outputSettings);
+
+		return document;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97574

## What Is Being Fixed

8 locations that parse rendered HTML with jsoup and serialize it back out inherit jsoup's default `prettyPrint(true)`, so the serializer spends extra work reflowing whitespace and emits larger page/fragment HTML than necessary. This diverges from the 9 existing production locations that already set `prettyPrint(false)`. `LayoutAdaptiveMediaProcessorImpl` additionally treated whitespace inconsistently: content without adaptive-media configuration was returned verbatim, while content with configuration was reflowed.

## How It Is Being Fixed

Each location now routes its parse through a private `_getDocument` helper that parses the HTML and sets `prettyPrint(false)` on the document's output settings before it is serialized. The existing `Jsoup.parse` call is kept (rather than switching to `parseBodyFragment`) so the serialized output is otherwise identical apart from the removed reflow whitespace.

`StatusStrutsActionTest` is the one unit test that asserts the exact serialized output; it is updated to expect the compact HTML, locking in the new behavior as a regression guard. The remaining locations are exercised only by integration tests that normalize whitespace away before comparing, so they neither break nor gain signal from this change.

## PR Check

**pr-check: PASS** — tested on `ab847752d6d55ec777a54225baec0a0802ce7623`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ab847752d6d55ec777a54225baec0a0802ce7623"} -->
