### PR TITLE
LPD-94450 Add keyboard support to the Audience Builder

### DIFF
--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/AudienceBuilder.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/AudienceBuilder.tsx
@@ -9,16 +9,15 @@ import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import ClayLink from '@clayui/link';
 import ClayToolbar from '@clayui/toolbar';
-import {
-	DragPreview,
-	ScreenReaderAnnouncerContextProvider,
-} from '@liferay/layout-js-components-web';
+import {ScreenReaderAnnouncerContextProvider} from '@liferay/layout-js-components-web';
 import React, {useReducer} from 'react';
 import {DndProvider} from 'react-dnd';
 import {HTML5Backend} from 'react-dnd-html5-backend';
 
 import AttributesSidebar from './components/AttributesSidebar';
 import ConditionsPanel from './components/ConditionsPanel';
+import DragPreviewWrapper from './keyboard_movement/DragPreviewWrapper';
+import {KeyboardMovementContextProvider} from './keyboard_movement/KeyboardMovementContext';
 import {initState, reducer, serializeCriteria} from './reducer';
 import {AudiencesCriteriaRulesGroup, AudiencesCriteriaType} from './types';
 
@@ -55,119 +54,125 @@ export default function AudienceBuilder({
 
 	return (
 		<ScreenReaderAnnouncerContextProvider>
-			<DragAndDropProvider backend={HTML5Backend}>
-				<DragPreview />
+			<KeyboardMovementContextProvider>
+				<DragAndDropProvider backend={HTML5Backend}>
+					<DragPreviewWrapper />
 
-				<div className="d-flex flex-column overflow-hidden">
-					<ClayToolbar>
-						<ClayLayout.ContainerFluid size={false}>
-							<ClayToolbar.Nav>
-								<ClayToolbar.Item>
-									<ClayLink
-										aria-label={Liferay.Language.get(
-											'back'
-										)}
-										button
-										displayType="unstyled"
-										href={backURL}
-										monospaced
-										title={backURLTitle}
-									>
-										<ClayIcon symbol="angle-left" />
-									</ClayLink>
-								</ClayToolbar.Item>
+					<div className="d-flex flex-column overflow-hidden">
+						<ClayToolbar>
+							<ClayLayout.ContainerFluid size={false}>
+								<ClayToolbar.Nav>
+									<ClayToolbar.Item>
+										<ClayLink
+											aria-label={Liferay.Language.get(
+												'back'
+											)}
+											button
+											displayType="unstyled"
+											href={backURL}
+											monospaced
+											title={backURLTitle}
+										>
+											<ClayIcon symbol="angle-left" />
+										</ClayLink>
+									</ClayToolbar.Item>
 
-								<ClayToolbar.Item expand>
-									<ClayToolbar.Section className="text-left">
-										<span className="font-weight-bold text-dark text-truncate">
-											{state.name ||
-												Liferay.Language.get(
-													'new-audience'
-												)}
-										</span>
-									</ClayToolbar.Section>
-								</ClayToolbar.Item>
+									<ClayToolbar.Item expand>
+										<ClayToolbar.Section className="text-left">
+											<span className="font-weight-bold text-dark text-truncate">
+												{state.name ||
+													Liferay.Language.get(
+														'new-audience'
+													)}
+											</span>
+										</ClayToolbar.Section>
+									</ClayToolbar.Item>
 
-								<ClayToolbar.Item>
-									<ClayLink
-										button
-										displayType="secondary"
-										href={backURL}
-										small
-									>
-										{Liferay.Language.get('cancel')}
-									</ClayLink>
-								</ClayToolbar.Item>
+									<ClayToolbar.Item>
+										<ClayLink
+											button
+											displayType="secondary"
+											href={backURL}
+											small
+										>
+											{Liferay.Language.get('cancel')}
+										</ClayLink>
+									</ClayToolbar.Item>
 
-								<ClayToolbar.Item>
-									<ClayButton
-										displayType="primary"
-										size="sm"
-										type="submit"
-									>
-										{Liferay.Language.get('save')}
-									</ClayButton>
-								</ClayToolbar.Item>
-							</ClayToolbar.Nav>
-						</ClayLayout.ContainerFluid>
-					</ClayToolbar>
+									<ClayToolbar.Item>
+										<ClayButton
+											displayType="primary"
+											size="sm"
+											type="submit"
+										>
+											{Liferay.Language.get('save')}
+										</ClayButton>
+									</ClayToolbar.Item>
+								</ClayToolbar.Nav>
+							</ClayLayout.ContainerFluid>
+						</ClayToolbar>
 
-					<div className="audience-builder-content d-flex">
-						<div className="audience-builder-sidebar border-right d-flex flex-column flex-shrink-0 px-4">
-							<AttributesSidebar
-								audiencesCriteriaTypes={audiencesCriteriaTypes}
-							/>
-						</div>
-
-						<div className="d-flex flex-column flex-grow-1 overflow-auto p-4">
-							<ClayForm.Group>
-								<label
-									className="font-weight-semi-bold text-3"
-									htmlFor={`${namespace}name`}
-								>
-									{Liferay.Language.get('name')}
-
-									<span className="reference-mark">
-										<ClayIcon symbol="asterisk" />
-									</span>
-								</label>
-
-								<ClayInput
-									className="bg-white border-0 font-weight-semi-bold h-auto mb-0 p-0 text-8"
-									id={`${namespace}name`}
-									maxLength={NAME_MAX_LENGTH}
-									name={`${namespace}name`}
-									onChange={(event) =>
-										dispatch({
-											name: event.target.value,
-											type: 'SET_NAME',
-										})
+						<div className="audience-builder-content d-flex">
+							<div className="audience-builder-sidebar border-right d-flex flex-column flex-shrink-0 px-4">
+								<AttributesSidebar
+									audiencesCriteriaTypes={
+										audiencesCriteriaTypes
 									}
-									placeholder={Liferay.Language.get(
-										'new-audience'
-									)}
-									required
-									type="text"
-									value={state.name}
 								/>
-							</ClayForm.Group>
+							</div>
 
-							<input
-								name={`${namespace}json`}
-								type="hidden"
-								value={serializeCriteria(state)}
-							/>
+							<div className="d-flex flex-column flex-grow-1 overflow-auto p-4">
+								<ClayForm.Group>
+									<label
+										className="font-weight-semi-bold text-3"
+										htmlFor={`${namespace}name`}
+									>
+										{Liferay.Language.get('name')}
 
-							<ConditionsPanel
-								audiencesCriteriaTypes={audiencesCriteriaTypes}
-								conjunction={state.conjunction}
-								dispatch={dispatch}
-								rules={state.rules}
-							/>
+										<span className="reference-mark">
+											<ClayIcon symbol="asterisk" />
+										</span>
+									</label>
+
+									<ClayInput
+										className="bg-white border-0 font-weight-semi-bold h-auto mb-0 p-0 text-8"
+										id={`${namespace}name`}
+										maxLength={NAME_MAX_LENGTH}
+										name={`${namespace}name`}
+										onChange={(event) =>
+											dispatch({
+												name: event.target.value,
+												type: 'SET_NAME',
+											})
+										}
+										placeholder={Liferay.Language.get(
+											'new-audience'
+										)}
+										required
+										type="text"
+										value={state.name}
+									/>
+								</ClayForm.Group>
+
+								<input
+									name={`${namespace}json`}
+									type="hidden"
+									value={serializeCriteria(state)}
+								/>
+
+								<ConditionsPanel
+									audiencesCriteriaTypes={
+										audiencesCriteriaTypes
+									}
+									conjunction={state.conjunction}
+									dispatch={dispatch}
+									rules={state.rules}
+								/>
+							</div>
 						</div>
 					</div>
-				</div>
-			</DragAndDropProvider>
+				</DragAndDropProvider>
+			</KeyboardMovementContextProvider>
 		</ScreenReaderAnnouncerContextProvider>
 	);
 }

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/AttributeListItem.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/AttributeListItem.tsx
@@ -60,11 +60,6 @@ export default function AttributeListItem({
 			role="menuitem"
 			tabIndex={navigationProps.tabIndex}
 		>
-			<ClayIcon
-				className="audience-builder-attribute__grip text-secondary"
-				symbol="drag"
-			/>
-
 			<span
 				className={classNames(
 					'align-items-center audience-builder-attribute__icon d-inline-flex justify-content-center rounded',

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/AttributeListItem.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/AttributeListItem.tsx
@@ -10,16 +10,19 @@ import {useDrag} from 'react-dnd';
 import {getEmptyImage} from 'react-dnd-html5-backend';
 
 import {DRAG_TYPES} from '../constants/dragTypes';
+import {NavigationItemProps} from '../hooks/useKeyboardNavigation';
 import {AudiencesCriteria} from '../types';
 
 interface IProps {
 	audiencesCriteria: AudiencesCriteria;
 	iconColor: string;
+	navigationProps: NavigationItemProps;
 }
 
 export default function AttributeListItem({
 	audiencesCriteria,
 	iconColor,
+	navigationProps,
 }: IProps) {
 	const [{isDragging}, handlerRef, previewRef] = useDrag({
 		collect: (monitor) => ({
@@ -37,6 +40,12 @@ export default function AttributeListItem({
 		previewRef(getEmptyImage(), {captureDraggingState: true});
 	}, [previewRef]);
 
+	const setRefs = (element: HTMLDivElement | null) => {
+		handlerRef(element);
+
+		navigationProps.ref(element);
+	};
+
 	return (
 		<div
 			className={classNames(
@@ -45,7 +54,11 @@ export default function AttributeListItem({
 					'audience-builder-attribute--dragging': isDragging,
 				}
 			)}
-			ref={handlerRef}
+			onFocus={navigationProps.onFocus}
+			onKeyDown={navigationProps.onKeyDown}
+			ref={setRefs}
+			role="menuitem"
+			tabIndex={navigationProps.tabIndex}
 		>
 			<ClayIcon
 				className="audience-builder-attribute__grip text-secondary"

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/AttributeListItem.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/AttributeListItem.tsx
@@ -5,12 +5,17 @@
 
 import ClayIcon from '@clayui/icon';
 import classNames from 'classnames';
+import {sub} from 'frontend-js-web';
 import React, {useEffect} from 'react';
 import {useDrag} from 'react-dnd';
 import {getEmptyImage} from 'react-dnd-html5-backend';
 
 import {DRAG_TYPES} from '../constants/dragTypes';
 import {NavigationItemProps} from '../hooks/useKeyboardNavigation';
+import {
+	useMovementSource,
+	useSetMovementSource,
+} from '../keyboard_movement/KeyboardMovementContext';
 import {AudiencesCriteria} from '../types';
 
 interface IProps {
@@ -36,6 +41,13 @@ export default function AttributeListItem({
 		},
 	});
 
+	const movementSource = useMovementSource();
+	const setMovementSource = useSetMovementSource();
+
+	const isMovementSource =
+		!movementSource?.ruleId &&
+		movementSource?.audiencesCriteria?.key === audiencesCriteria.key;
+
 	useEffect(() => {
 		previewRef(getEmptyImage(), {captureDraggingState: true});
 	}, [previewRef]);
@@ -48,14 +60,33 @@ export default function AttributeListItem({
 
 	return (
 		<div
+			aria-label={sub(
+				Liferay.Language.get('add-x'),
+				audiencesCriteria.label
+			)}
 			className={classNames(
 				'align-items-center audience-builder-attribute c-gap-3 d-flex px-2 rounded',
 				{
-					'audience-builder-attribute--dragging': isDragging,
+					'audience-builder-attribute--dragging':
+						isDragging || isMovementSource,
 				}
 			)}
 			onFocus={navigationProps.onFocus}
-			onKeyDown={navigationProps.onKeyDown}
+			onKeyDown={(event) => {
+				if (event.key === 'Enter' || event.key === ' ') {
+					event.preventDefault();
+
+					setMovementSource({
+						audiencesCriteria,
+						icon: audiencesCriteria.icon,
+						name: audiencesCriteria.label,
+					});
+
+					return;
+				}
+
+				navigationProps.onKeyDown(event);
+			}}
 			ref={setRefs}
 			role="menuitem"
 			tabIndex={navigationProps.tabIndex}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/AttributesSidebar.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/AttributesSidebar.tsx
@@ -12,6 +12,7 @@ import {
 	CATEGORY_ICON_COLORS,
 	DEFAULT_ICON_COLOR,
 } from '../constants/categoryIconColors';
+import useKeyboardNavigation from '../hooks/useKeyboardNavigation';
 import {AudiencesCriteriaType} from '../types';
 import AttributeListItem from './AttributeListItem';
 
@@ -32,6 +33,10 @@ export default function AttributesSidebar({audiencesCriteriaTypes}: IProps) {
 			(audiencesCriteria) =>
 				audiencesCriteria.label.toLowerCase().includes(normalizedQuery)
 		) ?? [];
+
+	const {getItemProps} = useKeyboardNavigation({
+		itemCount: audiencesCriterias.length,
+	});
 
 	return (
 		<div className="d-flex flex-column flex-grow-0 h-100">
@@ -64,8 +69,13 @@ export default function AttributesSidebar({audiencesCriteriaTypes}: IProps) {
 			/>
 
 			{audiencesCriterias.length ? (
-				<div className="overflow-auto">
-					{audiencesCriterias.map((audiencesCriteria) => (
+				<div
+					aria-label={Liferay.Language.get('attributes')}
+					aria-orientation="vertical"
+					className="overflow-auto"
+					role="menu"
+				>
+					{audiencesCriterias.map((audiencesCriteria, index) => (
 						<AttributeListItem
 							audiencesCriteria={audiencesCriteria}
 							iconColor={
@@ -73,6 +83,7 @@ export default function AttributesSidebar({audiencesCriteriaTypes}: IProps) {
 								DEFAULT_ICON_COLOR
 							}
 							key={audiencesCriteria.key}
+							navigationProps={getItemProps(index)}
 						/>
 					))}
 				</div>

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/ConditionsPanel.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/ConditionsPanel.tsx
@@ -16,6 +16,8 @@ import {
 } from '../constants/categoryIconColors';
 import {DRAG_TYPES} from '../constants/dragTypes';
 import useKeyboardNavigation from '../hooks/useKeyboardNavigation';
+import {useMovementSource} from '../keyboard_movement/KeyboardMovementContext';
+import KeyboardMovementManager from '../keyboard_movement/KeyboardMovementManager';
 import {Action} from '../reducer';
 import {AudiencesCriteria, AudiencesCriteriaType, Rule} from '../types';
 import RuleRow from './RuleRow';
@@ -64,9 +66,11 @@ export default function ConditionsPanel({
 
 	const announce = useScreenReaderAnnounce();
 
+	const movementSource = useMovementSource();
+
 	const {getItemProps} = useKeyboardNavigation({itemCount: rules.length});
 
-	const dndItems = rules.map((rule) => {
+	const movementItems = rules.map((rule) => {
 		const audiencesCriteria = audiencesCriteriasByKey[rule.attribute];
 
 		return {
@@ -111,6 +115,15 @@ export default function ConditionsPanel({
 
 	return (
 		<div className="border mt-4 rounded">
+			{movementSource ? (
+				<KeyboardMovementManager
+					dispatch={dispatch}
+					items={movementItems}
+					rules={rules}
+					source={movementSource}
+				/>
+			) : null}
+
 			<div className="px-4 py-3">
 				<p className="font-weight-bold mb-0 text-6">
 					{Liferay.Language.get('conditions')}
@@ -195,7 +208,7 @@ export default function ConditionsPanel({
 									}
 									iconColor={iconColorsByKey[rule.attribute]}
 									index={index}
-									items={dndItems}
+									items={movementItems}
 									navigationProps={getItemProps(index)}
 									onAddRule={handleAddRule}
 									onChange={(newRule) =>

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/ConditionsPanel.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/ConditionsPanel.tsx
@@ -15,6 +15,7 @@ import {
 	DEFAULT_ICON_COLOR,
 } from '../constants/categoryIconColors';
 import {DRAG_TYPES} from '../constants/dragTypes';
+import useKeyboardNavigation from '../hooks/useKeyboardNavigation';
 import {Action} from '../reducer';
 import {AudiencesCriteria, AudiencesCriteriaType, Rule} from '../types';
 import RuleRow from './RuleRow';
@@ -62,6 +63,8 @@ export default function ConditionsPanel({
 	);
 
 	const announce = useScreenReaderAnnounce();
+
+	const {getItemProps} = useKeyboardNavigation({itemCount: rules.length});
 
 	const dndItems = rules.map((rule) => {
 		const audiencesCriteria = audiencesCriteriasByKey[rule.attribute];
@@ -167,7 +170,12 @@ export default function ConditionsPanel({
 						</span>
 					</div>
 
-					<div className="px-3 py-2">
+					<div
+						aria-label={Liferay.Language.get('conditions')}
+						aria-orientation="vertical"
+						className="px-3 py-2"
+						role="menu"
+					>
 						{rules.map((rule, index) => (
 							<Fragment key={rule.id}>
 								{index > 0 ? (
@@ -188,6 +196,7 @@ export default function ConditionsPanel({
 									iconColor={iconColorsByKey[rule.attribute]}
 									index={index}
 									items={dndItems}
+									navigationProps={getItemProps(index)}
 									onAddRule={handleAddRule}
 									onChange={(newRule) =>
 										dispatch({

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
@@ -15,6 +15,7 @@ import {DropTargetMonitor, useDrop} from 'react-dnd';
 
 import {DRAG_TYPES} from '../constants/dragTypes';
 import {getOperatorLabel, getOperators} from '../constants/operators';
+import {NavigationItemProps} from '../hooks/useKeyboardNavigation';
 import {AudiencesCriteria, Rule} from '../types';
 
 type DropPosition = 'bottom' | 'top' | null;
@@ -35,6 +36,7 @@ interface IProps {
 	iconColor: string;
 	index: number;
 	items: DragItem[];
+	navigationProps: NavigationItemProps;
 	onAddRule: (audiencesCriteria: AudiencesCriteria, index?: number) => void;
 	onChange: (rule: Rule) => void;
 	onDelete: () => void;
@@ -64,6 +66,7 @@ export default function RuleRow({
 	iconColor,
 	index,
 	items,
+	navigationProps,
 	onAddRule,
 	onChange,
 	onDelete,
@@ -73,6 +76,12 @@ export default function RuleRow({
 }: IProps) {
 	const dragHandlerRef = useRef<HTMLSpanElement>(null);
 	const dropItemRef = useRef<HTMLDivElement | null>(null);
+
+	const setRowRef = (element: HTMLDivElement | null) => {
+		dropItemRef.current = element;
+
+		navigationProps.ref(element);
+	};
 
 	const [dropPosition, setDropPosition] = useState<DropPosition>(null);
 
@@ -119,7 +128,11 @@ export default function RuleRow({
 					'the-criteria-is-no-longer-available'
 				)}
 				className="align-items-center audience-builder-rule audience-builder-rule--error d-flex justify-content-between p-3"
-				ref={dropItemRef}
+				onFocus={navigationProps.onFocus}
+				onKeyDown={navigationProps.onKeyDown}
+				ref={setRowRef}
+				role="menuitem"
+				tabIndex={navigationProps.tabIndex}
 			>
 				<div className="align-items-center c-gap-3 d-flex">
 					<ClayIcon
@@ -152,8 +165,9 @@ export default function RuleRow({
 	const operators = getOperators(inputType, type);
 
 	return (
-		<div ref={attributeDrop}>
+		<div ref={attributeDrop} role="none">
 			<div
+				aria-label={label}
 				className={classNames(
 					'align-items-center audience-builder-rule d-flex justify-content-between p-3',
 					`audience-builder-rule--${iconColor}`,
@@ -167,7 +181,11 @@ export default function RuleRow({
 							(isOver && dropPosition === 'top'),
 					}
 				)}
-				ref={dropItemRef}
+				onFocus={navigationProps.onFocus}
+				onKeyDown={navigationProps.onKeyDown}
+				ref={setRowRef}
+				role="menuitem"
+				tabIndex={navigationProps.tabIndex}
 			>
 				<div className="align-items-center c-gap-3 d-flex">
 					<span

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
@@ -14,11 +14,15 @@ import React, {useRef, useState} from 'react';
 import {DropTargetMonitor, useDrop} from 'react-dnd';
 
 import {DRAG_TYPES} from '../constants/dragTypes';
+import {DROP_POSITIONS, DropPosition} from '../constants/dropPositions';
 import {getOperatorLabel, getOperators} from '../constants/operators';
 import {NavigationItemProps} from '../hooks/useKeyboardNavigation';
+import {
+	useMovementSource,
+	useMovementTarget,
+	useSetMovementSource,
+} from '../keyboard_movement/KeyboardMovementContext';
 import {AudiencesCriteria, Rule} from '../types';
-
-type DropPosition = 'bottom' | 'top' | null;
 
 interface DragItem {
 	icon: string;
@@ -48,7 +52,7 @@ interface IProps {
 const getDropPosition = (
 	ref: React.RefObject<HTMLElement>,
 	monitor: DropTargetMonitor
-): DropPosition => {
+): DropPosition | null => {
 	const clientOffset = monitor.getClientOffset();
 
 	if (!ref.current || !clientOffset) {
@@ -74,7 +78,7 @@ export default function RuleRow({
 	onReorder,
 	rule,
 }: IProps) {
-	const dragHandlerRef = useRef<HTMLSpanElement>(null);
+	const dragHandlerRef = useRef<HTMLButtonElement>(null);
 	const dropItemRef = useRef<HTMLDivElement | null>(null);
 
 	const setRowRef = (element: HTMLDivElement | null) => {
@@ -83,7 +87,22 @@ export default function RuleRow({
 		navigationProps.ref(element);
 	};
 
-	const [dropPosition, setDropPosition] = useState<DropPosition>(null);
+	const [dropPosition, setDropPosition] = useState<DropPosition | null>(null);
+
+	const movementSource = useMovementSource();
+	const movementTarget = useMovementTarget();
+	const setMovementSource = useSetMovementSource();
+
+	const isMovementSource = movementSource?.ruleId === rule.id;
+
+	const isMovementTarget =
+		Boolean(movementSource) && movementTarget.index === index;
+
+	const isMovementTargetBottomPosition =
+		isMovementTarget && movementTarget.position === DROP_POSITIONS.bottom;
+
+	const isMovementTargetTopPosition =
+		isMovementTarget && movementTarget.position === DROP_POSITIONS.top;
 
 	const {isDragging, isDropBottomPosition, isDropTopPosition} =
 		useDragAndDrop<DragItem>({
@@ -111,7 +130,7 @@ export default function RuleRow({
 			);
 		},
 		hover: (item, monitor) => {
-			let dropPosition: DropPosition = null;
+			let dropPosition: DropPosition | null = null;
 
 			if (isOver) {
 				dropPosition = getDropPosition(dropItemRef, monitor);
@@ -127,7 +146,16 @@ export default function RuleRow({
 				aria-label={Liferay.Language.get(
 					'the-criteria-is-no-longer-available'
 				)}
-				className="align-items-center audience-builder-rule audience-builder-rule--error d-flex justify-content-between p-3"
+				className={classNames(
+					'align-items-center audience-builder-rule audience-builder-rule--error d-flex justify-content-between p-3',
+					{
+						'audience-builder-rule--drop-bottom':
+							isDropBottomPosition ||
+							isMovementTargetBottomPosition,
+						'audience-builder-rule--drop-top':
+							isDropTopPosition || isMovementTargetTopPosition,
+					}
+				)}
 				onFocus={navigationProps.onFocus}
 				onKeyDown={navigationProps.onKeyDown}
 				ref={setRowRef}
@@ -172,13 +200,16 @@ export default function RuleRow({
 					'align-items-center audience-builder-rule d-flex justify-content-between p-3',
 					`audience-builder-rule--${iconColor}`,
 					{
-						'audience-builder-rule--dragging': isDragging,
+						'audience-builder-rule--dragging':
+							isDragging || isMovementSource,
 						'audience-builder-rule--drop-bottom':
 							isDropBottomPosition ||
-							(isOver && dropPosition === 'bottom'),
+							(isOver && dropPosition === 'bottom') ||
+							isMovementTargetBottomPosition,
 						'audience-builder-rule--drop-top':
 							isDropTopPosition ||
-							(isOver && dropPosition === 'top'),
+							(isOver && dropPosition === 'top') ||
+							isMovementTargetTopPosition,
 					}
 				)}
 				onFocus={navigationProps.onFocus}
@@ -188,20 +219,26 @@ export default function RuleRow({
 				tabIndex={navigationProps.tabIndex}
 			>
 				<div className="align-items-center c-gap-3 d-flex">
-					<span
-						aria-label={sub(
-							Liferay.Language.get('drag-x'),
-							Liferay.Language.get('condition')
-						)}
+					<ClayButtonWithIcon
+						aria-label={sub(Liferay.Language.get('move-x'), label)}
+						borderless
 						className="audience-builder-grip text-secondary"
+						displayType="secondary"
+						onClick={(event) => {
+							if (event.detail === 0) {
+								setMovementSource({
+									icon: audiencesCriteria.icon,
+									name: label,
+									ruleId: rule.id,
+								});
+							}
+						}}
 						ref={dragHandlerRef}
-						title={sub(
-							Liferay.Language.get('drag-x'),
-							Liferay.Language.get('condition')
-						)}
-					>
-						<ClayIcon symbol="drag" />
-					</span>
+						size="sm"
+						symbol="drag"
+						tabIndex={navigationProps.tabIndex}
+						title={sub(Liferay.Language.get('move-x'), label)}
+					/>
 
 					<span className="font-weight-semi-bold text-4 text-nowrap">
 						{label}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/constants/dropPositions.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/constants/dropPositions.ts
@@ -1,0 +1,11 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const DROP_POSITIONS = {
+	bottom: 'bottom',
+	top: 'top',
+} as const;
+
+export type DropPosition = keyof typeof DROP_POSITIONS;

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/constants/keyboardCodes.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/constants/keyboardCodes.ts
@@ -1,0 +1,16 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const ARROW_DOWN_KEY_CODE = 'ArrowDown';
+
+export const ARROW_UP_KEY_CODE = 'ArrowUp';
+
+export const END_KEY_CODE = 'End';
+
+export const ENTER_KEY_CODE = 'Enter';
+
+export const ESCAPE_KEY_CODE = 'Escape';
+
+export const HOME_KEY_CODE = 'Home';

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/hooks/useKeyboardNavigation.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/hooks/useKeyboardNavigation.ts
@@ -1,0 +1,143 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React, {useRef, useState} from 'react';
+
+export interface NavigationItemProps {
+	onFocus: () => void;
+	onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
+	ref: (element: HTMLElement | null) => void;
+	tabIndex: number;
+}
+
+export default function useKeyboardNavigation({
+	itemCount,
+}: {
+	itemCount: number;
+}) {
+	const [targetIndex, setTargetIndex] = useState(0);
+
+	const elementsRef = useRef<Array<HTMLElement | null>>([]);
+
+	const navigationTargetIndex = Math.min(
+		targetIndex,
+		Math.max(0, itemCount - 1)
+	);
+
+	const rtl =
+		Liferay.Language.direction?.[Liferay.ThemeDisplay.getLanguageId()] ===
+		'rtl';
+
+	const getItemProps = (index: number): NavigationItemProps => ({
+		onFocus: () => setTargetIndex(index),
+		onKeyDown: (event) => {
+			const target = event.target as HTMLElement;
+
+			const key = getKey(event, rtl);
+
+			const isHorizontalKey = key === 'ArrowLeft' || key === 'ArrowRight';
+
+			if (
+				target !== event.currentTarget &&
+				ownsArrowKeys(target, isHorizontalKey)
+			) {
+				return;
+			}
+
+			if (isHorizontalKey) {
+				const item = event.currentTarget as HTMLElement;
+
+				const focusableElements = Array.from(
+					item.querySelectorAll<HTMLElement>(
+						'a[href], button:not([disabled]), input, select, textarea'
+					)
+				);
+
+				const position = focusableElements.indexOf(target);
+
+				event.preventDefault();
+
+				if (key === 'ArrowRight') {
+					const nextElement =
+						position === -1
+							? focusableElements[0]
+							: focusableElements[position + 1];
+
+					nextElement?.focus();
+				}
+				else if (position === 0) {
+					item.focus();
+				}
+				else if (position > 0) {
+					focusableElements[position - 1].focus();
+				}
+
+				return;
+			}
+
+			let nextIndex = null;
+
+			if (key === 'ArrowDown') {
+				nextIndex = Math.min(index + 1, itemCount - 1);
+			}
+			else if (key === 'ArrowUp') {
+				nextIndex = Math.max(index - 1, 0);
+			}
+			else if (key === 'End') {
+				nextIndex = itemCount - 1;
+			}
+			else if (key === 'Home') {
+				nextIndex = 0;
+			}
+
+			if (nextIndex === null) {
+				return;
+			}
+
+			event.preventDefault();
+
+			setTargetIndex(nextIndex);
+
+			elementsRef.current[nextIndex]?.focus();
+		},
+		ref: (element) => {
+			elementsRef.current[index] = element;
+		},
+		tabIndex: index === navigationTargetIndex ? 0 : -1,
+	});
+
+	return {getItemProps};
+}
+
+function getKey(event: React.KeyboardEvent<HTMLElement>, rtl: boolean) {
+	const {key} = event;
+
+	if (!rtl) {
+		return key;
+	}
+
+	if (key === 'ArrowRight') {
+		return 'ArrowLeft';
+	}
+
+	if (key === 'ArrowLeft') {
+		return 'ArrowRight';
+	}
+
+	return key;
+}
+
+function ownsArrowKeys(target: HTMLElement, isHorizontalKey: boolean) {
+	if (
+		target.tagName === 'INPUT' ||
+		target.tagName === 'SELECT' ||
+		target.tagName === 'TEXTAREA' ||
+		target.getAttribute('role') === 'listbox'
+	) {
+		return true;
+	}
+
+	return target.getAttribute('role') === 'combobox' && !isHorizontalKey;
+}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/DragPreviewWrapper.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/DragPreviewWrapper.tsx
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {DragPreview} from '@liferay/layout-js-components-web';
+import React, {useEffect, useMemo} from 'react';
+
+import {useMovementSource, useMovementTarget} from './KeyboardMovementContext';
+
+export default function DragPreviewWrapper() {
+	const source = useMovementSource();
+	const target = useMovementTarget();
+
+	const alignment = useMemo(() => {
+		if (!source || target.index === null || !target.position) {
+			return undefined;
+		}
+
+		const element = document.querySelectorAll<HTMLElement>(
+			'.audience-builder-rule'
+		)[target.index];
+
+		if (!element) {
+			return undefined;
+		}
+
+		return {element, position: target.position};
+	}, [source, target]);
+
+	useEffect(() => {
+		alignment?.element.scrollIntoView?.({
+			behavior: 'smooth',
+			block: 'nearest',
+		});
+	}, [alignment]);
+
+	return (
+		<DragPreview
+			alignment={alignment}
+			getIcon={(item: {icon?: string; name?: string}) =>
+				source?.icon ?? item?.icon ?? ''
+			}
+			getLabel={(item: {icon?: string; name?: string}) =>
+				source?.name ?? item?.name ?? ''
+			}
+		/>
+	);
+}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementContext.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementContext.tsx
@@ -1,0 +1,104 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ScreenReaderAnnouncer} from '@liferay/layout-js-components-web';
+import React, {useCallback, useContext, useRef, useState} from 'react';
+
+import {DropPosition} from '../constants/dropPositions';
+import {AudiencesCriteria} from '../types';
+
+export interface MovementSource {
+	audiencesCriteria?: AudiencesCriteria;
+	icon: string;
+	name: string;
+	ruleId?: string;
+}
+
+export interface MovementTarget {
+	index: number | null;
+	position: DropPosition | null;
+}
+
+interface KeyboardMovementContextValue {
+	setSource: (source: MovementSource | null) => void;
+	setTarget: (target: MovementTarget) => void;
+	setText: (text: string) => void;
+	source: MovementSource | null;
+	target: MovementTarget;
+}
+
+const INITIAL_TARGET: MovementTarget = {
+	index: null,
+	position: null,
+};
+
+const KeyboardMovementContext =
+	React.createContext<KeyboardMovementContextValue>({
+		setSource: () => {},
+		setTarget: () => {},
+		setText: () => {},
+		source: null,
+		target: INITIAL_TARGET,
+	});
+
+export function KeyboardMovementContextProvider({
+	children,
+}: {
+	children: React.ReactNode;
+}) {
+	const [source, setSource] = useState<MovementSource | null>(null);
+	const [target, setTarget] = useState<MovementTarget>(INITIAL_TARGET);
+
+	const screenReaderAnnouncerRef = useRef<{
+		sendMessage: (message: string) => void;
+	}>(null);
+
+	const setText = useCallback((text: string) => {
+		screenReaderAnnouncerRef.current?.sendMessage(text);
+	}, []);
+
+	return (
+		<KeyboardMovementContext.Provider
+			value={{setSource, setTarget, setText, source, target}}
+		>
+			<ScreenReaderAnnouncer
+				aria-live="assertive"
+				ref={screenReaderAnnouncerRef}
+			/>
+
+			{children}
+		</KeyboardMovementContext.Provider>
+	);
+}
+
+export function useDisableKeyboardMovement() {
+	const {setSource, setTarget} = useContext(KeyboardMovementContext);
+
+	return useCallback(() => {
+		setSource(null);
+
+		setTarget(INITIAL_TARGET);
+	}, [setSource, setTarget]);
+}
+
+export function useMovementSource() {
+	return useContext(KeyboardMovementContext).source;
+}
+
+export function useMovementTarget() {
+	return useContext(KeyboardMovementContext).target;
+}
+
+export function useSetMovementSource() {
+	return useContext(KeyboardMovementContext).setSource;
+}
+
+export function useSetMovementTarget() {
+	return useContext(KeyboardMovementContext).setTarget;
+}
+
+export function useSetMovementText() {
+	return useContext(KeyboardMovementContext).setText;
+}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementManager.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementManager.tsx
@@ -1,0 +1,272 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {sub} from 'frontend-js-web';
+import {Dispatch, useEffect} from 'react';
+
+import {DROP_POSITIONS} from '../constants/dropPositions';
+import {
+	ARROW_DOWN_KEY_CODE,
+	ARROW_UP_KEY_CODE,
+	END_KEY_CODE,
+	ENTER_KEY_CODE,
+	ESCAPE_KEY_CODE,
+	HOME_KEY_CODE,
+} from '../constants/keyboardCodes';
+import {Action} from '../reducer';
+import {Rule} from '../types';
+import {
+	MovementSource,
+	MovementTarget,
+	useDisableKeyboardMovement,
+	useMovementTarget,
+	useSetMovementTarget,
+	useSetMovementText,
+} from './KeyboardMovementContext';
+
+const ACTION_TYPES = {
+	add: 'add',
+	move: 'move',
+} as const;
+
+const DIRECTIONS = {
+	down: 'down',
+	up: 'up',
+} as const;
+
+type Direction = keyof typeof DIRECTIONS;
+
+export interface MovementItem {
+	icon: string;
+	id: string;
+	name: string;
+}
+
+interface Props {
+	dispatch: Dispatch<Action>;
+	items: MovementItem[];
+	rules: Rule[];
+	source: MovementSource;
+}
+
+export default function KeyboardMovementManager({
+	dispatch,
+	items,
+	rules,
+	source,
+}: Props) {
+	const disableMovement = useDisableKeyboardMovement();
+	const setTarget = useSetMovementTarget();
+	const setText = useSetMovementText();
+	const target = useMovementTarget();
+
+	useEffect(() => {
+		if (target.index !== null) {
+			return;
+		}
+
+		if (!items.length) {
+			if (!source.ruleId && source.audiencesCriteria) {
+				dispatch({
+					audiencesCriteria: source.audiencesCriteria,
+					index: 0,
+					type: 'ADD_RULE',
+				});
+
+				setText(Liferay.Language.get('a-condition-was-added'));
+			}
+
+			disableMovement();
+
+			return;
+		}
+
+		setTarget(getInitialTarget(source, rules));
+
+		setText(
+			Liferay.Language.get(
+				'use-arrows-to-move-it-and-press-enter-to-select-the-new-position-press-esc-to-cancel'
+			)
+		);
+	}, [
+		disableMovement,
+		dispatch,
+		items,
+		rules,
+		setTarget,
+		setText,
+		source,
+		target,
+	]);
+
+	useEffect(() => {
+		const executeAction = () => {
+			if (target.index === null || !target.position) {
+				return;
+			}
+
+			const insertionIndex =
+				target.position === DROP_POSITIONS.bottom
+					? target.index + 1
+					: target.index;
+
+			const actionType = source.ruleId
+				? ACTION_TYPES.move
+				: ACTION_TYPES.add;
+
+			if (actionType === ACTION_TYPES.add) {
+				if (!source.audiencesCriteria) {
+					return;
+				}
+
+				dispatch({
+					audiencesCriteria: source.audiencesCriteria,
+					index: insertionIndex,
+					type: 'ADD_RULE',
+				});
+			}
+			else {
+				const sourceIndex = rules.findIndex(
+					(rule) => rule.id === source.ruleId
+				);
+
+				if (
+					insertionIndex === sourceIndex ||
+					insertionIndex === sourceIndex + 1
+				) {
+					setText('');
+
+					disableMovement();
+
+					return;
+				}
+
+				const nextRules = [...rules];
+
+				const [movedRule] = nextRules.splice(sourceIndex, 1);
+
+				nextRules.splice(
+					insertionIndex > sourceIndex
+						? insertionIndex - 1
+						: insertionIndex,
+					0,
+					movedRule
+				);
+
+				dispatch({rules: nextRules, type: 'REORDER_RULES'});
+			}
+
+			setText(
+				sub(Liferay.Language.get('x-placed-on-x-of-x'), [
+					source.name,
+					target.position,
+					items[target.index].name,
+				])
+			);
+
+			disableMovement();
+		};
+
+		const moveTarget = (nextTarget: MovementTarget | null) => {
+			if (!nextTarget || nextTarget.index === null) {
+				return;
+			}
+
+			setTarget(nextTarget);
+
+			setText(
+				sub(Liferay.Language.get('targeting-x-of-x'), [
+					nextTarget.position,
+					items[nextTarget.index].name,
+				])
+			);
+		};
+
+		const onKeyDown = (event: KeyboardEvent) => {
+			event.preventDefault();
+			event.stopPropagation();
+
+			if (event.code === ARROW_DOWN_KEY_CODE) {
+				moveTarget(
+					getNextTarget(target, DIRECTIONS.down, items.length)
+				);
+			}
+			else if (event.code === ARROW_UP_KEY_CODE) {
+				moveTarget(getNextTarget(target, DIRECTIONS.up, items.length));
+			}
+			else if (event.code === END_KEY_CODE) {
+				moveTarget({
+					index: items.length - 1,
+					position: DROP_POSITIONS.bottom,
+				});
+			}
+			else if (event.code === ENTER_KEY_CODE) {
+				executeAction();
+			}
+			else if (event.code === ESCAPE_KEY_CODE) {
+				setText('');
+
+				disableMovement();
+			}
+			else if (event.code === HOME_KEY_CODE) {
+				moveTarget({index: 0, position: DROP_POSITIONS.top});
+			}
+		};
+
+		window.addEventListener('keydown', onKeyDown, true);
+
+		return () => window.removeEventListener('keydown', onKeyDown, true);
+	});
+
+	return null;
+}
+
+export function getInitialTarget(
+	source: MovementSource,
+	rules: Rule[]
+): MovementTarget {
+	if (source.ruleId) {
+		return {
+			index: rules.findIndex((rule) => rule.id === source.ruleId),
+			position: DROP_POSITIONS.bottom,
+		};
+	}
+
+	return {index: rules.length - 1, position: DROP_POSITIONS.bottom};
+}
+
+export function getNextTarget(
+	target: MovementTarget,
+	direction: Direction,
+	itemsCount: number
+): MovementTarget | null {
+	const {index, position} = target;
+
+	if (index === null || !position) {
+		return null;
+	}
+
+	if (direction === DIRECTIONS.down) {
+		if (position === DROP_POSITIONS.top) {
+			return {index, position: DROP_POSITIONS.bottom};
+		}
+
+		if (index < itemsCount - 1) {
+			return {index: index + 1, position: DROP_POSITIONS.bottom};
+		}
+
+		return null;
+	}
+
+	if (position === DROP_POSITIONS.bottom) {
+		if (index === 0) {
+			return {index: 0, position: DROP_POSITIONS.top};
+		}
+
+		return {index: index - 1, position: DROP_POSITIONS.bottom};
+	}
+
+	return null;
+}

--- a/modules/apps/audiences/audiences-web/test/js/AudienceBuilder.test.tsx
+++ b/modules/apps/audiences/audiences-web/test/js/AudienceBuilder.test.tsx
@@ -3,11 +3,57 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {render} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {fireEvent, render, screen, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import AudienceBuilder from '../../src/main/resources/META-INF/resources/js/AudienceBuilder';
+import {AudiencesCriteriaType} from '../../src/main/resources/META-INF/resources/js/types';
+
+const AUDIENCES_CRITERIA_TYPES: AudiencesCriteriaType[] = [
+	{
+		audiencesCriterias: [
+			{
+				icon: 'user',
+				inputType: 'text',
+				key: 'age',
+				label: 'Age',
+				options: [],
+				type: 'number',
+			},
+			{
+				icon: 'user',
+				inputType: 'text',
+				key: 'city',
+				label: 'City',
+				options: [],
+				type: 'string',
+			},
+		],
+		key: 'user',
+		label: 'User',
+	},
+];
+
+const getSerializedRuleAttributes = (container: HTMLElement) => {
+	const input =
+		container.querySelector<HTMLInputElement>('input[name="json"]');
+
+	const serializedCriteria = JSON.parse(input!.value);
+
+	return serializedCriteria.rules.map(
+		(rule: {attribute: string}) => rule.attribute
+	);
+};
+
+const getAttributeElement = (label: string) => {
+	const attributeElement = screen
+		.getByText(label)
+		.closest('[role="menuitem"]') as HTMLElement;
+
+	return attributeElement;
+};
 
 describe('AudienceBuilder', () => {
 	beforeAll(() => {
@@ -42,5 +88,248 @@ describe('AudienceBuilder', () => {
 
 		expect(getByText('My Audience')).toBeTruthy();
 		expect(queryByText('new-audience')).toBeNull();
+	});
+
+	describe('keyboard movement', () => {
+		it('adds a condition from the sidebar at the chosen position', async () => {
+			const {container} = render(
+				<AudienceBuilder
+					audiencesCriteriaTypes={AUDIENCES_CRITERIA_TYPES}
+					rulesGroup={{
+						conjunction: 'AND',
+						rules: [
+							{attribute: 'age', operator: 'gt', value: '18'},
+						],
+					}}
+				/>
+			);
+
+			await userEvent.click(getAttributeElement('City'));
+			await userEvent.keyboard('{Enter}');
+
+			expect(
+				screen.getByText(
+					'use-arrows-to-move-it-and-press-enter-to-select-the-new-position-press-esc-to-cancel'
+				)
+			).toBeInTheDocument();
+
+			await userEvent.keyboard('{ArrowUp}');
+
+			expect(
+				container.querySelector('.audience-builder-rule')
+			).toHaveClass('audience-builder-rule--drop-top');
+
+			await userEvent.keyboard('{Enter}');
+
+			expect(getSerializedRuleAttributes(container)).toEqual([
+				'city',
+				'age',
+			]);
+		});
+
+		it('adds a condition at the end when confirming the initial target', async () => {
+			const {container} = render(
+				<AudienceBuilder
+					audiencesCriteriaTypes={AUDIENCES_CRITERIA_TYPES}
+					rulesGroup={{
+						conjunction: 'AND',
+						rules: [
+							{attribute: 'age', operator: 'gt', value: '18'},
+						],
+					}}
+				/>
+			);
+
+			await userEvent.click(getAttributeElement('City'));
+			await userEvent.keyboard('{Enter}{Enter}');
+
+			expect(getSerializedRuleAttributes(container)).toEqual([
+				'age',
+				'city',
+			]);
+		});
+
+		it('adds the condition immediately when there are no conditions', async () => {
+			const {container} = render(
+				<AudienceBuilder
+					audiencesCriteriaTypes={AUDIENCES_CRITERIA_TYPES}
+				/>
+			);
+
+			await userEvent.click(getAttributeElement('City'));
+			await userEvent.keyboard('{Enter}');
+
+			expect(
+				screen.getByText('a-condition-was-added')
+			).toBeInTheDocument();
+
+			expect(getSerializedRuleAttributes(container)).toEqual(['city']);
+		});
+
+		it('reorders a condition', async () => {
+			const {container} = render(
+				<AudienceBuilder
+					audiencesCriteriaTypes={AUDIENCES_CRITERIA_TYPES}
+					rulesGroup={{
+						conjunction: 'AND',
+						rules: [
+							{attribute: 'age', operator: 'gt', value: '18'},
+							{
+								attribute: 'city',
+								operator: 'eq',
+								value: 'Madrid',
+							},
+						],
+					}}
+				/>
+			);
+
+			fireEvent.click(screen.getAllByTitle('move-x')[0]);
+
+			await userEvent.keyboard('{ArrowDown}{Enter}');
+
+			expect(getSerializedRuleAttributes(container)).toEqual([
+				'city',
+				'age',
+			]);
+		});
+
+		it('reorders a condition above a removed-criteria error row', async () => {
+			const {container} = render(
+				<AudienceBuilder
+					audiencesCriteriaTypes={AUDIENCES_CRITERIA_TYPES}
+					rulesGroup={{
+						conjunction: 'AND',
+						rules: [
+							{attribute: 'removed', operator: 'eq', value: ''},
+							{attribute: 'age', operator: 'gt', value: '18'},
+						],
+					}}
+				/>
+			);
+
+			fireEvent.click(screen.getByTitle('move-x'));
+
+			await userEvent.keyboard('{ArrowUp}{ArrowUp}{Enter}');
+
+			expect(getSerializedRuleAttributes(container)).toEqual([
+				'age',
+				'removed',
+			]);
+		});
+
+		it('cancels the movement with escape', async () => {
+			const {container} = render(
+				<AudienceBuilder
+					audiencesCriteriaTypes={AUDIENCES_CRITERIA_TYPES}
+					rulesGroup={{
+						conjunction: 'AND',
+						rules: [
+							{attribute: 'age', operator: 'gt', value: '18'},
+							{
+								attribute: 'city',
+								operator: 'eq',
+								value: 'Madrid',
+							},
+						],
+					}}
+				/>
+			);
+
+			fireEvent.click(screen.getAllByTitle('move-x')[0]);
+
+			await userEvent.keyboard('{ArrowDown}{Escape}');
+
+			expect(getSerializedRuleAttributes(container)).toEqual([
+				'age',
+				'city',
+			]);
+		});
+	});
+
+	describe('keyboard navigation', () => {
+		it('moves the focus through the conditions with the arrow keys', async () => {
+			render(
+				<AudienceBuilder
+					audiencesCriteriaTypes={AUDIENCES_CRITERIA_TYPES}
+					rulesGroup={{
+						conjunction: 'AND',
+						rules: [
+							{attribute: 'age', operator: 'gt', value: '18'},
+							{
+								attribute: 'city',
+								operator: 'eq',
+								value: 'Madrid',
+							},
+						],
+					}}
+				/>
+			);
+
+			const conditionsMenu = screen.getByRole('menu', {
+				name: 'conditions',
+			});
+
+			const rows = within(conditionsMenu).getAllByRole('menuitem');
+
+			expect(rows[0]).toHaveAttribute('tabindex', '0');
+			expect(rows[1]).toHaveAttribute('tabindex', '-1');
+
+			const moveButtons = within(conditionsMenu).getAllByTitle('move-x');
+
+			expect(moveButtons[0]).toHaveAttribute('tabindex', '0');
+			expect(moveButtons[1]).toHaveAttribute('tabindex', '-1');
+
+			await userEvent.click(rows[0]);
+			await userEvent.keyboard('{ArrowDown}');
+
+			expect(rows[1]).toHaveFocus();
+			expect(moveButtons[1]).toHaveAttribute('tabindex', '0');
+
+			await userEvent.keyboard('{ArrowUp}');
+
+			expect(rows[0]).toHaveFocus();
+		});
+
+		it('moves the focus through the row controls with the horizontal arrow keys', async () => {
+			render(
+				<AudienceBuilder
+					audiencesCriteriaTypes={AUDIENCES_CRITERIA_TYPES}
+					rulesGroup={{
+						conjunction: 'AND',
+						rules: [
+							{attribute: 'age', operator: 'gt', value: '18'},
+						],
+					}}
+				/>
+			);
+
+			const conditionsMenu = screen.getByRole('menu', {
+				name: 'conditions',
+			});
+
+			const [row] = within(conditionsMenu).getAllByRole('menuitem');
+
+			const moveButton = within(conditionsMenu).getByTitle('move-x');
+
+			await userEvent.click(row);
+			await userEvent.keyboard('{ArrowRight}');
+
+			expect(moveButton).toHaveFocus();
+
+			await userEvent.keyboard('{ArrowRight}');
+
+			expect(
+				within(conditionsMenu).getByLabelText('operator')
+			).toHaveFocus();
+
+			await userEvent.keyboard('{ArrowLeft}');
+
+			expect(moveButton).toHaveFocus();
+
+			await userEvent.keyboard('{ArrowLeft}');
+
+			expect(row).toHaveFocus();
+		});
 	});
 });

--- a/modules/apps/audiences/audiences-web/test/js/components/AttributesSidebar.test.tsx
+++ b/modules/apps/audiences/audiences-web/test/js/components/AttributesSidebar.test.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import '@testing-library/jest-dom';
 import {render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -94,5 +95,32 @@ describe('AttributesSidebar', () => {
 		await waitFor(() =>
 			expect(screen.getByText('no-attributes-were-found')).toBeTruthy()
 		);
+	});
+
+	it('moves the focus through the attributes with the arrow keys', async () => {
+		render(
+			<DragAndDropProvider backend={HTML5Backend}>
+				<AttributesSidebar
+					audiencesCriteriaTypes={AUDIENCES_CRITERIA_TYPES}
+				/>
+			</DragAndDropProvider>
+		);
+
+		const age = screen.getByText('Age').closest('[role="menuitem"]');
+		const city = screen.getByText('City').closest('[role="menuitem"]');
+
+		expect(age).toHaveAttribute('tabindex', '0');
+		expect(city).toHaveAttribute('tabindex', '-1');
+
+		await userEvent.click(age as HTMLElement);
+		await userEvent.keyboard('{ArrowDown}');
+
+		expect(city).toHaveFocus();
+		expect(city).toHaveAttribute('tabindex', '0');
+		expect(age).toHaveAttribute('tabindex', '-1');
+
+		await userEvent.keyboard('{ArrowUp}');
+
+		expect(age).toHaveFocus();
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94450

## What Is Being Fixed

The Audience Builder could only be operated with a mouse: attributes were added by dragging them from the sidebar onto the conditions panel, and conditions were reordered by dragging their grip. Keyboard and screen reader users had no way to add or reorder conditions, and the sidebar attributes were not focusable at all.

## How It Is Being Fixed

The builder adopts the keyboard movement pattern used by layout-content-page-editor-web and layout-admin-web, implemented locally in audiences-web. A KeyboardMovementContext holds the movement source and target and announces every step through an assertive live region. A KeyboardMovementManager, mounted only while something is picked up, owns the session through a single capture-phase keydown listener: the arrow keys walk the drop positions, Home and End jump to the extremes, Enter drops by dispatching the same reducer actions the mouse paths already use, and Escape cancels. A DragPreviewWrapper aligns the shared DragPreview chip to the keyboard target, and the rule rows show the same drop indicator classes for the keyboard target as for the pointer, now also on the removed-criteria error row. A rule is picked up from its grip, which becomes a move button, and an attribute with Enter or Space on the focused item.

Navigation is covered by a new useKeyboardNavigation hook that turns the attributes sidebar and the conditions list into vertical menus with a single roving tab stop each: the vertical arrows move the focus between items and the horizontal arrows walk in and out of the focusable controls inside a row, while inputs and pickers keep the arrow keys they use themselves.

## PR Check

**pr-check: PASS** — tested on `f6dd5ed624021eac7f8bd58ee6b27aa371d4e4ea`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f6dd5ed624021eac7f8bd58ee6b27aa371d4e4ea"} -->
