### PR TITLE
LPD-97673 Deflake CMS structure publish and clean up repeatable groups

### DIFF
--- a/modules/test/playwright/helpers/ApiHelpers.ts
+++ b/modules/test/playwright/helpers/ApiHelpers.ts
@@ -564,38 +564,7 @@ export class DataApiHelpers extends ApiHelpers {
 				await objectActionAPIClient.deleteObjectAction(item.id);
 			}
 			else if (item.type === 'objectDefinition') {
-				const objectDefinitionAPIClient =
-					await this.buildRestClient(ObjectDefinitionAPI);
-
-				const {body: objectDefinition} =
-					await objectDefinitionAPIClient.getObjectDefinition(
-						item.id
-					);
-
-				const objectRelationshipRESTClient = await this.buildRestClient(
-					ObjectRelationshipAPI
-				);
-
-				// Check if there are edge relationship and update them before removing the definition
-
-				const {body: objectRelationships} =
-					await objectRelationshipRESTClient.getObjectDefinitionByExternalReferenceCodeObjectRelationshipsPage(
-						objectDefinition.externalReferenceCode
-					);
-
-				for (const objectRelationship of objectRelationships.items) {
-					if (objectRelationship.edge) {
-						await objectRelationshipRESTClient.putObjectRelationship(
-							objectRelationship.id,
-							{
-								...objectRelationship,
-								edge: false,
-							}
-						);
-					}
-				}
-
-				await objectDefinitionAPIClient.deleteObjectDefinition(item.id);
+				await this.deleteObjectDefinition(item.id);
 			}
 			else if (item.type === 'objectFolder') {
 				const objectFolderRESTClient =
@@ -775,6 +744,94 @@ export class DataApiHelpers extends ApiHelpers {
 					item.id
 				);
 			}
+		}
+	}
+
+	async collectObjectDefinitionIds(
+		objectDefinitionId: number,
+		objectDefinitionIds: number[],
+		visitedObjectDefinitionIds: Set<number>
+	) {
+		if (visitedObjectDefinitionIds.has(objectDefinitionId)) {
+			return;
+		}
+
+		visitedObjectDefinitionIds.add(objectDefinitionId);
+
+		const objectDefinitionAPIClient =
+			await this.buildRestClient(ObjectDefinitionAPI);
+
+		const {body: objectDefinition} =
+			await objectDefinitionAPIClient.getObjectDefinition(
+				objectDefinitionId
+			);
+
+		const objectRelationshipAPIClient = await this.buildRestClient(
+			ObjectRelationshipAPI
+		);
+
+		const {body: objectRelationships} =
+			await objectRelationshipAPIClient.getObjectDefinitionByExternalReferenceCodeObjectRelationshipsPage(
+				objectDefinition.externalReferenceCode
+			);
+
+		const isCMSObjectDefinition =
+			objectDefinition.objectFolderExternalReferenceCode?.startsWith(
+				'L_CMS'
+			);
+
+		for (const objectRelationship of objectRelationships.items) {
+			if (!objectRelationship.edge) {
+				continue;
+			}
+
+			if (
+				isCMSObjectDefinition &&
+				objectRelationship.objectDefinitionId2
+			) {
+				const {body: relatedObjectDefinition} =
+					await objectDefinitionAPIClient.getObjectDefinition(
+						objectRelationship.objectDefinitionId2
+					);
+
+				if (
+					relatedObjectDefinition.objectFolderExternalReferenceCode ===
+					'L_CMS_STRUCTURE_REPEATABLE_GROUPS'
+				) {
+					await this.collectObjectDefinitionIds(
+						objectRelationship.objectDefinitionId2,
+						objectDefinitionIds,
+						visitedObjectDefinitionIds
+					);
+				}
+			}
+
+			await objectRelationshipAPIClient.putObjectRelationship(
+				objectRelationship.id,
+				{
+					...objectRelationship,
+					edge: false,
+				}
+			);
+		}
+
+		objectDefinitionIds.push(objectDefinitionId);
+	}
+
+	async deleteObjectDefinition(objectDefinitionId: number) {
+		const objectDefinitionAPIClient =
+			await this.buildRestClient(ObjectDefinitionAPI);
+
+		const objectDefinitionIds: number[] = [];
+
+		await this.collectObjectDefinitionIds(
+			objectDefinitionId,
+			objectDefinitionIds,
+			new Set()
+		);
+
+		for (const id of objectDefinitionIds) {
+			await objectDefinitionAPIClient.deleteObjectDefinition(id);
 		}
 	}
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/pages/StructureBuilderPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/pages/StructureBuilderPage.ts
@@ -609,37 +609,17 @@ export class StructureBuilderPage {
 	}
 
 	async publishStructure() {
+		await this.publishButton.click();
+
+		await waitForAlert(this.page, 'published successfully', {
+			timeout: 10000,
+		});
+
 		const url = new URL(this.page.url());
 
 		const objectDefinitionId = url.searchParams.get('objectDefinitionId');
 
-		const publish = async () => {
-			await this.publishButton.click();
-
-			await waitForAlert(this.page, 'published successfully', {
-				timeout: 10000,
-			});
-		};
-
-		if (objectDefinitionId) {
-			await publish();
-
-			return Number(objectDefinitionId);
-		}
-
-		const [response] = await Promise.all([
-			this.page.waitForResponse(
-				(response) =>
-					response.url().includes('object-definitions') &&
-					response.status() === 200,
-				{timeout: 10000}
-			),
-			await publish(),
-		]);
-
-		const {id} = await response.json();
-
-		return id;
+		return objectDefinitionId ? Number(objectDefinitionId) : undefined;
 	}
 
 	async saveStructure(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97673

## What

Two independent fixes to the CMS structure builder Playwright suite, both around .

### Deflake 

 synchronized on a  that matched the  cache-refresh request. That request is an incidental side effect of  and only fires after the publish completes and the tree re-renders, so under CI load it could land outside the shared 10 second window and time out (the reported  failure). It now waits on the deterministic  alert and reads the created object definition id from the URL afterward, once publishing has set it.

### Cascade-clean repeatable group object definitions

The  autoDelete cleanup deleted only the tracked structure through the object-admin API, which does not cascade to the repeatable group child object definitions, so every run leaked orphaned definitions into the CMS folders. Mirroring , cleanup now walks the hierarchy with a visited set, disables every edge relationship, then deletes the structure together with its repeatable group definitions leaf-first. Referenced structures live in a different object folder and are left untouched.

## Testing

Ran under  against a local bundle:

-  target , plus the delete-and-republish test, pass.
-  5/5, confirming referenced structures are not cascade-deleted.
-  republish and configure-text-field tests pass, exercising the return-value callers.
- The CMS object-definition folders return to their built-in baseline after runs, so there are no leaks.

**pr-check: PASS** — tested on 

| Validation | Result |
| --- | --- |
| Source Format | PASS |