### PR TITLE
LPD-98058 Fix GetPagePreviewStrutsActionTest after Dialect removal

### DIFF
--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/struts/test/GetPagePreviewStrutsActionTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/struts/test/GetPagePreviewStrutsActionTest.java
@@ -151,9 +151,9 @@ public class GetPagePreviewStrutsActionTest {
 		Layout layout = _addLayout(group, false, LayoutConstants.TYPE_CONTENT);
 
 		_layoutSetLocalService.updateLookAndFeel(
-			group.getGroupId(), false, "dialect_WAR_dialecttheme", null, null);
+			group.getGroupId(), false, "cms_WAR_cmstheme", null, null);
 
-		_assertContainsContent("dialect_WAR_dialecttheme");
+		_assertContainsContent("cms_WAR_cmstheme");
 
 		_layoutLocalService.updateLookAndFeel(
 			group.getGroupId(), layout.isPrivateLayout(), layout.getLayoutId(),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98058

## Failing Test

`com.liferay.layout.internal.struts.test.GetPagePreviewStrutsActionTest`

`modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/struts/test/GetPagePreviewStrutsActionTest.java`

```
testGetPagePreviewContentPageWithSpecificTheme: java.lang.NullPointerException: Cannot invoke "com.liferay.portal.kernel.model.Theme.getServletContextName()" because "theme" is null
	at com.liferay.layout.internal.struts.test.GetPagePreviewStrutsActionTest._assertContainsContent(GetPagePreviewStrutsActionTest.java:399)
	at com.liferay.layout.internal.struts.test.GetPagePreviewStrutsActionTest.testGetPagePreviewContentPageWithSpecificTheme(GetPagePreviewStrutsActionTest.java:156)
```

## Root Cause

Commit `9e5b202` ("LPD-95803 Remove Dialect theme from the default build") deleted the `.lfrbuild-portal` markers of `frontend-theme-dialect`, so the Dialect theme no longer ships in the default build and `ThemeLocalService.fetchTheme` returns null for `dialect_WAR_dialecttheme`.

## Fix

Replace the Dialect theme with the CMS theme (`cms_WAR_cmstheme`), which ships in the default build. This is the same replacement the LPD-95803 Playwright rework applied. The layout-level override to the Classic theme, the actual contract under test (LPD-45260), is unchanged. All 8 tests in the class pass locally.

- `modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/struts/test/GetPagePreviewStrutsActionTest.java`

## pr-check

**pr-check: PASS** — tested on `b1205ff035b2fde4114879066314bf3109366539`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |
