### PR TITLE
LPD-97633 Add showFragmentNameInput prop to FragmentSetModal

### DIFF
--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/modals/FragmentSetModal.tsx
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/modals/FragmentSetModal.tsx
@@ -29,6 +29,7 @@ export default function FragmentSetModal({
 	fragmentEntryIds = [],
 	onSubmitFragmentCollection,
 	portletNamespace,
+	showFragmentNameInput = false,
 }: {
 	addFragmentCollectionURL?: string;
 	contributedEntryKeys?: string[];
@@ -36,9 +37,11 @@ export default function FragmentSetModal({
 	fragmentCollections: FragmentSet[];
 	fragmentEntryIds?: string[];
 	onSubmitFragmentCollection?: (
-		fragmentCollectionId: number
+		fragmentCollectionId: number,
+		fragmentName?: string
 	) => Promise<void> | void;
 	portletNamespace: string;
+	showFragmentNameInput?: boolean;
 }) {
 	const [visible, setVisible] = useState(true);
 
@@ -47,6 +50,7 @@ export default function FragmentSetModal({
 	});
 
 	const [errors, setErrors] = useState<Errors>({});
+	const [fragmentName, setFragmentName] = useState('');
 	const [showFragmentSetForm, setShowFragmentSetForm] = useState(
 		!fragmentCollections.length
 	);
@@ -54,9 +58,26 @@ export default function FragmentSetModal({
 	const formId = `${portletNamespace}form`;
 
 	const submitFragmentCollection = (fragmentCollectionId: number) => {
+		if (showFragmentNameInput && !fragmentName) {
+			setErrors({
+				name: sub(
+					Liferay.Language.get('x-field-is-required'),
+					Liferay.Language.get('name')
+				),
+			});
+
+			return;
+		}
+
 		if (onSubmitFragmentCollection) {
 			onClose();
-			onSubmitFragmentCollection(fragmentCollectionId);
+
+			if (showFragmentNameInput) {
+				onSubmitFragmentCollection(fragmentCollectionId, fragmentName);
+			}
+			else {
+				onSubmitFragmentCollection(fragmentCollectionId);
+			}
 
 			return;
 		}
@@ -128,9 +149,11 @@ export default function FragmentSetModal({
 			<ClayModal.Header
 				closeButtonAriaLabel={Liferay.Language.get('close')}
 			>
-				{showFragmentSetForm
-					? Liferay.Language.get('add-fragment-set')
-					: Liferay.Language.get('select-fragment-set')}
+				{showFragmentNameInput
+					? Liferay.Language.get('add-fragment')
+					: showFragmentSetForm
+						? Liferay.Language.get('add-fragment-set')
+						: Liferay.Language.get('select-fragment-set')}
 			</ClayModal.Header>
 
 			<ClayModal.Body>
@@ -141,6 +164,26 @@ export default function FragmentSetModal({
 					>
 						{errors.error}
 					</ClayAlert>
+				)}
+
+				{showFragmentNameInput && (
+					<FormField
+						error={errors.name}
+						id={`${portletNamespace}fragmentName`}
+						name={Liferay.Language.get('name')}
+						required
+					>
+						<ClayInput
+							id={`${portletNamespace}fragmentName`}
+							onChange={(event) => {
+								setErrors({...errors, name: null});
+								setFragmentName(event.target.value);
+							}}
+							required
+							type="text"
+							value={fragmentName}
+						/>
+					</FormField>
 				)}
 
 				{showFragmentSetForm ? (

--- a/modules/apps/layout/layout-js-components-web/test/components/modals/FragmentSetModal.test.js
+++ b/modules/apps/layout/layout-js-components-web/test/components/modals/FragmentSetModal.test.js
@@ -13,6 +13,7 @@ import FragmentSetModal from '../../../src/main/resources/META-INF/resources/js/
 const renderComponent = ({
 	fragmentCollections = [],
 	onSubmitFragmentCollection,
+	showFragmentNameInput,
 } = {}) => {
 	const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
 
@@ -20,6 +21,7 @@ const renderComponent = ({
 		<FragmentSetModal
 			fragmentCollections={fragmentCollections}
 			onSubmitFragmentCollection={onSubmitFragmentCollection}
+			showFragmentNameInput={showFragmentNameInput}
 		/>
 	);
 
@@ -138,5 +140,59 @@ describe('FragmentSetModal', () => {
 		await user.click(screen.getByText('save'));
 
 		expect(onSubmitFragmentCollection).toHaveBeenCalledWith(1);
+	});
+
+	it('submits the selected fragment collection with the fragment name when showFragmentNameInput is set', async () => {
+		const onSubmitFragmentCollection = jest.fn();
+		const user = renderComponent({
+			fragmentCollections: [
+				{fragmentCollectionId: 1, name: 'fragment-collection'},
+			],
+			onSubmitFragmentCollection,
+			showFragmentNameInput: true,
+		});
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		fireEvent.change(screen.getByLabelText('name'), {
+			target: {value: 'my-fragment'},
+		});
+
+		fireEvent.change(screen.getByLabelText('fragment-sets'), {
+			target: {value: '1'},
+		});
+
+		await user.click(screen.getByText('save'));
+
+		expect(onSubmitFragmentCollection).toHaveBeenCalledWith(
+			1,
+			'my-fragment'
+		);
+	});
+
+	it('shows required validation when the fragment name is empty and showFragmentNameInput is set', async () => {
+		const onSubmitFragmentCollection = jest.fn();
+		const user = renderComponent({
+			fragmentCollections: [
+				{fragmentCollectionId: 1, name: 'fragment-collection'},
+			],
+			onSubmitFragmentCollection,
+			showFragmentNameInput: true,
+		});
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		fireEvent.change(screen.getByLabelText('fragment-sets'), {
+			target: {value: '1'},
+		});
+
+		await user.click(screen.getByText('save'));
+
+		expect(onSubmitFragmentCollection).not.toHaveBeenCalled();
+		expect(screen.getByText('x-field-is-required')).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97633

## What Is Being Fixed

`FragmentSetModal` in `layout-js-components-web` collects a fragment set (either by picking an existing one or by creating a new one) and hands the resulting collection id to `onSubmitFragmentCollection`. There is no way to also collect a fragment name inside the same modal, so callers that need to open an "Add Fragment" flow have to duplicate the modal or wire a second step.

## How It Is Being Fixed

Adds an optional `showFragmentNameInput` prop. When set, the modal renders a required text input above the fragment set body, switches the header to `add-fragment`, and forwards the collected name to `onSubmitFragmentCollection(fragmentCollectionId, fragmentName)`. When the prop is omitted, the modal keeps the current header copy and invokes the callback with the single-argument shape, so every existing caller stays unaffected. A follow-up subtask under LPD-97407 will wire the Design Library resources listing to the new prop; the fragment portlet adaptation lands as a separate subtask.

## PR Check

**pr-check: PASS** — tested on `51e73d2090c94ef3541685f3f09df3bf3e34e77b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "51e73d2090c94ef3541685f3f09df3bf3e34e77b"} -->
