### PR TITLE
LPD-96221 Add end-to-end tests for audience element variations

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsList.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsList.tsx
@@ -64,6 +64,7 @@ export default function ElementVariationsList({
 									<ClayList.Item
 										flex
 										key={elementVariation.key}
+										tabIndex={0}
 									>
 										<ClayList.ItemField expand>
 											<ClayList.ItemTitle>

--- a/modules/test/playwright/fixtures/audiencesPagesTest.ts
+++ b/modules/test/playwright/fixtures/audiencesPagesTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {AudiencesPage} from '../pages/audiences-web/AudiencesPage';
+
+const audiencesPagesTest = test.extend<{
+	audiencesPage: AudiencesPage;
+}>({
+	audiencesPage: async ({page}, use) => {
+		await use(new AudiencesPage(page));
+	},
+});
+
+export {audiencesPagesTest};

--- a/modules/test/playwright/fixtures/pageEditorPagesTest.ts
+++ b/modules/test/playwright/fixtures/pageEditorPagesTest.ts
@@ -5,11 +5,16 @@
 
 import {test} from '@playwright/test';
 
+import {ElementVariationsPage} from '../pages/layout-content-page-editor-web/ElementVariationsPage';
 import {PageEditorPage} from '../pages/layout-content-page-editor-web/PageEditorPage';
 
 const pageEditorPagesTest = test.extend<{
+	elementVariationsPage: ElementVariationsPage;
 	pageEditorPage: PageEditorPage;
 }>({
+	elementVariationsPage: async ({page}, use) => {
+		await use(new ElementVariationsPage(page));
+	},
 	pageEditorPage: async ({page}, use) => {
 		await use(new PageEditorPage(page));
 	},

--- a/modules/test/playwright/pages/audiences-web/AudiencesPage.ts
+++ b/modules/test/playwright/pages/audiences-web/AudiencesPage.ts
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page, expect} from '@playwright/test';
+
+import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
+import {PORTLET_URLS} from '../../utils/portletUrls';
+import {waitForAlert} from '../../utils/waitForAlert';
+
+export class AudiencesPage {
+	readonly nameInput: Locator;
+	readonly newAudienceButton: Locator;
+	readonly page: Page;
+	readonly ruleDropZone: Locator;
+	readonly saveButton: Locator;
+	readonly valueInput: Locator;
+
+	constructor(page: Page) {
+		this.nameInput = page.getByPlaceholder('New Audience');
+		this.newAudienceButton = page
+			.getByRole('button', {name: 'New Audience'})
+			.first();
+		this.page = page;
+		this.ruleDropZone = page.locator('.audience-builder-drop-zone');
+		this.saveButton = page.getByRole('button', {name: 'Save'});
+		this.valueInput = page.getByLabel('Value');
+	}
+
+	async createAudience({
+		attributeName,
+		name,
+		operator,
+		value,
+		valueType = 'text',
+	}: {
+		attributeName: string;
+		name: string;
+		operator?: string;
+		value: string;
+		valueType?: 'select' | 'text';
+	}) {
+		await this.newAudienceButton.click();
+
+		await this.nameInput.fill(name);
+
+		await expect(async () => {
+			await this.page
+				.locator('.audience-builder-attribute', {
+					hasText: attributeName,
+				})
+				.dragTo(this.ruleDropZone);
+
+			await expect(
+				this.page.locator('.audience-builder-rule')
+			).toBeVisible({timeout: 2000});
+		}).toPass();
+
+		if (operator) {
+			await clickAndExpectToBeVisible({
+				autoClick: true,
+				target: this.page.getByRole('option', {name: operator}),
+				trigger: this.page.getByLabel('Operator'),
+			});
+		}
+
+		if (valueType === 'select') {
+			const selectedValue = await this.valueInput.textContent();
+
+			if (!selectedValue?.includes(value)) {
+				await clickAndExpectToBeVisible({
+					autoClick: true,
+					target: this.page.getByRole('option', {name: value}),
+					trigger: this.valueInput,
+				});
+			}
+		}
+		else {
+			await this.valueInput.fill(value);
+		}
+
+		await this.saveButton.click();
+
+		await waitForAlert(this.page);
+	}
+
+	async deleteAudience(name: string) {
+		this.page.once('dialog', (dialog) => dialog.accept());
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {name: 'Delete'}),
+			trigger: this.page
+				.locator('tr', {hasText: name})
+				.locator('button.dropdown-toggle'),
+		});
+
+		await waitForAlert(this.page);
+	}
+
+	async goto() {
+		await this.page.goto(PORTLET_URLS.audiences);
+	}
+}

--- a/modules/test/playwright/pages/layout-content-page-editor-web/ElementVariationsPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/ElementVariationsPage.ts
@@ -1,0 +1,113 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
+
+export class ElementVariationsPage {
+	readonly audienceInput: Locator;
+	readonly hideToggle: Locator;
+	readonly htmlInput: Locator;
+	readonly javaScriptInput: Locator;
+	readonly languageSelector: Locator;
+	readonly nameInput: Locator;
+	readonly newVariationButton: Locator;
+	readonly page: Page;
+	readonly pageElementPicker: Locator;
+	readonly saveButton: Locator;
+	readonly sidebar: Locator;
+
+	constructor(page: Page) {
+		this.audienceInput = page.getByLabel('Audience');
+		this.hideToggle = page.getByText('Hide Page Element');
+		this.htmlInput = page.getByLabel('HTML');
+		this.javaScriptInput = page.getByLabel('JavaScript');
+		this.languageSelector = page.getByLabel('Select a language');
+		this.nameInput = page.getByLabel('Name');
+		this.newVariationButton = page.getByRole('button', {
+			name: 'New Variation',
+		});
+		this.page = page;
+		this.pageElementPicker = page.getByLabel('Page Element');
+		this.saveButton = page.getByRole('button', {exact: true, name: 'Save'});
+		this.sidebar = page.locator('.element-variations__sidebar');
+	}
+
+	async createElementVariation({
+		audienceName,
+		hide = false,
+		html,
+		javaScript,
+		name,
+		pageElementLabel,
+		translations = [],
+	}: {
+		audienceName: string;
+		hide?: boolean;
+		html?: string;
+		javaScript?: string;
+		name: string;
+		pageElementLabel: string;
+		translations?: Array<{
+			html?: string;
+			javaScript?: string;
+			languageId: string;
+		}>;
+	}) {
+		await this.newVariationButton.click();
+
+		await this.nameInput.fill(name);
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('option', {name: pageElementLabel}),
+			trigger: this.pageElementPicker,
+		});
+
+		await this.audienceInput.fill(audienceName);
+
+		await this.page
+			.locator('.dropdown-menu')
+			.getByText(audienceName)
+			.click();
+
+		if (hide) {
+			await this.hideToggle.click();
+		}
+
+		if (html) {
+			await this.htmlInput.fill(html);
+		}
+
+		if (javaScript) {
+			await this.javaScriptInput.fill(javaScript);
+		}
+
+		for (const translation of translations) {
+			await this.selectLanguage(translation.languageId);
+
+			if (translation.html) {
+				await this.htmlInput.fill(translation.html);
+			}
+
+			if (translation.javaScript) {
+				await this.javaScriptInput.fill(translation.javaScript);
+			}
+		}
+
+		await this.saveButton.click();
+
+		await this.sidebar.getByText(name).waitFor();
+	}
+
+	async selectLanguage(languageId: string) {
+		await this.languageSelector.click();
+
+		await this.page
+			.getByRole('option', {name: `${languageId} Language`})
+			.click();
+	}
+}

--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -216,6 +216,14 @@ export class PageEditorPage {
 		});
 	}
 
+	async goToElementVariations() {
+		await this.page.getByLabel('Create Variations').click();
+
+		await this.page
+			.getByText('Element Variations', {exact: true})
+			.waitFor();
+	}
+
 	async goToFragmentComment(fragmentId: string) {
 		await this.selectFragment(fragmentId);
 

--- a/modules/test/playwright/tests/audiences-web/main/audiences.spec.ts
+++ b/modules/test/playwright/tests/audiences-web/main/audiences.spec.ts
@@ -11,7 +11,6 @@ import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
-import dragAndDropElement from '../../../utils/dragAndDropElement';
 import getRandomString from '../../../utils/getRandomString';
 import {PORTLET_URLS} from '../../../utils/portletUrls';
 import {waitForAlert} from '../../../utils/waitForAlert';
@@ -31,10 +30,8 @@ test(
 	{
 		tag: '@LPD-93951',
 	},
-	async ({page, site}) => {
-		await page.goto(
-			`/group${site.friendlyUrlPath}${PORTLET_URLS.audiences}`
-		);
+	async ({page}) => {
+		await page.goto(PORTLET_URLS.audiences);
 
 		// Create a new audience
 
@@ -46,12 +43,16 @@ test(
 
 		// Add the Browser Name condition and fill in its value
 
-		await dragAndDropElement({
-			dragTarget: page
+		await expect(async () => {
+			await page
 				.locator('.audience-builder-attribute')
-				.filter({hasText: 'Browser Name'}),
-			dropTarget: page.locator('.audience-builder-drop-zone'),
-		});
+				.filter({hasText: 'Browser Name'})
+				.dragTo(page.locator('.audience-builder-drop-zone'));
+
+			await expect(page.locator('.audience-builder-rule')).toBeVisible({
+				timeout: 2000,
+			});
+		}).toPass();
 
 		await page.getByLabel('Value').fill('Chrome');
 

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/elementVariations.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/elementVariations.spec.ts
@@ -1,0 +1,257 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {audiencesPagesTest} from '../../../fixtures/audiencesPagesTest';
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
+import getRandomString from '../../../utils/getRandomString';
+import {performLoginViaApi} from '../../../utils/performLogin';
+import getFragmentDefinition from './utils/getFragmentDefinition';
+import getPageDefinition from './utils/getPageDefinition';
+
+const test = mergeTests(
+	apiHelpersTest,
+	audiencesPagesTest,
+	dataApiHelpersTest,
+	featureFlagsTest({
+		'LPD-83647': {enabled: true},
+		'LPD-86901': {enabled: true},
+		'LPD-93951': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+test(
+	'Element variations are applied in view mode for a matching audience',
+	{tag: '@LPD-93951'},
+	async ({
+		apiHelpers,
+		audiencesPage,
+		browser,
+		elementVariationsPage,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+
+		// Create an audience matching the browser language
+
+		const audienceName = 'Audience ' + getRandomString();
+
+		await audiencesPage.goto();
+
+		await audiencesPage.createAudience({
+			attributeName: 'Language',
+			name: audienceName,
+			value: 'English (United States)',
+			valueType: 'select',
+		});
+
+		// Create a page with a Heading and a Paragraph fragment
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				getFragmentDefinition({
+					id: getRandomString(),
+					key: 'BASIC_COMPONENT-heading',
+				}),
+				getFragmentDefinition({
+					id: getRandomString(),
+					key: 'BASIC_COMPONENT-paragraph',
+				}),
+			]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		// Create a variation replacing the heading HTML and another one
+		// hiding the paragraph
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.goToElementVariations();
+
+		const variationText = 'Variation ' + getRandomString();
+
+		await elementVariationsPage.createElementVariation({
+			audienceName,
+			html: `<span>${variationText}</span>`,
+			name: 'Replace heading',
+			pageElementLabel: 'Heading (element-text)',
+		});
+
+		await elementVariationsPage.createElementVariation({
+			audienceName,
+			hide: true,
+			name: 'Hide paragraph',
+			pageElementLabel: 'Paragraph (element-text)',
+		});
+
+		// Publish the page
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.publishPage();
+
+		// The variations are applied in view mode
+
+		const paragraphDefaultText =
+			'A paragraph is a self-contained unit of a discourse';
+
+		await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`);
+
+		await expect(page.getByText(variationText)).toBeVisible();
+
+		await expect(page.getByText('Heading Example')).not.toBeVisible();
+
+		await expect(page.getByText(paragraphDefaultText)).not.toBeVisible();
+
+		// The page renders unchanged for a visitor matching no audience
+
+		const nonMatchingContext = await browser.newContext({locale: 'es-ES'});
+
+		const nonMatchingPage = await nonMatchingContext.newPage();
+
+		await performLoginViaApi({page: nonMatchingPage, screenName: 'test'});
+
+		await nonMatchingPage.goto(
+			`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`
+		);
+
+		await expect(
+			nonMatchingPage.getByText('Heading Example')
+		).toBeVisible();
+
+		await expect(
+			nonMatchingPage.getByText(paragraphDefaultText)
+		).toBeVisible();
+
+		await expect(
+			nonMatchingPage.getByText(variationText)
+		).not.toBeVisible();
+
+		await nonMatchingContext.close();
+
+		// Delete the audience, which is company scoped and does not go away
+		// with the site
+
+		await audiencesPage.goto();
+
+		await audiencesPage.deleteAudience(audienceName);
+	}
+);
+
+test(
+	'Translated HTML and JavaScript fields follow the page language',
+	{tag: '@LPD-93951'},
+	async ({
+		apiHelpers,
+		audiencesPage,
+		elementVariationsPage,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+
+		// Create an audience matching the browser name
+
+		const audienceName = 'Audience ' + getRandomString();
+
+		await audiencesPage.goto();
+
+		await audiencesPage.createAudience({
+			attributeName: 'Browser Name',
+			name: audienceName,
+			operator: 'Contains',
+			value: 'Chrome',
+		});
+
+		// Create a page with a Heading fragment
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				getFragmentDefinition({
+					id: getRandomString(),
+					key: 'BASIC_COMPONENT-heading',
+				}),
+			]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		// Create a variation with translated HTML and JavaScript fields
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.goToElementVariations();
+
+		const englishHTMLText = 'HTMLEN' + getRandomString();
+		const englishJavaScriptText = 'JSEN' + getRandomString();
+		const spanishHTMLText = 'HTMLES' + getRandomString();
+		const spanishJavaScriptText = 'JSES' + getRandomString();
+
+		await elementVariationsPage.createElementVariation({
+			audienceName,
+			html: `<span>${englishHTMLText}</span>`,
+			javaScript: `element.append(' ${englishJavaScriptText}');`,
+			name: 'Translated heading',
+			pageElementLabel: 'Heading (element-text)',
+			translations: [
+				{
+					html: `<span>${spanishHTMLText}</span>`,
+					javaScript: `element.append(' ${spanishJavaScriptText}');`,
+					languageId: 'es-ES',
+				},
+			],
+		});
+
+		// Publish the page
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.publishPage();
+
+		// The default page language applies the default language payloads
+
+		await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`);
+
+		await expect(page.getByText(englishHTMLText)).toBeVisible();
+
+		await expect(page.getByText(englishJavaScriptText)).toBeVisible();
+
+		// The translated page applies the translated payloads
+
+		await page.goto(
+			`/es/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`
+		);
+
+		await expect(page.getByText(spanishHTMLText)).toBeVisible();
+
+		await expect(page.getByText(spanishJavaScriptText)).toBeVisible();
+
+		await expect(page.getByText(englishHTMLText)).not.toBeVisible();
+
+		// Return to the default language before cleaning up
+
+		await page.goto(
+			`/en/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`
+		);
+
+		// Delete the audience, which is company scoped and does not go away
+		// with the site
+
+		await audiencesPage.goto();
+
+		await audiencesPage.deleteAudience(audienceName);
+	}
+);

--- a/modules/test/playwright/utils/portletUrls.ts
+++ b/modules/test/playwright/utils/portletUrls.ts
@@ -10,8 +10,7 @@ export const PORTLET_URLS = {
 		'/group/control_panel/manage?p_p_id=com_liferay_configuration_admin_web_portlet_InstanceSettingsPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_com_liferay_configuration_admin_web_portlet_InstanceSettingsPortlet_mvcRenderCommandName=%2Fconfiguration_admin%2Fview_configuration_screen&_com_liferay_configuration_admin_web_portlet_InstanceSettingsPortlet_configurationScreenKey=analytics-cloud-connection',
 	announcements:
 		'/~/control_panel/manage?p_p_id=com_liferay_announcements_web_portlet_AnnouncementsAdminPortlet',
-	audiences:
-		'/~/control_panel/manage?p_p_id=com_liferay_audiences_web_internal_portlet_AudiencesPortlet',
+	audiences: '/group/control_panel/manage/-/audiences/entries',
 	batchExportImport:
 		'/~/control_panel/manage?p_p_id=com_liferay_batch_planner_web_internal_portlet_BatchPlannerPortlet',
 	blogs: '/~/control_panel/manage?p_p_id=com_liferay_blogs_web_portlet_BlogsAdminPortlet',


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96221

## What Is Being Fixed

The audiences element variations feature (audience-driven hide, HTML, and JavaScript variations applied to published pages) had no functional test coverage. In addition, the `PORTLET_URLS.audiences` entry pointed at a portlet URL that does not resolve, and the drag interaction used to build audience rules was flaky in headless runs.

## How It Is Being Fixed

Two Playwright end-to-end tests cover the full flow: the first creates a language-based audience, seeds a page with a Heading and a Paragraph fragment, authors an HTML replacement variation and a hide variation, publishes, and asserts that a matching visitor sees both effects while a visitor with a nonmatching browser locale sees the untouched page; the second authors a variation with translated HTML and JavaScript payloads and asserts each page language applies its own translation.

The tests are driven through new page objects (`AudiencesPage`, `ElementVariationsPage`, plus a `goToElementVariations` action on `PageEditorPage`) wired into fixtures. Along the way, `PORTLET_URLS.audiences` now points at the audiences entries friendly URL, the audience rule drag is retried until the rule row appears (plain `dragTo`, which works where the shared drag util does not), and element variation list items are keyboard focusable via `tabIndex`.

## PR Check

**pr-check: PASS** — tested on `a344838a509bf371f4b04675db5cb1493c48ba6f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a344838a509bf371f4b04675db5cb1493c48ba6f"} -->
