### PR TITLE
LPD-88489 Reference fragment sets by external reference code

### DIFF
--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-api/src/main/java/com/liferay/headless/admin/fragment/dto/v1_0/BasicFragment.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-api/src/main/java/com/liferay/headless/admin/fragment/dto/v1_0/BasicFragment.java
@@ -164,6 +164,23 @@ public class BasicFragment extends Fragment implements Serializable {
 			sb.append(String.valueOf(fragmentSet));
 		}
 
+		String fragmentSetExternalReferenceCode =
+			getFragmentSetExternalReferenceCode();
+
+		if (fragmentSetExternalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fragmentSetExternalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(fragmentSetExternalReferenceCode));
+
+			sb.append("\"");
+		}
+
 		FragmentVersion[] fragmentVersions = getFragmentVersions();
 
 		if (fragmentVersions != null) {
@@ -386,4 +403,4 @@ public class BasicFragment extends Fragment implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1975705148
+// LIFERAY-REST-BUILDER-HASH:177224149

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-api/src/main/java/com/liferay/headless/admin/fragment/dto/v1_0/FormFragment.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-api/src/main/java/com/liferay/headless/admin/fragment/dto/v1_0/FormFragment.java
@@ -240,6 +240,23 @@ public class FormFragment extends Fragment implements Serializable {
 			sb.append(String.valueOf(fragmentSet));
 		}
 
+		String fragmentSetExternalReferenceCode =
+			getFragmentSetExternalReferenceCode();
+
+		if (fragmentSetExternalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fragmentSetExternalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(fragmentSetExternalReferenceCode));
+
+			sb.append("\"");
+		}
+
 		FragmentVersion[] fragmentVersions = getFragmentVersions();
 
 		if (fragmentVersions != null) {
@@ -462,4 +479,4 @@ public class FormFragment extends Fragment implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-180614183
+// LIFERAY-REST-BUILDER-HASH:624800786

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-api/src/main/java/com/liferay/headless/admin/fragment/dto/v1_0/Fragment.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-api/src/main/java/com/liferay/headless/admin/fragment/dto/v1_0/Fragment.java
@@ -289,7 +289,7 @@ public abstract class Fragment implements Serializable {
 	private Supplier<String> _externalReferenceCodeSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "The fragment's fragment set, referenced by its `externalReferenceCode`. During LAR import, it is created if it does not exist."
+		description = "The fragment's fragment set. On read, returned only when `nestedFields=fragmentSet` is requested. On write, used only during LAR import, where it is created if it does not exist."
 	)
 	@Valid
 	public FragmentSet getFragmentSet() {
@@ -326,13 +326,63 @@ public abstract class Fragment implements Serializable {
 	}
 
 	@GraphQLField(
-		description = "The fragment's fragment set, referenced by its `externalReferenceCode`. During LAR import, it is created if it does not exist."
+		description = "The fragment's fragment set. On read, returned only when `nestedFields=fragmentSet` is requested. On write, used only during LAR import, where it is created if it does not exist."
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected FragmentSet fragmentSet;
 
 	@JsonIgnore
 	private Supplier<FragmentSet> _fragmentSetSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The external reference code of the fragment's fragment set, used to reference an existing fragment set. Takes precedence over `fragmentSet` when both are set."
+	)
+	public String getFragmentSetExternalReferenceCode() {
+		if (_fragmentSetExternalReferenceCodeSupplier != null) {
+			fragmentSetExternalReferenceCode =
+				_fragmentSetExternalReferenceCodeSupplier.get();
+
+			_fragmentSetExternalReferenceCodeSupplier = null;
+		}
+
+		return fragmentSetExternalReferenceCode;
+	}
+
+	public void setFragmentSetExternalReferenceCode(
+		String fragmentSetExternalReferenceCode) {
+
+		this.fragmentSetExternalReferenceCode =
+			fragmentSetExternalReferenceCode;
+
+		_fragmentSetExternalReferenceCodeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setFragmentSetExternalReferenceCode(
+		UnsafeSupplier<String, Exception>
+			fragmentSetExternalReferenceCodeUnsafeSupplier) {
+
+		_fragmentSetExternalReferenceCodeSupplier = () -> {
+			try {
+				return fragmentSetExternalReferenceCodeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The external reference code of the fragment's fragment set, used to reference an existing fragment set. Takes precedence over `fragmentSet` when both are set."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String fragmentSetExternalReferenceCode;
+
+	@JsonIgnore
+	private Supplier<String> _fragmentSetExternalReferenceCodeSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The fragment's versions. A fragment can have up to 2 versions, one draft and one published (approved)."
@@ -811,6 +861,23 @@ public abstract class Fragment implements Serializable {
 			sb.append(String.valueOf(fragmentSet));
 		}
 
+		String fragmentSetExternalReferenceCode =
+			getFragmentSetExternalReferenceCode();
+
+		if (fragmentSetExternalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fragmentSetExternalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(fragmentSetExternalReferenceCode));
+
+			sb.append("\"");
+		}
+
 		FragmentVersion[] fragmentVersions = getFragmentVersions();
 
 		if (fragmentVersions != null) {
@@ -1071,4 +1138,4 @@ public abstract class Fragment implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1796289445
+// LIFERAY-REST-BUILDER-HASH:337064019

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-api/src/main/java/com/liferay/headless/admin/fragment/dto/v1_0/ResourceFolder.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-api/src/main/java/com/liferay/headless/admin/fragment/dto/v1_0/ResourceFolder.java
@@ -235,7 +235,7 @@ public class ResourceFolder implements Serializable {
 	private Supplier<String> _externalReferenceCodeSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "The resource folder's fragment set, referenced by its `externalReferenceCode`. During LAR import, it is created if it does not exist."
+		description = "The resource folder's fragment set. On read, returned only when `nestedFields=fragmentSet` is requested. On write, used only during LAR import, where it is created if it does not exist."
 	)
 	@Valid
 	public FragmentSet getFragmentSet() {
@@ -272,13 +272,63 @@ public class ResourceFolder implements Serializable {
 	}
 
 	@GraphQLField(
-		description = "The resource folder's fragment set, referenced by its `externalReferenceCode`. During LAR import, it is created if it does not exist."
+		description = "The resource folder's fragment set. On read, returned only when `nestedFields=fragmentSet` is requested. On write, used only during LAR import, where it is created if it does not exist."
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected FragmentSet fragmentSet;
 
 	@JsonIgnore
 	private Supplier<FragmentSet> _fragmentSetSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		description = "The external reference code of the resource folder's fragment set, used to reference an existing fragment set. Takes precedence over `fragmentSet` when both are set."
+	)
+	public String getFragmentSetExternalReferenceCode() {
+		if (_fragmentSetExternalReferenceCodeSupplier != null) {
+			fragmentSetExternalReferenceCode =
+				_fragmentSetExternalReferenceCodeSupplier.get();
+
+			_fragmentSetExternalReferenceCodeSupplier = null;
+		}
+
+		return fragmentSetExternalReferenceCode;
+	}
+
+	public void setFragmentSetExternalReferenceCode(
+		String fragmentSetExternalReferenceCode) {
+
+		this.fragmentSetExternalReferenceCode =
+			fragmentSetExternalReferenceCode;
+
+		_fragmentSetExternalReferenceCodeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setFragmentSetExternalReferenceCode(
+		UnsafeSupplier<String, Exception>
+			fragmentSetExternalReferenceCodeUnsafeSupplier) {
+
+		_fragmentSetExternalReferenceCodeSupplier = () -> {
+			try {
+				return fragmentSetExternalReferenceCodeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField(
+		description = "The external reference code of the resource folder's fragment set, used to reference an existing fragment set. Takes precedence over `fragmentSet` when both are set."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String fragmentSetExternalReferenceCode;
+
+	@JsonIgnore
+	private Supplier<String> _fragmentSetExternalReferenceCodeSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The resource folder's name."
@@ -322,7 +372,7 @@ public class ResourceFolder implements Serializable {
 	private Supplier<String> _nameSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "The resource folder's parent resource folder. On write, used only during LAR import, where it is created if it does not exist."
+		description = "The resource folder's parent resource folder. On read, returned only when `nestedFields=parentResourceFolder` is requested. On write, used only during LAR import, where it is created if it does not exist."
 	)
 	@Valid
 	public ResourceFolder getParentResourceFolder() {
@@ -360,7 +410,7 @@ public class ResourceFolder implements Serializable {
 	}
 
 	@GraphQLField(
-		description = "The resource folder's parent resource folder. On write, used only during LAR import, where it is created if it does not exist."
+		description = "The resource folder's parent resource folder. On read, returned only when `nestedFields=parentResourceFolder` is requested. On write, used only during LAR import, where it is created if it does not exist."
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected ResourceFolder parentResourceFolder;
@@ -521,6 +571,23 @@ public class ResourceFolder implements Serializable {
 			sb.append(String.valueOf(fragmentSet));
 		}
 
+		String fragmentSetExternalReferenceCode =
+			getFragmentSetExternalReferenceCode();
+
+		if (fragmentSetExternalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fragmentSetExternalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(fragmentSetExternalReferenceCode));
+
+			sb.append("\"");
+		}
+
 		String name = getName();
 
 		if (name != null) {
@@ -667,4 +734,4 @@ public class ResourceFolder implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-635616269
+// LIFERAY-REST-BUILDER-HASH:852636757

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-client/src/main/java/com/liferay/headless/admin/fragment/client/dto/v1_0/Fragment.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-client/src/main/java/com/liferay/headless/admin/fragment/client/dto/v1_0/Fragment.java
@@ -152,6 +152,32 @@ public abstract class Fragment implements Cloneable, Serializable {
 
 	protected FragmentSet fragmentSet;
 
+	public String getFragmentSetExternalReferenceCode() {
+		return fragmentSetExternalReferenceCode;
+	}
+
+	public void setFragmentSetExternalReferenceCode(
+		String fragmentSetExternalReferenceCode) {
+
+		this.fragmentSetExternalReferenceCode =
+			fragmentSetExternalReferenceCode;
+	}
+
+	public void setFragmentSetExternalReferenceCode(
+		UnsafeSupplier<String, Exception>
+			fragmentSetExternalReferenceCodeUnsafeSupplier) {
+
+		try {
+			fragmentSetExternalReferenceCode =
+				fragmentSetExternalReferenceCodeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String fragmentSetExternalReferenceCode;
+
 	public FragmentVersion[] getFragmentVersions() {
 		return fragmentVersions;
 	}
@@ -389,4 +415,4 @@ public abstract class Fragment implements Cloneable, Serializable {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1777192526
+// LIFERAY-REST-BUILDER-HASH:-415793736

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-client/src/main/java/com/liferay/headless/admin/fragment/client/dto/v1_0/ResourceFolder.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-client/src/main/java/com/liferay/headless/admin/fragment/client/dto/v1_0/ResourceFolder.java
@@ -131,6 +131,32 @@ public class ResourceFolder implements Cloneable, Serializable {
 
 	protected FragmentSet fragmentSet;
 
+	public String getFragmentSetExternalReferenceCode() {
+		return fragmentSetExternalReferenceCode;
+	}
+
+	public void setFragmentSetExternalReferenceCode(
+		String fragmentSetExternalReferenceCode) {
+
+		this.fragmentSetExternalReferenceCode =
+			fragmentSetExternalReferenceCode;
+	}
+
+	public void setFragmentSetExternalReferenceCode(
+		UnsafeSupplier<String, Exception>
+			fragmentSetExternalReferenceCodeUnsafeSupplier) {
+
+		try {
+			fragmentSetExternalReferenceCode =
+				fragmentSetExternalReferenceCodeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String fragmentSetExternalReferenceCode;
+
 	public String getName() {
 		return name;
 	}
@@ -230,4 +256,4 @@ public class ResourceFolder implements Cloneable, Serializable {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:214674976
+// LIFERAY-REST-BUILDER-HASH:-241184010

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-client/src/main/java/com/liferay/headless/admin/fragment/client/serdes/v1_0/BasicFragmentSerDes.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-client/src/main/java/com/liferay/headless/admin/fragment/client/serdes/v1_0/BasicFragmentSerDes.java
@@ -128,6 +128,21 @@ public class BasicFragmentSerDes {
 			sb.append(String.valueOf(basicFragment.getFragmentSet()));
 		}
 
+		if (basicFragment.getFragmentSetExternalReferenceCode() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fragmentSetExternalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				_escape(basicFragment.getFragmentSetExternalReferenceCode()));
+
+			sb.append("\"");
+		}
+
 		if (basicFragment.getFragmentVersions() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -307,6 +322,16 @@ public class BasicFragmentSerDes {
 				"fragmentSet", String.valueOf(basicFragment.getFragmentSet()));
 		}
 
+		if (basicFragment.getFragmentSetExternalReferenceCode() == null) {
+			map.put("fragmentSetExternalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"fragmentSetExternalReferenceCode",
+				String.valueOf(
+					basicFragment.getFragmentSetExternalReferenceCode()));
+		}
+
 		if (basicFragment.getFragmentVersions() == null) {
 			map.put("fragmentVersions", null);
 		}
@@ -406,6 +431,12 @@ public class BasicFragmentSerDes {
 			else if (Objects.equals(jsonParserFieldName, "fragmentSet")) {
 				return false;
 			}
+			else if (Objects.equals(
+						jsonParserFieldName,
+						"fragmentSetExternalReferenceCode")) {
+
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "fragmentVersions")) {
 				return false;
 			}
@@ -476,6 +507,15 @@ public class BasicFragmentSerDes {
 				if (jsonParserFieldValue != null) {
 					basicFragment.setFragmentSet(
 						FragmentSetSerDes.toDTO((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName,
+						"fragmentSetExternalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					basicFragment.setFragmentSetExternalReferenceCode(
+						(String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "fragmentVersions")) {
@@ -616,4 +656,4 @@ public class BasicFragmentSerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:951801515
+// LIFERAY-REST-BUILDER-HASH:-1756272449

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-client/src/main/java/com/liferay/headless/admin/fragment/client/serdes/v1_0/FormFragmentSerDes.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-client/src/main/java/com/liferay/headless/admin/fragment/client/serdes/v1_0/FormFragmentSerDes.java
@@ -152,6 +152,21 @@ public class FormFragmentSerDes {
 			sb.append(String.valueOf(formFragment.getFragmentSet()));
 		}
 
+		if (formFragment.getFragmentSetExternalReferenceCode() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fragmentSetExternalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				_escape(formFragment.getFragmentSetExternalReferenceCode()));
+
+			sb.append("\"");
+		}
+
 		if (formFragment.getFragmentVersions() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -337,6 +352,16 @@ public class FormFragmentSerDes {
 				"fragmentSet", String.valueOf(formFragment.getFragmentSet()));
 		}
 
+		if (formFragment.getFragmentSetExternalReferenceCode() == null) {
+			map.put("fragmentSetExternalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"fragmentSetExternalReferenceCode",
+				String.valueOf(
+					formFragment.getFragmentSetExternalReferenceCode()));
+		}
+
 		if (formFragment.getFragmentVersions() == null) {
 			map.put("fragmentVersions", null);
 		}
@@ -439,6 +464,12 @@ public class FormFragmentSerDes {
 			else if (Objects.equals(jsonParserFieldName, "fragmentSet")) {
 				return false;
 			}
+			else if (Objects.equals(
+						jsonParserFieldName,
+						"fragmentSetExternalReferenceCode")) {
+
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "fragmentVersions")) {
 				return false;
 			}
@@ -525,6 +556,15 @@ public class FormFragmentSerDes {
 				if (jsonParserFieldValue != null) {
 					formFragment.setFragmentSet(
 						FragmentSetSerDes.toDTO((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName,
+						"fragmentSetExternalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					formFragment.setFragmentSetExternalReferenceCode(
+						(String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "fragmentVersions")) {
@@ -664,4 +704,4 @@ public class FormFragmentSerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1730319614
+// LIFERAY-REST-BUILDER-HASH:-1216150376

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-client/src/main/java/com/liferay/headless/admin/fragment/client/serdes/v1_0/FragmentSerDes.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-client/src/main/java/com/liferay/headless/admin/fragment/client/serdes/v1_0/FragmentSerDes.java
@@ -130,6 +130,15 @@ public class FragmentSerDes {
 			map.put("fragmentSet", String.valueOf(fragment.getFragmentSet()));
 		}
 
+		if (fragment.getFragmentSetExternalReferenceCode() == null) {
+			map.put("fragmentSetExternalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"fragmentSetExternalReferenceCode",
+				String.valueOf(fragment.getFragmentSetExternalReferenceCode()));
+		}
+
 		if (fragment.getFragmentVersions() == null) {
 			map.put("fragmentVersions", null);
 		}
@@ -227,6 +236,12 @@ public class FragmentSerDes {
 			else if (Objects.equals(jsonParserFieldName, "fragmentSet")) {
 				return false;
 			}
+			else if (Objects.equals(
+						jsonParserFieldName,
+						"fragmentSetExternalReferenceCode")) {
+
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "fragmentVersions")) {
 				return false;
 			}
@@ -322,6 +337,15 @@ public class FragmentSerDes {
 				if (jsonParserFieldValue != null) {
 					fragment.setFragmentSet(
 						FragmentSetSerDes.toDTO((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName,
+						"fragmentSetExternalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					fragment.setFragmentSetExternalReferenceCode(
+						(String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "fragmentVersions")) {
@@ -461,4 +485,4 @@ public class FragmentSerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-282516193
+// LIFERAY-REST-BUILDER-HASH:-1654088476

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-client/src/main/java/com/liferay/headless/admin/fragment/client/serdes/v1_0/ResourceFolderSerDes.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-client/src/main/java/com/liferay/headless/admin/fragment/client/serdes/v1_0/ResourceFolderSerDes.java
@@ -118,6 +118,21 @@ public class ResourceFolderSerDes {
 			sb.append(String.valueOf(resourceFolder.getFragmentSet()));
 		}
 
+		if (resourceFolder.getFragmentSetExternalReferenceCode() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fragmentSetExternalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				_escape(resourceFolder.getFragmentSetExternalReferenceCode()));
+
+			sb.append("\"");
+		}
+
 		if (resourceFolder.getName() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -227,6 +242,16 @@ public class ResourceFolderSerDes {
 				"fragmentSet", String.valueOf(resourceFolder.getFragmentSet()));
 		}
 
+		if (resourceFolder.getFragmentSetExternalReferenceCode() == null) {
+			map.put("fragmentSetExternalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"fragmentSetExternalReferenceCode",
+				String.valueOf(
+					resourceFolder.getFragmentSetExternalReferenceCode()));
+		}
+
 		if (resourceFolder.getName() == null) {
 			map.put("name", null);
 		}
@@ -291,6 +316,12 @@ public class ResourceFolderSerDes {
 			else if (Objects.equals(jsonParserFieldName, "fragmentSet")) {
 				return false;
 			}
+			else if (Objects.equals(
+						jsonParserFieldName,
+						"fragmentSetExternalReferenceCode")) {
+
+				return false;
+			}
 			else if (Objects.equals(jsonParserFieldName, "name")) {
 				return false;
 			}
@@ -344,6 +375,15 @@ public class ResourceFolderSerDes {
 				if (jsonParserFieldValue != null) {
 					resourceFolder.setFragmentSet(
 						FragmentSetSerDes.toDTO((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName,
+						"fragmentSetExternalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					resourceFolder.setFragmentSetExternalReferenceCode(
+						(String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "name")) {
@@ -450,4 +490,4 @@ public class ResourceFolderSerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:796276868
+// LIFERAY-REST-BUILDER-HASH:1833199742

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/rest-openapi.yaml
@@ -59,7 +59,11 @@ components:
                 fragmentSet:
                     $ref: "#/components/schemas/FragmentSet"
                     description:
-                        The fragment's fragment set, referenced by its `externalReferenceCode`. During LAR import, it is created if it does not exist.
+                        The fragment's fragment set. On read, returned only when `nestedFields=fragmentSet` is requested. On write, used only during LAR import, where it is created if it does not exist.
+                fragmentSetExternalReferenceCode:
+                    description:
+                        The external reference code of the fragment's fragment set, used to reference an existing fragment set. Takes precedence over `fragmentSet` when both are set.
+                    type: string
                 fragmentVersions:
                     description:
                         The fragment's versions. A fragment can have up to 2 versions, one draft and one published (approved).

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/rest-openapi.yaml
@@ -188,7 +188,11 @@ components:
                 fragmentSet:
                     $ref: "#/components/schemas/FragmentSet"
                     description:
-                        The resource folder's fragment set, referenced by its `externalReferenceCode`. During LAR import, it is created if it does not exist.
+                        The resource folder's fragment set. On read, returned only when `nestedFields=fragmentSet` is requested. On write, used only during LAR import, where it is created if it does not exist.
+                fragmentSetExternalReferenceCode:
+                    description:
+                        The external reference code of the resource folder's fragment set, used to reference an existing fragment set. Takes precedence over `fragmentSet` when both are set.
+                    type: string
                 name:
                     description:
                         The resource folder's name.
@@ -196,7 +200,7 @@ components:
                 parentResourceFolder:
                     $ref: "#/components/schemas/ResourceFolder"
                     description:
-                        The resource folder's parent resource folder. On write, used only during LAR import, where it is created if it does not exist.
+                        The resource folder's parent resource folder. On read, returned only when `nestedFields=parentResourceFolder` is requested. On write, used only during LAR import, where it is created if it does not exist.
                 parentResourceFolderExternalReferenceCode:
                     description:
                         The external reference code of the resource folder's parent resource folder, used to reference an existing parent. Takes precedence over `parentResourceFolder` when both are set.
@@ -838,7 +842,7 @@ paths:
             tags: ["ResourceFolder"]
         put:
             description:
-                Updates the resource folder with the given external reference code, or creates it if it does not exist. On update, `dateModified` and `name` are honored; any values sent for `dateCreated`, `externalReferenceCode`, `fragmentSet`, `parentResourceFolder`, and `parentResourceFolderExternalReferenceCode` are ignored.
+                Updates the resource folder with the given external reference code, or creates it if it does not exist. On update, `dateModified` and `name` are honored; any values sent for `dateCreated`, `externalReferenceCode`, `fragmentSet`, `fragmentSetExternalReferenceCode`, `parentResourceFolder`, and `parentResourceFolderExternalReferenceCode` are ignored.
             operationId: putSiteResourceFolder
             parameters:
                 -   in: path

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/dto/v1_0/converter/FragmentDTOConverter.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/dto/v1_0/converter/FragmentDTOConverter.java
@@ -18,6 +18,7 @@ import com.liferay.headless.admin.fragment.dto.v1_0.FragmentVersion;
 import com.liferay.headless.admin.fragment.internal.dto.v1_0.util.CreatorUtil;
 import com.liferay.headless.admin.fragment.internal.util.FieldTypeUtil;
 import com.liferay.headless.admin.site.dto.v1_0.util.ThumbnailURLReferenceUtil;
+import com.liferay.petra.function.UnsafeSupplierValue;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -82,6 +83,11 @@ public class FragmentDTOConverter
 	private BasicFragment _toBasicFragment(
 		FragmentEntry fragmentEntry, List<FragmentVersion> fragmentVersions) {
 
+		UnsafeSupplierValue<FragmentCollection, Exception> unsafeSupplierValue =
+			new UnsafeSupplierValue<>(
+				() -> _fragmentCollectionLocalService.getFragmentCollection(
+					fragmentEntry.getFragmentCollectionId()));
+
 		BasicFragment basicFragment = new BasicFragment() {
 			{
 				setCacheable(fragmentEntry::isCacheable);
@@ -92,10 +98,17 @@ public class FragmentDTOConverter
 				setExternalReferenceCode(
 					fragmentEntry::getExternalReferenceCode);
 				setFragmentSet(
-					() -> _fragmentSetDTOConverter.toDTO(
-						null,
-						_fragmentCollectionLocalService.getFragmentCollection(
-							fragmentEntry.getFragmentCollectionId())));
+					() -> NestedFieldsSupplier.supply(
+						"fragmentSet",
+						fieldName -> _fragmentSetDTOConverter.toDTO(
+							null, unsafeSupplierValue.getValue())));
+				setFragmentSetExternalReferenceCode(
+					() -> {
+						FragmentCollection fragmentCollection =
+							unsafeSupplierValue.getValue();
+
+						return fragmentCollection.getExternalReferenceCode();
+					});
 				setIcon(fragmentEntry::getIcon);
 				setKey(fragmentEntry::getFragmentEntryKey);
 				setMarketplace(fragmentEntry::isMarketplace);
@@ -120,6 +133,11 @@ public class FragmentDTOConverter
 
 	private FormFragment _toFormFragment(
 		FragmentEntry fragmentEntry, List<FragmentVersion> fragmentVersions) {
+
+		UnsafeSupplierValue<FragmentCollection, Exception> unsafeSupplierValue =
+			new UnsafeSupplierValue<>(
+				() -> _fragmentCollectionLocalService.getFragmentCollection(
+					fragmentEntry.getFragmentCollectionId()));
 
 		FormFragment formFragment = new FormFragment() {
 			{
@@ -154,10 +172,17 @@ public class FragmentDTOConverter
 							FieldType.class);
 					});
 				setFragmentSet(
-					() -> _fragmentSetDTOConverter.toDTO(
-						null,
-						_fragmentCollectionLocalService.getFragmentCollection(
-							fragmentEntry.getFragmentCollectionId())));
+					() -> NestedFieldsSupplier.supply(
+						"fragmentSet",
+						fieldName -> _fragmentSetDTOConverter.toDTO(
+							null, unsafeSupplierValue.getValue())));
+				setFragmentSetExternalReferenceCode(
+					() -> {
+						FragmentCollection fragmentCollection =
+							unsafeSupplierValue.getValue();
+
+						return fragmentCollection.getExternalReferenceCode();
+					});
 				setIcon(fragmentEntry::getIcon);
 				setKey(fragmentEntry::getFragmentEntryKey);
 				setMarketplace(fragmentEntry::isMarketplace);

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/dto/v1_0/converter/ResourceFolderDTOConverter.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/dto/v1_0/converter/ResourceFolderDTOConverter.java
@@ -15,6 +15,7 @@ import com.liferay.headless.admin.fragment.internal.dto.v1_0.util.CreatorUtil;
 import com.liferay.petra.function.UnsafeSupplierValue;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
+import com.liferay.portal.vulcan.fields.NestedFieldsSupplier;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -36,8 +37,12 @@ public class ResourceFolderDTOConverter
 			DTOConverterContext dtoConverterContext, DLFolder dlFolder)
 		throws Exception {
 
-		UnsafeSupplierValue<DLFolder, Exception> unsafeSupplierValue =
-			new UnsafeSupplierValue<>(() -> _getParentDLFolder(dlFolder));
+		UnsafeSupplierValue<FragmentCollection, Exception>
+			fragmentCollectionUnsafeSupplierValue = new UnsafeSupplierValue<>(
+				() -> _getFragmentCollection(dlFolder));
+		UnsafeSupplierValue<DLFolder, Exception>
+			parentDLFolderUnsafeSupplierValue = new UnsafeSupplierValue<>(
+				() -> _getParentDLFolder(dlFolder));
 
 		return new ResourceFolder() {
 			{
@@ -45,24 +50,41 @@ public class ResourceFolderDTOConverter
 				setDateCreated(dlFolder::getCreateDate);
 				setDateModified(dlFolder::getModifiedDate);
 				setExternalReferenceCode(dlFolder::getExternalReferenceCode);
-				setFragmentSet(() -> _toFragmentSet(dlFolder));
-				setName(dlFolder::getName);
-				setParentResourceFolder(
+				setFragmentSet(
+					() -> NestedFieldsSupplier.supply(
+						"fragmentSet",
+						fieldName -> _toFragmentSet(
+							fragmentCollectionUnsafeSupplierValue.getValue())));
+				setFragmentSetExternalReferenceCode(
 					() -> {
-						DLFolder parentDLFolder =
-							unsafeSupplierValue.getValue();
+						FragmentCollection fragmentCollection =
+							fragmentCollectionUnsafeSupplierValue.getValue();
 
-						if (parentDLFolder == null) {
+						if (fragmentCollection == null) {
 							return null;
 						}
 
-						return ResourceFolderDTOConverter.this.toDTO(
-							dtoConverterContext, parentDLFolder);
+						return fragmentCollection.getExternalReferenceCode();
 					});
+				setName(dlFolder::getName);
+				setParentResourceFolder(
+					() -> NestedFieldsSupplier.supply(
+						"parentResourceFolder",
+						fieldName -> {
+							DLFolder parentDLFolder =
+								parentDLFolderUnsafeSupplierValue.getValue();
+
+							if (parentDLFolder == null) {
+								return null;
+							}
+
+							return ResourceFolderDTOConverter.this.toDTO(
+								dtoConverterContext, parentDLFolder);
+						}));
 				setParentResourceFolderExternalReferenceCode(
 					() -> {
 						DLFolder parentDLFolder =
-							unsafeSupplierValue.getValue();
+							parentDLFolderUnsafeSupplierValue.getValue();
 
 						if (parentDLFolder == null) {
 							return null;
@@ -74,7 +96,7 @@ public class ResourceFolderDTOConverter
 		};
 	}
 
-	private DLFolder _getFragmentCollectionDLFolder(DLFolder dlFolder) {
+	private FragmentCollection _getFragmentCollection(DLFolder dlFolder) {
 		DLFolder parentDLFolder = _dlFolderLocalService.fetchDLFolder(
 			dlFolder.getParentFolderId());
 
@@ -85,7 +107,8 @@ public class ResourceFolderDTOConverter
 				dlFolder.getParentFolderId());
 		}
 
-		return dlFolder;
+		return _fragmentCollectionLocalService.fetchFragmentCollection(
+			dlFolder.getGroupId(), dlFolder.getName());
 	}
 
 	private DLFolder _getParentDLFolder(DLFolder dlFolder) {
@@ -108,13 +131,8 @@ public class ResourceFolderDTOConverter
 		return parentDLFolder;
 	}
 
-	private FragmentSet _toFragmentSet(DLFolder dlFolder) throws Exception {
-		DLFolder fragmentCollectionDLFolder = _getFragmentCollectionDLFolder(
-			dlFolder);
-
-		FragmentCollection fragmentCollection =
-			_fragmentCollectionLocalService.fetchFragmentCollection(
-				dlFolder.getGroupId(), fragmentCollectionDLFolder.getName());
+	private FragmentSet _toFragmentSet(FragmentCollection fragmentCollection)
+		throws Exception {
 
 		if (fragmentCollection == null) {
 			return null;

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/dto/v1_0/converter/ResourceFolderDTOConverter.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/dto/v1_0/converter/ResourceFolderDTOConverter.java
@@ -8,10 +8,10 @@ package com.liferay.headless.admin.fragment.internal.dto.v1_0.converter;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.fragment.model.FragmentCollection;
-import com.liferay.fragment.service.FragmentCollectionLocalService;
 import com.liferay.headless.admin.fragment.dto.v1_0.FragmentSet;
 import com.liferay.headless.admin.fragment.dto.v1_0.ResourceFolder;
 import com.liferay.headless.admin.fragment.internal.dto.v1_0.util.CreatorUtil;
+import com.liferay.headless.admin.fragment.internal.resource.v1_0.util.FragmentSetUtil;
 import com.liferay.petra.function.UnsafeSupplierValue;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
@@ -39,7 +39,7 @@ public class ResourceFolderDTOConverter
 
 		UnsafeSupplierValue<FragmentCollection, Exception>
 			fragmentCollectionUnsafeSupplierValue = new UnsafeSupplierValue<>(
-				() -> _getFragmentCollection(dlFolder));
+				() -> FragmentSetUtil.getFragmentCollection(dlFolder));
 		UnsafeSupplierValue<DLFolder, Exception>
 			parentDLFolderUnsafeSupplierValue = new UnsafeSupplierValue<>(
 				() -> _getParentDLFolder(dlFolder));
@@ -96,21 +96,6 @@ public class ResourceFolderDTOConverter
 		};
 	}
 
-	private FragmentCollection _getFragmentCollection(DLFolder dlFolder) {
-		DLFolder parentDLFolder = _dlFolderLocalService.fetchDLFolder(
-			dlFolder.getParentFolderId());
-
-		while ((parentDLFolder != null) && !parentDLFolder.isMountPoint()) {
-			dlFolder = parentDLFolder;
-
-			parentDLFolder = _dlFolderLocalService.fetchDLFolder(
-				dlFolder.getParentFolderId());
-		}
-
-		return _fragmentCollectionLocalService.fetchFragmentCollection(
-			dlFolder.getGroupId(), dlFolder.getName());
-	}
-
 	private DLFolder _getParentDLFolder(DLFolder dlFolder) {
 		DLFolder parentDLFolder = _dlFolderLocalService.fetchDLFolder(
 			dlFolder.getParentFolderId());
@@ -143,9 +128,6 @@ public class ResourceFolderDTOConverter
 
 	@Reference
 	private DLFolderLocalService _dlFolderLocalService;
-
-	@Reference
-	private FragmentCollectionLocalService _fragmentCollectionLocalService;
 
 	@Reference(
 		target = "(component.name=com.liferay.headless.admin.fragment.internal.dto.v1_0.converter.FragmentSetDTOConverter)"

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/BaseFragmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/BaseFragmentResourceImpl.java
@@ -280,7 +280,7 @@ public abstract class BaseFragmentResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-fragment/v1.0/sites/{siteExternalReferenceCode}/fragments' -d $'{"cacheable": ___, "dateCreated": ___, "dateModified": ___, "externalReferenceCode": ___, "fragmentSet": ___, "fragmentVersions": ___, "icon": ___, "key": ___, "marketplace": ___, "name": ___, "readOnly": ___, "thumbnailURLReference": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-fragment/v1.0/sites/{siteExternalReferenceCode}/fragments' -d $'{"cacheable": ___, "dateCreated": ___, "dateModified": ___, "externalReferenceCode": ___, "fragmentSet": ___, "fragmentSetExternalReferenceCode": ___, "fragmentVersions": ___, "icon": ___, "key": ___, "marketplace": ___, "name": ___, "readOnly": ___, "thumbnailURLReference": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Adds a new fragment to a site."
@@ -367,7 +367,7 @@ public abstract class BaseFragmentResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-fragment/v1.0/sites/{siteExternalReferenceCode}/fragment-sets/{fragmentSetExternalReferenceCode}/fragments' -d $'{"cacheable": ___, "dateCreated": ___, "dateModified": ___, "externalReferenceCode": ___, "fragmentSet": ___, "fragmentVersions": ___, "icon": ___, "key": ___, "marketplace": ___, "name": ___, "readOnly": ___, "thumbnailURLReference": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-fragment/v1.0/sites/{siteExternalReferenceCode}/fragment-sets/{fragmentSetExternalReferenceCode}/fragments' -d $'{"cacheable": ___, "dateCreated": ___, "dateModified": ___, "externalReferenceCode": ___, "fragmentSet": ___, "fragmentSetExternalReferenceCode": ___, "fragmentVersions": ___, "icon": ___, "key": ___, "marketplace": ___, "name": ___, "readOnly": ___, "thumbnailURLReference": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Adds a new fragment to a fragment set."
@@ -488,7 +488,7 @@ public abstract class BaseFragmentResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-fragment/v1.0/sites/{siteExternalReferenceCode}/fragments/{fragmentExternalReferenceCode}' -d $'{"cacheable": ___, "dateCreated": ___, "dateModified": ___, "externalReferenceCode": ___, "fragmentSet": ___, "fragmentVersions": ___, "icon": ___, "key": ___, "marketplace": ___, "name": ___, "readOnly": ___, "thumbnailURLReference": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-fragment/v1.0/sites/{siteExternalReferenceCode}/fragments/{fragmentExternalReferenceCode}' -d $'{"cacheable": ___, "dateCreated": ___, "dateModified": ___, "externalReferenceCode": ___, "fragmentSet": ___, "fragmentSetExternalReferenceCode": ___, "fragmentVersions": ___, "icon": ___, "key": ___, "marketplace": ___, "name": ___, "readOnly": ___, "thumbnailURLReference": ___, "type": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Updates the fragment with the given external reference code, or creates it if it does not exist."
@@ -1286,4 +1286,4 @@ public abstract class BaseFragmentResourceImpl
 		LogFactoryUtil.getLog(BaseFragmentResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:1455275466
+// LIFERAY-REST-BUILDER-HASH:-1072311162

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/BaseResourceFolderResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/BaseResourceFolderResourceImpl.java
@@ -350,7 +350,7 @@ public abstract class BaseResourceFolderResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-fragment/v1.0/sites/{siteExternalReferenceCode}/fragment-sets/{fragmentSetExternalReferenceCode}/resource-folders' -d $'{"dateCreated": ___, "dateModified": ___, "externalReferenceCode": ___, "fragmentSet": ___, "name": ___, "parentResourceFolder": ___, "parentResourceFolderExternalReferenceCode": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-fragment/v1.0/sites/{siteExternalReferenceCode}/fragment-sets/{fragmentSetExternalReferenceCode}/resource-folders' -d $'{"dateCreated": ___, "dateModified": ___, "externalReferenceCode": ___, "fragmentSet": ___, "fragmentSetExternalReferenceCode": ___, "name": ___, "parentResourceFolder": ___, "parentResourceFolderExternalReferenceCode": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Adds a new resource folder to a fragment set."
@@ -397,7 +397,7 @@ public abstract class BaseResourceFolderResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-fragment/v1.0/sites/{siteExternalReferenceCode}/resource-folders' -d $'{"dateCreated": ___, "dateModified": ___, "externalReferenceCode": ___, "fragmentSet": ___, "name": ___, "parentResourceFolder": ___, "parentResourceFolderExternalReferenceCode": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-fragment/v1.0/sites/{siteExternalReferenceCode}/resource-folders' -d $'{"dateCreated": ___, "dateModified": ___, "externalReferenceCode": ___, "fragmentSet": ___, "fragmentSetExternalReferenceCode": ___, "name": ___, "parentResourceFolder": ___, "parentResourceFolderExternalReferenceCode": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Adds a new resource folder to the site."
@@ -569,10 +569,10 @@ public abstract class BaseResourceFolderResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-fragment/v1.0/sites/{siteExternalReferenceCode}/resource-folders/{resourceFolderExternalReferenceCode}' -d $'{"dateCreated": ___, "dateModified": ___, "externalReferenceCode": ___, "fragmentSet": ___, "name": ___, "parentResourceFolder": ___, "parentResourceFolderExternalReferenceCode": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-fragment/v1.0/sites/{siteExternalReferenceCode}/resource-folders/{resourceFolderExternalReferenceCode}' -d $'{"dateCreated": ___, "dateModified": ___, "externalReferenceCode": ___, "fragmentSet": ___, "fragmentSetExternalReferenceCode": ___, "name": ___, "parentResourceFolder": ___, "parentResourceFolderExternalReferenceCode": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
-		description = "Updates the resource folder with the given external reference code, or creates it if it does not exist. On update, `dateModified` and `name` are honored; any values sent for `dateCreated`, `externalReferenceCode`, `fragmentSet`, `parentResourceFolder`, and `parentResourceFolderExternalReferenceCode` are ignored."
+		description = "Updates the resource folder with the given external reference code, or creates it if it does not exist. On update, `dateModified` and `name` are honored; any values sent for `dateCreated`, `externalReferenceCode`, `fragmentSet`, `fragmentSetExternalReferenceCode`, `parentResourceFolder`, and `parentResourceFolderExternalReferenceCode` are ignored."
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -1373,4 +1373,4 @@ public abstract class BaseResourceFolderResourceImpl
 		LogFactoryUtil.getLog(BaseResourceFolderResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:627102681
+// LIFERAY-REST-BUILDER-HASH:-1746528856

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentResourceImpl.java
@@ -11,7 +11,6 @@ import com.liferay.fragment.exception.RequiredFragmentEntryVersionException;
 import com.liferay.fragment.exception.UnsupportedUnpublishFragmentEntryOperationException;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
-import com.liferay.fragment.service.FragmentCollectionLocalService;
 import com.liferay.fragment.service.FragmentCollectionService;
 import com.liferay.fragment.service.FragmentEntryLocalService;
 import com.liferay.fragment.service.FragmentEntryService;
@@ -30,7 +29,6 @@ import com.liferay.headless.common.spi.util.GroupUtil;
 import com.liferay.portal.kernel.exception.NoSuchModelException;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Field;
@@ -169,8 +167,7 @@ public class FragmentResourceImpl extends BaseFragmentResourceImpl {
 
 		return _addFragmentEntry(
 			fragment.getExternalReferenceCode(), fragment,
-			_getOrAddFragmentCollection(fragment.getFragmentSet(), groupId),
-			groupId);
+			_getOrAddFragmentCollection(fragment, groupId), groupId);
 	}
 
 	@Override
@@ -227,8 +224,7 @@ public class FragmentResourceImpl extends BaseFragmentResourceImpl {
 
 			return _addFragmentEntry(
 				fragmentExternalReferenceCode, fragment,
-				_getOrAddFragmentCollection(fragment.getFragmentSet(), groupId),
-				groupId);
+				_getOrAddFragmentCollection(fragment, groupId), groupId);
 		}
 	}
 
@@ -351,42 +347,17 @@ public class FragmentResourceImpl extends BaseFragmentResourceImpl {
 	}
 
 	private FragmentCollection _getOrAddFragmentCollection(
-			FragmentSet fragmentSet, long groupId)
+			Fragment fragment, long groupId)
 		throws Exception {
 
-		if ((fragmentSet == null) ||
-			Validator.isNull(fragmentSet.getExternalReferenceCode())) {
-
-			throw new IllegalArgumentException(
-				_language.get(
-					contextAcceptLanguage.getPreferredLocale(),
-					"a-fragment-set-external-reference-code-is-required-to-" +
-						"create-a-new-fragment"));
-		}
-
-		FragmentCollection fragmentCollection =
-			_fragmentCollectionLocalService.
-				fetchFragmentCollectionByExternalReferenceCode(
-					fragmentSet.getExternalReferenceCode(), groupId);
-
-		if (fragmentCollection != null) {
-			return fragmentCollection;
-		}
-
-		if (!LazyReferencingThreadLocal.isEnabled()) {
-			throw new IllegalArgumentException(
-				_language.format(
-					contextAcceptLanguage.getPreferredLocale(),
-					"no-fragment-set-was-found-with-external-reference-code-x",
-					fragmentSet.getExternalReferenceCode()));
-		}
-
-		return FragmentSetUtil.addFragmentCollection(
-			fragmentSet,
-			ServiceContextUtil.getServiceContext(
-				contextCompany.getCompanyId(), fragmentSet.getDateCreated(),
-				groupId, contextHttpServletRequest,
-				fragmentSet.getDateModified(), contextUser.getUserId()));
+		return FragmentSetUtil.getOrAddFragmentCollection(
+			contextCompany.getCompanyId(), fragment.getFragmentSet(),
+			fragment.getFragmentSetExternalReferenceCode(), groupId,
+			contextHttpServletRequest,
+			"a-fragment-set-external-reference-code-is-required-to-create-a-" +
+				"new-fragment",
+			contextAcceptLanguage.getPreferredLocale(),
+			contextUser.getUserId());
 	}
 
 	private long _getPreviewFileEntryId(Fragment fragment, long groupId)
@@ -486,11 +457,13 @@ public class FragmentResourceImpl extends BaseFragmentResourceImpl {
 
 		FragmentSet fragmentSet = fragment.getFragmentSet();
 
-		if ((fragmentSet != null) &&
-			Validator.isNotNull(fragmentSet.getExternalReferenceCode())) {
+		if (((fragmentSet != null) &&
+			 Validator.isNotNull(fragmentSet.getExternalReferenceCode())) ||
+			Validator.isNotNull(
+				fragment.getFragmentSetExternalReferenceCode())) {
 
 			FragmentCollection fragmentCollection = _getOrAddFragmentCollection(
-				fragmentSet, groupId);
+				fragment, groupId);
 
 			fragmentCollectionId = fragmentCollection.getFragmentCollectionId();
 		}
@@ -549,9 +522,6 @@ public class FragmentResourceImpl extends BaseFragmentResourceImpl {
 
 	@Reference
 	private DTOConverterRegistry _dtoConverterRegistry;
-
-	@Reference
-	private FragmentCollectionLocalService _fragmentCollectionLocalService;
 
 	@Reference
 	private FragmentCollectionService _fragmentCollectionService;

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/ResourceFolderResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/ResourceFolderResourceImpl.java
@@ -12,7 +12,6 @@ import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.service.FragmentCollectionLocalService;
 import com.liferay.fragment.service.FragmentCollectionService;
-import com.liferay.headless.admin.fragment.dto.v1_0.FragmentSet;
 import com.liferay.headless.admin.fragment.dto.v1_0.ResourceFolder;
 import com.liferay.headless.admin.fragment.internal.odata.entity.v1_0.ResourceFolderEntityModel;
 import com.liferay.headless.admin.fragment.internal.resource.v1_0.util.FragmentSetUtil;
@@ -218,9 +217,8 @@ public class ResourceFolderResourceImpl extends BaseResourceFolderResourceImpl {
 
 		return _toResourceFolder(
 			_addDLFolder(
-				_getOrAddFragmentCollection(
-					resourceFolder.getFragmentSet(), groupId),
-				groupId, resourceFolder));
+				_getOrAddFragmentCollection(groupId, resourceFolder), groupId,
+				resourceFolder));
 	}
 
 	@Override
@@ -245,8 +243,7 @@ public class ResourceFolderResourceImpl extends BaseResourceFolderResourceImpl {
 
 			return _toResourceFolder(
 				_addDLFolder(
-					_getOrAddFragmentCollection(
-						resourceFolder.getFragmentSet(), groupId),
+					_getOrAddFragmentCollection(groupId, resourceFolder),
 					groupId, resourceFolder));
 		}
 
@@ -308,42 +305,17 @@ public class ResourceFolderResourceImpl extends BaseResourceFolderResourceImpl {
 	}
 
 	private FragmentCollection _getOrAddFragmentCollection(
-			FragmentSet fragmentSet, long groupId)
+			long groupId, ResourceFolder resourceFolder)
 		throws Exception {
 
-		if ((fragmentSet == null) ||
-			Validator.isNull(fragmentSet.getExternalReferenceCode())) {
-
-			throw new IllegalArgumentException(
-				_language.get(
-					contextAcceptLanguage.getPreferredLocale(),
-					"a-fragment-set-external-reference-code-is-required-to-" +
-						"create-a-new-resource-folder"));
-		}
-
-		FragmentCollection fragmentCollection =
-			_fragmentCollectionLocalService.
-				fetchFragmentCollectionByExternalReferenceCode(
-					fragmentSet.getExternalReferenceCode(), groupId);
-
-		if (fragmentCollection != null) {
-			return fragmentCollection;
-		}
-
-		if (!LazyReferencingThreadLocal.isEnabled()) {
-			throw new IllegalArgumentException(
-				_language.format(
-					contextAcceptLanguage.getPreferredLocale(),
-					"no-fragment-set-was-found-with-external-reference-code-x",
-					fragmentSet.getExternalReferenceCode()));
-		}
-
-		return FragmentSetUtil.addFragmentCollection(
-			fragmentSet,
-			ServiceContextUtil.getServiceContext(
-				contextCompany.getCompanyId(), fragmentSet.getDateCreated(),
-				groupId, contextHttpServletRequest,
-				fragmentSet.getDateModified(), contextUser.getUserId()));
+		return FragmentSetUtil.getOrAddFragmentCollection(
+			contextCompany.getCompanyId(), resourceFolder.getFragmentSet(),
+			resourceFolder.getFragmentSetExternalReferenceCode(), groupId,
+			contextHttpServletRequest,
+			"a-fragment-set-external-reference-code-is-required-to-create-a-" +
+				"new-resource-folder",
+			contextAcceptLanguage.getPreferredLocale(),
+			contextUser.getUserId());
 	}
 
 	private DLFolder _getParentDLFolder(
@@ -389,8 +361,7 @@ public class ResourceFolderResourceImpl extends BaseResourceFolderResourceImpl {
 			}
 
 			parentDLFolder = _addDLFolder(
-				_getOrAddFragmentCollection(
-					parentResourceFolder.getFragmentSet(), groupId),
+				_getOrAddFragmentCollection(groupId, parentResourceFolder),
 				groupId, parentResourceFolder);
 		}
 

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/ResourceFolderResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/ResourceFolderResourceImpl.java
@@ -282,26 +282,11 @@ public class ResourceFolderResourceImpl extends BaseResourceFolderResourceImpl {
 	}
 
 	private void _checkResourceFolder(DLFolder dlFolder) throws Exception {
-		if (_getFragmentCollection(dlFolder) == null) {
+		if (FragmentSetUtil.getFragmentCollection(dlFolder) == null) {
 			throw new NoSuchFolderException(
 				"No resource folder exists with external reference code " +
 					dlFolder.getExternalReferenceCode());
 		}
-	}
-
-	private FragmentCollection _getFragmentCollection(DLFolder dlFolder) {
-		DLFolder parentDLFolder = _dlFolderLocalService.fetchDLFolder(
-			dlFolder.getParentFolderId());
-
-		while ((parentDLFolder != null) && !parentDLFolder.isMountPoint()) {
-			dlFolder = parentDLFolder;
-
-			parentDLFolder = _dlFolderLocalService.fetchDLFolder(
-				dlFolder.getParentFolderId());
-		}
-
-		return _fragmentCollectionLocalService.fetchFragmentCollection(
-			dlFolder.getGroupId(), dlFolder.getName());
 	}
 
 	private FragmentCollection _getOrAddFragmentCollection(
@@ -366,7 +351,7 @@ public class ResourceFolderResourceImpl extends BaseResourceFolderResourceImpl {
 		}
 
 		if ((parentDLFolder != null) &&
-			(_getFragmentCollection(parentDLFolder) == null)) {
+			(FragmentSetUtil.getFragmentCollection(parentDLFolder) == null)) {
 
 			parentDLFolder = null;
 		}

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/util/FragmentSetUtil.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/util/FragmentSetUtil.java
@@ -6,10 +6,19 @@
 package com.liferay.headless.admin.fragment.internal.resource.v1_0.util;
 
 import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.service.FragmentCollectionLocalServiceUtil;
 import com.liferay.fragment.service.FragmentCollectionServiceUtil;
 import com.liferay.headless.admin.fragment.dto.v1_0.FragmentSet;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Locale;
+import java.util.Objects;
 
 /**
  * @author Rubén Pulido
@@ -26,6 +35,61 @@ public class FragmentSetUtil {
 			fragmentSet.getName(), fragmentSet.getDescription(),
 			GetterUtil.getBoolean(fragmentSet.getMarketplace()),
 			serviceContext);
+	}
+
+	public static FragmentCollection getOrAddFragmentCollection(
+			long companyId, FragmentSet fragmentSet,
+			String fragmentSetExternalReferenceCode, long groupId,
+			HttpServletRequest httpServletRequest, String key, Locale locale,
+			long userId)
+		throws Exception {
+
+		if (Validator.isNull(fragmentSetExternalReferenceCode)) {
+			if (!LazyReferencingThreadLocal.isEnabled() ||
+				(fragmentSet == null) ||
+				Validator.isNull(fragmentSet.getExternalReferenceCode())) {
+
+				throw new IllegalArgumentException(
+					LanguageUtil.get(locale, key));
+			}
+
+			fragmentSetExternalReferenceCode =
+				fragmentSet.getExternalReferenceCode();
+		}
+
+		FragmentCollection fragmentCollection =
+			FragmentCollectionLocalServiceUtil.
+				fetchFragmentCollectionByExternalReferenceCode(
+					fragmentSetExternalReferenceCode, groupId);
+
+		if (fragmentCollection != null) {
+			return fragmentCollection;
+		}
+
+		if ((fragmentSet != null) && LazyReferencingThreadLocal.isEnabled()) {
+			if (!Objects.equals(
+					fragmentSet.getExternalReferenceCode(),
+					fragmentSetExternalReferenceCode)) {
+
+				throw new IllegalArgumentException(
+					LanguageUtil.get(
+						locale,
+						"the-fragment-set-external-reference-codes-do-not-" +
+							"match"));
+			}
+
+			return addFragmentCollection(
+				fragmentSet,
+				ServiceContextUtil.getServiceContext(
+					companyId, fragmentSet.getDateCreated(), groupId,
+					httpServletRequest, fragmentSet.getDateModified(), userId));
+		}
+
+		throw new IllegalArgumentException(
+			LanguageUtil.format(
+				locale,
+				"no-fragment-set-was-found-with-external-reference-code-x",
+				fragmentSetExternalReferenceCode));
 	}
 
 }

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/util/FragmentSetUtil.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/util/FragmentSetUtil.java
@@ -5,6 +5,8 @@
 
 package com.liferay.headless.admin.fragment.internal.resource.v1_0.util;
 
+import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.document.library.kernel.service.DLFolderLocalServiceUtil;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.service.FragmentCollectionLocalServiceUtil;
 import com.liferay.fragment.service.FragmentCollectionServiceUtil;
@@ -35,6 +37,21 @@ public class FragmentSetUtil {
 			fragmentSet.getName(), fragmentSet.getDescription(),
 			GetterUtil.getBoolean(fragmentSet.getMarketplace()),
 			serviceContext);
+	}
+
+	public static FragmentCollection getFragmentCollection(DLFolder dlFolder) {
+		DLFolder parentDLFolder = DLFolderLocalServiceUtil.fetchDLFolder(
+			dlFolder.getParentFolderId());
+
+		while ((parentDLFolder != null) && !parentDLFolder.isMountPoint()) {
+			dlFolder = parentDLFolder;
+
+			parentDLFolder = DLFolderLocalServiceUtil.fetchDLFolder(
+				dlFolder.getParentFolderId());
+		}
+
+		return FragmentCollectionLocalServiceUtil.fetchFragmentCollection(
+			dlFolder.getGroupId(), dlFolder.getName());
 	}
 
 	public static FragmentCollection getOrAddFragmentCollection(

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/BaseFragmentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/BaseFragmentResourceTestCase.java
@@ -189,6 +189,7 @@ public abstract class BaseFragmentResourceTestCase {
 		Fragment fragment = randomFragment();
 
 		fragment.setExternalReferenceCode(regex);
+		fragment.setFragmentSetExternalReferenceCode(regex);
 		fragment.setIcon(regex);
 		fragment.setKey(regex);
 		fragment.setName(regex);
@@ -200,6 +201,8 @@ public abstract class BaseFragmentResourceTestCase {
 		fragment = FragmentSerDes.toDTO(json);
 
 		Assert.assertEquals(regex, fragment.getExternalReferenceCode());
+		Assert.assertEquals(
+			regex, fragment.getFragmentSetExternalReferenceCode());
 		Assert.assertEquals(regex, fragment.getIcon());
 		Assert.assertEquals(regex, fragment.getKey());
 		Assert.assertEquals(regex, fragment.getName());
@@ -749,6 +752,8 @@ public abstract class BaseFragmentResourceTestCase {
 				dateModified = RandomTestUtil.nextDate();
 				externalReferenceCode = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
+				fragmentSetExternalReferenceCode = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
 				icon = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				key = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				marketplace = RandomTestUtil.randomBoolean();
@@ -768,6 +773,8 @@ public abstract class BaseFragmentResourceTestCase {
 				dateCreated = RandomTestUtil.nextDate();
 				dateModified = RandomTestUtil.nextDate();
 				externalReferenceCode = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				fragmentSetExternalReferenceCode = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				icon = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				key = StringUtil.toLowerCase(RandomTestUtil.randomString());
@@ -807,6 +814,8 @@ public abstract class BaseFragmentResourceTestCase {
 				dateModified = RandomTestUtil.nextDate();
 				externalReferenceCode = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
+				fragmentSetExternalReferenceCode = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
 				icon = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				key = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				marketplace = RandomTestUtil.randomBoolean();
@@ -827,6 +836,8 @@ public abstract class BaseFragmentResourceTestCase {
 				dateCreated = RandomTestUtil.nextDate();
 				dateModified = RandomTestUtil.nextDate();
 				externalReferenceCode = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				fragmentSetExternalReferenceCode = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				icon = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				key = StringUtil.toLowerCase(RandomTestUtil.randomString());
@@ -1052,6 +1063,17 @@ public abstract class BaseFragmentResourceTestCase {
 
 			if (Objects.equals("fragmentSet", additionalAssertFieldName)) {
 				if (fragment.getFragmentSet() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"fragmentSetExternalReferenceCode",
+					additionalAssertFieldName)) {
+
+				if (fragment.getFragmentSetExternalReferenceCode() == null) {
 					valid = false;
 				}
 
@@ -1313,6 +1335,20 @@ public abstract class BaseFragmentResourceTestCase {
 				if (!Objects.deepEquals(
 						fragment1.getFragmentSet(),
 						fragment2.getFragmentSet())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"fragmentSetExternalReferenceCode",
+					additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						fragment1.getFragmentSetExternalReferenceCode(),
+						fragment2.getFragmentSetExternalReferenceCode())) {
 
 					return false;
 				}
@@ -1648,6 +1684,52 @@ public abstract class BaseFragmentResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("fragmentSetExternalReferenceCode")) {
+			Object object = fragment.getFragmentSetExternalReferenceCode();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("fragmentVersions")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
@@ -1865,6 +1947,8 @@ public abstract class BaseFragmentResourceTestCase {
 				fragment.setDateModified(RandomTestUtil.nextDate());
 				fragment.setExternalReferenceCode(
 					StringUtil.toLowerCase(RandomTestUtil.randomString()));
+				fragment.setFragmentSetExternalReferenceCode(
+					StringUtil.toLowerCase(RandomTestUtil.randomString()));
 				fragment.setIcon(
 					StringUtil.toLowerCase(RandomTestUtil.randomString()));
 				fragment.setKey(
@@ -1885,6 +1969,8 @@ public abstract class BaseFragmentResourceTestCase {
 				fragment.setDateCreated(RandomTestUtil.nextDate());
 				fragment.setDateModified(RandomTestUtil.nextDate());
 				fragment.setExternalReferenceCode(
+					StringUtil.toLowerCase(RandomTestUtil.randomString()));
+				fragment.setFragmentSetExternalReferenceCode(
 					StringUtil.toLowerCase(RandomTestUtil.randomString()));
 				fragment.setIcon(
 					StringUtil.toLowerCase(RandomTestUtil.randomString()));
@@ -2149,4 +2235,4 @@ public abstract class BaseFragmentResourceTestCase {
 		_fragmentResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-344471918
+// LIFERAY-REST-BUILDER-HASH:-1356236161

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/BaseResourceFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/BaseResourceFolderResourceTestCase.java
@@ -186,6 +186,7 @@ public abstract class BaseResourceFolderResourceTestCase {
 		ResourceFolder resourceFolder = randomResourceFolder();
 
 		resourceFolder.setExternalReferenceCode(regex);
+		resourceFolder.setFragmentSetExternalReferenceCode(regex);
 		resourceFolder.setName(regex);
 		resourceFolder.setParentResourceFolderExternalReferenceCode(regex);
 
@@ -196,6 +197,8 @@ public abstract class BaseResourceFolderResourceTestCase {
 		resourceFolder = ResourceFolderSerDes.toDTO(json);
 
 		Assert.assertEquals(regex, resourceFolder.getExternalReferenceCode());
+		Assert.assertEquals(
+			regex, resourceFolder.getFragmentSetExternalReferenceCode());
 		Assert.assertEquals(regex, resourceFolder.getName());
 		Assert.assertEquals(
 			regex,
@@ -1285,6 +1288,19 @@ public abstract class BaseResourceFolderResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals(
+					"fragmentSetExternalReferenceCode",
+					additionalAssertFieldName)) {
+
+				if (resourceFolder.getFragmentSetExternalReferenceCode() ==
+						null) {
+
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("name", additionalAssertFieldName)) {
 				if (resourceFolder.getName() == null) {
 					valid = false;
@@ -1488,6 +1504,21 @@ public abstract class BaseResourceFolderResourceTestCase {
 				if (!Objects.deepEquals(
 						resourceFolder1.getFragmentSet(),
 						resourceFolder2.getFragmentSet())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"fragmentSetExternalReferenceCode",
+					additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						resourceFolder1.getFragmentSetExternalReferenceCode(),
+						resourceFolder2.
+							getFragmentSetExternalReferenceCode())) {
 
 					return false;
 				}
@@ -1756,6 +1787,53 @@ public abstract class BaseResourceFolderResourceTestCase {
 				"Invalid entity field " + entityFieldName);
 		}
 
+		if (entityFieldName.equals("fragmentSetExternalReferenceCode")) {
+			Object object =
+				resourceFolder.getFragmentSetExternalReferenceCode();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
 		if (entityFieldName.equals("name")) {
 			Object object = resourceFolder.getName();
 
@@ -1906,6 +1984,8 @@ public abstract class BaseResourceFolderResourceTestCase {
 				dateCreated = RandomTestUtil.nextDate();
 				dateModified = RandomTestUtil.nextDate();
 				externalReferenceCode = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				fragmentSetExternalReferenceCode = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				parentResourceFolderExternalReferenceCode =
@@ -2158,4 +2238,4 @@ public abstract class BaseResourceFolderResourceTestCase {
 			_resourceFolderResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:180874773
+// LIFERAY-REST-BUILDER-HASH:1311295979

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
@@ -192,6 +192,7 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		_testGetSiteFragmentApproved();
 		_testGetSiteFragmentApprovedAndDraft();
 		_testGetSiteFragmentDraft();
+		_testGetSiteFragmentFragmentSet();
 		_testGetSiteFragmentThumbnailURLReference();
 		_testGetSiteFragmentWithFormFragment();
 	}
@@ -1213,6 +1214,28 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 	private void _testGetSiteFragmentDraft() throws Exception {
 		_testGetSiteFragment(false, true);
+	}
+
+	private void _testGetSiteFragmentFragmentSet() throws Exception {
+		Fragment postFragment = _postSiteFragment(randomFragment());
+
+		Fragment getFragment = fragmentResource.getSiteFragment(
+			testGroup.getExternalReferenceCode(),
+			postFragment.getExternalReferenceCode());
+
+		Assert.assertNull(getFragment.getFragmentSet());
+
+		FragmentResource fragmentResource = _getFragmentResource("fragmentSet");
+
+		getFragment = fragmentResource.getSiteFragment(
+			testGroup.getExternalReferenceCode(),
+			postFragment.getExternalReferenceCode());
+
+		FragmentSet fragmentSet = getFragment.getFragmentSet();
+
+		Assert.assertEquals(
+			_fragmentCollection.getExternalReferenceCode(),
+			fragmentSet.getExternalReferenceCode());
 	}
 
 	private void _testGetSiteFragmentSetFragmentsPageWithNonexistentFragmentSet()

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
@@ -185,7 +185,7 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 	@Override
 	@Test
-	@TestInfo("LPD-95281")
+	@TestInfo({"LPD-88489", "LPD-95281"})
 	public void testGetSiteFragment() throws Exception {
 		super.testGetSiteFragment();
 
@@ -216,7 +216,7 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 	@Override
 	@Test
-	@TestInfo("LPD-95281")
+	@TestInfo({"LPD-88489", "LPD-95281"})
 	public void testPostSiteFragment() throws Exception {
 		super.testPostSiteFragment();
 
@@ -269,7 +269,7 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 	@Override
 	@Test
-	@TestInfo("LPD-95281")
+	@TestInfo({"LPD-88489", "LPD-95281"})
 	public void testPutSiteFragment() throws Exception {
 		_testPutSiteFragmentBatch();
 		_testPutSiteFragmentCreateApproved();
@@ -309,8 +309,9 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {
-			"cacheable", "externalReferenceCode", "fragmentSet",
-			"fragmentVersions", "key", "marketplace", "name", "readOnly"
+			"cacheable", "externalReferenceCode",
+			"fragmentSetExternalReferenceCode", "fragmentVersions", "key",
+			"marketplace", "name", "readOnly"
 		};
 	}
 
@@ -319,6 +320,8 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		Fragment fragment = _randomBasicFragment();
 
 		fragment.setFragmentSet(_toFragmentSet(_fragmentCollection));
+		fragment.setFragmentSetExternalReferenceCode(
+			_fragmentCollection.getExternalReferenceCode());
 		fragment.setFragmentVersions(_randomFragmentVersions());
 
 		return fragment;
@@ -568,32 +571,6 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		Assert.assertEquals(fragment.getName(), fragmentEntry.getName());
 	}
 
-	private void _assertFragmentSet(
-		FragmentCollection expectedFragmentCollection,
-		FragmentSet fragmentSet) {
-
-		Assert.assertEquals(
-			expectedFragmentCollection.getExternalReferenceCode(),
-			fragmentSet.getExternalReferenceCode());
-		Assert.assertEquals(
-			expectedFragmentCollection.getName(), fragmentSet.getName());
-		Assert.assertEquals(
-			expectedFragmentCollection.getDescription(),
-			fragmentSet.getDescription());
-	}
-
-	private void _assertFragmentSet(
-		FragmentSet expectedFragmentSet, FragmentSet fragmentSet) {
-
-		Assert.assertEquals(
-			expectedFragmentSet.getDescription(), fragmentSet.getDescription());
-		Assert.assertEquals(
-			expectedFragmentSet.getExternalReferenceCode(),
-			fragmentSet.getExternalReferenceCode());
-		Assert.assertEquals(
-			expectedFragmentSet.getName(), fragmentSet.getName());
-	}
-
 	private void _assertGetSiteFragmentsPageWithFilter(
 			Fragment expectedFragment, String filterString,
 			Fragment notExpectedFragment)
@@ -811,6 +788,9 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 			fragment.setFragmentSet(_toFragmentSet(_fragmentCollection));
 		}
 
+		fragment.setFragmentSetExternalReferenceCode(
+			_fragmentCollection.getExternalReferenceCode());
+
 		if (ArrayUtil.isEmpty(fragment.getFragmentVersions())) {
 			fragment.setFragmentVersions(_randomFragmentVersions());
 		}
@@ -943,6 +923,8 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		FormFragment formFragment = new FormFragment() {
 			{
 				setFragmentSet(_toFragmentSet(_fragmentCollection));
+				setFragmentSetExternalReferenceCode(
+					_fragmentCollection.getExternalReferenceCode());
 				setFragmentVersions(
 					new FragmentVersion[] {
 						_randomFragmentVersion(FragmentVersion.Status.APPROVED)
@@ -995,6 +977,12 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 		fragment.setExternalReferenceCode(externalReferenceCode);
 		fragment.setFragmentSet(_toFragmentSet(fragmentCollection));
+
+		if (fragmentCollection != null) {
+			fragment.setFragmentSetExternalReferenceCode(
+				fragmentCollection.getExternalReferenceCode());
+		}
+
 		fragment.setFragmentVersions(
 			fragmentVersions.toArray(new FragmentVersion[0]));
 
@@ -1612,12 +1600,14 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 		FragmentCollection fragmentCollection = _addFragmentCollection();
 
-		fragment.setFragmentSet(
-			_randomFragmentSet(fragmentCollection.getExternalReferenceCode()));
+		fragment.setFragmentSetExternalReferenceCode(
+			fragmentCollection.getExternalReferenceCode());
 
 		Fragment postFragment = _postSiteFragment(fragment);
 
-		_assertFragmentSet(fragmentCollection, postFragment.getFragmentSet());
+		Assert.assertEquals(
+			fragmentCollection.getExternalReferenceCode(),
+			postFragment.getFragmentSetExternalReferenceCode());
 	}
 
 	private void _testPostSiteFragmentFragmentSetExternalReferenceCodeNullProblemException()
@@ -1625,7 +1615,7 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 		Fragment fragment = randomFragment();
 
-		fragment.setFragmentSet(_randomFragmentSet(null));
+		fragment.setFragmentSetExternalReferenceCode((String)null);
 
 		_assertProblemException(
 			"a-fragment-set-external-reference-code-is-required-to-create-a-" +
@@ -1645,13 +1635,18 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 		fragment.setFragmentSet(fragmentSet);
 
+		fragment.setFragmentSetExternalReferenceCode(
+			fragmentSetExternalReferenceCode);
+
 		try (SafeCloseable safeCloseable =
 				LazyReferencingTestUtil.setLazyReferencingWithSafeCloseable(
 					true)) {
 
 			Fragment postFragment = _postSiteFragment(fragment);
 
-			_assertFragmentSet(fragmentSet, postFragment.getFragmentSet());
+			Assert.assertEquals(
+				fragmentSet.getExternalReferenceCode(),
+				postFragment.getFragmentSetExternalReferenceCode());
 
 			Assert.assertNotNull(
 				_fragmentCollectionLocalService.
@@ -1668,8 +1663,8 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 		String fragmentSetExternalReferenceCode = RandomTestUtil.randomString();
 
-		fragment.setFragmentSet(
-			_randomFragmentSet(fragmentSetExternalReferenceCode));
+		fragment.setFragmentSetExternalReferenceCode(
+			fragmentSetExternalReferenceCode);
 
 		_assertProblemException(
 			"no-fragment-set-was-found-with-external-reference-code-x",
@@ -1688,6 +1683,7 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		Fragment fragment = randomFragment();
 
 		fragment.setFragmentSet((FragmentSet)null);
+		fragment.setFragmentSetExternalReferenceCode((String)null);
 
 		_assertProblemException(
 			"a-fragment-set-external-reference-code-is-required-to-create-a-" +
@@ -1790,7 +1786,9 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 		Fragment postFragment = _postSiteFragmentSetFragment(fragment);
 
-		_assertFragmentSet(_fragmentCollection, postFragment.getFragmentSet());
+		Assert.assertEquals(
+			_fragmentCollection.getExternalReferenceCode(),
+			postFragment.getFragmentSetExternalReferenceCode());
 	}
 
 	private void _testPostSiteFragmentSetFragmentFragmentSetExternalReferenceCodeNull()
@@ -1802,7 +1800,9 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 		Fragment postFragment = _postSiteFragmentSetFragment(fragment);
 
-		_assertFragmentSet(_fragmentCollection, postFragment.getFragmentSet());
+		Assert.assertEquals(
+			_fragmentCollection.getExternalReferenceCode(),
+			postFragment.getFragmentSetExternalReferenceCode());
 	}
 
 	private void _testPostSiteFragmentSetFragmentFragmentSetInPathNonexistingProblemException()
@@ -1839,11 +1839,9 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 		Fragment postFragment = _postSiteFragmentSetFragment(fragment);
 
-		FragmentSet postFragmentSet = postFragment.getFragmentSet();
-
 		Assert.assertEquals(
 			_fragmentCollection.getExternalReferenceCode(),
-			postFragmentSet.getExternalReferenceCode());
+			postFragment.getFragmentSetExternalReferenceCode());
 
 		Assert.assertNull(
 			_fragmentCollectionLocalService.
@@ -1860,7 +1858,9 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 		Fragment postFragment = _postSiteFragmentSetFragment(fragment);
 
-		_assertFragmentSet(_fragmentCollection, postFragment.getFragmentSet());
+		Assert.assertEquals(
+			_fragmentCollection.getExternalReferenceCode(),
+			postFragment.getFragmentSetExternalReferenceCode());
 	}
 
 	private void _testPostSiteFragmentSetFragmentWithFormFragment()
@@ -2218,14 +2218,16 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 		FragmentCollection fragmentCollection = _addFragmentCollection();
 
-		fragment.setFragmentSet(
-			_randomFragmentSet(fragmentCollection.getExternalReferenceCode()));
+		fragment.setFragmentSetExternalReferenceCode(
+			fragmentCollection.getExternalReferenceCode());
 
 		Fragment putFragment = fragmentResource.putSiteFragment(
 			testGroup.getExternalReferenceCode(), externalReferenceCode,
 			fragment);
 
-		_assertFragmentSet(fragmentCollection, putFragment.getFragmentSet());
+		Assert.assertEquals(
+			fragmentCollection.getExternalReferenceCode(),
+			putFragment.getFragmentSetExternalReferenceCode());
 	}
 
 	private void _testPutSiteFragmentCreateFragmentSetExternalReferenceCodeNullProblemException()
@@ -2236,7 +2238,7 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		Fragment fragment = _randomFragment(
 			true, false, externalReferenceCode, null);
 
-		fragment.setFragmentSet(_randomFragmentSet(null));
+		fragment.setFragmentSetExternalReferenceCode((String)null);
 
 		_testPutSiteFragmentProblemException(
 			externalReferenceCode, fragment,
@@ -2259,6 +2261,9 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 		fragment.setFragmentSet(fragmentSet);
 
+		fragment.setFragmentSetExternalReferenceCode(
+			fragmentSetExternalReferenceCode);
+
 		try (SafeCloseable safeCloseable =
 				LazyReferencingTestUtil.setLazyReferencingWithSafeCloseable(
 					true)) {
@@ -2267,7 +2272,9 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 				testGroup.getExternalReferenceCode(), externalReferenceCode,
 				fragment);
 
-			_assertFragmentSet(fragmentSet, putFragment.getFragmentSet());
+			Assert.assertEquals(
+				fragmentSet.getExternalReferenceCode(),
+				putFragment.getFragmentSetExternalReferenceCode());
 
 			Assert.assertNotNull(
 				_fragmentCollectionLocalService.
@@ -2287,8 +2294,8 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 		String fragmentSetExternalReferenceCode = RandomTestUtil.randomString();
 
-		fragment.setFragmentSet(
-			_randomFragmentSet(fragmentSetExternalReferenceCode));
+		fragment.setFragmentSetExternalReferenceCode(
+			fragmentSetExternalReferenceCode);
 
 		_assertProblemException(
 			"no-fragment-set-was-found-with-external-reference-code-x",
@@ -2312,6 +2319,7 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 			true, false, externalReferenceCode, null);
 
 		fragment.setFragmentSet((FragmentSet)null);
+		fragment.setFragmentSetExternalReferenceCode((String)null);
 
 		_testPutSiteFragmentProblemException(
 			externalReferenceCode, fragment,
@@ -2491,14 +2499,16 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 		FragmentCollection fragmentCollection = _addFragmentCollection();
 
-		fragment.setFragmentSet(
-			_randomFragmentSet(fragmentCollection.getExternalReferenceCode()));
+		fragment.setFragmentSetExternalReferenceCode(
+			fragmentCollection.getExternalReferenceCode());
 
 		Fragment putFragment = fragmentResource.putSiteFragment(
 			testGroup.getExternalReferenceCode(),
 			postFragment.getExternalReferenceCode(), fragment);
 
-		_assertFragmentSet(fragmentCollection, putFragment.getFragmentSet());
+		Assert.assertEquals(
+			fragmentCollection.getExternalReferenceCode(),
+			putFragment.getFragmentSetExternalReferenceCode());
 	}
 
 	private void _testPutSiteFragmentUpdateFragmentSetExternalReferenceCodeNull()
@@ -2517,7 +2527,9 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 			testGroup.getExternalReferenceCode(),
 			postFragment.getExternalReferenceCode(), fragment);
 
-		_assertFragmentSet(_fragmentCollection, putFragment.getFragmentSet());
+		Assert.assertEquals(
+			_fragmentCollection.getExternalReferenceCode(),
+			putFragment.getFragmentSetExternalReferenceCode());
 	}
 
 	private void _testPutSiteFragmentUpdateFragmentSetNonexisting()
@@ -2537,6 +2549,9 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 		fragment.setFragmentSet(fragmentSet);
 
+		fragment.setFragmentSetExternalReferenceCode(
+			fragmentSetExternalReferenceCode);
+
 		try (SafeCloseable safeCloseable =
 				LazyReferencingTestUtil.setLazyReferencingWithSafeCloseable(
 					true)) {
@@ -2545,7 +2560,9 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 				testGroup.getExternalReferenceCode(),
 				postFragment.getExternalReferenceCode(), fragment);
 
-			_assertFragmentSet(fragmentSet, putFragment.getFragmentSet());
+			Assert.assertEquals(
+				fragmentSet.getExternalReferenceCode(),
+				putFragment.getFragmentSetExternalReferenceCode());
 
 			Assert.assertNotNull(
 				_fragmentCollectionLocalService.
@@ -2567,8 +2584,8 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 		String fragmentSetExternalReferenceCode = RandomTestUtil.randomString();
 
-		fragment.setFragmentSet(
-			_randomFragmentSet(fragmentSetExternalReferenceCode));
+		fragment.setFragmentSetExternalReferenceCode(
+			fragmentSetExternalReferenceCode);
 
 		_assertProblemException(
 			"no-fragment-set-was-found-with-external-reference-code-x",
@@ -2597,7 +2614,9 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 			testGroup.getExternalReferenceCode(),
 			postFragment.getExternalReferenceCode(), fragment);
 
-		_assertFragmentSet(_fragmentCollection, putFragment.getFragmentSet());
+		Assert.assertEquals(
+			_fragmentCollection.getExternalReferenceCode(),
+			putFragment.getFragmentSetExternalReferenceCode());
 	}
 
 	private void _testPutSiteFragmentUpdateThumbnailURLReferenceExternalReferenceCode()

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
@@ -713,7 +713,8 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 		String endpoint = StringBundler.concat(
 			"headless-admin-fragment/v1.0/sites/", siteExternalReferenceCode,
-			"/fragments/export-batch?contentType=JSON");
+			"/fragments/export-batch?contentType=JSON",
+			"&batchNestedFields=fragmentSet");
 
 		if (filterString != null) {
 			endpoint = StringBundler.concat(

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
@@ -227,6 +227,8 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		_testPostSiteFragmentDuplicateExternalReferenceCodeProblemException();
 		_testPostSiteFragmentDuplicateKeyProblemException();
 		_testPostSiteFragmentEmpty();
+		_testPostSiteFragmentFragmentSetAndFragmentSetExternalReferenceCode();
+		_testPostSiteFragmentFragmentSetAndFragmentSetExternalReferenceCodeProblemException();
 		_testPostSiteFragmentFragmentSetExisting();
 		_testPostSiteFragmentFragmentSetExternalReferenceCodeNullProblemException();
 		_testPostSiteFragmentFragmentSetNonexisting();
@@ -1593,6 +1595,48 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 	private void _testPostSiteFragmentEmpty() throws Exception {
 		_testPostFragmentEmpty(this::_postSiteFragment);
+	}
+
+	private void _testPostSiteFragmentFragmentSetAndFragmentSetExternalReferenceCode()
+		throws Exception {
+
+		Fragment fragment = randomFragment();
+
+		FragmentCollection fragmentCollection1 = _addFragmentCollection();
+		FragmentCollection fragmentCollection2 = _addFragmentCollection();
+
+		fragment.setFragmentSet(
+			_randomFragmentSet(fragmentCollection1.getExternalReferenceCode()));
+		fragment.setFragmentSetExternalReferenceCode(
+			fragmentCollection2.getExternalReferenceCode());
+
+		Fragment postFragment = _postSiteFragment(fragment);
+
+		Assert.assertEquals(
+			fragmentCollection2.getExternalReferenceCode(),
+			postFragment.getFragmentSetExternalReferenceCode());
+	}
+
+	private void _testPostSiteFragmentFragmentSetAndFragmentSetExternalReferenceCodeProblemException()
+		throws Exception {
+
+		Fragment fragment = randomFragment();
+
+		fragment.setFragmentSet(
+			_randomFragmentSet(RandomTestUtil.randomString()));
+		fragment.setFragmentSetExternalReferenceCode(
+			RandomTestUtil.randomString());
+
+		_assertProblemException(
+			"the-fragment-set-external-reference-codes-do-not-match",
+			() -> {
+				try (SafeCloseable safeCloseable =
+						LazyReferencingTestUtil.
+							setLazyReferencingWithSafeCloseable(true)) {
+
+					_postSiteFragment(fragment);
+				}
+			});
 	}
 
 	private void _testPostSiteFragmentFragmentSetExisting() throws Exception {

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/ResourceFolderResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/ResourceFolderResourceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
@@ -199,13 +200,14 @@ public class ResourceFolderResourceTest
 
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
-		return new String[] {"externalReferenceCode", "name"};
+		return new String[] {
+			"externalReferenceCode", "fragmentSetExternalReferenceCode", "name"
+		};
 	}
 
 	@Override
 	protected ResourceFolder randomResourceFolder() throws Exception {
-		return _randomResourceFolder(
-			_toFragmentSet(_getFragmentSetExternalReferenceCode()));
+		return _randomResourceFolder(_getFragmentSetExternalReferenceCode());
 	}
 
 	@Override
@@ -215,9 +217,6 @@ public class ResourceFolderResourceTest
 				String fragmentSetExternalReferenceCode,
 				ResourceFolder resourceFolder)
 		throws Exception {
-
-		resourceFolder.setFragmentSet(
-			_toFragmentSet(fragmentSetExternalReferenceCode));
 
 		return resourceFolderResource.postSiteFragmentSetResourceFolder(
 			siteExternalReferenceCode, fragmentSetExternalReferenceCode,
@@ -280,8 +279,8 @@ public class ResourceFolderResourceTest
 		FragmentCollection fragmentCollection = _addFragmentCollection(
 			group.getGroupId());
 
-		resourceFolder.setFragmentSet(
-			_toFragmentSet(fragmentCollection.getExternalReferenceCode()));
+		resourceFolder.setFragmentSetExternalReferenceCode(
+			fragmentCollection.getExternalReferenceCode());
 
 		return resourceFolderResource.postSiteResourceFolder(
 			siteExternalReferenceCode, resourceFolder);
@@ -302,11 +301,10 @@ public class ResourceFolderResourceTest
 				ResourceFolder resourceFolder)
 		throws Exception {
 
-		FragmentSet fragmentSet = resourceFolder.getFragmentSet();
-
 		return resourceFolderResource.postSiteFragmentSetResourceFolder(
 			testGroup.getExternalReferenceCode(),
-			fragmentSet.getExternalReferenceCode(), resourceFolder);
+			resourceFolder.getFragmentSetExternalReferenceCode(),
+			resourceFolder);
 	}
 
 	@Override
@@ -428,6 +426,43 @@ public class ResourceFolderResourceTest
 		return _fragmentSetExternalReferenceCode;
 	}
 
+	private ResourceFolderResource _getResourceFolderResource(
+			String nestedFields)
+		throws Exception {
+
+		User user = UserTestUtil.getAdminUser(testCompany.getCompanyId());
+
+		return ResourceFolderResource.builder(
+		).authentication(
+			user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).parameters(
+			"nestedFields", nestedFields
+		).build();
+	}
+
+	private ResourceFolder _getSiteResourceFolder(String externalReferenceCode)
+		throws Exception {
+
+		return _getSiteResourceFolder(
+			externalReferenceCode, testGroup.getExternalReferenceCode());
+	}
+
+	private ResourceFolder _getSiteResourceFolder(
+			String externalReferenceCode, String siteExternalReferenceCode)
+		throws Exception {
+
+		ResourceFolderResource resourceFolderResource =
+			_getResourceFolderResource("fragmentSet,parentResourceFolder");
+
+		return resourceFolderResource.getSiteResourceFolder(
+			siteExternalReferenceCode, externalReferenceCode);
+	}
+
 	private ResourceFolder _postSiteResourceFolder(
 			ResourceFolder parentResourceFolder)
 		throws Exception {
@@ -443,20 +478,20 @@ public class ResourceFolderResourceTest
 
 		return resourceFolderResource.postSiteResourceFolder(
 			testGroup.getExternalReferenceCode(),
-			_randomResourceFolder(
-				_toFragmentSet(fragmentSetExternalReferenceCode)));
+			_randomResourceFolder(fragmentSetExternalReferenceCode));
 	}
 
-	private ResourceFolder _randomResourceFolder(FragmentSet fragmentSet)
+	private ResourceFolder _putSiteResourceFolder(
+			ResourceFolder resourceFolder,
+			String resourceFolderExternalReferenceCode)
 		throws Exception {
 
-		ResourceFolder resourceFolder = super.randomResourceFolder();
+		ResourceFolderResource resourceFolderResource =
+			_getResourceFolderResource("fragmentSet,parentResourceFolder");
 
-		resourceFolder.setFragmentSet(fragmentSet);
-		resourceFolder.setParentResourceFolderExternalReferenceCode(
-			(String)null);
-
-		return resourceFolder;
+		return resourceFolderResource.putSiteResourceFolder(
+			testGroup.getExternalReferenceCode(),
+			resourceFolderExternalReferenceCode, resourceFolder);
 	}
 
 	private ResourceFolder _randomResourceFolder(
@@ -465,9 +500,24 @@ public class ResourceFolderResourceTest
 
 		ResourceFolder resourceFolder = super.randomResourceFolder();
 
-		resourceFolder.setFragmentSet(parentResourceFolder.getFragmentSet());
+		resourceFolder.setFragmentSetExternalReferenceCode(
+			parentResourceFolder.getFragmentSetExternalReferenceCode());
 		resourceFolder.setParentResourceFolderExternalReferenceCode(
 			parentResourceFolder.getExternalReferenceCode());
+
+		return resourceFolder;
+	}
+
+	private ResourceFolder _randomResourceFolder(
+			String fragmentSetExternalReferenceCode)
+		throws Exception {
+
+		ResourceFolder resourceFolder = super.randomResourceFolder();
+
+		resourceFolder.setFragmentSetExternalReferenceCode(
+			fragmentSetExternalReferenceCode);
+		resourceFolder.setParentResourceFolderExternalReferenceCode(
+			(String)null);
 
 		return resourceFolder;
 	}
@@ -603,7 +653,7 @@ public class ResourceFolderResourceTest
 			testGroup.getExternalReferenceCode(),
 			fragmentCollection.getExternalReferenceCode(),
 			_randomResourceFolder(
-				_toFragmentSet(fragmentCollection.getExternalReferenceCode())));
+				fragmentCollection.getExternalReferenceCode()));
 
 		Page<ResourceFolder> page =
 			_resourceFolderResource.getSiteFragmentSetResourceFoldersPage(
@@ -875,7 +925,7 @@ public class ResourceFolderResourceTest
 			testGroup.getGroupId());
 
 		ResourceFolder parentResourceFolder = _randomResourceFolder(
-			_toFragmentSet(fragmentCollection.getExternalReferenceCode()));
+			fragmentCollection.getExternalReferenceCode());
 
 		ResourceFolder postParentResourceFolder =
 			resourceFolderResource.postSiteResourceFolder(
@@ -886,10 +936,8 @@ public class ResourceFolderResourceTest
 				testGroup.getExternalReferenceCode(),
 				_randomResourceFolder(parentResourceFolder));
 
-		ResourceFolder getResourceFolder =
-			resourceFolderResource.getSiteResourceFolder(
-				testGroup.getExternalReferenceCode(),
-				postResourceFolder.getExternalReferenceCode());
+		ResourceFolder getResourceFolder = _getSiteResourceFolder(
+			postResourceFolder.getExternalReferenceCode());
 
 		FragmentSet getFragmentSet = getResourceFolder.getFragmentSet();
 
@@ -910,7 +958,7 @@ public class ResourceFolderResourceTest
 			testGroup.getGroupId());
 
 		ResourceFolder parentResourceFolder = _randomResourceFolder(
-			_toFragmentSet(fragmentCollection.getExternalReferenceCode()));
+			fragmentCollection.getExternalReferenceCode());
 
 		ResourceFolder postParentResourceFolder =
 			resourceFolderResource.postSiteResourceFolder(
@@ -936,10 +984,9 @@ public class ResourceFolderResourceTest
 					Http.Method.POST));
 		}
 
-		ResourceFolder importedResourceFolder =
-			resourceFolderResource.getSiteResourceFolder(
-				irrelevantGroup.getExternalReferenceCode(),
-				postResourceFolder.getExternalReferenceCode());
+		ResourceFolder importedResourceFolder = _getSiteResourceFolder(
+			postResourceFolder.getExternalReferenceCode(),
+			irrelevantGroup.getExternalReferenceCode());
 
 		FragmentSet importedFragmentSet =
 			importedResourceFolder.getFragmentSet();
@@ -969,7 +1016,7 @@ public class ResourceFolderResourceTest
 			testGroup.getGroupId());
 
 		ResourceFolder parentResourceFolder = _randomResourceFolder(
-			_toFragmentSet(fragmentCollection.getExternalReferenceCode()));
+			fragmentCollection.getExternalReferenceCode());
 
 		ResourceFolder postParentResourceFolder =
 			resourceFolderResource.postSiteResourceFolder(
@@ -1022,10 +1069,9 @@ public class ResourceFolderResourceTest
 			postParentResourceFolder.getExternalReferenceCode(),
 			importedParentResourceFolder.getExternalReferenceCode());
 
-		ResourceFolder importedResourceFolder =
-			resourceFolderResource.getSiteResourceFolder(
-				irrelevantGroup.getExternalReferenceCode(),
-				postResourceFolder.getExternalReferenceCode());
+		ResourceFolder importedResourceFolder = _getSiteResourceFolder(
+			postResourceFolder.getExternalReferenceCode(),
+			irrelevantGroup.getExternalReferenceCode());
 
 		ResourceFolder importedResourceFolderParentResourceFolder =
 			importedResourceFolder.getParentResourceFolder();
@@ -1046,11 +1092,10 @@ public class ResourceFolderResourceTest
 			resourceFolderResource.postSiteResourceFolder(
 				testGroup.getExternalReferenceCode(),
 				_randomResourceFolder(
-					_toFragmentSet(
-						fragmentCollection.getExternalReferenceCode())));
+					fragmentCollection.getExternalReferenceCode()));
 
 		ResourceFolder resourceFolder = _randomResourceFolder(
-			_toFragmentSet(fragmentCollection.getExternalReferenceCode()));
+			fragmentCollection.getExternalReferenceCode());
 
 		resourceFolder.setExternalReferenceCode(
 			postResourceFolder.getExternalReferenceCode());
@@ -1064,8 +1109,7 @@ public class ResourceFolderResourceTest
 	private void _testPostSiteResourceFolderFragmentSetExternalReferenceCodeNullProblemException()
 		throws Exception {
 
-		ResourceFolder resourceFolder = _randomResourceFolder(
-			new FragmentSet());
+		ResourceFolder resourceFolder = _randomResourceFolder((String)null);
 
 		_assertProblemException(
 			"a-fragment-set-external-reference-code-is-required-to-create-a-" +
@@ -1080,7 +1124,7 @@ public class ResourceFolderResourceTest
 		String fragmentSetExternalReferenceCode = RandomTestUtil.randomString();
 
 		ResourceFolder resourceFolder = _randomResourceFolder(
-			_toFragmentSet(fragmentSetExternalReferenceCode));
+			fragmentSetExternalReferenceCode);
 
 		_assertProblemException(
 			"no-fragment-set-was-found-with-external-reference-code-x",
@@ -1096,7 +1140,7 @@ public class ResourceFolderResourceTest
 			testGroup.getGroupId());
 
 		ResourceFolder resourceFolder = _randomResourceFolder(
-			_toFragmentSet(fragmentCollection.getExternalReferenceCode()));
+			fragmentCollection.getExternalReferenceCode());
 
 		ResourceFolder postParentResourceFolder1 = _postSiteResourceFolder(
 			fragmentCollection.getExternalReferenceCode());
@@ -1111,10 +1155,8 @@ public class ResourceFolderResourceTest
 			resourceFolderResource.postSiteResourceFolder(
 				testGroup.getExternalReferenceCode(), resourceFolder);
 
-		ResourceFolder getResourceFolder =
-			resourceFolderResource.getSiteResourceFolder(
-				testGroup.getExternalReferenceCode(),
-				postResourceFolder.getExternalReferenceCode());
+		ResourceFolder getResourceFolder = _getSiteResourceFolder(
+			postResourceFolder.getExternalReferenceCode());
 
 		ResourceFolder getParentResourceFolder =
 			getResourceFolder.getParentResourceFolder();
@@ -1131,11 +1173,11 @@ public class ResourceFolderResourceTest
 			testGroup.getGroupId());
 
 		ResourceFolder resourceFolder = _randomResourceFolder(
-			_toFragmentSet(fragmentCollection.getExternalReferenceCode()));
+			fragmentCollection.getExternalReferenceCode());
 
 		resourceFolder.setParentResourceFolder(
 			_randomResourceFolder(
-				_toFragmentSet(fragmentCollection.getExternalReferenceCode())));
+				fragmentCollection.getExternalReferenceCode()));
 		resourceFolder.setParentResourceFolderExternalReferenceCode(
 			RandomTestUtil.randomString());
 
@@ -1159,7 +1201,7 @@ public class ResourceFolderResourceTest
 			testGroup.getGroupId());
 
 		ResourceFolder resourceFolder = _randomResourceFolder(
-			_toFragmentSet(fragmentCollection.getExternalReferenceCode()));
+			fragmentCollection.getExternalReferenceCode());
 
 		ResourceFolder postParentResourceFolder = _postSiteResourceFolder(
 			fragmentCollection.getExternalReferenceCode());
@@ -1171,10 +1213,8 @@ public class ResourceFolderResourceTest
 			resourceFolderResource.postSiteResourceFolder(
 				testGroup.getExternalReferenceCode(), resourceFolder);
 
-		ResourceFolder getResourceFolder =
-			resourceFolderResource.getSiteResourceFolder(
-				testGroup.getExternalReferenceCode(),
-				postResourceFolder.getExternalReferenceCode());
+		ResourceFolder getResourceFolder = _getSiteResourceFolder(
+			postResourceFolder.getExternalReferenceCode());
 
 		Assert.assertEquals(
 			postParentResourceFolder.getExternalReferenceCode(),
@@ -1195,7 +1235,7 @@ public class ResourceFolderResourceTest
 			testGroup.getGroupId());
 
 		ResourceFolder resourceFolder = _randomResourceFolder(
-			_toFragmentSet(fragmentCollection.getExternalReferenceCode()));
+			fragmentCollection.getExternalReferenceCode());
 
 		ResourceFolder postParentResourceFolder = _postSiteResourceFolder(
 			fragmentCollection.getExternalReferenceCode());
@@ -1206,10 +1246,8 @@ public class ResourceFolderResourceTest
 			resourceFolderResource.postSiteResourceFolder(
 				testGroup.getExternalReferenceCode(), resourceFolder);
 
-		ResourceFolder getResourceFolder =
-			resourceFolderResource.getSiteResourceFolder(
-				testGroup.getExternalReferenceCode(),
-				postResourceFolder.getExternalReferenceCode());
+		ResourceFolder getResourceFolder = _getSiteResourceFolder(
+			postResourceFolder.getExternalReferenceCode());
 
 		Assert.assertNull(getResourceFolder.getParentResourceFolder());
 		Assert.assertNull(
@@ -1226,7 +1264,7 @@ public class ResourceFolderResourceTest
 			RandomTestUtil.randomString();
 
 		ResourceFolder resourceFolder = _randomResourceFolder(
-			_toFragmentSet(fragmentCollection.getExternalReferenceCode()));
+			fragmentCollection.getExternalReferenceCode());
 
 		resourceFolder.setParentResourceFolderExternalReferenceCode(
 			parentResourceFolderExternalReferenceCode);
@@ -1245,7 +1283,7 @@ public class ResourceFolderResourceTest
 			testGroup.getGroupId());
 
 		ResourceFolder parentResourceFolder = _randomResourceFolder(
-			_toFragmentSet(fragmentCollection.getExternalReferenceCode()));
+			fragmentCollection.getExternalReferenceCode());
 
 		Folder folder = _addPortletFolder();
 
@@ -1253,7 +1291,7 @@ public class ResourceFolderResourceTest
 			folder.getExternalReferenceCode());
 
 		ResourceFolder resourceFolder = _randomResourceFolder(
-			_toFragmentSet(fragmentCollection.getExternalReferenceCode()));
+			fragmentCollection.getExternalReferenceCode());
 
 		resourceFolder.setParentResourceFolder(parentResourceFolder);
 		resourceFolder.setParentResourceFolderExternalReferenceCode(
@@ -1285,7 +1323,7 @@ public class ResourceFolderResourceTest
 			folder.getExternalReferenceCode();
 
 		ResourceFolder resourceFolder = _randomResourceFolder(
-			_toFragmentSet(fragmentCollection.getExternalReferenceCode()));
+			fragmentCollection.getExternalReferenceCode());
 
 		resourceFolder.setParentResourceFolderExternalReferenceCode(
 			parentResourceFolderExternalReferenceCode);
@@ -1318,7 +1356,7 @@ public class ResourceFolderResourceTest
 			testGroup.getGroupId());
 
 		ResourceFolder originalResourceFolder = _randomResourceFolder(
-			_toFragmentSet(fragmentCollection.getExternalReferenceCode()));
+			fragmentCollection.getExternalReferenceCode());
 
 		ResourceFolder putResourceFolder =
 			resourceFolderResource.putSiteResourceFolder(
@@ -1340,10 +1378,9 @@ public class ResourceFolderResourceTest
 			updatedResourceFolder.
 				getParentResourceFolderExternalReferenceCode());
 
-		putResourceFolder = resourceFolderResource.putSiteResourceFolder(
-			testGroup.getExternalReferenceCode(),
-			originalResourceFolder.getExternalReferenceCode(),
-			updatedResourceFolder);
+		putResourceFolder = _putSiteResourceFolder(
+			updatedResourceFolder,
+			originalResourceFolder.getExternalReferenceCode());
 
 		Assert.assertEquals(
 			originalResourceFolder.getExternalReferenceCode(),
@@ -1360,10 +1397,8 @@ public class ResourceFolderResourceTest
 			fragmentCollection.getExternalReferenceCode(),
 			fragmentSet.getExternalReferenceCode());
 
-		ResourceFolder getResourceFolder =
-			resourceFolderResource.getSiteResourceFolder(
-				testGroup.getExternalReferenceCode(),
-				originalResourceFolder.getExternalReferenceCode());
+		ResourceFolder getResourceFolder = _getSiteResourceFolder(
+			originalResourceFolder.getExternalReferenceCode());
 
 		Assert.assertEquals(
 			originalResourceFolder.getExternalReferenceCode(),
@@ -1380,12 +1415,11 @@ public class ResourceFolderResourceTest
 		ResourceFolder childResourceFolder = _postSiteResourceFolder(
 			parentResourceFolder);
 
-		putResourceFolder = resourceFolderResource.putSiteResourceFolder(
-			testGroup.getExternalReferenceCode(),
-			childResourceFolder.getExternalReferenceCode(),
+		putResourceFolder = _putSiteResourceFolder(
 			_randomResourceFolder(
 				_postSiteResourceFolder(
-					irrelevantFragmentCollection.getExternalReferenceCode())));
+					irrelevantFragmentCollection.getExternalReferenceCode())),
+			childResourceFolder.getExternalReferenceCode());
 
 		ResourceFolder putParentResourceFolder =
 			putResourceFolder.getParentResourceFolder();
@@ -1406,7 +1440,7 @@ public class ResourceFolderResourceTest
 			testGroup.getGroupId());
 
 		ResourceFolder resourceFolder = _randomResourceFolder(
-			_toFragmentSet(fragmentCollection.getExternalReferenceCode()));
+			fragmentCollection.getExternalReferenceCode());
 
 		ResourceFolder postParentResourceFolder = _postSiteResourceFolder(
 			fragmentCollection.getExternalReferenceCode());
@@ -1419,10 +1453,8 @@ public class ResourceFolderResourceTest
 				testGroup.getExternalReferenceCode(),
 				resourceFolder.getExternalReferenceCode(), resourceFolder);
 
-		ResourceFolder getResourceFolder =
-			resourceFolderResource.getSiteResourceFolder(
-				testGroup.getExternalReferenceCode(),
-				putResourceFolder.getExternalReferenceCode());
+		ResourceFolder getResourceFolder = _getSiteResourceFolder(
+			putResourceFolder.getExternalReferenceCode());
 
 		Assert.assertEquals(
 			postParentResourceFolder.getExternalReferenceCode(),

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/ResourceFolderResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/ResourceFolderResourceTest.java
@@ -394,9 +394,11 @@ public class ResourceFolderResourceTest
 			"COMPLETED", false,
 			HTTPTestUtil.invokeToJSONObject(
 				null,
-				"headless-admin-fragment/v1.0/sites/" +
-					siteExternalReferenceCode +
-						"/resource-folders/export-batch?contentType=JSON",
+				StringBundler.concat(
+					"headless-admin-fragment/v1.0/sites/",
+					siteExternalReferenceCode,
+					"/resource-folders/export-batch?contentType=JSON",
+					"&batchNestedFields=fragmentSet,parentResourceFolder"),
 				Http.Method.POST));
 
 		try (InputStream inputStream = HTTPTestUtil.invokeToInputStream(

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/ResourceFolderResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/ResourceFolderResourceTest.java
@@ -127,6 +127,8 @@ public class ResourceFolderResourceTest
 	public void testGetSiteResourceFolder() throws Exception {
 		super.testGetSiteResourceFolder();
 
+		_testGetSiteResourceFolderFragmentSet();
+		_testGetSiteResourceFolderParentResourceFolder();
 		_testGetSiteResourceFolderPortletFolderProblemException();
 		_testGetSiteResourceFolderResourceFolderNonexistentProblemException();
 		_testGetSiteResourceFolderWithoutPermissionsProblemException();
@@ -665,6 +667,70 @@ public class ResourceFolderResourceTest
 				Pagination.of(1, 10));
 
 		Assert.assertEquals(0, page.getTotalCount());
+	}
+
+	private void _testGetSiteResourceFolderFragmentSet() throws Exception {
+		FragmentCollection fragmentCollection = _addFragmentCollection(
+			testGroup.getGroupId());
+
+		ResourceFolder postResourceFolder =
+			resourceFolderResource.postSiteResourceFolder(
+				testGroup.getExternalReferenceCode(),
+				_randomResourceFolder(
+					fragmentCollection.getExternalReferenceCode()));
+
+		ResourceFolder getResourceFolder =
+			resourceFolderResource.getSiteResourceFolder(
+				testGroup.getExternalReferenceCode(),
+				postResourceFolder.getExternalReferenceCode());
+
+		Assert.assertNull(getResourceFolder.getFragmentSet());
+
+		getResourceFolder = _getSiteResourceFolder(
+			postResourceFolder.getExternalReferenceCode());
+
+		FragmentSet fragmentSet = getResourceFolder.getFragmentSet();
+
+		Assert.assertEquals(
+			fragmentCollection.getExternalReferenceCode(),
+			fragmentSet.getExternalReferenceCode());
+	}
+
+	private void _testGetSiteResourceFolderParentResourceFolder()
+		throws Exception {
+
+		FragmentCollection fragmentCollection = _addFragmentCollection(
+			testGroup.getGroupId());
+
+		ResourceFolder postParentResourceFolder = _postSiteResourceFolder(
+			fragmentCollection.getExternalReferenceCode());
+
+		ResourceFolder resourceFolder = _randomResourceFolder(
+			fragmentCollection.getExternalReferenceCode());
+
+		resourceFolder.setParentResourceFolderExternalReferenceCode(
+			postParentResourceFolder.getExternalReferenceCode());
+
+		ResourceFolder postResourceFolder =
+			resourceFolderResource.postSiteResourceFolder(
+				testGroup.getExternalReferenceCode(), resourceFolder);
+
+		ResourceFolder getResourceFolder =
+			resourceFolderResource.getSiteResourceFolder(
+				testGroup.getExternalReferenceCode(),
+				postResourceFolder.getExternalReferenceCode());
+
+		Assert.assertNull(getResourceFolder.getParentResourceFolder());
+
+		getResourceFolder = _getSiteResourceFolder(
+			postResourceFolder.getExternalReferenceCode());
+
+		ResourceFolder getParentResourceFolder =
+			getResourceFolder.getParentResourceFolder();
+
+		Assert.assertEquals(
+			postParentResourceFolder.getExternalReferenceCode(),
+			getParentResourceFolder.getExternalReferenceCode());
 	}
 
 	private void _testGetSiteResourceFolderPortletFolderProblemException()

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/ResourceFolderResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/ResourceFolderResourceTest.java
@@ -176,6 +176,9 @@ public class ResourceFolderResourceTest
 		_testPostSiteResourceFolderBatch();
 		_testPostSiteResourceFolderBatchLazyReferencingParentResourceFolder();
 		_testPostSiteResourceFolderDuplicateExternalReferenceCodeProblemException();
+		_testPostSiteResourceFolderFragmentSetAndFragmentSetExternalReferenceCode();
+		_testPostSiteResourceFolderFragmentSetAndFragmentSetExternalReferenceCodeProblemException();
+		_testPostSiteResourceFolderFragmentSetExternalReferenceCode();
 		_testPostSiteResourceFolderFragmentSetExternalReferenceCodeNullProblemException();
 		_testPostSiteResourceFolderFragmentSetNonexistentProblemException();
 		_testPostSiteResourceFolderParentResourceFolderAndParentResourceFolderExternalReferenceCode();
@@ -1104,6 +1107,88 @@ public class ResourceFolderResourceTest
 			"CONFLICT", "this-external-reference-code-is-already-in-use",
 			() -> resourceFolderResource.postSiteResourceFolder(
 				testGroup.getExternalReferenceCode(), resourceFolder));
+	}
+
+	private void _testPostSiteResourceFolderFragmentSetAndFragmentSetExternalReferenceCode()
+		throws Exception {
+
+		FragmentCollection fragmentCollection1 = _addFragmentCollection(
+			testGroup.getGroupId());
+
+		FragmentCollection fragmentCollection2 = _addFragmentCollection(
+			testGroup.getGroupId());
+
+		ResourceFolder resourceFolder = _randomResourceFolder(
+			fragmentCollection2.getExternalReferenceCode());
+
+		resourceFolder.setFragmentSet(
+			_toFragmentSet(fragmentCollection1.getExternalReferenceCode()));
+
+		ResourceFolder postResourceFolder =
+			resourceFolderResource.postSiteResourceFolder(
+				testGroup.getExternalReferenceCode(), resourceFolder);
+
+		ResourceFolder getResourceFolder = _getSiteResourceFolder(
+			postResourceFolder.getExternalReferenceCode());
+
+		FragmentSet getFragmentSet = getResourceFolder.getFragmentSet();
+
+		Assert.assertEquals(
+			fragmentCollection2.getExternalReferenceCode(),
+			getFragmentSet.getExternalReferenceCode());
+
+		Assert.assertEquals(
+			fragmentCollection2.getExternalReferenceCode(),
+			getResourceFolder.getFragmentSetExternalReferenceCode());
+	}
+
+	private void _testPostSiteResourceFolderFragmentSetAndFragmentSetExternalReferenceCodeProblemException()
+		throws Exception {
+
+		ResourceFolder resourceFolder = _randomResourceFolder(
+			RandomTestUtil.randomString());
+
+		resourceFolder.setFragmentSet(
+			_toFragmentSet(RandomTestUtil.randomString()));
+
+		_assertProblemException(
+			"the-fragment-set-external-reference-codes-do-not-match",
+			() -> {
+				try (SafeCloseable safeCloseable =
+						LazyReferencingTestUtil.
+							setLazyReferencingWithSafeCloseable(true)) {
+
+					resourceFolderResource.postSiteResourceFolder(
+						testGroup.getExternalReferenceCode(), resourceFolder);
+				}
+			});
+	}
+
+	private void _testPostSiteResourceFolderFragmentSetExternalReferenceCode()
+		throws Exception {
+
+		FragmentCollection fragmentCollection = _addFragmentCollection(
+			testGroup.getGroupId());
+
+		ResourceFolder resourceFolder = _randomResourceFolder(
+			fragmentCollection.getExternalReferenceCode());
+
+		ResourceFolder postResourceFolder =
+			resourceFolderResource.postSiteResourceFolder(
+				testGroup.getExternalReferenceCode(), resourceFolder);
+
+		ResourceFolder getResourceFolder = _getSiteResourceFolder(
+			postResourceFolder.getExternalReferenceCode());
+
+		FragmentSet getFragmentSet = getResourceFolder.getFragmentSet();
+
+		Assert.assertEquals(
+			fragmentCollection.getExternalReferenceCode(),
+			getFragmentSet.getExternalReferenceCode());
+
+		Assert.assertEquals(
+			fragmentCollection.getExternalReferenceCode(),
+			getResourceFolder.getFragmentSetExternalReferenceCode());
 	}
 
 	private void _testPostSiteResourceFolderFragmentSetExternalReferenceCodeNullProblemException()

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -20918,6 +20918,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=The fragment can
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page.
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=The fragment entry cannot be deleted because it is required by one or more page templates.
 the-fragment-entry-could-not-be-found=The fragment entry could not be found.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match.
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed.
 the-fragment-was-copied-successfully=The fragment was copied successfully.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=لم يعد با
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=تتعذر إضافة الجزء لأنه يحتوي على عنصر واجهة المستخدم ({0}) والذي لا يظهر سوى مرة واحدة فقط في الصفحة.
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=يتعذر حذف إدخال التجزئة لأنه مطلوب بواسطة قالب صفحة واحد أو أكثر.
 the-fragment-entry-could-not-be-found=تعذر العثور على إدخال المقطع.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=تم نسخ المقطع بنجاح.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=تم إنشاء الجزء بنجاح. يمكنك عرضه في {0}.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Фрагмент
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Записът на фрагмента не може да бъде изтрит, защото се изисква от един или повече шаблони за страници. (Automatic Translation)
 the-fragment-entry-could-not-be-found=Записът за фрагмент не може да бъде намерен. (Automatic Translation)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -20914,6 +20914,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=El fragment no e
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=El fragment no s'ha pogut afegir perquè conté un giny ({0}) que només pot aparèixer un cop a la pàgina.
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=No es pot suprimir l'entrada del fragment perquè una o més plantilles de pàgina la necessiten.
 the-fragment-entry-could-not-be-found=No s'ha pogut trobar l'entrada del fragment.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=El fragment s'ha copiat correctament.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=El fragment s'ha creat correctament. El podeu veure a {0}.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=The fragment can
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=The fragment entry cannot be deleted because it is required by one or more page templates. (Automatic Copy)
 the-fragment-entry-could-not-be-found=The fragment entry could not be found. (Automatic Copy)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Fragmentet kan i
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Fragmentposten kan ikke slettes, fordi den kræves af en eller flere sideskabeloner. (Automatic Translation)
 the-fragment-entry-could-not-be-found=The fragment entry could not be found. (Automatic Copy)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -20914,6 +20914,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Das Fragment kan
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=Das Fragment konnte nicht hinzugefügt werden, da es ein Widget ({0}) enthält, das nur einmal auf der Seite erscheinen kann.
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Der Fragment-Eintrag kann nicht gelöscht werden, da er von einer oder mehreren Seitenvorlagen benötigt wird.
 the-fragment-entry-could-not-be-found=Der Fragment-Eintrag konnte nicht gefunden werden.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=Das Fragment wurde erfolgreich kopiert.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=Das Fragment wurde erfolgreich erstellt. Sie können es sich ansehen in {0}.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
@@ -20914,6 +20914,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Das Fragment kan
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=Das Fragment konnte nicht hinzugefügt werden, da es ein Widget ({0}) enthält, das nur einmal auf der Seite erscheinen kann.
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Der Fragment-Eintrag kann nicht gelöscht werden, da er von einer oder mehreren Seitenvorlagen benötigt wird.
 the-fragment-entry-could-not-be-found=Der Fragment-Eintrag konnte nicht gefunden werden.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=Das Fragment wurde erfolgreich kopiert.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=Das Fragment wurde erfolgreich erstellt. Sie können es sich ansehen in {0}.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
@@ -20914,6 +20914,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Das Fragment kan
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=Das Fragment konnte nicht hinzugefügt werden, da es ein Widget ({0}) enthält, das nur einmal auf der Seite erscheinen kann.
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Der Fragment-Eintrag kann nicht gelöscht werden, da er von einer oder mehreren Seitenvorlagen benötigt wird.
 the-fragment-entry-could-not-be-found=Der Fragment-Eintrag konnte nicht gefunden werden.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=Das Fragment wurde erfolgreich kopiert.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=Das Fragment wurde erfolgreich erstellt. Sie können es sich ansehen in {0}.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Δεν είνα�
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Δεν είναι δυνατή η διαγραφή της καταχώρησης τμήματος, επειδή απαιτείται από ένα ή περισσότερα πρότυπα σελίδας. (Automatic Translation)
 the-fragment-entry-could-not-be-found=Δεν ήταν δυνατή η πρόσβαση στην καταχώρηση του τμήματος. (Automatic Translation)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -20918,6 +20918,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=The fragment can
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page.
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=The fragment entry cannot be deleted because it is required by one or more page templates.
 the-fragment-entry-could-not-be-found=The fragment entry could not be found.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match.
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed.
 the-fragment-was-copied-successfully=The fragment was copied successfully.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=The fragment can
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=The fragment entry cannot be deleted because it is required by one or more page templates. (Automatic Copy)
 the-fragment-entry-could-not-be-found=The fragment entry could not be found. (Automatic Copy)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=The fragment can
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=The fragment entry cannot be deleted because it is required by one or more page templates. (Automatic Copy)
 the-fragment-entry-could-not-be-found=The fragment entry could not be found. (Automatic Copy)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=The fragment can
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=The fragment entry cannot be deleted because it is required by one or more page templates. (Automatic Copy)
 the-fragment-entry-could-not-be-found=The fragment entry could not be found. (Automatic Copy)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_IE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_IE.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=The fragment can
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=The fragment entry cannot be deleted because it is required by one or more page templates. (Automatic Copy)
 the-fragment-entry-could-not-be-found=The fragment entry could not be found. (Automatic Copy)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -20914,6 +20914,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Ya no se puede a
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=No se pudo añadir el fragmento porque contiene un widget ({0}) que solo puede aparecer una vez en la página.
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=No se puede eliminar la entrada de fragmento porque se necesita para una o más plantillas de página.
 the-fragment-entry-could-not-be-found=No se encuentra la entrada del fragmento.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=El fragmento se copió correctamente.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=El fragmento se creó correctamente. Puede verlo aquí: {0}.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -20914,6 +20914,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Ya no se puede a
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=No se pudo añadir el fragmento porque contiene un widget ({0}) que solo puede aparecer una vez en la página.
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=No se puede eliminar la entrada de fragmento porque se necesita para una o más plantillas de página.
 the-fragment-entry-could-not-be-found=No se encuentra la entrada del fragmento.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=El fragmento se copió correctamente.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=El fragmento se creó correctamente. Puede verlo aquí: {0}.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -20914,6 +20914,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Ya no se puede a
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=No se pudo añadir el fragmento porque contiene un widget ({0}) que solo puede aparecer una vez en la página.
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=No se puede eliminar la entrada de fragmento porque se necesita para una o más plantillas de página.
 the-fragment-entry-could-not-be-found=No se encuentra la entrada del fragmento.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=El fragmento se copió correctamente.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=El fragmento se creó correctamente. Puede verlo aquí: {0}.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -20914,6 +20914,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Ya no se puede a
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=No se pudo añadir el fragmento porque contiene un widget ({0}) que solo puede aparecer una vez en la página.
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=No se puede eliminar la entrada de fragmento porque se necesita para una o más plantillas de página.
 the-fragment-entry-could-not-be-found=No se encuentra la entrada del fragmento.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=El fragmento se copió correctamente.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=El fragmento se creó correctamente. Puede verlo aquí: {0}.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Fragmenti ei saa
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Fragmendikirjet ei saa kustutada, kuna seda nõuab üks või mitu lehemalli. (Automatic Translation)
 the-fragment-entry-could-not-be-found=Fragmendikirjet ei leitud. (Automatic Translation)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=The fragment can
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=The fragment entry cannot be deleted because it is required by one or more page templates. (Automatic Copy)
 the-fragment-entry-could-not-be-found=The fragment entry could not be found. (Automatic Copy)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=قطعه دیگ�
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=ورودی قطعه را نمی توان حذف کرد زیرا توسط یک یا چند قالب صفحه مورد نیاز است. (Automatic Translation)
 the-fragment-entry-could-not-be-found=ورود قطعه را نمی توان یافت. (Automatic Translation)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -20910,6 +20910,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Fragmenttia ei e
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=Fragmenttia ei voi lisätä, koska se sisältää pienoissovelluksen ({0}), joka voi näkyä sivulla vain kerran.
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Sivunosaa ei voida poistaa, koska yksi tai useampi sivumalli vaatii sitä.
 the-fragment-entry-could-not-be-found=Sivunosan merkintää ei löytynyt.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=Fragmentin kopioiminen onnistui.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=Fragmentin luominen onnistui. Voit tarkastella sitä kohteessa {0}.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -20914,6 +20914,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Le fragment ne p
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=Le fragment n'a pas pu être ajouté, car il contient un widget ({0}) qui ne peut apparaître qu'une seule fois sur la page.
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=L'entrée de fragment ne peut être supprimée parce qu'elle est nécessaire pour un ou plusieurs modèles de page.
 the-fragment-entry-could-not-be-found=L'entrée de fragment est introuvable.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=Le fragment a été copié avec succès.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=Le fragment a été créé avec succès. Vous pouvez le voir dans {0}.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
@@ -20914,6 +20914,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Le fragment ne p
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=Le fragment n'a pas pu être ajouté, car il contient un widget ({0}) qui ne peut apparaître qu'une seule fois sur la page.
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=L'entrée de fragment ne peut être supprimée parce qu'elle est nécessaire pour un ou plusieurs modèles de page.
 the-fragment-entry-could-not-be-found=L'entrée de fragment est introuvable.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=Le fragment a été copié avec succès.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=Le fragment a été créé avec succès. Vous pouvez le voir dans {0}.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Le fragment ne p
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=L'entrée de fragment ne peut être supprimée parce qu'elle est nécessaire pour un ou plusieurs modèles de page.
 the-fragment-entry-could-not-be-found=L'entrée de fragment est introuvable.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
@@ -20914,6 +20914,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Le fragment ne p
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=Le fragment n'a pas pu être ajouté, car il contient un widget ({0}) qui ne peut apparaître qu'une seule fois sur la page.
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=L'entrée de fragment ne peut être supprimée parce qu'elle est nécessaire pour un ou plusieurs modèles de page.
 the-fragment-entry-could-not-be-found=L'entrée de fragment est introuvable.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=Le fragment a été copié avec succès.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=Le fragment a été créé avec succès. Vous pouvez le voir dans {0}.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=The fragment can
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=The fragment entry cannot be deleted because it is required by one or more page templates. (Automatic Copy)
 the-fragment-entry-could-not-be-found=The fragment entry could not be found. (Automatic Copy)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=टुकड़�
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=टुकड़ा प्रविष्टि हटाया नहीं जा सकता है क्योंकि यह एक या एक से अधिक पृष्ठ टेम्पलेट्स के लिए आवश्यक है । (Automatic Translation)
 the-fragment-entry-could-not-be-found=टुकड़ा प्रवेश नहीं मिल सका। (Automatic Translation)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=The fragment can
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=The fragment entry cannot be deleted because it is required by one or more page templates. (Automatic Copy)
 the-fragment-entry-could-not-be-found=The fragment entry could not be found. (Automatic Copy)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr_BA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr_BA.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=The fragment can
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=The fragment entry cannot be deleted because it is required by one or more page templates. (Automatic Copy)
 the-fragment-entry-could-not-be-found=The fragment entry could not be found. (Automatic Copy)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -20915,6 +20915,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=A töredék nem 
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=A töredék nem adható hozzá, mert egy widgetet ({0}) tartalmaz, amely az oldalon csak egyszer jelenhet meg.
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=A töredék bejegyzés nem törölhető, mert egy vagy több oldalsablonnak szüksége van rá.
 the-fragment-entry-could-not-be-found=A fragmensbejegyzés nem található.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=A töredék másolása sikeres volt.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=A töredék sikeresen létrejött. Itt megtekintheti: {0}.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Fragmen tidak la
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Entri fragmen tidak dapat dihapus karena diperlukan oleh satu atau beberapa templat halaman. (Automatic Translation)
 the-fragment-entry-could-not-be-found=Entri fragmen tak bisa ditemukan. (Automatic Translation)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -20913,6 +20913,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Il frammento non
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Il frammento non può essere cancellato perché utilizzato da una o più modelli di pagina.
 the-fragment-entry-could-not-be-found=Impossibile trovare la voce del frammento. (Automatic Translation)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
@@ -20914,6 +20914,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Il frammento non
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Il frammento non può essere cancellato perché utilizzato da una o più modelli di pagina.
 the-fragment-entry-could-not-be-found=Impossibile trovare la voce del frammento. (Automatic Translation)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=לא ניתן ע
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=לא ניתן למחוק את הקטע משום שהוא דרוש על ידי תבנית עמוד אחת או יותר.
 the-fragment-entry-could-not-be-found=ערך הקטע לא נמצא. (Automatic Translation)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -20914,6 +20914,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=このフラグ�
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=このフラグメントはページに 1 回しか表示できないウィジェット ({0}) を含むため、追加できませんでした。
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=１つ以上のページテンプレートから参照されているため、フラグメントエントリーは削除できません。
 the-fragment-entry-could-not-be-found=フラグメントエントリーが見つかりませんでした。
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=フラグメントが正常にコピーされました。
 the-fragment-was-created-successfully.-you-can-view-it-in-x=フラグメントが正常に作成されました。{0}で表示できます。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=The fragment can
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=The fragment entry cannot be deleted because it is required by one or more page templates. (Automatic Copy)
 the-fragment-entry-could-not-be-found=The fragment entry could not be found. (Automatic Copy)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -20918,6 +20918,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=The fragment can
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=The fragment entry cannot be deleted because it is required by one or more page templates.
 the-fragment-entry-could-not-be-found=The fragment entry could not be found.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -20911,6 +20911,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=프래그먼트�
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=조각 항목은 하나 이상의 페이지 템플릿에 필요하기 때문에 삭제할 수 없습니다.
 the-fragment-entry-could-not-be-found=조각 항목을 찾을 수 없습니다.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=ບໍ່ສາ�
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=ບໍ່ສາມາດເພີ່ມ Fragment ໄດ້ ເນື່ອງຈາກມັນມີວິດເຈັດ ({0}) ທີ່ສາມາດສະແດງໄດ້ພຽງຄັ້ງດຽວໃນໜ້າ.
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=ບໍ່ສາມາດລຶບລາຍການ Fragment ໄດ້ ເນື່ອງຈາກຖືກນຳໃຊ້ໂດຍໜຶ່ງ ຫຼື ຫຼາຍເທັມເພຼດໜ້າ.
 the-fragment-entry-could-not-be-found=ບໍ່ພົບລາຍການ Fragment.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=ຄັດລອກ Fragment ສຳເລັດແລ້ວ.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=ສ້າງ Fragment ສຳເລັດແລ້ວ. ທ່ານສາມາດເບິ່ງໄດ້ໃນ {0}.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Fragmento pridė
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Fragmento įrašo panaikinti negalima, nes to reikalauja vienas ar daugiau puslapio šablonų. (Automatic Translation)
 the-fragment-entry-could-not-be-found=Fragmento įrašo rasti nepavyko. (Automatic Translation)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=The fragment can
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=The fragment entry cannot be deleted because it is required by one or more page templates. (Automatic Copy)
 the-fragment-entry-could-not-be-found=The fragment entry could not be found. (Automatic Copy)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Serpihan tidak l
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Entri serpihan tidak dapat dihapuskan kerana ia diperlukan oleh satu atau lebih templat halaman. (Automatic Translation)
 the-fragment-entry-could-not-be-found=Entri serpihan tidak dijumpai. (Automatic Translation)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_my.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_my.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=The fragment can
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=The fragment entry cannot be deleted because it is required by one or more page templates. (Automatic Copy)
 the-fragment-entry-could-not-be-found=The fragment entry could not be found. (Automatic Copy)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Fragmentet kan i
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Fragmentinnlegget kan ikke slettes da det er påkrevd av en eller flere sidemaler.
 the-fragment-entry-could-not-be-found=Finner ikke fragmentoppføringen. (Automatic Translation)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -20915,6 +20915,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Het fragment kan
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=Het fragment kon niet worden toegevoegd omdat het een widget bevat ({0}) die slechts eenmaal kan verschijnen op de pagina.
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=De fragmentinvoer kan niet verwijderd worden omdat hij vereist is voor een of meerdere paginasjablonen.
 the-fragment-entry-could-not-be-found=De fragmentrecord is niet gevonden.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=Het fragment is gekopieerd.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=Het fragment is gemaakt. U kunt het bekijken in {0}.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -20915,6 +20915,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Het fragment kan
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=Het fragment kon niet worden toegevoegd omdat het een widget bevat ({0}) die slechts eenmaal kan verschijnen op de pagina.
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=De fragmentinvoer kan niet verwijderd worden omdat hij vereist is voor een of meerdere paginasjablonen.
 the-fragment-entry-could-not-be-found=De fragmentrecord is niet gevonden.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=Het fragment is gekopieerd.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=Het fragment is gemaakt. U kunt het bekijken in {0}.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Fragmentet kan i
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Fragmentinnlegget kan ikke slettes da det er påkrevd av en eller flere sidemaler.
 the-fragment-entry-could-not-be-found=Finner ikke fragmentoppføringen. (Automatic Translation)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Fragment nie mo�
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Nie można usunąć wpisu fragmentu, ponieważ jest on wymagany przez co najmniej jeden szablon strony. (Automatic Translation)
 the-fragment-entry-could-not-be-found=Nie można odnaleźć wpisu fragmentu. (Automatic Translation)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=O fragmento já 
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=O fragmento não pode ser adicionado porque contém um widget ({0}) que só pode aparecer uma vez na página.
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=A entrada de fragmento não pode ser excluída porque é exigida por um ou mais modelos de página.
 the-fragment-entry-could-not-be-found=Não foi possível encontrar a entrada de fragmento.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=O fragmento foi copiado com sucesso.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=O modelo foi criado com sucesso. Você pode visualizá-lo em {0}.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -20914,6 +20914,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=O fragmento já 
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=O fragmento não pode ser adicionado porque contém um widget ({0}) que só pode aparecer uma vez na página.
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=A entrada de fragmento não pode ser excluída porque é exigida por um ou mais modelos de página.
 the-fragment-entry-could-not-be-found=Não foi possível encontrar a entrada de fragmento.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=O fragmento foi copiado com sucesso.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=O modelo foi criado com sucesso. Você pode visualizá-lo em {0}.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Fragmentul nu ma
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Imposibil de șters intrarea fragment, deoarece este solicitată de unul sau mai multe șabloane de pagină. (Automatic Translation)
 the-fragment-entry-could-not-be-found=Imposibil de găsit intrarea fragmentului. (Automatic Translation)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Фрагмент
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Запись фрагмента не может быть удалена, поскольку она требуется одним или несколько шаблонов страниц. (Automatic Translation)
 the-fragment-entry-could-not-be-found=Не удалось найти фрагмент. (Automatic Translation)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=Фрагмент был успешно скопирован.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Fragment už nie
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Položku fragmentu nie je možné odstrániť, pretože ju vyžaduje jedna alebo viac šablón strán. (Automatic Translation)
 the-fragment-entry-could-not-be-found=Položka fragmentu sa nenašla. (Automatic Translation)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Fragmenta ni ve�
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Vnosa fragmenta ni mogoče izbrisati, ker ga zahteva ena ali več predlog strani. (Automatic Translation)
 the-fragment-entry-could-not-be-found=Vnosa fragmenta ni bilo mogoče najti. (Automatic Translation)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=The fragment can
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=The fragment entry cannot be deleted because it is required by one or more page templates. (Automatic Copy)
 the-fragment-entry-could-not-be-found=The fragment entry could not be found. (Automatic Copy)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=The fragment can
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=The fragment entry cannot be deleted because it is required by one or more page templates. (Automatic Copy)
 the-fragment-entry-could-not-be-found=The fragment entry could not be found. (Automatic Copy)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Det g책r inte l�
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=Det gick inte att l채gga till fragmentet eftersom det inneh책ller en widget ({0}) som bara kan visas en g책ng p책 sidan.
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Det g책r inte att ta bort fragmentposten eftersom den kr채vs av en eller flera mallar.
 the-fragment-entry-could-not-be-found=Fragmentposten hittades inte.
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=Fragmentet har kopierats.
 the-fragment-was-created-successfully.-you-can-view-it-in-x=Fragmentet har skapats. Du kan visa det i {0}.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Fragment-ஐ இ
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Fragment entry நீக்க முடியாது. ஏனெனில் ஒன்று அல்லது அதற்கு மேற்பட்ட page templates-கள் தேவைப்படும்.
 the-fragment-entry-could-not-be-found=The fragment entry could not be found. (Automatic Copy)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=ไม่สา�
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=ไม่สามารถลบรายการส่วนได้เนื่องจากต้องการโดยเทมเพลตหน้าอย่างน้อยหนึ่งรายการ
 the-fragment-entry-could-not-be-found=ไม่พบรายการแฟรกเมนต์
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Parça silindiğ
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Parça girdisi, bir veya daha fazla sayfa şablonu tarafından gerekli olduğundan silinemiyor. (Automatic Translation)
 the-fragment-entry-could-not-be-found=Parça girdisi bulunamadı. (Automatic Translation)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Фрагмент
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Не вдалося видалити елемент фрагмента, оскільки він потрібен для одного або кілька шаблонів сторінок. (Automatic Translation)
 the-fragment-entry-could-not-be-found=Не вдалося знайти елемент фрагмента. (Automatic Translation)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -20912,6 +20912,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=Đoạn văn kh�
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=Mục nhập đoạn không thể bị xóa vì nó được yêu cầu bởi một hoặc nhiều mẫu trang. (Automatic Translation)
 the-fragment-entry-could-not-be-found=Không tìm thấy mục nhập mảnh. (Automatic Translation)
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -20914,6 +20914,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=无法再添加�
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=无法添加片段，因为它包含只能在页面中出现一次的微件 ({0})。
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=由于一个或多个页面模板需要此片段条目，无法将其删除。
 the-fragment-entry-could-not-be-found=找不到片段条目。
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=片段复制成功。
 the-fragment-was-created-successfully.-you-can-view-it-in-x=片段已成功创建。可以在 {0} 中查看它。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -20913,6 +20913,7 @@ the-fragment-can-no-longer-be-added-because-it-has-been-deleted=由於此頁面�
 the-fragment-could-not-be-added-because-it-contains-a-widget-x-that-can-only-appear-once-on-the-page=The fragment could not be added because it contains a widget ({0}) that can only appear once on the page. (Automatic Copy)
 the-fragment-entry-cannot-be-deleted-because-it-is-required-by-one-or-more-page-templates=無法刪除片段條目，因為它需要一個或多個頁面範本。 (Automatic Translation)
 the-fragment-entry-could-not-be-found=找不到頁面片段條目。
+the-fragment-set-external-reference-codes-do-not-match=The fragment set external reference codes do not match. (Automatic Copy)
 the-fragment-type-cannot-be-changed=The fragment type cannot be changed. (Automatic Copy)
 the-fragment-was-copied-successfully=The fragment was copied successfully. (Automatic Copy)
 the-fragment-was-created-successfully.-you-can-view-it-in-x=The fragment was created successfully. You can view it in {0}. (Automatic Copy)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88489

## What Is Being Fixed

Headless APIs link related entities by external reference code: a scalar `xExternalReferenceCode` field drives the write, and the related object is returned on read only when requested through `nestedFields`. Resource folders already point to their parent this way (`parentResourceFolderExternalReferenceCode`), as do display page template folders (`parentDisplayPageTemplateFolderExternalReferenceCode`) and accounts to their parent account (`parentAccountExternalReferenceCode`). The fragment set relationship did not follow this pattern: fragments and resource folders could reference their fragment set only through a nested `fragmentSet` object, which is awkward for clients to send and does not fit the batch (LAR) import flow.

## How It Is Being Fixed

Adds a `fragmentSetExternalReferenceCode` field to the `Fragment` and `ResourceFolder` DTOs, behind the `LPD-39244` feature flag. The regular write path resolves the fragment set from this field; the nested `fragmentSet` object is consulted only during a LAR import (creating the set lazily and rejecting a mismatch between the two), with the shared resolve-or-create logic in `FragmentSetUtil`. On read, the nested `fragmentSet` and `parentResourceFolder` objects are returned only when requested through `nestedFields` (and `batchNestedFields` for the batch export). The integration tests cover both resources symmetrically across write, read, and batch export.

## PR Check

**pr-check: PASS** - tested on `5caf0f7379ea8c8f15467bf3bc3ebb8ec058fc16`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5caf0f7379ea8c8f15467bf3bc3ebb8ec058fc16"} -->
