### PR TITLE
LPD-97602 Skip HTML parsing when editable values contain no markup

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/internal/parser/ActionEditableElementParser.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/internal/parser/ActionEditableElementParser.java
@@ -41,7 +41,7 @@ public class ActionEditableElementParser extends BaseEditableElementParser {
 
 	@Override
 	public void replace(Element element, String value) {
-		element.html(value);
+		replaceContent(element, value);
 	}
 
 	@Override

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/internal/parser/BaseEditableElementParser.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/internal/parser/BaseEditableElementParser.java
@@ -7,7 +7,9 @@ package com.liferay.fragment.entry.processor.editable.internal.parser;
 
 import com.liferay.fragment.entry.processor.editable.parser.EditableElementParser;
 import com.liferay.fragment.exception.FragmentEntryContentException;
+import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.util.ResourceBundle;
@@ -36,6 +38,17 @@ public abstract class BaseEditableElementParser
 					resourceBundle,
 					"editable-fields-cannot-include-nested-editables-drop-" +
 						"zones-or-widgets-in-it"));
+		}
+	}
+
+	protected void replaceContent(Element element, String value) {
+		if (value.indexOf(CharPool.LESS_THAN) == -1) {
+			element.empty();
+
+			element.appendText(HtmlUtil.unescape(value));
+		}
+		else {
+			element.html(value);
 		}
 	}
 

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/internal/parser/DateTimeEditableElementParser.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/internal/parser/DateTimeEditableElementParser.java
@@ -41,7 +41,7 @@ public class DateTimeEditableElementParser extends BaseEditableElementParser {
 
 	@Override
 	public void replace(Element element, String value) {
-		element.html(value);
+		replaceContent(element, value);
 	}
 
 	@Override

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/internal/parser/LinkEditableElementParser.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/internal/parser/LinkEditableElementParser.java
@@ -29,7 +29,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Jürgen Kappler
  */
 @Component(property = "type=link", service = EditableElementParser.class)
-public class LinkEditableElementParser implements EditableElementParser {
+public class LinkEditableElementParser extends BaseEditableElementParser {
 
 	@Override
 	public JSONObject getAttributes(Element element) {
@@ -92,7 +92,7 @@ public class LinkEditableElementParser implements EditableElementParser {
 		Element replaceableElement = elements.get(0);
 
 		if (configJSONObject == null) {
-			replaceableElement.html(value);
+			replaceContent(replaceableElement, value);
 
 			return;
 		}
@@ -141,7 +141,7 @@ public class LinkEditableElementParser implements EditableElementParser {
 			}
 		}
 
-		replaceableElement.html(value);
+		replaceContent(replaceableElement, value);
 	}
 
 	@Override

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/internal/parser/TextEditableElementParser.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/internal/parser/TextEditableElementParser.java
@@ -7,10 +7,8 @@ package com.liferay.fragment.entry.processor.editable.internal.parser;
 
 import com.liferay.fragment.entry.processor.editable.parser.EditableElementParser;
 import com.liferay.fragment.exception.FragmentEntryContentException;
-import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -18,7 +16,6 @@ import java.util.Objects;
 import java.util.ResourceBundle;
 
 import org.jsoup.nodes.Element;
-import org.jsoup.nodes.TextNode;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -53,7 +50,7 @@ public class TextEditableElementParser extends BaseEditableElementParser {
 		Element element, String value, JSONObject configJSONObject) {
 
 		if (configJSONObject == null) {
-			element.html(value);
+			replaceContent(element, value);
 
 			return;
 		}
@@ -76,14 +73,7 @@ public class TextEditableElementParser extends BaseEditableElementParser {
 			element.addClass(textStyleValue);
 		}
 
-		if (value.indexOf(CharPool.LESS_THAN) == -1) {
-			element.empty();
-
-			element.appendChild(new TextNode(HtmlUtil.unescape(value)));
-		}
-		else {
-			element.html(value);
-		}
+		replaceContent(element, value);
 	}
 
 	@Override


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97602

## What Is Being Fixed

The editable element parsers that inject a stored value into a fragment's HTML always called Jsoup's `Element.html(String)`, which spins up the full HTML fragment parser (tokenizer, tree builder, state machine) even when the value is plain text with no markup — the common case for text, action, date-time, and link editables. This is wasted parsing work and allocation on every such editable rendered on a page.

## How It Is Being Fixed

A shared `replaceContent(Element, String)` helper is added to `BaseEditableElementParser`. When the value contains no `<`, it sets the content as a single unescaped text node and skips the parser entirely; otherwise it falls back to `Element.html(...)`. This is the pattern `TextEditableElementParser` already used for its configured branch, now extracted and reused across the 5 call sites in the text, action, date-time, and link parsers. `LinkEditableElementParser` now extends `BaseEditableElementParser` like its siblings so it can share the helper — a behavior-neutral change, since it fully overrides `validate`.

## Why Are There No Tests?

This is a behavior-preserving optimization with no new public surface. The existing `EditableFragmentEntryProcessorTest` integration suite covers the text, action, and link `replace` render paths and passes on this branch.

## PR Check

**pr-check: PASS** — tested on `cbc0a54f6721e3cb28fc221a39cba290e259dfef`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "cbc0a54f6721e3cb28fc221a39cba290e259dfef"} -->
