### PR TITLE
LPD-97633 Allow a custom fragment name in FragmentSetModal

### DIFF
--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/modals/FragmentSetModal.tsx
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/modals/FragmentSetModal.tsx
@@ -17,21 +17,23 @@ type FragmentSet = {fragmentCollectionId: number; name: string};
 
 type Errors = {
 	error?: string;
+	fragmentName?: string | null;
 	fragmentSets?: string | null;
 	name?: string | null;
 };
 
 export default function FragmentSetModal({
 	addFragmentCollectionURL,
+	allowCustomName = false,
 	contributedEntryKeys = [],
 	copyFragmentEntriesURL,
 	fragmentCollections = [],
 	fragmentEntryIds = [],
 	onSubmitFragmentCollection,
 	portletNamespace,
-	showFragmentNameInput = false,
 }: {
 	addFragmentCollectionURL?: string;
+	allowCustomName?: boolean;
 	contributedEntryKeys?: string[];
 	copyFragmentEntriesURL?: string;
 	fragmentCollections: FragmentSet[];
@@ -41,13 +43,8 @@ export default function FragmentSetModal({
 		fragmentName?: string
 	) => Promise<void> | void;
 	portletNamespace: string;
-	showFragmentNameInput?: boolean;
 }) {
-	const [visible, setVisible] = useState(true);
-
-	const {observer, onClose} = useModal({
-		onClose: () => setVisible(false),
-	});
+	const {observer, onOpenChange, open} = useModal({defaultOpen: true});
 
 	const [errors, setErrors] = useState<Errors>({});
 	const [fragmentName, setFragmentName] = useState('');
@@ -58,26 +55,10 @@ export default function FragmentSetModal({
 	const formId = `${portletNamespace}form`;
 
 	const submitFragmentCollection = (fragmentCollectionId: number) => {
-		if (showFragmentNameInput && !fragmentName) {
-			setErrors({
-				name: sub(
-					Liferay.Language.get('x-field-is-required'),
-					Liferay.Language.get('name')
-				),
-			});
-
-			return;
-		}
-
 		if (onSubmitFragmentCollection) {
-			onClose();
+			onOpenChange(false);
 
-			if (showFragmentNameInput) {
-				onSubmitFragmentCollection(fragmentCollectionId, fragmentName);
-			}
-			else {
-				onSubmitFragmentCollection(fragmentCollectionId);
-			}
+			onSubmitFragmentCollection(fragmentCollectionId, fragmentName);
 
 			return;
 		}
@@ -117,7 +98,7 @@ export default function FragmentSetModal({
 			method: 'POST',
 		})
 			.then((response) => {
-				onClose();
+				onOpenChange(false);
 
 				if (response.redirected) {
 					navigate(response.url);
@@ -140,7 +121,16 @@ export default function FragmentSetModal({
 			});
 	};
 
-	if (!visible) {
+	let title = Liferay.Language.get('select-fragment-set');
+
+	if (allowCustomName) {
+		title = Liferay.Language.get('add-fragment');
+	}
+	else if (showFragmentSetForm) {
+		title = Liferay.Language.get('add-fragment-set');
+	}
+
+	if (!open) {
 		return null;
 	}
 
@@ -149,11 +139,7 @@ export default function FragmentSetModal({
 			<ClayModal.Header
 				closeButtonAriaLabel={Liferay.Language.get('close')}
 			>
-				{showFragmentNameInput
-					? Liferay.Language.get('add-fragment')
-					: showFragmentSetForm
-						? Liferay.Language.get('add-fragment-set')
-						: Liferay.Language.get('select-fragment-set')}
+				{title}
 			</ClayModal.Header>
 
 			<ClayModal.Body>
@@ -166,43 +152,29 @@ export default function FragmentSetModal({
 					</ClayAlert>
 				)}
 
-				{showFragmentNameInput && (
-					<FormField
-						error={errors.name}
-						id={`${portletNamespace}fragmentName`}
-						name={Liferay.Language.get('name')}
-						required
-					>
-						<ClayInput
-							id={`${portletNamespace}fragmentName`}
-							onChange={(event) => {
-								setErrors({...errors, name: null});
-								setFragmentName(event.target.value);
-							}}
-							required
-							type="text"
-							value={fragmentName}
-						/>
-					</FormField>
-				)}
-
 				{showFragmentSetForm ? (
 					<FragmentSetForm
 						addFragmentCollectionURL={addFragmentCollectionURL}
+						allowCustomName={allowCustomName}
 						errors={errors}
 						formId={formId}
 						fragmentCollections={fragmentCollections}
+						fragmentName={fragmentName}
 						portletNamespace={portletNamespace}
 						setErrors={setErrors}
+						setFragmentName={setFragmentName}
 						submitFragmentCollection={submitFragmentCollection}
 					/>
 				) : (
 					<FragmentSetSelector
+						allowCustomName={allowCustomName}
 						errors={errors}
 						formId={formId}
 						fragmentCollections={fragmentCollections}
+						fragmentName={fragmentName}
 						portletNamespace={portletNamespace}
 						setErrors={setErrors}
+						setFragmentName={setFragmentName}
 						submitFragmentCollection={submitFragmentCollection}
 					/>
 				)}
@@ -223,7 +195,10 @@ export default function FragmentSetModal({
 				}
 				last={
 					<ClayButton.Group spaced>
-						<ClayButton displayType="secondary" onClick={onClose}>
+						<ClayButton
+							displayType="secondary"
+							onClick={() => onOpenChange(false)}
+						>
 							{Liferay.Language.get('cancel')}
 						</ClayButton>
 
@@ -241,19 +216,59 @@ export default function FragmentSetModal({
 	);
 }
 
+function FragmentNameField({
+	errors,
+	fragmentName,
+	portletNamespace,
+	setErrors,
+	setFragmentName,
+}: {
+	errors: Errors;
+	fragmentName: string;
+	portletNamespace: string;
+	setErrors: (errors: Errors) => void;
+	setFragmentName: (fragmentName: string) => void;
+}) {
+	return (
+		<FormField
+			error={errors.fragmentName}
+			id={`${portletNamespace}fragmentName`}
+			name={Liferay.Language.get('name')}
+			required
+		>
+			<ClayInput
+				id={`${portletNamespace}fragmentName`}
+				onChange={(event) => {
+					setErrors({...errors, fragmentName: null});
+					setFragmentName(event.target.value);
+				}}
+				required
+				type="text"
+				value={fragmentName}
+			/>
+		</FormField>
+	);
+}
+
 function FragmentSetSelector({
+	allowCustomName,
 	errors,
 	formId,
 	fragmentCollections,
+	fragmentName,
 	portletNamespace,
 	setErrors,
+	setFragmentName,
 	submitFragmentCollection,
 }: {
+	allowCustomName: boolean;
 	errors: Errors;
 	formId: string;
 	fragmentCollections: FragmentSet[];
+	fragmentName: string;
 	portletNamespace: string;
 	setErrors: (errors: Errors) => void;
+	setFragmentName: (fragmentName: string) => void;
 	submitFragmentCollection: (fragmentCollectionId: number) => void;
 }) {
 	const [selectedFragmentCollection, setSelectedFragmentCollection] =
@@ -276,13 +291,24 @@ function FragmentSetSelector({
 	const handleSubmit = (event: FormEvent) => {
 		event.preventDefault();
 
+		const nextErrors: Errors = {};
+
+		if (allowCustomName && !fragmentName) {
+			nextErrors.fragmentName = sub(
+				Liferay.Language.get('x-field-is-required'),
+				Liferay.Language.get('name')
+			);
+		}
+
 		if (!selectedFragmentCollection) {
-			setErrors({
-				fragmentSets: sub(
-					Liferay.Language.get('x-field-is-required'),
-					Liferay.Language.get('fragment-set')
-				),
-			});
+			nextErrors.fragmentSets = sub(
+				Liferay.Language.get('x-field-is-required'),
+				Liferay.Language.get('fragment-set')
+			);
+		}
+
+		if (Object.keys(nextErrors).length) {
+			setErrors(nextErrors);
 
 			return;
 		}
@@ -291,12 +317,29 @@ function FragmentSetSelector({
 	};
 
 	return (
-		<ClayForm id={formId} onSubmit={handleSubmit}>
+		<ClayForm
+			id={formId}
+
+			// @ts-ignore
+
+			noValidate
+			onSubmit={handleSubmit}
+		>
 			<p className="text-secondary">
 				{Liferay.Language.get(
 					'select-an-existing-set-or-create-a-new-one-to-save-your-fragment'
 				)}
 			</p>
+
+			{allowCustomName && (
+				<FragmentNameField
+					errors={errors}
+					fragmentName={fragmentName}
+					portletNamespace={portletNamespace}
+					setErrors={setErrors}
+					setFragmentName={setFragmentName}
+				/>
+			)}
 
 			<FormField
 				error={errors.fragmentSets}
@@ -320,19 +363,25 @@ function FragmentSetSelector({
 
 function FragmentSetForm({
 	addFragmentCollectionURL,
+	allowCustomName,
 	errors,
 	formId,
 	fragmentCollections,
+	fragmentName,
 	portletNamespace,
 	setErrors,
+	setFragmentName,
 	submitFragmentCollection,
 }: {
 	addFragmentCollectionURL?: string;
+	allowCustomName: boolean;
 	errors: Errors;
 	formId: string;
 	fragmentCollections: FragmentSet[];
+	fragmentName: string;
 	portletNamespace: string;
 	setErrors: (errors: Errors) => void;
+	setFragmentName: (fragmentName: string) => void;
 	submitFragmentCollection: (fragmentCollectionId: number) => void;
 }) {
 	const [name, setName] = useState(() =>
@@ -343,13 +392,24 @@ function FragmentSetForm({
 	const handleSubmit = (event: FormEvent) => {
 		event.preventDefault();
 
+		const nextErrors: Errors = {};
+
+		if (allowCustomName && !fragmentName) {
+			nextErrors.fragmentName = sub(
+				Liferay.Language.get('x-field-is-required'),
+				Liferay.Language.get('name')
+			);
+		}
+
 		if (!name) {
-			setErrors({
-				name: sub(
-					Liferay.Language.get('x-field-is-required'),
-					Liferay.Language.get('name')
-				),
-			});
+			nextErrors.name = sub(
+				Liferay.Language.get('x-field-is-required'),
+				Liferay.Language.get('name')
+			);
+		}
+
+		if (Object.keys(nextErrors).length) {
+			setErrors(nextErrors);
 
 			return;
 		}
@@ -395,6 +455,16 @@ function FragmentSetForm({
 						'add-a-fragment-set-to-save-your-fragment'
 					)}
 				</p>
+			)}
+
+			{allowCustomName && (
+				<FragmentNameField
+					errors={errors}
+					fragmentName={fragmentName}
+					portletNamespace={portletNamespace}
+					setErrors={setErrors}
+					setFragmentName={setFragmentName}
+				/>
 			)}
 
 			<FormField

--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/modals/FragmentSetModal.tsx
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/modals/FragmentSetModal.tsx
@@ -29,6 +29,7 @@ export default function FragmentSetModal({
 	fragmentEntryIds = [],
 	onSubmitFragmentCollection,
 	portletNamespace,
+	showFragmentNameInput = false,
 }: {
 	addFragmentCollectionURL?: string;
 	contributedEntryKeys?: string[];
@@ -36,9 +37,11 @@ export default function FragmentSetModal({
 	fragmentCollections: FragmentSet[];
 	fragmentEntryIds?: string[];
 	onSubmitFragmentCollection?: (
-		fragmentCollectionId: number
+		fragmentCollectionId: number,
+		fragmentName?: string
 	) => Promise<void> | void;
 	portletNamespace: string;
+	showFragmentNameInput?: boolean;
 }) {
 	const [visible, setVisible] = useState(true);
 
@@ -47,6 +50,7 @@ export default function FragmentSetModal({
 	});
 
 	const [errors, setErrors] = useState<Errors>({});
+	const [fragmentName, setFragmentName] = useState('');
 	const [showFragmentSetForm, setShowFragmentSetForm] = useState(
 		!fragmentCollections.length
 	);
@@ -54,9 +58,26 @@ export default function FragmentSetModal({
 	const formId = `${portletNamespace}form`;
 
 	const submitFragmentCollection = (fragmentCollectionId: number) => {
+		if (showFragmentNameInput && !fragmentName) {
+			setErrors({
+				name: sub(
+					Liferay.Language.get('x-field-is-required'),
+					Liferay.Language.get('name')
+				),
+			});
+
+			return;
+		}
+
 		if (onSubmitFragmentCollection) {
 			onClose();
-			onSubmitFragmentCollection(fragmentCollectionId);
+
+			if (showFragmentNameInput) {
+				onSubmitFragmentCollection(fragmentCollectionId, fragmentName);
+			}
+			else {
+				onSubmitFragmentCollection(fragmentCollectionId);
+			}
 
 			return;
 		}
@@ -128,9 +149,11 @@ export default function FragmentSetModal({
 			<ClayModal.Header
 				closeButtonAriaLabel={Liferay.Language.get('close')}
 			>
-				{showFragmentSetForm
-					? Liferay.Language.get('add-fragment-set')
-					: Liferay.Language.get('select-fragment-set')}
+				{showFragmentNameInput
+					? Liferay.Language.get('add-fragment')
+					: showFragmentSetForm
+						? Liferay.Language.get('add-fragment-set')
+						: Liferay.Language.get('select-fragment-set')}
 			</ClayModal.Header>
 
 			<ClayModal.Body>
@@ -141,6 +164,26 @@ export default function FragmentSetModal({
 					>
 						{errors.error}
 					</ClayAlert>
+				)}
+
+				{showFragmentNameInput && (
+					<FormField
+						error={errors.name}
+						id={`${portletNamespace}fragmentName`}
+						name={Liferay.Language.get('name')}
+						required
+					>
+						<ClayInput
+							id={`${portletNamespace}fragmentName`}
+							onChange={(event) => {
+								setErrors({...errors, name: null});
+								setFragmentName(event.target.value);
+							}}
+							required
+							type="text"
+							value={fragmentName}
+						/>
+					</FormField>
 				)}
 
 				{showFragmentSetForm ? (

--- a/modules/apps/layout/layout-js-components-web/test/components/modals/FragmentSetModal.test.js
+++ b/modules/apps/layout/layout-js-components-web/test/components/modals/FragmentSetModal.test.js
@@ -11,17 +11,17 @@ import React from 'react';
 import FragmentSetModal from '../../../src/main/resources/META-INF/resources/js/components/modals/FragmentSetModal';
 
 const renderComponent = ({
+	allowCustomName,
 	fragmentCollections = [],
 	onSubmitFragmentCollection,
-	showFragmentNameInput,
 } = {}) => {
 	const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
 
 	render(
 		<FragmentSetModal
+			allowCustomName={allowCustomName}
 			fragmentCollections={fragmentCollections}
 			onSubmitFragmentCollection={onSubmitFragmentCollection}
-			showFragmentNameInput={showFragmentNameInput}
 		/>
 	);
 
@@ -139,17 +139,17 @@ describe('FragmentSetModal', () => {
 
 		await user.click(screen.getByText('save'));
 
-		expect(onSubmitFragmentCollection).toHaveBeenCalledWith(1);
+		expect(onSubmitFragmentCollection).toHaveBeenCalledWith(1, '');
 	});
 
-	it('submits the selected fragment collection with the fragment name when showFragmentNameInput is set', async () => {
+	it('submits the selected fragment collection with the fragment name when allowCustomName is set', async () => {
 		const onSubmitFragmentCollection = jest.fn();
 		const user = renderComponent({
+			allowCustomName: true,
 			fragmentCollections: [
 				{fragmentCollectionId: 1, name: 'fragment-collection'},
 			],
 			onSubmitFragmentCollection,
-			showFragmentNameInput: true,
 		});
 
 		act(() => {
@@ -172,14 +172,14 @@ describe('FragmentSetModal', () => {
 		);
 	});
 
-	it('shows required validation when the fragment name is empty and showFragmentNameInput is set', async () => {
+	it('shows required validation when the fragment name is empty and allowCustomName is set', async () => {
 		const onSubmitFragmentCollection = jest.fn();
 		const user = renderComponent({
+			allowCustomName: true,
 			fragmentCollections: [
 				{fragmentCollectionId: 1, name: 'fragment-collection'},
 			],
 			onSubmitFragmentCollection,
-			showFragmentNameInput: true,
 		});
 
 		act(() => {
@@ -192,6 +192,24 @@ describe('FragmentSetModal', () => {
 
 		await user.click(screen.getByText('save'));
 
+		expect(onSubmitFragmentCollection).not.toHaveBeenCalled();
+		expect(screen.getByText('x-field-is-required')).toBeInTheDocument();
+	});
+
+	it('does not create the fragment set when the fragment name is empty and allowCustomName is set', async () => {
+		const onSubmitFragmentCollection = jest.fn();
+		const user = renderComponent({
+			allowCustomName: true,
+			onSubmitFragmentCollection,
+		});
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		await user.click(screen.getByText('save'));
+
+		expect(fetch).not.toHaveBeenCalled();
 		expect(onSubmitFragmentCollection).not.toHaveBeenCalled();
 		expect(screen.getByText('x-field-is-required')).toBeInTheDocument();
 	});

--- a/modules/apps/layout/layout-js-components-web/test/components/modals/FragmentSetModal.test.js
+++ b/modules/apps/layout/layout-js-components-web/test/components/modals/FragmentSetModal.test.js
@@ -13,6 +13,7 @@ import FragmentSetModal from '../../../src/main/resources/META-INF/resources/js/
 const renderComponent = ({
 	fragmentCollections = [],
 	onSubmitFragmentCollection,
+	showFragmentNameInput,
 } = {}) => {
 	const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
 
@@ -20,6 +21,7 @@ const renderComponent = ({
 		<FragmentSetModal
 			fragmentCollections={fragmentCollections}
 			onSubmitFragmentCollection={onSubmitFragmentCollection}
+			showFragmentNameInput={showFragmentNameInput}
 		/>
 	);
 
@@ -138,5 +140,59 @@ describe('FragmentSetModal', () => {
 		await user.click(screen.getByText('save'));
 
 		expect(onSubmitFragmentCollection).toHaveBeenCalledWith(1);
+	});
+
+	it('submits the selected fragment collection with the fragment name when showFragmentNameInput is set', async () => {
+		const onSubmitFragmentCollection = jest.fn();
+		const user = renderComponent({
+			fragmentCollections: [
+				{fragmentCollectionId: 1, name: 'fragment-collection'},
+			],
+			onSubmitFragmentCollection,
+			showFragmentNameInput: true,
+		});
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		fireEvent.change(screen.getByLabelText('name'), {
+			target: {value: 'my-fragment'},
+		});
+
+		fireEvent.change(screen.getByLabelText('fragment-sets'), {
+			target: {value: '1'},
+		});
+
+		await user.click(screen.getByText('save'));
+
+		expect(onSubmitFragmentCollection).toHaveBeenCalledWith(
+			1,
+			'my-fragment'
+		);
+	});
+
+	it('shows required validation when the fragment name is empty and showFragmentNameInput is set', async () => {
+		const onSubmitFragmentCollection = jest.fn();
+		const user = renderComponent({
+			fragmentCollections: [
+				{fragmentCollectionId: 1, name: 'fragment-collection'},
+			],
+			onSubmitFragmentCollection,
+			showFragmentNameInput: true,
+		});
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		fireEvent.change(screen.getByLabelText('fragment-sets'), {
+			target: {value: '1'},
+		});
+
+		await user.click(screen.getByText('save'));
+
+		expect(onSubmitFragmentCollection).not.toHaveBeenCalled();
+		expect(screen.getByText('x-field-is-required')).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97633

## What Is Being Fixed

Flows that save a new fragment through the fragment set modal can only choose the destination set. There is no way to name the fragment being added, so upcoming consumers of the modal cannot collect a fragment name in the same step.

## How It Is Being Fixed

FragmentSetModal accepts an allowCustomName prop that renders a required Name field and passes the value as a second argument to onSubmitFragmentCollection. The field renders inside both the set selector and the new set form, so it is validated together with the other fields before any request runs; validating it later would create the fragment set before reporting the missing name, and a retry would create a duplicate set. The name error uses its own key so it cannot light up the set name field, the name is always forwarded to the callback since the parameter is optional, and the modal open state moves to the useModal defaultOpen API.

## PR Check

**pr-check: PASS** — tested on `3150bdf96ab99fdc02d26ef6226a6bce76a4e649`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "3150bdf96ab99fdc02d26ef6226a6bce76a4e649"} -->
