### PR TITLE
LPD-96450 Resolve mapped object entries to the latest approved version

### DIFF
--- a/modules/apps/info/info-api/bnd.bnd
+++ b/modules/apps/info/info-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Info API
 Bundle-SymbolicName: com.liferay.info.api
-Bundle-Version: 38.10.1
+Bundle-Version: 38.11.0
 Export-Package:\
 	com.liferay.info.collection.provider,\
 	com.liferay.info.constants,\

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/item/InfoItemIdentifier.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/item/InfoItemIdentifier.java
@@ -15,6 +15,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface InfoItemIdentifier {
 
+	public static final String VERSION_EDITABLE = "VERSION_EDITABLE";
+
 	public static final String VERSION_LATEST = "VERSION_LATEST";
 
 	public static final String VERSION_LATEST_APPROVED =

--- a/modules/apps/info/info-api/src/main/resources/com/liferay/info/item/packageinfo
+++ b/modules/apps/info/info-api/src/main/resources/com/liferay/info/item/packageinfo
@@ -1,1 +1,1 @@
-version 7.4.0
+version 7.5.0

--- a/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/request/struts/EditInfoItemStrutsAction.java
+++ b/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/request/struts/EditInfoItemStrutsAction.java
@@ -606,7 +606,7 @@ public class EditInfoItemStrutsAction implements StrutsAction {
 			return null;
 		}
 
-		infoItemIdentifier.setVersion(InfoItemIdentifier.VERSION_LATEST);
+		infoItemIdentifier.setVersion(InfoItemIdentifier.VERSION_EDITABLE);
 
 		return infoItemIdentifier;
 	}

--- a/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/request/struts/EditInfoItemStrutsAction.java
+++ b/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/request/struts/EditInfoItemStrutsAction.java
@@ -587,21 +587,28 @@ public class EditInfoItemStrutsAction implements StrutsAction {
 	private InfoItemIdentifier _getInfoItemIdentifier(
 		HttpServletRequest httpServletRequest) {
 
+		InfoItemIdentifier infoItemIdentifier = null;
+
 		long classPK = ParamUtil.getLong(httpServletRequest, "classPK");
 		String externalReferenceCode = ParamUtil.getString(
 			httpServletRequest, "externalReferenceCode");
 
 		if (classPK > 0) {
-			return new ClassPKInfoItemIdentifier(classPK);
+			infoItemIdentifier = new ClassPKInfoItemIdentifier(classPK);
 		}
 		else if (Validator.isNotNull(externalReferenceCode)) {
-			return new ERCInfoItemIdentifier(
+			infoItemIdentifier = new ERCInfoItemIdentifier(
 				externalReferenceCode,
 				ParamUtil.getString(
 					httpServletRequest, "scopeExternalReferenceCode", null));
 		}
+		else {
+			return null;
+		}
 
-		return null;
+		infoItemIdentifier.setVersion(InfoItemIdentifier.VERSION_LATEST);
+
+		return infoItemIdentifier;
 	}
 
 	private LayoutStructure _getLayoutStructure(

--- a/modules/apps/info/info-test/src/testIntegration/java/com/liferay/info/request/struts/test/EditInfoItemStrutsActionTest.java
+++ b/modules/apps/info/info-test/src/testIntegration/java/com/liferay/info/request/struts/test/EditInfoItemStrutsActionTest.java
@@ -772,6 +772,41 @@ public class EditInfoItemStrutsActionTest {
 	}
 
 	@Test
+	@TestInfo("LPD-96450")
+	public void testUpdateInfoItemWithDraftObjectEntry() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), _user.getUserId());
+
+		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
+
+		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
+			0, _user.getUserId(), _objectDefinition.getObjectDefinitionId(), 0,
+			null,
+			HashMapBuilder.<String, Serializable>put(
+				"myText", RandomTestUtil.randomString()
+			).build(),
+			serviceContext);
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_DRAFT, objectEntry.getStatus());
+
+		Assert.assertNull(
+			_execute(
+				HashMapBuilder.<String, List<String>>put(
+					"classPK",
+					Collections.singletonList(
+						String.valueOf(objectEntry.getObjectEntryId()))
+				).build()));
+
+		objectEntry = _objectEntryLocalService.fetchObjectEntry(
+			objectEntry.getObjectEntryId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, objectEntry.getStatus());
+	}
+
+	@Test
 	public void testUpdateInfoItemWithEmptyValues() throws Exception {
 		MockHttpServletResponse mockHttpServletResponse =
 			new MockHttpServletResponse();

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemObjectProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemObjectProvider.java
@@ -146,6 +146,7 @@ public class JournalArticleInfoItemObjectProvider
 		throws PortalException {
 
 		if (Validator.isNull(version) ||
+			Objects.equals(version, InfoItemIdentifier.VERSION_EDITABLE) ||
 			Objects.equals(
 				version, InfoItemIdentifier.VERSION_LATEST_APPROVED)) {
 
@@ -173,6 +174,7 @@ public class JournalArticleInfoItemObjectProvider
 		throws PortalException {
 
 		if (Validator.isNull(version) ||
+			Objects.equals(version, InfoItemIdentifier.VERSION_EDITABLE) ||
 			Objects.equals(
 				version, InfoItemIdentifier.VERSION_LATEST_APPROVED)) {
 
@@ -193,6 +195,7 @@ public class JournalArticleInfoItemObjectProvider
 		throws PortalException {
 
 		if (Validator.isNull(version) ||
+			Objects.equals(version, InfoItemIdentifier.VERSION_EDITABLE) ||
 			Objects.equals(
 				version, InfoItemIdentifier.VERSION_LATEST_APPROVED)) {
 
@@ -223,6 +226,7 @@ public class JournalArticleInfoItemObjectProvider
 		throws PortalException {
 
 		if (Validator.isNull(version) ||
+			Objects.equals(version, InfoItemIdentifier.VERSION_EDITABLE) ||
 			Objects.equals(
 				version, InfoItemIdentifier.VERSION_LATEST_APPROVED)) {
 

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/info/item/provider/KBArticleInfoItemObjectProvider.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/info/item/provider/KBArticleInfoItemObjectProvider.java
@@ -84,6 +84,7 @@ public class KBArticleInfoItemObjectProvider
 
 	private KBArticle _getKBArticle(long classPK, String version) {
 		if (Validator.isNull(version) ||
+			Objects.equals(version, InfoItemIdentifier.VERSION_EDITABLE) ||
 			Objects.equals(
 				version, InfoItemIdentifier.VERSION_LATEST_APPROVED)) {
 
@@ -108,6 +109,7 @@ public class KBArticleInfoItemObjectProvider
 		String externalReferenceCode, long groupId, String version) {
 
 		if (Validator.isNull(version) ||
+			Objects.equals(version, InfoItemIdentifier.VERSION_EDITABLE) ||
 			Objects.equals(
 				version, InfoItemIdentifier.VERSION_LATEST_APPROVED)) {
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemObjectProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemObjectProviderTest.java
@@ -17,7 +17,10 @@ import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.related.models.test.util.ObjectEntryTestUtil;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
-import com.liferay.portal.kernel.scheduler.TimeUnit;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
+import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.Sync;
@@ -26,7 +29,11 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.workflow.WorkflowTask;
+import com.liferay.portal.kernel.workflow.WorkflowTaskManager;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -34,7 +41,6 @@ import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.io.Serializable;
 
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -69,7 +75,7 @@ public class ObjectEntryInfoItemObjectProviderTest {
 	@Before
 	public void setUp() throws Exception {
 		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
-			false, false, true,
+			true, false, true,
 			List.of(
 				new TextObjectFieldBuilder(
 				).userId(
@@ -84,126 +90,11 @@ public class ObjectEntryInfoItemObjectProviderTest {
 	}
 
 	@Test
-	public void testGetInfoItemExpiredObjectEntryWithLatestApprovedVersion()
-		throws Exception {
-
-		String approvedValue = RandomTestUtil.randomString();
-
-		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
-			0, _objectDefinition.getObjectDefinitionId(),
-			HashMapBuilder.<String, Serializable>put(
-				_OBJECT_FIELD_NAME, approvedValue
-			).build());
-
-		objectEntry = _objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
-			objectEntry.getObjectEntryFolderId(),
-			HashMapBuilder.<String, Serializable>put(
-				_OBJECT_FIELD_NAME, RandomTestUtil.randomString()
-			).build(),
-			ServiceContextTestUtil.getServiceContext());
-
-		objectEntry = _objectEntryLocalService.expireObjectEntry(
-			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
-			ServiceContextTestUtil.getServiceContext());
-
-		Assert.assertTrue(objectEntry.isExpired());
-
-		ObjectEntry infoItemObjectEntry = _getInfoItem(
-			objectEntry.getObjectEntryId());
-
-		Assert.assertTrue(infoItemObjectEntry.isApproved());
-
-		Map<String, Serializable> values = infoItemObjectEntry.getValues();
-
-		Assert.assertEquals(approvedValue, values.get(_OBJECT_FIELD_NAME));
-	}
-
-	@Test
-	public void testGetInfoItemExpiredObjectEntryWithoutLatestApprovedVersion()
-		throws Exception {
-
-		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
-			0, _objectDefinition.getObjectDefinitionId(),
-			HashMapBuilder.<String, Serializable>put(
-				_OBJECT_FIELD_NAME, RandomTestUtil.randomString()
-			).build());
-
-		objectEntry = _objectEntryLocalService.expireObjectEntry(
-			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
-			ServiceContextTestUtil.getServiceContext());
-
-		Assert.assertTrue(objectEntry.isExpired());
-
-		_assertNoSuchInfoItemException(objectEntry.getObjectEntryId());
-	}
-
-	@Test
-	public void testGetInfoItemScheduledObjectEntryWithLatestApprovedVersion()
-		throws Exception {
-
-		String approvedValue = RandomTestUtil.randomString();
-
-		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
-			0, _objectDefinition.getObjectDefinitionId(),
-			HashMapBuilder.<String, Serializable>put(
-				_OBJECT_FIELD_NAME, approvedValue
-			).build());
-
-		Assert.assertTrue(objectEntry.isApproved());
-
-		objectEntry = _objectEntryLocalService.updateObjectEntry(
-			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
-			objectEntry.getObjectEntryFolderId(),
-			HashMapBuilder.<String, Serializable>put(
-				_OBJECT_FIELD_NAME, RandomTestUtil.randomString()
-			).put(
-				"displayDate",
-				new Date(System.currentTimeMillis() + TimeUnit.DAY.toMillis(1))
-			).build(),
-			ServiceContextTestUtil.getServiceContext());
-
-		Assert.assertTrue(objectEntry.isScheduled());
-
-		ObjectEntry infoItemObjectEntry = _getInfoItem(
-			objectEntry.getObjectEntryId());
-
-		Assert.assertTrue(infoItemObjectEntry.isApproved());
-
-		Map<String, Serializable> values = infoItemObjectEntry.getValues();
-
-		Assert.assertEquals(approvedValue, values.get(_OBJECT_FIELD_NAME));
-	}
-
-	@Test
-	public void testGetInfoItemScheduledObjectEntryWithoutLatestApprovedVersion()
-		throws Exception {
-
-		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
-			0, _objectDefinition.getObjectDefinitionId(),
-			HashMapBuilder.<String, Serializable>put(
-				_OBJECT_FIELD_NAME, RandomTestUtil.randomString()
-			).put(
-				"displayDate",
-				new Date(System.currentTimeMillis() + TimeUnit.DAY.toMillis(1))
-			).build());
-
-		Assert.assertTrue(objectEntry.isScheduled());
-
-		_assertNoSuchInfoItemException(objectEntry.getObjectEntryId());
-	}
-
-	private void _assertNoSuchInfoItemException(long objectEntryId) {
-		try {
-			_getInfoItem(objectEntryId);
-
-			Assert.fail();
-		}
-		catch (NoSuchInfoItemException noSuchInfoItemException) {
-			Assert.assertEquals(
-				"Unable to get an approved object entry " + objectEntryId,
-				noSuchInfoItemException.getMessage());
-		}
+	public void testGetInfoItem() throws Exception {
+		_testGetInfoItemApprovedObjectEntry();
+		_testGetInfoItemDraftObjectEntryWithLatestApprovedVersion();
+		_testGetInfoItemExpiredObjectEntryWithoutLatestApprovedVersion();
+		_testGetInfoItemPendingObjectEntryWithLatestApprovedVersion();
 	}
 
 	private ObjectEntry _getInfoItem(long classPK)
@@ -218,6 +109,152 @@ public class ObjectEntryInfoItemObjectProviderTest {
 			new ClassPKInfoItemIdentifier(classPK));
 	}
 
+	private void _testGetInfoItemApprovedObjectEntry() throws Exception {
+		String value = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			0, _objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME, value
+			).build());
+
+		Assert.assertTrue(objectEntry.isApproved());
+
+		ObjectEntry infoItemObjectEntry = _getInfoItem(
+			objectEntry.getObjectEntryId());
+
+		Assert.assertTrue(infoItemObjectEntry.isApproved());
+
+		Map<String, Serializable> values = infoItemObjectEntry.getValues();
+
+		Assert.assertEquals(value, values.get(_OBJECT_FIELD_NAME));
+	}
+
+	private void _testGetInfoItemDraftObjectEntryWithLatestApprovedVersion()
+		throws Exception {
+
+		String approvedValue = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			0, _objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME, approvedValue
+			).build());
+
+		Assert.assertTrue(objectEntry.isApproved());
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
+
+		objectEntry = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			objectEntry.getObjectEntryFolderId(),
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME, RandomTestUtil.randomString()
+			).build(),
+			serviceContext);
+
+		Assert.assertTrue(objectEntry.isDraft());
+
+		ObjectEntry infoItemObjectEntry = _getInfoItem(
+			objectEntry.getObjectEntryId());
+
+		Assert.assertTrue(infoItemObjectEntry.isApproved());
+
+		Map<String, Serializable> values = infoItemObjectEntry.getValues();
+
+		Assert.assertEquals(approvedValue, values.get(_OBJECT_FIELD_NAME));
+	}
+
+	private void _testGetInfoItemExpiredObjectEntryWithoutLatestApprovedVersion()
+		throws Exception {
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			0, _objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME, RandomTestUtil.randomString()
+			).build());
+
+		objectEntry = _objectEntryLocalService.expireObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertTrue(objectEntry.isExpired());
+
+		long objectEntryId = objectEntry.getObjectEntryId();
+
+		AssertUtils.assertFailure(
+			NoSuchInfoItemException.class,
+			"Unable to get an approved object entry " + objectEntryId,
+			() -> _getInfoItem(objectEntryId));
+	}
+
+	private void _testGetInfoItemPendingObjectEntryWithLatestApprovedVersion()
+		throws Exception {
+
+		String approvedValue = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			0, _objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME, approvedValue
+			).build());
+
+		Assert.assertTrue(objectEntry.isApproved());
+
+		_workflowDefinitionLinkLocalService.updateWorkflowDefinitionLink(
+			TestPropsValues.getUserId(), TestPropsValues.getCompanyId(), 0,
+			_objectDefinition.getClassName(), 0, 0, "Single Approver", 1);
+
+		String pendingValue = RandomTestUtil.randomString();
+
+		objectEntry = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			objectEntry.getObjectEntryFolderId(),
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME, pendingValue
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertTrue(objectEntry.isPending());
+
+		ObjectEntry infoItemObjectEntry = _getInfoItem(
+			objectEntry.getObjectEntryId());
+
+		Assert.assertTrue(infoItemObjectEntry.isApproved());
+
+		Map<String, Serializable> values = infoItemObjectEntry.getValues();
+
+		Assert.assertEquals(approvedValue, values.get(_OBJECT_FIELD_NAME));
+
+		List<WorkflowTask> workflowTasks =
+			_workflowTaskManager.getWorkflowTasksBySubmittingUser(
+				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				false, 0, 1, null);
+
+		WorkflowTask workflowTask = workflowTasks.get(0);
+
+		_workflowTaskManager.assignWorkflowTaskToUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			workflowTask.getWorkflowTaskId(), TestPropsValues.getUserId(),
+			StringPool.BLANK, null, null);
+
+		_workflowTaskManager.completeWorkflowTask(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			workflowTask.getWorkflowTaskId(), Constants.APPROVE,
+			StringPool.BLANK, null);
+
+		infoItemObjectEntry = _getInfoItem(objectEntry.getObjectEntryId());
+
+		Assert.assertTrue(infoItemObjectEntry.isApproved());
+
+		values = infoItemObjectEntry.getValues();
+
+		Assert.assertEquals(pendingValue, values.get(_OBJECT_FIELD_NAME));
+	}
+
 	private static final String _OBJECT_FIELD_NAME =
 		"a" + RandomTestUtil.randomString();
 
@@ -229,5 +266,12 @@ public class ObjectEntryInfoItemObjectProviderTest {
 
 	@Inject
 	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private WorkflowDefinitionLinkLocalService
+		_workflowDefinitionLinkLocalService;
+
+	@Inject
+	private WorkflowTaskManager _workflowTaskManager;
 
 }

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemObjectProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/web/internal/info/item/provider/test/ObjectEntryInfoItemObjectProviderTest.java
@@ -1,0 +1,233 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.web.internal.info.item.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.info.exception.NoSuchInfoItemException;
+import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.item.provider.InfoItemObjectProvider;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.field.builder.TextObjectFieldBuilder;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.related.models.test.util.ObjectEntryTestUtil;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.portal.kernel.scheduler.TimeUnit;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+import java.io.Serializable;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Roselaine Marques
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+@Sync
+public class ObjectEntryInfoItemObjectProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			SynchronousDestinationTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		UserTestUtil.setUser(TestPropsValues.getUser());
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
+			false, false, true,
+			List.of(
+				new TextObjectFieldBuilder(
+				).userId(
+					TestPropsValues.getUserId()
+				).labelMap(
+					LocalizedMapUtil.getLocalizedMap(
+						RandomTestUtil.randomString())
+				).name(
+					_OBJECT_FIELD_NAME
+				).build()),
+			ObjectDefinitionConstants.SCOPE_COMPANY);
+	}
+
+	@Test
+	public void testGetInfoItemExpiredObjectEntryWithLatestApprovedVersion()
+		throws Exception {
+
+		String approvedValue = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			0, _objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME, approvedValue
+			).build());
+
+		objectEntry = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			objectEntry.getObjectEntryFolderId(),
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME, RandomTestUtil.randomString()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		objectEntry = _objectEntryLocalService.expireObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertTrue(objectEntry.isExpired());
+
+		ObjectEntry infoItemObjectEntry = _getInfoItem(
+			objectEntry.getObjectEntryId());
+
+		Assert.assertTrue(infoItemObjectEntry.isApproved());
+
+		Map<String, Serializable> values = infoItemObjectEntry.getValues();
+
+		Assert.assertEquals(approvedValue, values.get(_OBJECT_FIELD_NAME));
+	}
+
+	@Test
+	public void testGetInfoItemExpiredObjectEntryWithoutLatestApprovedVersion()
+		throws Exception {
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			0, _objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME, RandomTestUtil.randomString()
+			).build());
+
+		objectEntry = _objectEntryLocalService.expireObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertTrue(objectEntry.isExpired());
+
+		_assertNoSuchInfoItemException(objectEntry.getObjectEntryId());
+	}
+
+	@Test
+	public void testGetInfoItemScheduledObjectEntryWithLatestApprovedVersion()
+		throws Exception {
+
+		String approvedValue = RandomTestUtil.randomString();
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			0, _objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME, approvedValue
+			).build());
+
+		Assert.assertTrue(objectEntry.isApproved());
+
+		objectEntry = _objectEntryLocalService.updateObjectEntry(
+			TestPropsValues.getUserId(), objectEntry.getObjectEntryId(),
+			objectEntry.getObjectEntryFolderId(),
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME, RandomTestUtil.randomString()
+			).put(
+				"displayDate",
+				new Date(System.currentTimeMillis() + TimeUnit.DAY.toMillis(1))
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Assert.assertTrue(objectEntry.isScheduled());
+
+		ObjectEntry infoItemObjectEntry = _getInfoItem(
+			objectEntry.getObjectEntryId());
+
+		Assert.assertTrue(infoItemObjectEntry.isApproved());
+
+		Map<String, Serializable> values = infoItemObjectEntry.getValues();
+
+		Assert.assertEquals(approvedValue, values.get(_OBJECT_FIELD_NAME));
+	}
+
+	@Test
+	public void testGetInfoItemScheduledObjectEntryWithoutLatestApprovedVersion()
+		throws Exception {
+
+		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
+			0, _objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				_OBJECT_FIELD_NAME, RandomTestUtil.randomString()
+			).put(
+				"displayDate",
+				new Date(System.currentTimeMillis() + TimeUnit.DAY.toMillis(1))
+			).build());
+
+		Assert.assertTrue(objectEntry.isScheduled());
+
+		_assertNoSuchInfoItemException(objectEntry.getObjectEntryId());
+	}
+
+	private void _assertNoSuchInfoItemException(long objectEntryId) {
+		try {
+			_getInfoItem(objectEntryId);
+
+			Assert.fail();
+		}
+		catch (NoSuchInfoItemException noSuchInfoItemException) {
+			Assert.assertEquals(
+				"Unable to get an approved object entry " + objectEntryId,
+				noSuchInfoItemException.getMessage());
+		}
+	}
+
+	private ObjectEntry _getInfoItem(long classPK)
+		throws NoSuchInfoItemException {
+
+		InfoItemObjectProvider<ObjectEntry> infoItemObjectProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemObjectProvider.class, _objectDefinition.getClassName(),
+				ClassPKInfoItemIdentifier.INFO_ITEM_SERVICE_FILTER);
+
+		return infoItemObjectProvider.getInfoItem(
+			new ClassPKInfoItemIdentifier(classPK));
+	}
+
+	private static final String _OBJECT_FIELD_NAME =
+		"a" + RandomTestUtil.randomString();
+
+	@Inject
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
+
+	@DeleteAfterTestRun
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+}

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemObjectProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemObjectProvider.java
@@ -31,6 +31,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author Guilherme Camacho
@@ -76,7 +77,8 @@ public class ObjectEntryInfoItemObjectProvider
 						classPKInfoItemIdentifier.getClassPK());
 			}
 
-			return objectEntry;
+			return _resolveLatestApprovedObjectEntry(
+				objectEntry, classPKInfoItemIdentifier.getVersion());
 		}
 
 		ServiceContext serviceContext =
@@ -89,7 +91,9 @@ public class ObjectEntryInfoItemObjectProvider
 			serviceContext.getRequest());
 
 		if (objectEntries.containsKey(ercInfoItemIdentifier)) {
-			return objectEntries.get(ercInfoItemIdentifier);
+			return _resolveLatestApprovedObjectEntry(
+				objectEntries.get(ercInfoItemIdentifier),
+				ercInfoItemIdentifier.getVersion());
 		}
 
 		Group group = null;
@@ -143,7 +147,9 @@ public class ObjectEntryInfoItemObjectProvider
 				objectEntries.put(
 					ercInfoItemIdentifier, serviceBuilderObjectEntry);
 
-				return serviceBuilderObjectEntry;
+				return _resolveLatestApprovedObjectEntry(
+					serviceBuilderObjectEntry,
+					ercInfoItemIdentifier.getVersion());
 			}
 		}
 		catch (Exception exception) {
@@ -175,6 +181,33 @@ public class ObjectEntryInfoItemObjectProvider
 		}
 
 		return objectEntries;
+	}
+
+	private ObjectEntry _resolveLatestApprovedObjectEntry(
+			ObjectEntry objectEntry, String version)
+		throws NoSuchInfoItemException {
+
+		if ((Validator.isNotNull(version) &&
+			 !Objects.equals(
+				 version, InfoItemIdentifier.VERSION_LATEST_APPROVED)) ||
+			objectEntry.isApproved()) {
+
+			return objectEntry;
+		}
+
+		ObjectEntry latestApprovedObjectEntry =
+			_objectEntryLocalService.fetchObjectEntryByHeadObjectEntryId(
+				objectEntry.getObjectEntryId());
+
+		if ((latestApprovedObjectEntry != null) &&
+			latestApprovedObjectEntry.isApproved()) {
+
+			return latestApprovedObjectEntry;
+		}
+
+		throw new NoSuchInfoItemException(
+			"Unable to get an approved object entry " +
+				objectEntry.getObjectEntryId());
 	}
 
 	private static final String _OBJECT_ENTRIES =

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/util/ObjectEntryUtil.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/util/ObjectEntryUtil.java
@@ -26,6 +26,7 @@ import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.relationship.util.ObjectRelationshipUtil;
 import com.liferay.object.rest.dto.v1_0.FileEntry;
 import com.liferay.object.rest.dto.v1_0.ListEntry;
+import com.liferay.object.rest.dto.v1_0.Status;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.object.service.ObjectEntryLocalServiceUtil;
 import com.liferay.object.service.ObjectRelationshipLocalServiceUtil;
@@ -177,6 +178,13 @@ public class ObjectEntryUtil {
 			objectDefinition.getObjectDefinitionId());
 		serviceBuilderObjectEntry.setDefaultLanguageId(
 			objectEntry.getDefaultLanguageId());
+
+		Status status = objectEntry.getStatus();
+
+		if (status != null) {
+			serviceBuilderObjectEntry.setStatus(
+				GetterUtil.getInteger(status.getCode()));
+		}
 
 		return new ProxyObjectEntry(serviceBuilderObjectEntry, objectEntry);
 	}

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemObjectProviderTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemObjectProviderTest.java
@@ -91,7 +91,7 @@ public class ObjectEntryInfoItemObjectProviderTest {
 	@Test
 	public void testGetInfoItemLiferayObjectEntry() throws Exception {
 		long classPK = RandomTestUtil.randomLong();
-		ObjectEntry objectEntry = Mockito.mock(ObjectEntry.class);
+		ObjectEntry objectEntry = _mockObjectEntry(true);
 
 		Mockito.when(
 			_objectEntryLocalService.fetchObjectEntry(classPK)
@@ -102,6 +102,150 @@ public class ObjectEntryInfoItemObjectProviderTest {
 		Assert.assertEquals(
 			objectEntry,
 			_assertGetInfoItem(new ClassPKInfoItemIdentifier(classPK)));
+
+		Mockito.verify(
+			_objectEntryLocalService, Mockito.never()
+		).fetchObjectEntryByHeadObjectEntryId(
+			Mockito.anyLong()
+		);
+
+		Mockito.verifyNoInteractions(_objectEntryManagerRegistry);
+	}
+
+	@Test
+	public void testGetInfoItemLiferayObjectEntryNonapprovedWithLatestApproved()
+		throws Exception {
+
+		long classPK = RandomTestUtil.randomLong();
+		ObjectEntry objectEntry = _mockObjectEntry(false);
+
+		Mockito.when(
+			objectEntry.getObjectEntryId()
+		).thenReturn(
+			classPK
+		);
+
+		Mockito.when(
+			_objectEntryLocalService.fetchObjectEntry(classPK)
+		).thenReturn(
+			objectEntry
+		);
+
+		ObjectEntry latestApprovedObjectEntry = _mockObjectEntry(true);
+
+		Mockito.when(
+			_objectEntryLocalService.fetchObjectEntryByHeadObjectEntryId(
+				classPK)
+		).thenReturn(
+			latestApprovedObjectEntry
+		);
+
+		Assert.assertEquals(
+			latestApprovedObjectEntry,
+			_assertGetInfoItem(new ClassPKInfoItemIdentifier(classPK)));
+
+		ClassPKInfoItemIdentifier classPKInfoItemIdentifier =
+			new ClassPKInfoItemIdentifier(classPK);
+
+		classPKInfoItemIdentifier.setVersion(
+			InfoItemIdentifier.VERSION_LATEST_APPROVED);
+
+		Assert.assertEquals(
+			latestApprovedObjectEntry,
+			_assertGetInfoItem(classPKInfoItemIdentifier));
+
+		Mockito.verifyNoInteractions(_objectEntryManagerRegistry);
+	}
+
+	@Test
+	public void testGetInfoItemLiferayObjectEntryNonapprovedWithLatestVersion()
+		throws Exception {
+
+		long classPK = RandomTestUtil.randomLong();
+		ObjectEntry objectEntry = _mockObjectEntry(false);
+
+		Mockito.when(
+			_objectEntryLocalService.fetchObjectEntry(classPK)
+		).thenReturn(
+			objectEntry
+		);
+
+		ClassPKInfoItemIdentifier classPKInfoItemIdentifier =
+			new ClassPKInfoItemIdentifier(classPK);
+
+		classPKInfoItemIdentifier.setVersion(InfoItemIdentifier.VERSION_LATEST);
+
+		Assert.assertEquals(
+			objectEntry, _assertGetInfoItem(classPKInfoItemIdentifier));
+
+		Mockito.verify(
+			_objectEntryLocalService, Mockito.never()
+		).fetchObjectEntryByHeadObjectEntryId(
+			Mockito.anyLong()
+		);
+
+		Mockito.verifyNoInteractions(_objectEntryManagerRegistry);
+	}
+
+	@Test
+	public void testGetInfoItemLiferayObjectEntryNonapprovedWithNonapprovedLatestApproved() {
+		long classPK = RandomTestUtil.randomLong();
+		ObjectEntry objectEntry = _mockObjectEntry(false);
+
+		Mockito.when(
+			objectEntry.getObjectEntryId()
+		).thenReturn(
+			classPK
+		);
+
+		Mockito.when(
+			_objectEntryLocalService.fetchObjectEntry(classPK)
+		).thenReturn(
+			objectEntry
+		);
+
+		ObjectEntry latestApprovedObjectEntry = _mockObjectEntry(false);
+
+		Mockito.when(
+			_objectEntryLocalService.fetchObjectEntryByHeadObjectEntryId(
+				classPK)
+		).thenReturn(
+			latestApprovedObjectEntry
+		);
+
+		_assertGetInfoItemNoSuchInfoItemException(
+			new ClassPKInfoItemIdentifier(classPK),
+			"Unable to get an approved object entry " + classPK);
+
+		Mockito.verifyNoInteractions(_objectEntryManagerRegistry);
+	}
+
+	@Test
+	public void testGetInfoItemLiferayObjectEntryNonapprovedWithoutLatestApproved() {
+		long classPK = RandomTestUtil.randomLong();
+		ObjectEntry objectEntry = _mockObjectEntry(false);
+
+		Mockito.when(
+			objectEntry.getObjectEntryId()
+		).thenReturn(
+			classPK
+		);
+
+		Mockito.when(
+			_objectEntryLocalService.fetchObjectEntry(classPK)
+		).thenReturn(
+			objectEntry
+		);
+
+		_assertGetInfoItemNoSuchInfoItemException(
+			new ClassPKInfoItemIdentifier(classPK),
+			"Unable to get an approved object entry " + classPK);
+
+		Mockito.verify(
+			_objectEntryLocalService
+		).fetchObjectEntryByHeadObjectEntryId(
+			classPK
+		);
 
 		Mockito.verifyNoInteractions(_objectEntryManagerRegistry);
 	}
@@ -126,7 +270,7 @@ public class ObjectEntryInfoItemObjectProviderTest {
 	@Test
 	public void testGetInfoItemProxyObjectEntry() throws Exception {
 		String externalReferenceCode = RandomTestUtil.randomString();
-		ObjectEntry objectEntry = Mockito.mock(ObjectEntry.class);
+		ObjectEntry objectEntry = _mockObjectEntry(true);
 
 		_setUpProxyObjectEntry(externalReferenceCode, objectEntry);
 
@@ -139,6 +283,49 @@ public class ObjectEntryInfoItemObjectProviderTest {
 	}
 
 	@Test
+	public void testGetInfoItemProxyObjectEntryCachedNonapproved()
+		throws Exception {
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		ERCInfoItemIdentifier ercInfoItemIdentifier = new ERCInfoItemIdentifier(
+			externalReferenceCode);
+
+		ObjectEntry objectEntry = _mockObjectEntry(false);
+
+		long objectEntryId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			objectEntry.getObjectEntryId()
+		).thenReturn(
+			objectEntryId
+		);
+
+		ObjectEntry latestApprovedObjectEntry = _mockObjectEntry(true);
+
+		Mockito.when(
+			_objectEntryLocalService.fetchObjectEntryByHeadObjectEntryId(
+				objectEntryId)
+		).thenReturn(
+			latestApprovedObjectEntry
+		);
+
+		Assert.assertEquals(
+			latestApprovedObjectEntry,
+			_assertGetInfoItem(
+				ercInfoItemIdentifier,
+				_getHttpServletRequest(
+					HashMapBuilder.<String, Object>put(
+						_OBJECT_ENTRIES,
+						HashMapBuilder.<InfoItemIdentifier, ObjectEntry>put(
+							ercInfoItemIdentifier, objectEntry
+						).build()
+					).build())));
+
+		Mockito.verifyNoInteractions(_objectEntryManager);
+	}
+
+	@Test
 	public void testGetInfoItemProxyObjectEntryInfoItemIdentifierCachedInObjectEntriesAttribute()
 		throws Exception {
 
@@ -147,7 +334,7 @@ public class ObjectEntryInfoItemObjectProviderTest {
 		ERCInfoItemIdentifier ercInfoItemIdentifier = new ERCInfoItemIdentifier(
 			externalReferenceCode);
 
-		ObjectEntry objectEntry = Mockito.mock(ObjectEntry.class);
+		ObjectEntry objectEntry = _mockObjectEntry(true);
 
 		_setUpProxyObjectEntry(externalReferenceCode, objectEntry);
 
@@ -169,12 +356,44 @@ public class ObjectEntryInfoItemObjectProviderTest {
 
 		Map<String, Object> attributes = new HashMap<>();
 		String externalReferenceCode = RandomTestUtil.randomString();
-		ObjectEntry objectEntry = Mockito.mock(ObjectEntry.class);
+		ObjectEntry objectEntry = _mockObjectEntry(true);
 
 		_assertGetInfoItemProxyObjectEntry(
 			attributes, new ERCInfoItemIdentifier(externalReferenceCode),
 			_getHttpServletRequest(attributes), objectEntry,
 			_setUpProxyObjectEntry(externalReferenceCode, objectEntry));
+	}
+
+	@Test
+	public void testGetInfoItemProxyObjectEntryNonapprovedWithLatestApproved()
+		throws Exception {
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+		ObjectEntry objectEntry = _mockObjectEntry(false);
+
+		long objectEntryId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			objectEntry.getObjectEntryId()
+		).thenReturn(
+			objectEntryId
+		);
+
+		_setUpProxyObjectEntry(externalReferenceCode, objectEntry);
+
+		ObjectEntry latestApprovedObjectEntry = _mockObjectEntry(true);
+
+		Mockito.when(
+			_objectEntryLocalService.fetchObjectEntryByHeadObjectEntryId(
+				objectEntryId)
+		).thenReturn(
+			latestApprovedObjectEntry
+		);
+
+		Assert.assertEquals(
+			latestApprovedObjectEntry,
+			_assertGetInfoItem(
+				new ERCInfoItemIdentifier(externalReferenceCode)));
 	}
 
 	@Test
@@ -201,7 +420,7 @@ public class ObjectEntryInfoItemObjectProviderTest {
 	public void testGetInfoItemProxyObjectEntryNullHttpServletRequest()
 		throws Exception {
 
-		ObjectEntry objectEntry = Mockito.mock(ObjectEntry.class);
+		ObjectEntry objectEntry = _mockObjectEntry(true);
 
 		String externalReferenceCode = RandomTestUtil.randomString();
 
@@ -410,6 +629,18 @@ public class ObjectEntryInfoItemObjectProviderTest {
 		);
 
 		return httpServletRequest;
+	}
+
+	private ObjectEntry _mockObjectEntry(boolean approved) {
+		ObjectEntry objectEntry = Mockito.mock(ObjectEntry.class);
+
+		Mockito.when(
+			objectEntry.isApproved()
+		).thenReturn(
+			approved
+		);
+
+		return objectEntry;
 	}
 
 	private void _pushServiceContext(HttpServletRequest httpServletRequest) {

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemObjectProviderTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemObjectProviderTest.java
@@ -113,144 +113,6 @@ public class ObjectEntryInfoItemObjectProviderTest {
 	}
 
 	@Test
-	public void testGetInfoItemLiferayObjectEntryNonapprovedWithLatestApproved()
-		throws Exception {
-
-		long classPK = RandomTestUtil.randomLong();
-		ObjectEntry objectEntry = _mockObjectEntry(false);
-
-		Mockito.when(
-			objectEntry.getObjectEntryId()
-		).thenReturn(
-			classPK
-		);
-
-		Mockito.when(
-			_objectEntryLocalService.fetchObjectEntry(classPK)
-		).thenReturn(
-			objectEntry
-		);
-
-		ObjectEntry latestApprovedObjectEntry = _mockObjectEntry(true);
-
-		Mockito.when(
-			_objectEntryLocalService.fetchObjectEntryByHeadObjectEntryId(
-				classPK)
-		).thenReturn(
-			latestApprovedObjectEntry
-		);
-
-		Assert.assertEquals(
-			latestApprovedObjectEntry,
-			_assertGetInfoItem(new ClassPKInfoItemIdentifier(classPK)));
-
-		ClassPKInfoItemIdentifier classPKInfoItemIdentifier =
-			new ClassPKInfoItemIdentifier(classPK);
-
-		classPKInfoItemIdentifier.setVersion(
-			InfoItemIdentifier.VERSION_LATEST_APPROVED);
-
-		Assert.assertEquals(
-			latestApprovedObjectEntry,
-			_assertGetInfoItem(classPKInfoItemIdentifier));
-
-		Mockito.verifyNoInteractions(_objectEntryManagerRegistry);
-	}
-
-	@Test
-	public void testGetInfoItemLiferayObjectEntryNonapprovedWithLatestVersion()
-		throws Exception {
-
-		long classPK = RandomTestUtil.randomLong();
-		ObjectEntry objectEntry = _mockObjectEntry(false);
-
-		Mockito.when(
-			_objectEntryLocalService.fetchObjectEntry(classPK)
-		).thenReturn(
-			objectEntry
-		);
-
-		ClassPKInfoItemIdentifier classPKInfoItemIdentifier =
-			new ClassPKInfoItemIdentifier(classPK);
-
-		classPKInfoItemIdentifier.setVersion(InfoItemIdentifier.VERSION_LATEST);
-
-		Assert.assertEquals(
-			objectEntry, _assertGetInfoItem(classPKInfoItemIdentifier));
-
-		Mockito.verify(
-			_objectEntryLocalService, Mockito.never()
-		).fetchObjectEntryByHeadObjectEntryId(
-			Mockito.anyLong()
-		);
-
-		Mockito.verifyNoInteractions(_objectEntryManagerRegistry);
-	}
-
-	@Test
-	public void testGetInfoItemLiferayObjectEntryNonapprovedWithNonapprovedLatestApproved() {
-		long classPK = RandomTestUtil.randomLong();
-		ObjectEntry objectEntry = _mockObjectEntry(false);
-
-		Mockito.when(
-			objectEntry.getObjectEntryId()
-		).thenReturn(
-			classPK
-		);
-
-		Mockito.when(
-			_objectEntryLocalService.fetchObjectEntry(classPK)
-		).thenReturn(
-			objectEntry
-		);
-
-		ObjectEntry latestApprovedObjectEntry = _mockObjectEntry(false);
-
-		Mockito.when(
-			_objectEntryLocalService.fetchObjectEntryByHeadObjectEntryId(
-				classPK)
-		).thenReturn(
-			latestApprovedObjectEntry
-		);
-
-		_assertGetInfoItemNoSuchInfoItemException(
-			new ClassPKInfoItemIdentifier(classPK),
-			"Unable to get an approved object entry " + classPK);
-
-		Mockito.verifyNoInteractions(_objectEntryManagerRegistry);
-	}
-
-	@Test
-	public void testGetInfoItemLiferayObjectEntryNonapprovedWithoutLatestApproved() {
-		long classPK = RandomTestUtil.randomLong();
-		ObjectEntry objectEntry = _mockObjectEntry(false);
-
-		Mockito.when(
-			objectEntry.getObjectEntryId()
-		).thenReturn(
-			classPK
-		);
-
-		Mockito.when(
-			_objectEntryLocalService.fetchObjectEntry(classPK)
-		).thenReturn(
-			objectEntry
-		);
-
-		_assertGetInfoItemNoSuchInfoItemException(
-			new ClassPKInfoItemIdentifier(classPK),
-			"Unable to get an approved object entry " + classPK);
-
-		Mockito.verify(
-			_objectEntryLocalService
-		).fetchObjectEntryByHeadObjectEntryId(
-			classPK
-		);
-
-		Mockito.verifyNoInteractions(_objectEntryManagerRegistry);
-	}
-
-	@Test
 	public void testGetInfoItemLiferayObjectEntryNoSuchInfoItemException() {
 		long classPK = RandomTestUtil.randomLong();
 
@@ -268,6 +130,216 @@ public class ObjectEntryInfoItemObjectProviderTest {
 	}
 
 	@Test
+	public void testGetInfoItemNonapprovedCachedProxyObjectEntry()
+		throws Exception {
+
+		ERCInfoItemIdentifier ercInfoItemIdentifier = new ERCInfoItemIdentifier(
+			RandomTestUtil.randomString());
+
+		ObjectEntry objectEntry = _mockObjectEntry(false);
+
+		long objectEntryId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			objectEntry.getObjectEntryId()
+		).thenReturn(
+			objectEntryId
+		);
+
+		ObjectEntry headObjectEntry = _mockObjectEntry(true);
+
+		Mockito.when(
+			_objectEntryLocalService.fetchObjectEntryByHeadObjectEntryId(
+				objectEntryId)
+		).thenReturn(
+			headObjectEntry
+		);
+
+		Assert.assertEquals(
+			headObjectEntry,
+			_assertGetInfoItem(
+				ercInfoItemIdentifier,
+				_getHttpServletRequest(
+					HashMapBuilder.<String, Object>put(
+						_OBJECT_ENTRIES,
+						HashMapBuilder.<InfoItemIdentifier, ObjectEntry>put(
+							ercInfoItemIdentifier, objectEntry
+						).build()
+					).build())));
+
+		Mockito.verifyNoInteractions(_objectEntryManager);
+	}
+
+	@Test
+	public void testGetInfoItemNonapprovedLiferayObjectEntryWithApprovedHeadObjectEntry()
+		throws Exception {
+
+		long objectEntryId = RandomTestUtil.randomLong();
+		ObjectEntry objectEntry = _mockObjectEntry(false);
+
+		Mockito.when(
+			objectEntry.getObjectEntryId()
+		).thenReturn(
+			objectEntryId
+		);
+
+		Mockito.when(
+			_objectEntryLocalService.fetchObjectEntry(objectEntryId)
+		).thenReturn(
+			objectEntry
+		);
+
+		ObjectEntry headObjectEntry = _mockObjectEntry(true);
+
+		Mockito.when(
+			_objectEntryLocalService.fetchObjectEntryByHeadObjectEntryId(
+				objectEntryId)
+		).thenReturn(
+			headObjectEntry
+		);
+
+		Assert.assertEquals(
+			headObjectEntry,
+			_assertGetInfoItem(new ClassPKInfoItemIdentifier(objectEntryId)));
+
+		ClassPKInfoItemIdentifier classPKInfoItemIdentifier =
+			new ClassPKInfoItemIdentifier(objectEntryId);
+
+		classPKInfoItemIdentifier.setVersion(
+			InfoItemIdentifier.VERSION_LATEST_APPROVED);
+
+		Assert.assertEquals(
+			headObjectEntry, _assertGetInfoItem(classPKInfoItemIdentifier));
+
+		Mockito.verifyNoInteractions(_objectEntryManagerRegistry);
+	}
+
+	@Test
+	public void testGetInfoItemNonapprovedLiferayObjectEntryWithLatestVersion()
+		throws Exception {
+
+		long objectEntryId = RandomTestUtil.randomLong();
+		ObjectEntry objectEntry = _mockObjectEntry(false);
+
+		Mockito.when(
+			_objectEntryLocalService.fetchObjectEntry(objectEntryId)
+		).thenReturn(
+			objectEntry
+		);
+
+		ClassPKInfoItemIdentifier classPKInfoItemIdentifier =
+			new ClassPKInfoItemIdentifier(objectEntryId);
+
+		classPKInfoItemIdentifier.setVersion(InfoItemIdentifier.VERSION_LATEST);
+
+		Assert.assertEquals(
+			objectEntry, _assertGetInfoItem(classPKInfoItemIdentifier));
+
+		Mockito.verify(
+			_objectEntryLocalService, Mockito.never()
+		).fetchObjectEntryByHeadObjectEntryId(
+			Mockito.anyLong()
+		);
+
+		Mockito.verifyNoInteractions(_objectEntryManagerRegistry);
+	}
+
+	@Test
+	public void testGetInfoItemNonapprovedLiferayObjectEntryWithNonapprovedHeadObjectEntry() {
+		long objectEntryId = RandomTestUtil.randomLong();
+		ObjectEntry objectEntry = _mockObjectEntry(false);
+
+		Mockito.when(
+			objectEntry.getObjectEntryId()
+		).thenReturn(
+			objectEntryId
+		);
+
+		Mockito.when(
+			_objectEntryLocalService.fetchObjectEntry(objectEntryId)
+		).thenReturn(
+			objectEntry
+		);
+
+		ObjectEntry headObjectEntry = _mockObjectEntry(false);
+
+		Mockito.when(
+			_objectEntryLocalService.fetchObjectEntryByHeadObjectEntryId(
+				objectEntryId)
+		).thenReturn(
+			headObjectEntry
+		);
+
+		_assertGetInfoItemNoSuchInfoItemException(
+			new ClassPKInfoItemIdentifier(objectEntryId),
+			"Unable to get an approved object entry " + objectEntryId);
+
+		Mockito.verifyNoInteractions(_objectEntryManagerRegistry);
+	}
+
+	@Test
+	public void testGetInfoItemNonapprovedLiferayObjectEntryWithoutHeadObjectEntry() {
+		long objectEntryId = RandomTestUtil.randomLong();
+		ObjectEntry objectEntry = _mockObjectEntry(false);
+
+		Mockito.when(
+			objectEntry.getObjectEntryId()
+		).thenReturn(
+			objectEntryId
+		);
+
+		Mockito.when(
+			_objectEntryLocalService.fetchObjectEntry(objectEntryId)
+		).thenReturn(
+			objectEntry
+		);
+
+		_assertGetInfoItemNoSuchInfoItemException(
+			new ClassPKInfoItemIdentifier(objectEntryId),
+			"Unable to get an approved object entry " + objectEntryId);
+
+		Mockito.verify(
+			_objectEntryLocalService
+		).fetchObjectEntryByHeadObjectEntryId(
+			objectEntryId
+		);
+
+		Mockito.verifyNoInteractions(_objectEntryManagerRegistry);
+	}
+
+	@Test
+	public void testGetInfoItemNonapprovedProxyObjectEntryWithApprovedHeadObjectEntry()
+		throws Exception {
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+		ObjectEntry objectEntry = _mockObjectEntry(false);
+
+		long objectEntryId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			objectEntry.getObjectEntryId()
+		).thenReturn(
+			objectEntryId
+		);
+
+		_setUpProxyObjectEntry(externalReferenceCode, objectEntry);
+
+		ObjectEntry headObjectEntry = _mockObjectEntry(true);
+
+		Mockito.when(
+			_objectEntryLocalService.fetchObjectEntryByHeadObjectEntryId(
+				objectEntryId)
+		).thenReturn(
+			headObjectEntry
+		);
+
+		Assert.assertEquals(
+			headObjectEntry,
+			_assertGetInfoItem(
+				new ERCInfoItemIdentifier(externalReferenceCode)));
+	}
+
+	@Test
 	public void testGetInfoItemProxyObjectEntry() throws Exception {
 		String externalReferenceCode = RandomTestUtil.randomString();
 		ObjectEntry objectEntry = _mockObjectEntry(true);
@@ -280,49 +352,6 @@ public class ObjectEntryInfoItemObjectProviderTest {
 				new ERCInfoItemIdentifier(externalReferenceCode)));
 
 		Mockito.verifyNoInteractions(_objectEntryLocalService);
-	}
-
-	@Test
-	public void testGetInfoItemProxyObjectEntryCachedNonapproved()
-		throws Exception {
-
-		String externalReferenceCode = RandomTestUtil.randomString();
-
-		ERCInfoItemIdentifier ercInfoItemIdentifier = new ERCInfoItemIdentifier(
-			externalReferenceCode);
-
-		ObjectEntry objectEntry = _mockObjectEntry(false);
-
-		long objectEntryId = RandomTestUtil.randomLong();
-
-		Mockito.when(
-			objectEntry.getObjectEntryId()
-		).thenReturn(
-			objectEntryId
-		);
-
-		ObjectEntry latestApprovedObjectEntry = _mockObjectEntry(true);
-
-		Mockito.when(
-			_objectEntryLocalService.fetchObjectEntryByHeadObjectEntryId(
-				objectEntryId)
-		).thenReturn(
-			latestApprovedObjectEntry
-		);
-
-		Assert.assertEquals(
-			latestApprovedObjectEntry,
-			_assertGetInfoItem(
-				ercInfoItemIdentifier,
-				_getHttpServletRequest(
-					HashMapBuilder.<String, Object>put(
-						_OBJECT_ENTRIES,
-						HashMapBuilder.<InfoItemIdentifier, ObjectEntry>put(
-							ercInfoItemIdentifier, objectEntry
-						).build()
-					).build())));
-
-		Mockito.verifyNoInteractions(_objectEntryManager);
 	}
 
 	@Test
@@ -362,38 +391,6 @@ public class ObjectEntryInfoItemObjectProviderTest {
 			attributes, new ERCInfoItemIdentifier(externalReferenceCode),
 			_getHttpServletRequest(attributes), objectEntry,
 			_setUpProxyObjectEntry(externalReferenceCode, objectEntry));
-	}
-
-	@Test
-	public void testGetInfoItemProxyObjectEntryNonapprovedWithLatestApproved()
-		throws Exception {
-
-		String externalReferenceCode = RandomTestUtil.randomString();
-		ObjectEntry objectEntry = _mockObjectEntry(false);
-
-		long objectEntryId = RandomTestUtil.randomLong();
-
-		Mockito.when(
-			objectEntry.getObjectEntryId()
-		).thenReturn(
-			objectEntryId
-		);
-
-		_setUpProxyObjectEntry(externalReferenceCode, objectEntry);
-
-		ObjectEntry latestApprovedObjectEntry = _mockObjectEntry(true);
-
-		Mockito.when(
-			_objectEntryLocalService.fetchObjectEntryByHeadObjectEntryId(
-				objectEntryId)
-		).thenReturn(
-			latestApprovedObjectEntry
-		);
-
-		Assert.assertEquals(
-			latestApprovedObjectEntry,
-			_assertGetInfoItem(
-				new ERCInfoItemIdentifier(externalReferenceCode)));
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96450

> **Cross-team review request.** The primary PR is liferay-bpm/liferay-portal#6398, where most of the change lives in `object-web`. This PR is opened against the Page Management fork so your team can review the `info-api` and `info-impl` changes, which are your code. It carries the full branch — the files to review on your side are called out below.

## Page Management Review Focus

- **`info-api` — `InfoItemIdentifier`**: adds a new `VERSION_EDITABLE` sentinel constant, resolved per provider the same way `VERSION_LATEST` and `VERSION_LATEST_APPROVED` are. The exported package is version-bumped accordingly (`com.liferay.info.item` `packageinfo` 7.4.0 → 7.5.0, bundle `38.10.1 → 38.11.0`).
- **`info-impl` — `EditInfoItemStrutsAction`**: `_getInfoItemIdentifier` stamps `VERSION_EDITABLE` when editing. The commit history shows the progression on purpose: the first approach stamps `VERSION_LATEST` (which changed web content editing), then the follow-up switches it to the `VERSION_EDITABLE` sentinel so each provider resolves the editable version for its own domain, without hijacking the meaning `VERSION_LATEST` already carries.

## What Is Being Fixed

A CMS content entry mapped directly onto a DXP page through fragment editables kept rendering its field values after the entry became non-approved. Editing an approved entry and saving it as a draft, or submitting it for approval so it became pending, made the fragment show the draft or pending value instead of the last approved version, and an expired entry likewise kept rendering instead of disappearing. Direct display page access was already gated, so the schedule and workflow status were enforced everywhere except fragment mapping.

Constraining the provider surfaced a companion regression: publishing a brand-new draft object entry through the inline edit form failed with a generic error, because the edit action resolves the entry being edited through the same provider, and a brand-new draft has no approved version to fall back to.

## How It Is Being Fixed

The object entry InfoItemObjectProvider resolves a non-approved head to the latest approved sibling and renders nothing when no approved version exists, and ObjectEntryUtil.toObjectEntry copies the workflow status onto the proxy object entry so the external reference code branch gates the same way as the class PK branch.

For editing, rather than forcing a version on every edited info item, the edit action stamps the new InfoItemIdentifier.VERSION_EDITABLE sentinel, and each provider resolves it in doGetInfoItem. The object entry provider resolves it to the version being edited, so the CMS editor loads the draft it is publishing, while the journal and knowledge base providers resolve it through their existing editable branch, leaving web content and knowledge base editing unchanged.

Note: `journal-web` and `knowledge-base-web` are also updated to resolve `VERSION_EDITABLE`; those modules are owned by their respective teams.
