### PR TITLE
LPD-97713 | Fix missing self-referencing relationships in object structures

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/buildStructure.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/buildStructure.ts
@@ -487,20 +487,18 @@ function getRelatedContentObjectRelationships(
 	const relationships: ObjectRelationship[] = [];
 
 	for (const objectDefinition of Object.values(objectDefinitions)) {
-		if (
-			mainObjectDefinition.externalReferenceCode ===
-			objectDefinition.externalReferenceCode
-		) {
-			continue;
-		}
-
 		for (const objectRelationship of objectDefinition.objectRelationships ||
 			[]) {
 			if (
 				objectRelationship.objectDefinitionExternalReferenceCode2 ===
 					mainObjectDefinition.externalReferenceCode &&
 				objectRelationship.type === 'oneToMany' &&
-				!objectRelationship.edge
+				!objectRelationship.edge &&
+				!(
+					objectDefinition.externalReferenceCode ===
+						mainObjectDefinition.externalReferenceCode &&
+					isRepeatableGroup(objectRelationship, objectDefinitions)
+				)
 			) {
 				relationships.push(objectRelationship);
 			}

--- a/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/utils/buildStructure.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/utils/buildStructure.test.ts
@@ -6,8 +6,10 @@
 import {
 	ObjectDefinition,
 	ObjectField,
+	ObjectRelationship,
 } from '../../../../src/main/resources/META-INF/resources/js/common/types/ObjectDefinition';
 import buildObjectDefinition from '../../../../src/main/resources/META-INF/resources/js/structure_builder/utils/buildObjectDefinition';
+import buildObjectRelationships from '../../../../src/main/resources/META-INF/resources/js/structure_builder/utils/buildObjectRelationships';
 import buildStructure from '../../../../src/main/resources/META-INF/resources/js/structure_builder/utils/buildStructure';
 import {Field} from '../../../../src/main/resources/META-INF/resources/js/structure_builder/utils/field';
 import getUuid from '../../../../src/main/resources/META-INF/resources/js/structure_builder/utils/getUuid';
@@ -415,6 +417,74 @@ describe('buildStructure', () => {
 				multiselection: false,
 				name: 'selfRelatedContent',
 				relatedStructureERC: 'SELF_ERC',
+			}),
+		]);
+	});
+
+	it('Round-trips a related content field referencing the same structure', () => {
+		const objectRelationship: ObjectRelationship = {
+			deletionType: 'disassociate',
+			externalReferenceCode: 'self-related-content',
+			label: {en_US: 'Self Related Content'},
+			name: 'selfRelatedContent',
+			objectDefinitionExternalReferenceCode1: 'SELF_ERC',
+			objectDefinitionExternalReferenceCode2: 'SELF_ERC',
+			type: 'oneToMany',
+		};
+
+		const objectDefinition = createObjectDefinition({
+			externalReferenceCode: 'SELF_ERC',
+			objectRelationships: [objectRelationship],
+		});
+
+		const structure = buildStructure({
+			mainObjectDefinition: objectDefinition,
+			objectDefinitions: {SELF_ERC: objectDefinition},
+		});
+
+		expect(
+			buildObjectRelationships({
+				children: structure.children,
+				structureERC: structure.erc,
+			})
+		).toEqual([objectRelationship]);
+	});
+
+	it('Builds a self-referencing repeatable group definition only as a repeatable group', () => {
+		const objectDefinition = createObjectDefinition({
+			externalReferenceCode: 'SELF_GROUP_ERC',
+			objectFolderExternalReferenceCode:
+				'L_CMS_STRUCTURE_REPEATABLE_GROUPS',
+			objectRelationships: [
+				{
+					deletionType: 'disassociate',
+					externalReferenceCode: 'self-group',
+					label: {en_US: 'Self Group'},
+					name: 'selfGroup',
+					objectDefinitionExternalReferenceCode1: 'SELF_GROUP_ERC',
+					objectDefinitionExternalReferenceCode2: 'SELF_GROUP_ERC',
+					type: 'oneToMany',
+				},
+			],
+		});
+
+		const structure = buildStructure({
+			mainObjectDefinition: objectDefinition,
+			objectDefinitions: {SELF_GROUP_ERC: objectDefinition},
+		});
+
+		const children = Array.from(structure.children.values());
+
+		expect(
+			children.filter((child) => child.type === 'related-content')
+		).toEqual([]);
+
+		expect(
+			children.filter((child) => child.type === 'repeatable-group')
+		).toEqual([
+			expect.objectContaining({
+				erc: 'SELF_GROUP_ERC',
+				relationshipERC: 'self-group',
 			}),
 		]);
 	});

--- a/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/utils/buildStructure.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/utils/buildStructure.test.ts
@@ -384,6 +384,41 @@ describe('buildStructure', () => {
 		expect(fieldNames).not.toContain('content');
 	});
 
+	it('Restores a related content field referencing the same structure', () => {
+		const objectDefinition = createObjectDefinition({
+			externalReferenceCode: 'SELF_ERC',
+			objectRelationships: [
+				{
+					deletionType: 'disassociate',
+					externalReferenceCode: 'self-related-content',
+					label: {en_US: 'Self Related Content'},
+					name: 'selfRelatedContent',
+					objectDefinitionExternalReferenceCode1: 'SELF_ERC',
+					objectDefinitionExternalReferenceCode2: 'SELF_ERC',
+					type: 'oneToMany',
+				},
+			],
+		});
+
+		const structure = buildStructure({
+			mainObjectDefinition: objectDefinition,
+			objectDefinitions: {SELF_ERC: objectDefinition},
+		});
+
+		const relatedContents = Array.from(structure.children.values()).filter(
+			(child) => child.type === 'related-content'
+		);
+
+		expect(relatedContents).toEqual([
+			expect.objectContaining({
+				erc: 'self-related-content',
+				multiselection: false,
+				name: 'selfRelatedContent',
+				relatedStructureERC: 'SELF_ERC',
+			}),
+		]);
+	});
+
 	it('Includes only title and file system fields for custom object definitions', () => {
 		const objectDefinition = createObjectDefinition({
 			externalReferenceCode: 'CUSTOM_OBJECT_ERC',


### PR DESCRIPTION
{[LPD-97713](https://liferay.atlassian.net/browse/LPD-97713)}

When a CMS structure has a related content field that points back to the same structure (a self-referencing relationship), the structure builder was silently dropping that field, so it disappeared when the structure was loaded or restored.

This change makes self-referencing related content fields survive the round trip like any other relationship, and adds a test covering that case.

# How am I fixing it?

Related content fields are rebuilt by scanning all object definitions for relationships targeting the current structure. The scan skipped the structure's own definition, so self-referencing relationships were lost.

Since the filtering conditions inside the loop already identify the right relationships on their own, removing the skip restores self-references without affecting anything else.

# How can you verify that it works?

Run the included automated tests.

[LPD-97713]: https://liferay.atlassian.net/browse/LPD-97713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ