### PR TITLE
LPD-97996 Return null for missing or unparseable URL configuration values

### DIFF
--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/util/configuration/FragmentEntryConfigurationParserImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/util/configuration/FragmentEntryConfigurationParserImpl.java
@@ -833,26 +833,30 @@ public class FragmentEntryConfigurationParserImpl
 	}
 
 	private Object _getURLValue(String value) {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		if ((serviceContext == null) || Validator.isNull(value) ||
-			(serviceContext.getThemeDisplay() == null)) {
-
-			return StringPool.POUND;
+		if (Validator.isNull(value)) {
+			return null;
 		}
 
 		JSONObject jsonObject = (JSONObject)_getFieldValue(
 			FragmentConfigurationFieldDataType.OBJECT, value);
 
 		if (jsonObject == null) {
-			return StringPool.POUND;
+			return null;
 		}
 
 		JSONObject layoutJSONObject = jsonObject.getJSONObject("layout");
 
 		if (layoutJSONObject == null) {
 			return jsonObject.getString("href");
+		}
+
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if ((serviceContext == null) ||
+			(serviceContext.getThemeDisplay() == null)) {
+
+			return StringPool.POUND;
 		}
 
 		ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/util/test/FragmentEntryConfigurationParserTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/util/test/FragmentEntryConfigurationParserTest.java
@@ -100,95 +100,90 @@ public class FragmentEntryConfigurationParserTest {
 
 		ServiceContextThreadLocal.pushServiceContext(serviceContext);
 
-		try {
-			String name = RandomTestUtil.randomString();
+		String name = RandomTestUtil.randomString();
 
-			JSONObject configurationValuesJSONObject =
-				_fragmentEntryConfigurationParser.getConfigurationJSONObject(
+		JSONObject configurationValuesJSONObject =
+			_fragmentEntryConfigurationParser.getConfigurationJSONObject(
+				JSONUtil.put(
+					"fieldSets",
 					JSONUtil.put(
-						"fieldSets",
 						JSONUtil.put(
+							"fields",
 							JSONUtil.put(
-								"fields",
 								JSONUtil.put(
-									JSONUtil.put(
-										"label", RandomTestUtil.randomString()
-									).put(
-										"name", name
-									).put(
-										"type", "url"
-									))))),
-					JSONUtil.put(
-						FragmentEntryProcessorConstants.
-							KEY_FREEMARKER_FRAGMENT_ENTRY_PROCESSOR,
-						JSONUtil.put(
-							name,
-							JSONUtil.put(
-								"layout",
-								JSONUtil.put(
-									"externalReferenceCode",
-									layout1.getExternalReferenceCode()
+									"label", RandomTestUtil.randomString()
 								).put(
-									"title", name
-								)))),
-					LocaleUtil.US);
-
-			Assert.assertEquals(
-				_portal.getLayoutFullURL(
-					layout1, serviceContext.getThemeDisplay()),
-				configurationValuesJSONObject.getString(name));
-
-			Group group2 = GroupTestUtil.addGroup();
-
-			Layout layout2 = _layoutLocalService.addLayout(
-				layout1.getExternalReferenceCode(), TestPropsValues.getUserId(),
-				group2.getGroupId(), false,
-				LayoutConstants.DEFAULT_PARENT_LAYOUT_ID,
-				RandomTestUtil.randomString(), StringPool.BLANK,
-				StringPool.BLANK, LayoutConstants.TYPE_CONTENT, false,
-				StringPool.BLANK, serviceContext);
-
-			configurationValuesJSONObject =
-				_fragmentEntryConfigurationParser.getConfigurationJSONObject(
-					JSONUtil.put(
-						"fieldSets",
-						JSONUtil.put(
-							JSONUtil.put(
-								"fields",
-								JSONUtil.put(
-									JSONUtil.put(
-										"label", RandomTestUtil.randomString()
-									).put(
-										"name", name
-									).put(
-										"type", "url"
-									))))),
-					JSONUtil.put(
-						FragmentEntryProcessorConstants.
-							KEY_FREEMARKER_FRAGMENT_ENTRY_PROCESSOR,
-						JSONUtil.put(
-							name,
-							JSONUtil.put(
-								"layout",
-								JSONUtil.put(
-									"externalReferenceCode",
-									layout1.getExternalReferenceCode()
+									"name", name
 								).put(
-									"scopeExternalReferenceCode",
-									group2.getExternalReferenceCode()
-								).put(
-									"title", name
-								)))),
-					LocaleUtil.US);
+									"type", "url"
+								))))),
+				JSONUtil.put(
+					FragmentEntryProcessorConstants.
+						KEY_FREEMARKER_FRAGMENT_ENTRY_PROCESSOR,
+					JSONUtil.put(
+						name,
+						JSONUtil.put(
+							"layout",
+							JSONUtil.put(
+								"externalReferenceCode",
+								layout1.getExternalReferenceCode()
+							).put(
+								"title", name
+							)))),
+				LocaleUtil.US);
 
-			Assert.assertEquals(
-				_portal.getLayoutFullURL(
-					layout2, serviceContext.getThemeDisplay()),
-				configurationValuesJSONObject.getString(name));
-		}
-		finally {
-			ServiceContextThreadLocal.popServiceContext();
-		}
+		Assert.assertEquals(
+			_portal.getLayoutFullURL(layout1, serviceContext.getThemeDisplay()),
+			configurationValuesJSONObject.getString(name));
+
+		Group group2 = GroupTestUtil.addGroup();
+
+		Layout layout2 = _layoutLocalService.addLayout(
+			layout1.getExternalReferenceCode(), TestPropsValues.getUserId(),
+			group2.getGroupId(), false,
+			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID,
+			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
+			LayoutConstants.TYPE_CONTENT, false, StringPool.BLANK,
+			serviceContext);
+
+		configurationValuesJSONObject =
+			_fragmentEntryConfigurationParser.getConfigurationJSONObject(
+				JSONUtil.put(
+					"fieldSets",
+					JSONUtil.put(
+						JSONUtil.put(
+							"fields",
+							JSONUtil.put(
+								JSONUtil.put(
+									"label", RandomTestUtil.randomString()
+								).put(
+									"name", name
+								).put(
+									"type", "url"
+								))))),
+				JSONUtil.put(
+					FragmentEntryProcessorConstants.
+						KEY_FREEMARKER_FRAGMENT_ENTRY_PROCESSOR,
+					JSONUtil.put(
+						name,
+						JSONUtil.put(
+							"layout",
+							JSONUtil.put(
+								"externalReferenceCode",
+								layout1.getExternalReferenceCode()
+							).put(
+								"scopeExternalReferenceCode",
+								group2.getExternalReferenceCode()
+							).put(
+								"title", name
+							)))),
+				LocaleUtil.US);
+
+		Assert.assertEquals(
+			_portal.getLayoutFullURL(layout2, serviceContext.getThemeDisplay()),
+			configurationValuesJSONObject.getString(name));
+
+		ServiceContextThreadLocal.popServiceContext();
 	}
 
 	@Test

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/util/test/FragmentEntryConfigurationParserTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/util/test/FragmentEntryConfigurationParserTest.java
@@ -174,6 +174,38 @@ public class FragmentEntryConfigurationParserTest {
 	}
 
 	@Test
+	@TestInfo("LPD-97996")
+	public void testGetFieldValueURLConfiguration() throws Exception {
+		_testGetFieldValueURLConfiguration(null, StringPool.BLANK);
+		_testGetFieldValueURLConfiguration(null, RandomTestUtil.randomString());
+
+		Group group = _groupLocalService.getGroup(TestPropsValues.getGroupId());
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(group);
+
+		ServiceContext serviceContext = _getAndPushServiceContext(
+			group, layout);
+
+		_testGetFieldValueURLConfiguration(
+			StringPool.POUND,
+			JSONUtil.put(
+				"layout",
+				JSONUtil.put(
+					"externalReferenceCode", RandomTestUtil.randomString())
+			).toString());
+
+		_testGetFieldValueURLConfiguration(
+			_portal.getLayoutFullURL(layout, serviceContext.getThemeDisplay()),
+			JSONUtil.put(
+				"layout",
+				JSONUtil.put(
+					"externalReferenceCode", layout.getExternalReferenceCode())
+			).toString());
+
+		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
 	@TestInfo("LPD-77079")
 	public void testGetFieldValueWithLocalizableFields() {
 		_testGetFieldValueWithLocalizableField(
@@ -232,6 +264,34 @@ public class FragmentEntryConfigurationParserTest {
 		return JSONFactoryUtil.createJSONObject(
 			new String(
 				FileUtil.getBytes(getClass(), "dependencies/" + fileName)));
+	}
+
+	private void _testGetFieldValueURLConfiguration(
+		Object expectedValue, String value) {
+
+		String name = RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			expectedValue,
+			_fragmentEntryConfigurationParser.getFieldValue(
+				JSONUtil.put(
+					"fieldSets",
+					JSONUtil.put(
+						JSONUtil.put(
+							"fields",
+							JSONUtil.put(
+								JSONUtil.put(
+									"label", RandomTestUtil.randomString()
+								).put(
+									"name", name
+								).put(
+									"type", "url"
+								))))),
+				JSONUtil.put(
+					FragmentEntryProcessorConstants.
+						KEY_FREEMARKER_FRAGMENT_ENTRY_PROCESSOR,
+					JSONUtil.put(name, value)),
+				name));
 	}
 
 	private void _testGetFieldValueWithLocalizableField(

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/util/test/FragmentEntryConfigurationParserTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/util/test/FragmentEntryConfigurationParserTest.java
@@ -84,21 +84,8 @@ public class FragmentEntryConfigurationParserTest {
 
 		Layout layout1 = LayoutTestUtil.addTypeContentLayout(group1);
 
-		ServiceContext serviceContext =
-			ServiceContextTestUtil.getServiceContext(group1.getGroupId());
-
-		HttpServletRequest mockHttpServletRequest =
-			ContentLayoutTestUtil.getMockHttpServletRequest(
-				_companyLocalService.getCompany(group1.getCompanyId()), group1,
-				layout1);
-
-		mockHttpServletRequest.setAttribute(
-			JavaConstants.JAKARTA_PORTLET_RESPONSE,
-			new MockLiferayPortletRenderResponse());
-
-		serviceContext.setRequest(mockHttpServletRequest);
-
-		ServiceContextThreadLocal.pushServiceContext(serviceContext);
+		ServiceContext serviceContext = _getAndPushServiceContext(
+			group1, layout1);
 
 		String name = RandomTestUtil.randomString();
 
@@ -207,6 +194,28 @@ public class FragmentEntryConfigurationParserTest {
 	@Test
 	public void testTranslateConfigurationEs() throws Exception {
 		_testTranslateConfiguration("es");
+	}
+
+	private ServiceContext _getAndPushServiceContext(Group group, Layout layout)
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(group.getGroupId());
+
+		HttpServletRequest mockHttpServletRequest =
+			ContentLayoutTestUtil.getMockHttpServletRequest(
+				_companyLocalService.getCompany(group.getCompanyId()), group,
+				layout);
+
+		mockHttpServletRequest.setAttribute(
+			JavaConstants.JAKARTA_PORTLET_RESPONSE,
+			new MockLiferayPortletRenderResponse());
+
+		serviceContext.setRequest(mockHttpServletRequest);
+
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+		return serviceContext;
 	}
 
 	private ResourceBundle _getResourceBundle(String language) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97996

## What Is Being Fixed

A fragment with a URL-typed configuration field renders `<a href="#">` on first render, even when the FreeMarker template guards the anchor with `<#if configuration.link?has_content>`. In 2025.Q2.1 the guard worked and the anchor was skipped when the field was unset. The regression was introduced by LPD-67912, which reshaped `FragmentEntryConfigurationParserImpl._getURLValue` to return `StringPool.POUND` for a missing or unparseable value. Because `"#"?has_content` is `true`, the guard now lets the anchor through with `href="#"`.

## How It Is Being Fixed

`_getURLValue` now returns `null` when the raw configuration value is empty or when the JSON cannot be parsed, so `?has_content` evaluates to false and guarded anchors are skipped. `StringPool.POUND` is preserved as the fallback only for the case where the configuration references a layout that cannot be resolved, matching the intended semantics from 2025.Q2.1.

## PR Check

**pr-check: PASS** — tested on `416af138980581af28cf3746fe270a3c87efdf8a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "416af138980581af28cf3746fe270a3c87efdf8a"} -->
