### PR TITLE
LPD-97719 REST API support Part 2: Fragment Sets in Design Library scope

### DIFF
--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-api/src/main/java/com/liferay/headless/admin/fragment/resource/v1_0/FragmentSetResource.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-api/src/main/java/com/liferay/headless/admin/fragment/resource/v1_0/FragmentSetResource.java
@@ -56,6 +56,17 @@ public interface FragmentSetResource {
 			String fragmentSetExternalReferenceCode)
 		throws Exception;
 
+	public FragmentSet getDesignLibraryFragmentSet(
+			String designLibraryExternalReferenceCode,
+			String fragmentSetExternalReferenceCode)
+		throws Exception;
+
+	public Page<FragmentSet> getDesignLibraryFragmentSetsPage(
+			String designLibraryExternalReferenceCode,
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination)
+		throws Exception;
+
 	public FragmentSet getSiteFragmentSet(
 			String siteExternalReferenceCode,
 			String fragmentSetExternalReferenceCode)
@@ -182,4 +193,4 @@ public interface FragmentSetResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2098913088
+// LIFERAY-REST-BUILDER-HASH:1376008915

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-client/src/main/java/com/liferay/headless/admin/fragment/client/resource/v1_0/FragmentSetResource.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-client/src/main/java/com/liferay/headless/admin/fragment/client/resource/v1_0/FragmentSetResource.java
@@ -54,6 +54,27 @@ public interface FragmentSetResource {
 			String fragmentSetExternalReferenceCode)
 		throws Exception;
 
+	public FragmentSet getDesignLibraryFragmentSet(
+			String designLibraryExternalReferenceCode,
+			String fragmentSetExternalReferenceCode)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getDesignLibraryFragmentSetHttpResponse(
+			String designLibraryExternalReferenceCode,
+			String fragmentSetExternalReferenceCode)
+		throws Exception;
+
+	public Page<FragmentSet> getDesignLibraryFragmentSetsPage(
+			String designLibraryExternalReferenceCode, String filterString,
+			Pagination pagination)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			getDesignLibraryFragmentSetsPageHttpResponse(
+				String designLibraryExternalReferenceCode, String filterString,
+				Pagination pagination)
+		throws Exception;
+
 	public FragmentSet getSiteFragmentSet(
 			String siteExternalReferenceCode,
 			String fragmentSetExternalReferenceCode)
@@ -440,6 +461,245 @@ public interface FragmentSetResource {
 			httpInvoker.path(
 				"fragmentSetExternalReferenceCode",
 				fragmentSetExternalReferenceCode);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public FragmentSet getDesignLibraryFragmentSet(
+				String designLibraryExternalReferenceCode,
+				String fragmentSetExternalReferenceCode)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getDesignLibraryFragmentSetHttpResponse(
+					designLibraryExternalReferenceCode,
+					fragmentSetExternalReferenceCode);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return FragmentSetSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse getDesignLibraryFragmentSetHttpResponse(
+				String designLibraryExternalReferenceCode,
+				String fragmentSetExternalReferenceCode)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-admin-fragment/v1.0/design-libraries/{designLibraryExternalReferenceCode}/fragment-sets/{fragmentSetExternalReferenceCode}");
+
+			httpInvoker.path(
+				"designLibraryExternalReferenceCode",
+				designLibraryExternalReferenceCode);
+			httpInvoker.path(
+				"fragmentSetExternalReferenceCode",
+				fragmentSetExternalReferenceCode);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Page<FragmentSet> getDesignLibraryFragmentSetsPage(
+				String designLibraryExternalReferenceCode, String filterString,
+				Pagination pagination)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getDesignLibraryFragmentSetsPageHttpResponse(
+					designLibraryExternalReferenceCode, filterString,
+					pagination);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, FragmentSetSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getDesignLibraryFragmentSetsPageHttpResponse(
+					String designLibraryExternalReferenceCode,
+					String filterString, Pagination pagination)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (filterString != null) {
+				httpInvoker.parameter("filter", filterString);
+			}
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-admin-fragment/v1.0/design-libraries/{designLibraryExternalReferenceCode}/fragment-sets");
+
+			httpInvoker.path(
+				"designLibraryExternalReferenceCode",
+				designLibraryExternalReferenceCode);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -1151,4 +1411,4 @@ public interface FragmentSetResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-891460321
+// LIFERAY-REST-BUILDER-HASH:-766081169

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/rest-openapi.yaml
@@ -233,6 +233,51 @@ info:
     version: v1.0
 openapi: 3.0.1
 paths:
+    "/design-libraries/{designLibraryExternalReferenceCode}/fragment-sets":
+        get:
+            description:
+                Retrieves the fragment sets of the design library.
+            operationId: getDesignLibraryFragmentSetsPage
+            parameters:
+                -   in: path
+                    name: designLibraryExternalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: query
+                    name: fields
+                    schema:
+                        type: string
+                -   in: query
+                    name: filter
+                    schema:
+                        type: string
+                -   in: query
+                    name: page
+                    schema:
+                        type: integer
+                -   in: query
+                    name: pageSize
+                    schema:
+                        type: integer
+                -   in: query
+                    name: restrictFields
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/FragmentSet"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/FragmentSet"
+                                type: array
+            tags: ["FragmentSet"]
     "/design-libraries/{designLibraryExternalReferenceCode}/fragment-sets/{fragmentSetExternalReferenceCode}":
         delete:
             description:

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/rest-openapi.yaml
@@ -255,6 +255,39 @@ paths:
                         application/json: {}
                         application/xml: {}
             tags: ["FragmentSet"]
+        get:
+            description:
+                Retrieves a specific fragment set of a design library.
+            operationId: getDesignLibraryFragmentSet
+            parameters:
+                -   in: path
+                    name: designLibraryExternalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: path
+                    name: fragmentSetExternalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+                -   in: query
+                    name: fields
+                    schema:
+                        type: string
+                -   in: query
+                    name: restrictFields
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/FragmentSet"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/FragmentSet"
+            tags: ["FragmentSet"]
     "/sites/{siteExternalReferenceCode}/fragment-sets":
         get:
             description:

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/BaseFragmentSetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/BaseFragmentSetResourceImpl.java
@@ -154,6 +154,115 @@ public abstract class BaseFragmentSetResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-admin-fragment/v1.0/design-libraries/{designLibraryExternalReferenceCode}/fragment-sets/{fragmentSetExternalReferenceCode}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves a specific fragment set of a design library."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "designLibraryExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "fragmentSetExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "FragmentSet")}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path(
+		"/design-libraries/{designLibraryExternalReferenceCode}/fragment-sets/{fragmentSetExternalReferenceCode}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public FragmentSet getDesignLibraryFragmentSet(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("designLibraryExternalReferenceCode")
+			String designLibraryExternalReferenceCode,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("fragmentSetExternalReferenceCode")
+			String fragmentSetExternalReferenceCode)
+		throws Exception {
+
+		return new FragmentSet();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-admin-fragment/v1.0/design-libraries/{designLibraryExternalReferenceCode}/fragment-sets'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the fragment sets of the design library."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "designLibraryExternalReferenceCode"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "filter"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "FragmentSet")}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path(
+		"/design-libraries/{designLibraryExternalReferenceCode}/fragment-sets"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<FragmentSet> getDesignLibraryFragmentSetsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("designLibraryExternalReferenceCode")
+			String designLibraryExternalReferenceCode,
+			@jakarta.ws.rs.core.Context
+				com.liferay.portal.kernel.search.filter.Filter filter,
+			@jakarta.ws.rs.core.Context Pagination pagination)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -X 'GET' 'http://localhost:8080/o/headless-admin-fragment/v1.0/sites/{siteExternalReferenceCode}/fragment-sets/{fragmentSetExternalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
@@ -1227,4 +1336,4 @@ public abstract class BaseFragmentSetResourceImpl
 		LogFactoryUtil.getLog(BaseFragmentSetResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-893355317
+// LIFERAY-REST-BUILDER-HASH:-771251805

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentSetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentSetResourceImpl.java
@@ -92,6 +92,24 @@ public class FragmentSetResourceImpl
 	}
 
 	@Override
+	public FragmentSet getDesignLibraryFragmentSet(
+			String designLibraryExternalReferenceCode,
+			String fragmentSetExternalReferenceCode)
+		throws Exception {
+
+		EnabledUtil.checkDesignLibrariesEnabled(contextCompany);
+
+		long groupId = GroupUtil.getDepotGroupId(
+			contextCompany.getCompanyId(), designLibraryExternalReferenceCode,
+			DepotConstants.TYPE_DESIGN_LIBRARY);
+
+		return _getFragmentSet(
+			fragmentSetExternalReferenceCode, groupId,
+			_getDesignLibraryActionsUnsafeFunction(
+				designLibraryExternalReferenceCode, groupId));
+	}
+
+	@Override
 	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
 		return _entityModel;
 	}
@@ -133,10 +151,8 @@ public class FragmentSetResourceImpl
 			true, true, contextCompany.getCompanyId(),
 			siteExternalReferenceCode);
 
-		return _toFragmentSet(
-			_fragmentCollectionService.
-				getFragmentCollectionByExternalReferenceCode(
-					fragmentSetExternalReferenceCode, groupId),
+		return _getFragmentSet(
+			fragmentSetExternalReferenceCode, groupId,
 			_getSiteActionsUnsafeFunction(groupId, siteExternalReferenceCode));
 	}
 
@@ -269,6 +285,20 @@ public class FragmentSetResourceImpl
 			FragmentCollectionActionUtil.getDesignLibraryActions(
 				contextScopeChecker, designLibraryExternalReferenceCode,
 				fragmentCollection, manageFragmentEntries, contextUriInfo);
+	}
+
+	private FragmentSet _getFragmentSet(
+			String externalReferenceCode, long groupId,
+			UnsafeFunction
+				<FragmentCollection, Map<String, Map<String, String>>,
+				 Exception> unsafeFunction)
+		throws Exception {
+
+		return _toFragmentSet(
+			_fragmentCollectionService.
+				getFragmentCollectionByExternalReferenceCode(
+					externalReferenceCode, groupId),
+			unsafeFunction);
 	}
 
 	private UnsafeFunction

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentSetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentSetResourceImpl.java
@@ -6,17 +6,25 @@
 package com.liferay.headless.admin.fragment.internal.resource.v1_0;
 
 import com.liferay.depot.constants.DepotConstants;
+import com.liferay.fragment.constants.FragmentActionKeys;
+import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.service.FragmentCollectionLocalService;
 import com.liferay.fragment.service.FragmentCollectionService;
 import com.liferay.headless.admin.fragment.dto.v1_0.FragmentSet;
 import com.liferay.headless.admin.fragment.internal.odata.entity.v1_0.FragmentSetEntityModel;
+import com.liferay.headless.admin.fragment.internal.resource.v1_0.util.FragmentCollectionActionUtil;
 import com.liferay.headless.admin.fragment.internal.resource.v1_0.util.ServiceContextUtil;
 import com.liferay.headless.admin.fragment.internal.util.EnabledUtil;
 import com.liferay.headless.admin.fragment.resource.v1_0.FragmentSetResource;
 import com.liferay.headless.common.spi.util.GroupUtil;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -31,6 +39,7 @@ import com.liferay.portal.vulcan.util.SearchUtil;
 import jakarta.ws.rs.core.MultivaluedMap;
 
 import java.util.Collections;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -89,10 +98,27 @@ public class FragmentSetResourceImpl
 
 	@Override
 	public FragmentSet getItem(Long id) throws Exception {
-		EnabledUtil.checkDesignLibrariesEnabled(contextCompany);
+		FragmentCollection fragmentCollection =
+			_fragmentCollectionService.getFragmentCollection(id);
+
+		Group group = _groupLocalService.getGroup(
+			fragmentCollection.getGroupId());
+
+		if (group.isDepot()) {
+			EnabledUtil.checkDesignLibrariesEnabled(contextCompany);
+
+			return _toFragmentSet(
+				fragmentCollection,
+				_getDesignLibraryActionsUnsafeFunction(
+					group.getExternalReferenceCode(), group.getGroupId()));
+		}
+
+		EnabledUtil.checkEnabled(contextCompany);
 
 		return _toFragmentSet(
-			_fragmentCollectionService.getFragmentCollection(id));
+			fragmentCollection,
+			_getSiteActionsUnsafeFunction(
+				group.getGroupId(), group.getExternalReferenceCode()));
 	}
 
 	@Override
@@ -103,13 +129,15 @@ public class FragmentSetResourceImpl
 
 		EnabledUtil.checkEnabled(contextCompany);
 
+		long groupId = GroupUtil.getGroupId(
+			true, true, contextCompany.getCompanyId(),
+			siteExternalReferenceCode);
+
 		return _toFragmentSet(
 			_fragmentCollectionService.
 				getFragmentCollectionByExternalReferenceCode(
-					fragmentSetExternalReferenceCode,
-					GroupUtil.getGroupId(
-						true, true, contextCompany.getCompanyId(),
-						siteExternalReferenceCode)));
+					fragmentSetExternalReferenceCode, groupId),
+			_getSiteActionsUnsafeFunction(groupId, siteExternalReferenceCode));
 	}
 
 	@Override
@@ -123,6 +151,11 @@ public class FragmentSetResourceImpl
 		long groupId = GroupUtil.getGroupId(
 			true, true, contextCompany.getCompanyId(),
 			siteExternalReferenceCode);
+
+		UnsafeFunction
+			<FragmentCollection, Map<String, Map<String, String>>, Exception>
+				unsafeFunction = _getSiteActionsUnsafeFunction(
+					groupId, siteExternalReferenceCode);
 
 		return SearchUtil.search(
 			Collections.emptyMap(),
@@ -145,7 +178,7 @@ public class FragmentSetResourceImpl
 					return null;
 				}
 
-				return _toFragmentSet(fragmentCollection);
+				return _toFragmentSet(fragmentCollection, unsafeFunction);
 			});
 	}
 
@@ -168,7 +201,8 @@ public class FragmentSetResourceImpl
 				ServiceContextUtil.getServiceContext(
 					contextCompany.getCompanyId(), fragmentSet.getDateCreated(),
 					groupId, contextHttpServletRequest,
-					fragmentSet.getDateModified(), contextUser.getUserId())));
+					fragmentSet.getDateModified(), contextUser.getUserId())),
+			_getSiteActionsUnsafeFunction(groupId, siteExternalReferenceCode));
 	}
 
 	@Override
@@ -199,7 +233,9 @@ public class FragmentSetResourceImpl
 						fragmentSet.getDateCreated(), groupId,
 						contextHttpServletRequest,
 						fragmentSet.getDateModified(),
-						contextUser.getUserId())));
+						contextUser.getUserId())),
+				_getSiteActionsUnsafeFunction(
+					groupId, siteExternalReferenceCode));
 		}
 
 		ServiceContextThreadLocal.pushServiceContext(
@@ -212,19 +248,60 @@ public class FragmentSetResourceImpl
 			return _toFragmentSet(
 				_fragmentCollectionService.updateFragmentCollection(
 					fragmentCollection.getFragmentCollectionId(),
-					fragmentSet.getName(), fragmentSet.getDescription()));
+					fragmentSet.getName(), fragmentSet.getDescription()),
+				_getSiteActionsUnsafeFunction(
+					groupId, siteExternalReferenceCode));
 		}
 		finally {
 			ServiceContextThreadLocal.popServiceContext();
 		}
 	}
 
-	private FragmentSet _toFragmentSet(FragmentCollection fragmentCollection)
+	private UnsafeFunction
+		<FragmentCollection, Map<String, Map<String, String>>, Exception>
+			_getDesignLibraryActionsUnsafeFunction(
+				String designLibraryExternalReferenceCode, long groupId) {
+
+		boolean manageFragmentEntries = _hasManageFragmentEntriesPermission(
+			groupId);
+
+		return fragmentCollection ->
+			FragmentCollectionActionUtil.getDesignLibraryActions(
+				contextScopeChecker, designLibraryExternalReferenceCode,
+				fragmentCollection, manageFragmentEntries, contextUriInfo);
+	}
+
+	private UnsafeFunction
+		<FragmentCollection, Map<String, Map<String, String>>, Exception>
+			_getSiteActionsUnsafeFunction(
+				long groupId, String siteExternalReferenceCode) {
+
+		boolean manageFragmentEntries = _hasManageFragmentEntriesPermission(
+			groupId);
+
+		return fragmentCollection ->
+			FragmentCollectionActionUtil.getSiteActions(
+				contextScopeChecker, fragmentCollection, manageFragmentEntries,
+				siteExternalReferenceCode, contextUriInfo);
+	}
+
+	private boolean _hasManageFragmentEntriesPermission(long groupId) {
+		return _portletResourcePermission.contains(
+			PermissionThreadLocal.getPermissionChecker(), groupId,
+			FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
+	}
+
+	private FragmentSet _toFragmentSet(
+			FragmentCollection fragmentCollection,
+			UnsafeFunction
+				<FragmentCollection, Map<String, Map<String, String>>,
+				 Exception> unsafeFunction)
 		throws Exception {
 
 		return _fragmentSetDTOConverter.toDTO(
 			new DefaultDTOConverterContext(
-				false, null, _dtoConverterRegistry, contextHttpServletRequest,
+				false, unsafeFunction.apply(fragmentCollection), null,
+				_dtoConverterRegistry, contextHttpServletRequest,
 				fragmentCollection.getFragmentCollectionId(),
 				contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
 				contextUser),
@@ -248,5 +325,13 @@ public class FragmentSetResourceImpl
 	)
 	private DTOConverter<FragmentCollection, FragmentSet>
 		_fragmentSetDTOConverter;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference(
+		target = "(resource.name=" + FragmentConstants.RESOURCE_NAME + ")"
+	)
+	private PortletResourcePermission _portletResourcePermission;
 
 }

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentSetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentSetResourceImpl.java
@@ -110,6 +110,24 @@ public class FragmentSetResourceImpl
 	}
 
 	@Override
+	public Page<FragmentSet> getDesignLibraryFragmentSetsPage(
+			String designLibraryExternalReferenceCode, Filter filter,
+			Pagination pagination)
+		throws Exception {
+
+		EnabledUtil.checkDesignLibrariesEnabled(contextCompany);
+
+		long groupId = GroupUtil.getDepotGroupId(
+			contextCompany.getCompanyId(), designLibraryExternalReferenceCode,
+			DepotConstants.TYPE_DESIGN_LIBRARY);
+
+		return _search(
+			filter, groupId, pagination,
+			_getDesignLibraryActionsUnsafeFunction(
+				designLibraryExternalReferenceCode, groupId));
+	}
+
+	@Override
 	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
 		return _entityModel;
 	}
@@ -168,34 +186,9 @@ public class FragmentSetResourceImpl
 			true, true, contextCompany.getCompanyId(),
 			siteExternalReferenceCode);
 
-		UnsafeFunction
-			<FragmentCollection, Map<String, Map<String, String>>, Exception>
-				unsafeFunction = _getSiteActionsUnsafeFunction(
-					groupId, siteExternalReferenceCode);
-
-		return SearchUtil.search(
-			Collections.emptyMap(),
-			booleanQuery -> {
-			},
-			filter, FragmentCollection.class.getName(), null, pagination,
-			queryConfig -> queryConfig.setSelectedFieldNames(
-				Field.ENTRY_CLASS_PK),
-			searchContext -> {
-				searchContext.setCompanyId(contextCompany.getCompanyId());
-				searchContext.setGroupIds(new long[] {groupId});
-			},
-			null,
-			document -> {
-				FragmentCollection fragmentCollection =
-					_fragmentCollectionService.fetchFragmentCollection(
-						GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK)));
-
-				if (fragmentCollection == null) {
-					return null;
-				}
-
-				return _toFragmentSet(fragmentCollection, unsafeFunction);
-			});
+		return _search(
+			filter, groupId, pagination,
+			_getSiteActionsUnsafeFunction(groupId, siteExternalReferenceCode));
 	}
 
 	@Override
@@ -321,12 +314,41 @@ public class FragmentSetResourceImpl
 			FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
 	}
 
+	private Page<FragmentSet> _search(
+			Filter filter, long groupId, Pagination pagination,
+			UnsafeFunction
+				<FragmentCollection, Map<String, Map<String, String>>,
+				 Exception> unsafeFunction)
+		throws Exception {
+
+		return SearchUtil.search(
+			Collections.emptyMap(),
+			booleanQuery -> {
+			},
+			filter, FragmentCollection.class.getName(), null, pagination,
+			queryConfig -> queryConfig.setSelectedFieldNames(
+				Field.ENTRY_CLASS_PK),
+			searchContext -> {
+				searchContext.setCompanyId(contextCompany.getCompanyId());
+				searchContext.setGroupIds(new long[] {groupId});
+			},
+			null,
+			document -> _toFragmentSet(
+				_fragmentCollectionService.fetchFragmentCollection(
+					GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK))),
+				unsafeFunction));
+	}
+
 	private FragmentSet _toFragmentSet(
 			FragmentCollection fragmentCollection,
 			UnsafeFunction
 				<FragmentCollection, Map<String, Map<String, String>>,
 				 Exception> unsafeFunction)
 		throws Exception {
+
+		if (fragmentCollection == null) {
+			return null;
+		}
 
 		return _fragmentSetDTOConverter.toDTO(
 			new DefaultDTOConverterContext(

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/util/FragmentCollectionActionUtil.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/util/FragmentCollectionActionUtil.java
@@ -44,6 +44,11 @@ public class FragmentCollectionActionUtil {
 			_addAction(
 				contextScopeChecker, fragmentCollection,
 				"deleteDesignLibraryFragmentSet", templateParameterMap, uriInfo)
+		).put(
+			"get",
+			_addAction(
+				contextScopeChecker, fragmentCollection,
+				"getDesignLibraryFragmentSet", templateParameterMap, uriInfo)
 		).build();
 	}
 

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/util/FragmentCollectionActionUtil.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/util/FragmentCollectionActionUtil.java
@@ -1,0 +1,97 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.fragment.internal.resource.v1_0.util;
+
+import com.liferay.fragment.constants.FragmentActionKeys;
+import com.liferay.fragment.constants.FragmentConstants;
+import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.headless.admin.fragment.internal.resource.v1_0.FragmentSetResourceImpl;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.vulcan.util.ActionUtil;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public class FragmentCollectionActionUtil {
+
+	public static Map<String, Map<String, String>> getDesignLibraryActions(
+		Object contextScopeChecker, String designLibraryExternalReferenceCode,
+		FragmentCollection fragmentCollection, boolean manageFragmentEntries,
+		UriInfo uriInfo) {
+
+		if (!manageFragmentEntries) {
+			return Collections.emptyMap();
+		}
+
+		Map<String, String> templateParameterMap = HashMapBuilder.put(
+			"designLibraryExternalReferenceCode",
+			designLibraryExternalReferenceCode
+		).put(
+			"fragmentSetExternalReferenceCode",
+			fragmentCollection.getExternalReferenceCode()
+		).build();
+
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"delete",
+			_addAction(
+				contextScopeChecker, fragmentCollection,
+				"deleteDesignLibraryFragmentSet", templateParameterMap, uriInfo)
+		).build();
+	}
+
+	public static Map<String, Map<String, String>> getSiteActions(
+		Object contextScopeChecker, FragmentCollection fragmentCollection,
+		boolean manageFragmentEntries, String siteExternalReferenceCode,
+		UriInfo uriInfo) {
+
+		if (!manageFragmentEntries) {
+			return Collections.emptyMap();
+		}
+
+		Map<String, String> templateParameterMap = HashMapBuilder.put(
+			"fragmentSetExternalReferenceCode",
+			fragmentCollection.getExternalReferenceCode()
+		).put(
+			"siteExternalReferenceCode", siteExternalReferenceCode
+		).build();
+
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"delete",
+			_addAction(
+				contextScopeChecker, fragmentCollection,
+				"deleteSiteFragmentSet", templateParameterMap, uriInfo)
+		).put(
+			"get",
+			_addAction(
+				contextScopeChecker, fragmentCollection, "getSiteFragmentSet",
+				templateParameterMap, uriInfo)
+		).put(
+			"replace",
+			_addAction(
+				contextScopeChecker, fragmentCollection, "putSiteFragmentSet",
+				templateParameterMap, uriInfo)
+		).build();
+	}
+
+	private static Map<String, String> _addAction(
+		Object contextScopeChecker, FragmentCollection fragmentCollection,
+		String methodName, Map<String, String> templateParameterMap,
+		UriInfo uriInfo) {
+
+		return ActionUtil.addAction(
+			FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES,
+			FragmentSetResourceImpl.class,
+			fragmentCollection.getFragmentCollectionId(), methodName,
+			contextScopeChecker, null, FragmentConstants.RESOURCE_NAME,
+			fragmentCollection.getGroupId(), templateParameterMap, uriInfo);
+	}
+
+}

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/BaseFragmentSetResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/BaseFragmentSetResourceTestCase.java
@@ -213,6 +213,17 @@ public abstract class BaseFragmentSetResourceTestCase {
 			fragmentSetResource.deleteDesignLibraryFragmentSetHttpResponse(
 				testDeleteDesignLibraryFragmentSet_getDesignLibraryExternalReferenceCode(),
 				fragmentSet.getExternalReferenceCode()));
+
+		assertHttpResponseStatusCode(
+			404,
+			fragmentSetResource.getDesignLibraryFragmentSetHttpResponse(
+				testDeleteDesignLibraryFragmentSet_getDesignLibraryExternalReferenceCode(),
+				fragmentSet.getExternalReferenceCode()));
+		assertHttpResponseStatusCode(
+			404,
+			fragmentSetResource.getDesignLibraryFragmentSetHttpResponse(
+				testDeleteDesignLibraryFragmentSet_getDesignLibraryExternalReferenceCode(),
+				"-"));
 	}
 
 	protected FragmentSet testDeleteDesignLibraryFragmentSet_addFragmentSet()
@@ -263,6 +274,317 @@ public abstract class BaseFragmentSetResourceTestCase {
 		throws Exception {
 
 		return testGroup.getExternalReferenceCode();
+	}
+
+	@Test
+	public void testGetDesignLibraryFragmentSet() throws Exception {
+		FragmentSet postFragmentSet =
+			testGetDesignLibraryFragmentSet_addFragmentSet();
+
+		FragmentSet getFragmentSet =
+			fragmentSetResource.getDesignLibraryFragmentSet(
+				testGetDesignLibraryFragmentSet_getDesignLibraryExternalReferenceCode(),
+				postFragmentSet.getExternalReferenceCode());
+
+		assertEquals(postFragmentSet, getFragmentSet);
+		assertValid(getFragmentSet);
+	}
+
+	protected FragmentSet testGetDesignLibraryFragmentSet_addFragmentSet()
+		throws Exception {
+
+		return fragmentSetResource.postSiteFragmentSet(
+			testGroup.getExternalReferenceCode(), randomFragmentSet());
+	}
+
+	protected String
+			testGetDesignLibraryFragmentSet_getDesignLibraryExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGetDesignLibraryFragmentSetsPage() throws Exception {
+		String designLibraryExternalReferenceCode =
+			testGetDesignLibraryFragmentSetsPage_getDesignLibraryExternalReferenceCode();
+		String irrelevantDesignLibraryExternalReferenceCode =
+			testGetDesignLibraryFragmentSetsPage_getIrrelevantDesignLibraryExternalReferenceCode();
+
+		Page<FragmentSet> page =
+			fragmentSetResource.getDesignLibraryFragmentSetsPage(
+				designLibraryExternalReferenceCode, null, Pagination.of(1, 10));
+
+		long totalCount = page.getTotalCount();
+
+		if (irrelevantDesignLibraryExternalReferenceCode != null) {
+			FragmentSet irrelevantFragmentSet =
+				testGetDesignLibraryFragmentSetsPage_addFragmentSet(
+					irrelevantDesignLibraryExternalReferenceCode,
+					randomIrrelevantFragmentSet());
+
+			page = fragmentSetResource.getDesignLibraryFragmentSetsPage(
+				irrelevantDesignLibraryExternalReferenceCode, null,
+				Pagination.of(1, (int)totalCount + 1));
+
+			Assert.assertEquals(totalCount + 1, page.getTotalCount());
+
+			assertContains(
+				irrelevantFragmentSet, (List<FragmentSet>)page.getItems());
+			assertValid(
+				page,
+				testGetDesignLibraryFragmentSetsPage_getExpectedActions(
+					irrelevantDesignLibraryExternalReferenceCode));
+		}
+
+		FragmentSet fragmentSet1 =
+			testGetDesignLibraryFragmentSetsPage_addFragmentSet(
+				designLibraryExternalReferenceCode, randomFragmentSet());
+
+		FragmentSet fragmentSet2 =
+			testGetDesignLibraryFragmentSetsPage_addFragmentSet(
+				designLibraryExternalReferenceCode, randomFragmentSet());
+
+		page = fragmentSetResource.getDesignLibraryFragmentSetsPage(
+			designLibraryExternalReferenceCode, null, Pagination.of(1, 10));
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(fragmentSet1, (List<FragmentSet>)page.getItems());
+		assertContains(fragmentSet2, (List<FragmentSet>)page.getItems());
+		assertValid(
+			page,
+			testGetDesignLibraryFragmentSetsPage_getExpectedActions(
+				designLibraryExternalReferenceCode));
+	}
+
+	protected Map<String, Map<String, String>>
+			testGetDesignLibraryFragmentSetsPage_getExpectedActions(
+				String designLibraryExternalReferenceCode)
+		throws Exception {
+
+		Map<String, Map<String, String>> expectedActions = new HashMap<>();
+
+		return expectedActions;
+	}
+
+	@Test
+	public void testGetDesignLibraryFragmentSetsPageWithFilterDateTimeEquals()
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.DATE_TIME);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		String designLibraryExternalReferenceCode =
+			testGetDesignLibraryFragmentSetsPage_getDesignLibraryExternalReferenceCode();
+
+		FragmentSet fragmentSet1 = randomFragmentSet();
+
+		fragmentSet1 = testGetDesignLibraryFragmentSetsPage_addFragmentSet(
+			designLibraryExternalReferenceCode, fragmentSet1);
+
+		for (EntityField entityField : entityFields) {
+			Page<FragmentSet> page =
+				fragmentSetResource.getDesignLibraryFragmentSetsPage(
+					designLibraryExternalReferenceCode,
+					getFilterString(entityField, "between", fragmentSet1),
+					Pagination.of(1, 2));
+
+			assertEquals(
+				Collections.singletonList(fragmentSet1),
+				(List<FragmentSet>)page.getItems());
+		}
+	}
+
+	@Test
+	public void testGetDesignLibraryFragmentSetsPageWithFilterDoubleEquals()
+		throws Exception {
+
+		testGetDesignLibraryFragmentSetsPageWithFilter(
+			"eq", EntityField.Type.DOUBLE);
+	}
+
+	@Test
+	public void testGetDesignLibraryFragmentSetsPageWithFilterStringContains()
+		throws Exception {
+
+		testGetDesignLibraryFragmentSetsPageWithFilter(
+			"contains", EntityField.Type.STRING);
+	}
+
+	@Test
+	public void testGetDesignLibraryFragmentSetsPageWithFilterStringEquals()
+		throws Exception {
+
+		testGetDesignLibraryFragmentSetsPageWithFilter(
+			"eq", EntityField.Type.STRING);
+	}
+
+	@Test
+	public void testGetDesignLibraryFragmentSetsPageWithFilterStringStartsWith()
+		throws Exception {
+
+		testGetDesignLibraryFragmentSetsPageWithFilter(
+			"startswith", EntityField.Type.STRING);
+	}
+
+	protected void testGetDesignLibraryFragmentSetsPageWithFilter(
+			String operator, EntityField.Type type)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		String designLibraryExternalReferenceCode =
+			testGetDesignLibraryFragmentSetsPage_getDesignLibraryExternalReferenceCode();
+
+		FragmentSet fragmentSet1 =
+			testGetDesignLibraryFragmentSetsPage_addFragmentSet(
+				designLibraryExternalReferenceCode, randomFragmentSet());
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		FragmentSet fragmentSet2 =
+			testGetDesignLibraryFragmentSetsPage_addFragmentSet(
+				designLibraryExternalReferenceCode, randomFragmentSet());
+
+		for (EntityField entityField : entityFields) {
+			Page<FragmentSet> page =
+				fragmentSetResource.getDesignLibraryFragmentSetsPage(
+					designLibraryExternalReferenceCode,
+					getFilterString(entityField, operator, fragmentSet1),
+					Pagination.of(1, 2));
+
+			assertEquals(
+				Collections.singletonList(fragmentSet1),
+				(List<FragmentSet>)page.getItems());
+		}
+	}
+
+	@Test
+	public void testGetDesignLibraryFragmentSetsPageWithPagination()
+		throws Exception {
+
+		String designLibraryExternalReferenceCode =
+			testGetDesignLibraryFragmentSetsPage_getDesignLibraryExternalReferenceCode();
+
+		Page<FragmentSet> fragmentSetsPage =
+			fragmentSetResource.getDesignLibraryFragmentSetsPage(
+				designLibraryExternalReferenceCode, null, null);
+
+		int totalCount = GetterUtil.getInteger(
+			fragmentSetsPage.getTotalCount());
+
+		FragmentSet fragmentSet1 =
+			testGetDesignLibraryFragmentSetsPage_addFragmentSet(
+				designLibraryExternalReferenceCode, randomFragmentSet());
+
+		FragmentSet fragmentSet2 =
+			testGetDesignLibraryFragmentSetsPage_addFragmentSet(
+				designLibraryExternalReferenceCode, randomFragmentSet());
+
+		FragmentSet fragmentSet3 =
+			testGetDesignLibraryFragmentSetsPage_addFragmentSet(
+				designLibraryExternalReferenceCode, randomFragmentSet());
+
+		// See com.liferay.portal.vulcan.internal.configuration.HeadlessAPICompanyConfiguration#pageSizeLimit
+
+		int pageSizeLimit = 500;
+
+		if (totalCount >= (pageSizeLimit - 2)) {
+			Page<FragmentSet> page1 =
+				fragmentSetResource.getDesignLibraryFragmentSetsPage(
+					designLibraryExternalReferenceCode, null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 1.0) / pageSizeLimit),
+						pageSizeLimit));
+
+			Assert.assertEquals(totalCount + 3, page1.getTotalCount());
+
+			assertContains(fragmentSet1, (List<FragmentSet>)page1.getItems());
+
+			Page<FragmentSet> page2 =
+				fragmentSetResource.getDesignLibraryFragmentSetsPage(
+					designLibraryExternalReferenceCode, null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 2.0) / pageSizeLimit),
+						pageSizeLimit));
+
+			assertContains(fragmentSet2, (List<FragmentSet>)page2.getItems());
+
+			Page<FragmentSet> page3 =
+				fragmentSetResource.getDesignLibraryFragmentSetsPage(
+					designLibraryExternalReferenceCode, null,
+					Pagination.of(
+						(int)Math.ceil((totalCount + 3.0) / pageSizeLimit),
+						pageSizeLimit));
+
+			assertContains(fragmentSet3, (List<FragmentSet>)page3.getItems());
+		}
+		else {
+			Page<FragmentSet> page1 =
+				fragmentSetResource.getDesignLibraryFragmentSetsPage(
+					designLibraryExternalReferenceCode, null,
+					Pagination.of(1, totalCount + 2));
+
+			List<FragmentSet> fragmentSets1 =
+				(List<FragmentSet>)page1.getItems();
+
+			Assert.assertEquals(
+				fragmentSets1.toString(), totalCount + 2, fragmentSets1.size());
+
+			Page<FragmentSet> page2 =
+				fragmentSetResource.getDesignLibraryFragmentSetsPage(
+					designLibraryExternalReferenceCode, null,
+					Pagination.of(2, totalCount + 2));
+
+			Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+			List<FragmentSet> fragmentSets2 =
+				(List<FragmentSet>)page2.getItems();
+
+			Assert.assertEquals(
+				fragmentSets2.toString(), 1, fragmentSets2.size());
+
+			Page<FragmentSet> page3 =
+				fragmentSetResource.getDesignLibraryFragmentSetsPage(
+					designLibraryExternalReferenceCode, null,
+					Pagination.of(1, (int)totalCount + 3));
+
+			assertContains(fragmentSet1, (List<FragmentSet>)page3.getItems());
+			assertContains(fragmentSet2, (List<FragmentSet>)page3.getItems());
+			assertContains(fragmentSet3, (List<FragmentSet>)page3.getItems());
+		}
+	}
+
+	protected FragmentSet testGetDesignLibraryFragmentSetsPage_addFragmentSet(
+			String designLibraryExternalReferenceCode, FragmentSet fragmentSet)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testGetDesignLibraryFragmentSetsPage_getDesignLibraryExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testGetDesignLibraryFragmentSetsPage_getIrrelevantDesignLibraryExternalReferenceCode()
+		throws Exception {
+
+		return null;
 	}
 
 	@Test
@@ -1714,4 +2036,4 @@ public abstract class BaseFragmentSetResourceTestCase {
 			_fragmentSetResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1318768798
+// LIFERAY-REST-BUILDER-HASH:-576482506

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.feature.flag.constants.FeatureFlagConstants;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -127,6 +128,12 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 				fetchFragmentCollectionByExternalReferenceCode(
 					fragmentSet.getExternalReferenceCode(),
 					testGroup.getGroupId()));
+	}
+
+	@Override
+	@Test
+	public void testGetDesignLibraryFragmentSetsPage() throws Exception {
+		super.testGetDesignLibraryFragmentSetsPage();
 	}
 
 	@Override
@@ -352,6 +359,28 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 	@Override
 	protected String
 			testGetDesignLibraryFragmentSet_getDesignLibraryExternalReferenceCode()
+		throws Exception {
+
+		Group group = _depotEntry.getGroup();
+
+		return group.getExternalReferenceCode();
+	}
+
+	@Override
+	protected FragmentSet testGetDesignLibraryFragmentSetsPage_addFragmentSet(
+			String designLibraryExternalReferenceCode, FragmentSet fragmentSet)
+		throws Exception {
+
+		return _addDesignLibraryFragmentSet(
+			fragmentSet,
+			_groupLocalService.getGroupByExternalReferenceCode(
+				designLibraryExternalReferenceCode,
+				TestPropsValues.getCompanyId()));
+	}
+
+	@Override
+	protected String
+			testGetDesignLibraryFragmentSetsPage_getDesignLibraryExternalReferenceCode()
 		throws Exception {
 
 		Group group = _depotEntry.getGroup();
@@ -741,6 +770,9 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 
 	@Inject
 	private FragmentCollectionLocalService _fragmentCollectionLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
 
 	@Inject
 	private Language _language;

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -341,6 +342,24 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 	}
 
 	@Override
+	protected FragmentSet testGetDesignLibraryFragmentSet_addFragmentSet()
+		throws Exception {
+
+		return _addDesignLibraryFragmentSet(
+			randomFragmentSet(), _depotEntry.getGroup());
+	}
+
+	@Override
+	protected String
+			testGetDesignLibraryFragmentSet_getDesignLibraryExternalReferenceCode()
+		throws Exception {
+
+		Group group = _depotEntry.getGroup();
+
+		return group.getExternalReferenceCode();
+	}
+
+	@Override
 	protected Map<String, Map<String, String>>
 			testGetSiteFragmentSetsPage_getExpectedActions(
 				String siteExternalReferenceCode)
@@ -365,6 +384,25 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 			null, type,
 			ServiceContextTestUtil.getServiceContext(
 				testGroup.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private FragmentSet _addDesignLibraryFragmentSet(
+			FragmentSet fragmentSet, Group group)
+		throws Exception {
+
+		FragmentCollection fragmentCollection =
+			_fragmentCollectionLocalService.addFragmentCollection(
+				fragmentSet.getExternalReferenceCode(),
+				TestPropsValues.getUserId(), group.getGroupId(),
+				fragmentSet.getKey(), fragmentSet.getName(),
+				fragmentSet.getDescription(),
+				GetterUtil.getBoolean(fragmentSet.getMarketplace()),
+				ServiceContextTestUtil.getServiceContext(
+					group.getGroupId(), TestPropsValues.getUserId()));
+
+		return fragmentSetResource.getDesignLibraryFragmentSet(
+			group.getExternalReferenceCode(),
+			fragmentCollection.getExternalReferenceCode());
 	}
 
 	private FragmentCollection _addFragmentCollection(Group group)

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -132,8 +132,24 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 
 	@Override
 	@Test
+	public void testGetDesignLibraryFragmentSet() throws Exception {
+		super.testGetDesignLibraryFragmentSet();
+
+		_testGetDesignLibraryFragmentSetActions();
+	}
+
+	@Override
+	@Test
 	public void testGetDesignLibraryFragmentSetsPage() throws Exception {
 		super.testGetDesignLibraryFragmentSetsPage();
+	}
+
+	@Override
+	@Test
+	public void testGetSiteFragmentSet() throws Exception {
+		super.testGetSiteFragmentSet();
+
+		_testGetSiteFragmentSetActions();
 	}
 
 	@Override
@@ -444,6 +460,19 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 				group.getGroupId(), TestPropsValues.getUserId()));
 	}
 
+	private void _assertActionHref(
+		Map<String, Map<String, String>> actions, String content,
+		String... keys) {
+
+		for (String key : keys) {
+			Map<String, String> action = actions.get(key);
+
+			String href = action.get("href");
+
+			Assert.assertTrue(key, href.contains(content));
+		}
+	}
+
 	private void _assertFragmentCollection(FragmentSet fragmentSet, Group group)
 		throws Exception {
 
@@ -602,6 +631,40 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 			() -> fragmentSetResource.deleteDesignLibraryFragmentSet(
 				testGroup.getExternalReferenceCode(),
 				RandomTestUtil.randomString()));
+	}
+
+	private void _testGetDesignLibraryFragmentSetActions() throws Exception {
+		Group group = _depotEntry.getGroup();
+
+		FragmentSet fragmentSet = _addDesignLibraryFragmentSet(
+			randomFragmentSet(), group);
+
+		FragmentSet getFragmentSet =
+			fragmentSetResource.getDesignLibraryFragmentSet(
+				group.getExternalReferenceCode(),
+				fragmentSet.getExternalReferenceCode());
+
+		_assertActionHref(
+			getFragmentSet.getActions(),
+			StringBundler.concat(
+				"/design-libraries/", group.getExternalReferenceCode(),
+				"/fragment-sets/", fragmentSet.getExternalReferenceCode()),
+			"delete", "get");
+	}
+
+	private void _testGetSiteFragmentSetActions() throws Exception {
+		FragmentSet postFragmentSet = testGetSiteFragmentSet_addFragmentSet();
+
+		FragmentSet getFragmentSet = fragmentSetResource.getSiteFragmentSet(
+			testGetSiteFragmentSet_getSiteExternalReferenceCode(),
+			postFragmentSet.getExternalReferenceCode());
+
+		_assertActionHref(
+			getFragmentSet.getActions(),
+			StringBundler.concat(
+				"/sites/", testGroup.getExternalReferenceCode(),
+				"/fragment-sets/", postFragmentSet.getExternalReferenceCode()),
+			"delete", "get", "replace");
 	}
 
 	private void _testPostSiteFragmentSetBatch() throws Exception {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97719

## What Is Being Fixed

Fragment Sets under the Design Library scope have no headless REST
endpoints. Consumers can neither look up a design library fragment set,
list its page, nor surface delete/get actions on the DTO from a design
library group.

## How It Is Being Fixed

Introduces the design library counterparts of the site endpoints:
getDesignLibraryFragmentSet and getDesignLibraryFragmentSetsPage, and
populates the FragmentSet DTO actions map for both site and design
library scopes through a shared FragmentCollectionActionUtil that
threads contextScopeChecker so OAuth2 scope checks apply.

The commits from LPD-97408 (already in review at
https://github.com/liferay-page-management/liferay-portal/pull/18706)
are included as dependencies: the design library delete endpoint, the
VulcanCRUDItemDelegate wiring for search embedding, the site-scope
actions on the DTO, and the enabling utilities. They are prerequisites
of the design library reads and DTO actions this PR adds.

## PR Check

**pr-check: PASS** — tested on `b1b14f27b4a8d784fa57fa7c76fa7ed2a4962f7d`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b1b14f27b4a8d784fa57fa7c76fa7ed2a4962f7d"} -->
