### PR TITLE
LPD-96714 Open the CMS file selector for upload fields in a space

### DIFF
--- a/modules/apps/fragment/fragment-impl/build.gradle
+++ b/modules/apps/fragment/fragment-impl/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 	compileOnly project(":apps:asset:asset-taglib")
 	compileOnly project(":apps:change-tracking:change-tracking-api")
 	compileOnly project(":apps:change-tracking:change-tracking-spi")
+	compileOnly project(":apps:depot:depot-api")
 	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:flags:flags-taglib")
 	compileOnly project(":apps:fragment:fragment-api")

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/input/template/parser/FragmentEntryInputTemplateNodeContextHelperImpl.java
@@ -5,6 +5,9 @@
 
 package com.liferay.fragment.internal.input.template.parser;
 
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.fragment.constants.FragmentConfigurationFieldDataType;
@@ -477,7 +480,7 @@ public class FragmentEntryInputTemplateNodeContextHelperImpl
 
 		Group group = themeDisplay.getScopeGroup();
 
-		inputTemplateNode.addAttribute("isCMS", group.isCMS());
+		inputTemplateNode.addAttribute("isCMS", _isCMSGroup(group));
 
 		String previewURL = _getPreviewURL(httpServletRequest, value);
 
@@ -1261,6 +1264,26 @@ public class FragmentEntryInputTemplateNodeContextHelperImpl
 			defaultValue, infoField, locale, infoFieldValue.getValue());
 	}
 
+	private boolean _isCMSGroup(Group group) {
+		if (group.isCMS()) {
+			return true;
+		}
+
+		if (group.isDepot()) {
+			DepotEntry depotEntry =
+				_depotEntryLocalService.fetchGroupDepotEntry(
+					group.getGroupId());
+
+			if ((depotEntry != null) &&
+				(depotEntry.getType() == DepotConstants.TYPE_SPACE)) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	private Object _parseValue(
 		String defaultValue, InfoField infoField, Locale locale, Object value) {
 
@@ -1438,6 +1461,9 @@ public class FragmentEntryInputTemplateNodeContextHelperImpl
 
 	@Reference
 	private CountryLocalService _countryLocalService;
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;

--- a/modules/test/playwright/helpers/ApiHelpers.ts
+++ b/modules/test/playwright/helpers/ApiHelpers.ts
@@ -88,6 +88,7 @@ import {JSONWebServicesUserGroupApiHelper} from './json-web-services/JSONWebServ
 type ContentType = 'application/json' | 'application/x-www-form-urlencoded';
 
 type TDataApiHelpersData = {
+	applicationName?: string;
 	id: any;
 	type: string;
 };
@@ -596,6 +597,12 @@ export class DataApiHelpers extends ApiHelpers {
 				}
 
 				await objectDefinitionAPIClient.deleteObjectDefinition(item.id);
+			}
+			else if (item.type === 'objectEntry') {
+				await this.objectEntry.deleteObjectEntry(
+					item.applicationName!,
+					item.id
+				);
 			}
 			else if (item.type === 'objectFolder') {
 				const objectFolderRESTClient =

--- a/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/uploadField.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/uploadField.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {getRandomInt} from '../../../utils/getRandomInt';
+import getRandomString from '../../../utils/getRandomString';
+import chooseFileFromCMSLibrary from '../../layout-content-page-editor-web/main/utils/chooseFileFromCMSLibrary';
+import {cmsPagesTest} from '../main/fixtures/cmsPagesTest';
+import {structureBuilderPagesTest} from './fixtures/structureBuilderPagesTest';
+
+const test = mergeTests(
+	cmsPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-17564': {enabled: true},
+	}),
+	loginTest(),
+	structureBuilderPagesTest
+);
+
+test(
+	'Every repeat of an upload field opens the same CMS item selector',
+	{tag: '@LPD-96714'},
+	async ({apiHelpers, contentsPage, page, structureBuilderPage}) => {
+		const fileName = `file_${getRandomString()}.png`;
+		const structureLabel = `StructureName${getRandomInt()}`;
+
+		// Seed a file in the Default space so it can be found in the selector
+
+		const objectEntry = await apiHelpers.objectEntry.postObjectEntry(
+			{
+				file: {
+					fileBase64: 'R0lGODlhAQABAAAAACw=',
+					name: fileName,
+				},
+				objectEntryFolderExternalReferenceCode: 'L_FILES',
+				title: fileName,
+			},
+			'cms/basic-documents',
+			'Default'
+		);
+
+		apiHelpers.data.push({
+			applicationName: 'cms/basic-documents',
+			id: objectEntry.id,
+			type: 'objectEntry',
+		});
+
+		// Create a structure whose upload field selects from the item selector
+		// and is a repeatable group
+
+		await structureBuilderPage.createStructureFromData({
+			label: structureLabel,
+			page: structureBuilderPage,
+			publish: false,
+		});
+
+		await structureBuilderPage.addField('Upload');
+
+		await structureBuilderPage.changeFieldSettings({
+			label: 'Upload from DM',
+			name: 'uploadFromDM',
+			requestFile: 'document-library',
+		});
+
+		await structureBuilderPage.createRepeatableGroup({
+			fields: [{label: 'Upload from DM'}],
+			label: 'Repeatable Group',
+		});
+
+		await structureBuilderPage.publishStructure();
+
+		// Create a content for the structure in the Default space
+
+		await contentsPage.goto();
+
+		await contentsPage.createContent(structureLabel);
+
+		const uploadFragments = page.locator('.file-upload');
+
+		// The first repeat selects the seeded file through the CMS item selector
+
+		await chooseFileFromCMSLibrary({
+			fileName,
+			page,
+			trigger: uploadFragments.nth(0).getByText('Select File', {
+				exact: true,
+			}),
+		});
+
+		// The second repeat opens the same CMS item selector and finds the same
+		// file instead of a different, empty selector
+
+		await page.getByText('Add New', {exact: true}).first().click();
+
+		await chooseFileFromCMSLibrary({
+			fileName,
+			page,
+			trigger: uploadFragments.nth(1).getByText('Select File', {
+				exact: true,
+			}),
+		});
+
+		// Deleting the auto-tracked structure also removes this draft content
+
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96714

## What Is Being Fixed

In a CMS space, a repeatable upload field configured with "Upload or Select from Item Selector" opened a different, empty selector for added repeats. The first entry used the CMS item selector, but after "+ Add New" the next entry opened the generic document library selector, where no space, library, or previously uploaded document was visible.

## How It Is Being Fixed

FragmentEntryInputTemplateNodeContextHelperImpl set the "isCMS" attribute from group.isCMS(), which is only true for the CMS group. A space is backed by a depot of type SPACE, so the attribute was false and the upload field fell back to the generic selector. A new _isCMSGroup helper also returns true when the scope group is a space (a depot whose type is DepotConstants.TYPE_SPACE), so every repeat of the upload field opens the CMS item selector.

## PR Check

**pr-check: PASS** — tested on `1b4f71ed840926a9adedea912a71eefd5c85278c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |

Java Unit Tests and JavaScript Unit Tests matched the diff but were intentionally skipped: the changed class has no unit-test counterpart (it is exercised by an integration test), and the JavaScript Unit Tests command would have run the entire Playwright end-to-end suite because the changed files are Playwright specs.

<!-- pr-check {"result": "success", "sha": "1b4f71ed840926a9adedea912a71eefd5c85278c"} -->
