### PR TITLE
LPD-97875 Detect all FreeMarker runtime tags in a fragment

### DIFF
--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/processor/PortletRegistryImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/processor/PortletRegistryImpl.java
@@ -33,8 +33,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -113,24 +111,36 @@ public class PortletRegistryImpl implements PortletRegistry {
 			portletIds.add(_portal.getJsSafePortletId(portletId));
 		}
 
-		Matcher liferayPortletRuntimeMatcher =
-			_liferayPortletRuntimePattern.matcher(fragmentEntryLink.getHtml());
+		int index = html.indexOf(_LIFERAY_PORTLET_MACRO);
 
-		while (liferayPortletRuntimeMatcher.find()) {
-			String portletName = _getAttributeValue(
-				"portletName", liferayPortletRuntimeMatcher.group(2));
+		while (index != -1) {
+			int contentIndex = index + _LIFERAY_PORTLET_MACRO.length();
+
+			if (!html.startsWith(".runtime", contentIndex) &&
+				!html.startsWith("[\"runtime\"]", contentIndex)) {
+
+				index = html.indexOf(_LIFERAY_PORTLET_MACRO, index + 1);
+
+				continue;
+			}
+
+			int endIndex = html.indexOf("/]", contentIndex);
+
+			if (endIndex == -1) {
+				break;
+			}
+
+			String macro = html.substring(index, endIndex);
+
+			index = html.indexOf(_LIFERAY_PORTLET_MACRO, endIndex);
+
+			String portletName = _getAttributeValue("portletName", macro);
 
 			if (Validator.isNull(portletName)) {
 				continue;
 			}
 
-			String instanceId = _getAttributeValue(
-				"instanceId", liferayPortletRuntimeMatcher.group(1));
-
-			if (Validator.isNull(instanceId)) {
-				instanceId = _getAttributeValue(
-					"instanceId", liferayPortletRuntimeMatcher.group(3));
-			}
+			String instanceId = _getAttributeValue("instanceId", macro);
 
 			String portletId = PortletIdCodec.encode(
 				PortletIdCodec.decodePortletName(portletName),
@@ -254,13 +264,10 @@ public class PortletRegistryImpl implements PortletRegistry {
 		return document;
 	}
 
+	private static final String _LIFERAY_PORTLET_MACRO = "[@liferay_portlet";
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		PortletRegistryImpl.class);
-
-	private static final Pattern _liferayPortletRuntimePattern =
-		Pattern.compile(
-			"\\[@liferay_portlet(?=\\.runtime|\\[\"runtime\"\\])([\\s\\S]*)?" +
-				"(portletName=\"\\w+\")([\\s\\S]*)?\\/\\]");
 
 	private final Map<String, String> _aliasPortletNames =
 		new ConcurrentHashMap<>();

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/processor/PortletRegistryImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/processor/PortletRegistryImpl.java
@@ -78,79 +78,8 @@ public class PortletRegistryImpl implements PortletRegistry {
 
 		String html = fragmentEntryLink.getHtml();
 
-		if (!html.contains("@liferay_portlet") &&
-			!html.contains("lfr-widget-")) {
-
-			return portletIds;
-		}
-
-		if (document == null) {
-			document = _getDocument(html);
-		}
-
-		for (Element element : document.select("*")) {
-			String tagName = element.tagName();
-
-			if (!StringUtil.startsWith(tagName, "lfr-widget-")) {
-				continue;
-			}
-
-			String alias = StringUtil.removeSubstring(tagName, "lfr-widget-");
-
-			String portletName = getPortletName(alias);
-
-			if (Validator.isNull(portletName)) {
-				continue;
-			}
-
-			String portletId = PortletIdCodec.encode(
-				PortletIdCodec.decodePortletName(portletName),
-				PortletIdCodec.decodeUserId(portletName),
-				fragmentEntryLink.getNamespace() + element.attr("id"));
-
-			portletIds.add(_portal.getJsSafePortletId(portletId));
-		}
-
-		int index = html.indexOf(_LIFERAY_PORTLET_MACRO);
-
-		while (index != -1) {
-			int contentIndex = index + _LIFERAY_PORTLET_MACRO.length();
-
-			if (!html.startsWith(".runtime", contentIndex) &&
-				!html.startsWith("[\"runtime\"]", contentIndex)) {
-
-				index = html.indexOf(_LIFERAY_PORTLET_MACRO, index + 1);
-
-				continue;
-			}
-
-			int endIndex = html.indexOf("/]", contentIndex);
-
-			if (endIndex == -1) {
-				break;
-			}
-
-			String macro = html.substring(index, endIndex);
-
-			index = html.indexOf(_LIFERAY_PORTLET_MACRO, endIndex);
-
-			String portletName = _getAttributeValue("portletName", macro);
-
-			if (Validator.isNull(portletName)) {
-				continue;
-			}
-
-			String instanceId = _getAttributeValue("instanceId", macro);
-
-			String portletId = PortletIdCodec.encode(
-				PortletIdCodec.decodePortletName(portletName),
-				PortletIdCodec.decodeUserId(portletName),
-				StringUtil.replace(
-					instanceId, "fragmentEntryLinkNamespace",
-					fragmentEntryLink.getNamespace()));
-
-			portletIds.add(_portal.getJsSafePortletId(portletId));
-		}
+		_addRuntimeTagPortletIds(fragmentEntryLink, html, portletIds);
+		_addWidgetTagPortletIds(document, fragmentEntryLink, html, portletIds);
 
 		return portletIds;
 	}
@@ -228,6 +157,88 @@ public class PortletRegistryImpl implements PortletRegistry {
 					"Unable to write portlet paths " + portlet.getPortletId(),
 					exception);
 			}
+		}
+	}
+
+	private void _addRuntimeTagPortletIds(
+		FragmentEntryLink fragmentEntryLink, String html,
+		List<String> portletIds) {
+
+		int index = html.indexOf(_LIFERAY_PORTLET_MACRO);
+
+		while (index != -1) {
+			int contentIndex = index + _LIFERAY_PORTLET_MACRO.length();
+
+			if (!html.startsWith(".runtime", contentIndex) &&
+				!html.startsWith("[\"runtime\"]", contentIndex)) {
+
+				index = html.indexOf(_LIFERAY_PORTLET_MACRO, index + 1);
+
+				continue;
+			}
+
+			int endIndex = html.indexOf("/]", contentIndex);
+
+			if (endIndex == -1) {
+				break;
+			}
+
+			String macro = html.substring(index, endIndex);
+
+			index = html.indexOf(_LIFERAY_PORTLET_MACRO, endIndex);
+
+			String portletName = _getAttributeValue("portletName", macro);
+
+			if (Validator.isNull(portletName)) {
+				continue;
+			}
+
+			String instanceId = _getAttributeValue("instanceId", macro);
+
+			String portletId = PortletIdCodec.encode(
+				PortletIdCodec.decodePortletName(portletName),
+				PortletIdCodec.decodeUserId(portletName),
+				StringUtil.replace(
+					instanceId, "fragmentEntryLinkNamespace",
+					fragmentEntryLink.getNamespace()));
+
+			portletIds.add(_portal.getJsSafePortletId(portletId));
+		}
+	}
+
+	private void _addWidgetTagPortletIds(
+		Document document, FragmentEntryLink fragmentEntryLink, String html,
+		List<String> portletIds) {
+
+		if (!html.contains("lfr-widget-")) {
+			return;
+		}
+
+		if (document == null) {
+			document = _getDocument(html);
+		}
+
+		for (Element element : document.select("*")) {
+			String tagName = element.tagName();
+
+			if (!StringUtil.startsWith(tagName, "lfr-widget-")) {
+				continue;
+			}
+
+			String alias = StringUtil.removeSubstring(tagName, "lfr-widget-");
+
+			String portletName = getPortletName(alias);
+
+			if (Validator.isNull(portletName)) {
+				continue;
+			}
+
+			String portletId = PortletIdCodec.encode(
+				PortletIdCodec.decodePortletName(portletName),
+				PortletIdCodec.decodeUserId(portletName),
+				fragmentEntryLink.getNamespace() + element.attr("id"));
+
+			portletIds.add(_portal.getJsSafePortletId(portletId));
 		}
 	}
 

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/processor/PortletRegistryImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/processor/PortletRegistryImpl.java
@@ -210,7 +210,7 @@ public class PortletRegistryImpl implements PortletRegistry {
 		Document document, FragmentEntryLink fragmentEntryLink, String html,
 		List<String> portletIds) {
 
-		if (!html.contains("lfr-widget-")) {
+		if (!html.contains(_LFR_WIDGET_TAG_PREFIX)) {
 			return;
 		}
 
@@ -221,11 +221,12 @@ public class PortletRegistryImpl implements PortletRegistry {
 		for (Element element : document.select("*")) {
 			String tagName = element.tagName();
 
-			if (!StringUtil.startsWith(tagName, "lfr-widget-")) {
+			if (!StringUtil.startsWith(tagName, _LFR_WIDGET_TAG_PREFIX)) {
 				continue;
 			}
 
-			String alias = StringUtil.removeSubstring(tagName, "lfr-widget-");
+			String alias = StringUtil.removeSubstring(
+				tagName, _LFR_WIDGET_TAG_PREFIX);
 
 			String portletName = getPortletName(alias);
 
@@ -274,6 +275,8 @@ public class PortletRegistryImpl implements PortletRegistry {
 
 		return document;
 	}
+
+	private static final String _LFR_WIDGET_TAG_PREFIX = "lfr-widget-";
 
 	private static final String _LIFERAY_PORTLET_MACRO = "[@liferay_portlet";
 

--- a/modules/apps/fragment/fragment-impl/src/test/java/com/liferay/fragment/internal/processor/PortletRegistryImplTest.java
+++ b/modules/apps/fragment/fragment-impl/src/test/java/com/liferay/fragment/internal/processor/PortletRegistryImplTest.java
@@ -195,6 +195,40 @@ public class PortletRegistryImplTest {
 	}
 
 	@Test
+	public void testGetFragmentEntryLinkPortletIdsMultipleFreeMarkerRuntimeTags() {
+		String instanceId1 = RandomTestUtil.randomString();
+		String instanceId2 = RandomTestUtil.randomString();
+		String instanceId3 = RandomTestUtil.randomString();
+		String portletName1 = RandomTestUtil.randomString();
+		String portletName2 = RandomTestUtil.randomString();
+		String portletName3 = RandomTestUtil.randomString();
+
+		_assertGetFragmentEntryLinkPortletIds(
+			_getFragmentEntryLink(
+				StringBundler.concat(
+					"<div class=\"fragment_1\">", RandomTestUtil.randomString(),
+					"[@liferay_portlet.runtime\n\tinstanceId=\"", instanceId1,
+					"\"\n\tportletName=\"", portletName1, "\"\n/]",
+					RandomTestUtil.randomString(),
+					"[@liferay_portlet.runtime instanceId=\"", instanceId2,
+					"\" portletName=\"", portletName2, "\" /]",
+					RandomTestUtil.randomString(),
+					"[@liferay_portlet[\"runtime\"] instanceId=\"", instanceId3,
+					"\" portletName=\"", portletName3, "\" /]",
+					RandomTestUtil.randomString(), "</div>"),
+				RandomTestUtil.randomString()),
+			PortletIdCodec.encode(
+				PortletIdCodec.decodePortletName(portletName1),
+				PortletIdCodec.decodeUserId(portletName1), instanceId1),
+			PortletIdCodec.encode(
+				PortletIdCodec.decodePortletName(portletName2),
+				PortletIdCodec.decodeUserId(portletName2), instanceId2),
+			PortletIdCodec.encode(
+				PortletIdCodec.decodePortletName(portletName3),
+				PortletIdCodec.decodeUserId(portletName3), instanceId3));
+	}
+
+	@Test
 	public void testGetFragmentEntryLinkPortletIdsTypePortlet() {
 		String instanceId = RandomTestUtil.randomString();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97875

## What Is Being Fixed

A fragment can embed more than one portlet through the `[@liferay_portlet.runtime .../]` FreeMarker macro. When detecting which portlets a fragment references, the code matched these macros with a single greedy regular expression. Because `[\s\S]*` is greedy and spans macro boundaries, a fragment containing multiple macros produced one match that captured only the last macro's `portletName`, and its `instanceId` could even be read from a different macro. As a result, `writePortletPaths` wrote the header and footer resource paths for only one portlet and silently dropped the rest, so every embedded portlet but one could be missing its required paths at render time.

## How It Is Being Fixed

The greedy regular expression is replaced with a manual scan that walks the HTML from one `[@liferay_portlet` occurrence to the next, bounding each macro to its own first `/]`. Each macro is parsed independently for its `portletName` and `instanceId` through the existing `_getAttributeValue` helper, which already handles either attribute order, so every macro in the fragment contributes its portlet. The FreeMarker runtime prefix check (`.runtime` or `["runtime"]`) is preserved, and the `lfr-widget-` element detection still uses the parsed document since those are real HTML elements. The now-unused `Pattern` and `Matcher` imports and the regex field are removed.

## PR Check

**pr-check: PASS** — tested on `dfea28cfbd0e9c426f0a439d4883a94dd605d3fb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "dfea28cfbd0e9c426f0a439d4883a94dd605d3fb"} -->
