### PR TITLE
LPD-97999 Integrate charts into the CMS performance dashboard

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/package.json
+++ b/modules/apps/site/site-cms-site-initializer/package.json
@@ -36,6 +36,7 @@
 		"@liferay/ai-hub-cell-js-components-web": "*",
 		"@liferay/analytics-reports-js-components-web": "*",
 		"@liferay/frontend-data-set-web": "*",
+		"@liferay/frontend-js-charts-web": "*",
 		"@liferay/frontend-js-item-selector-web": "*",
 		"@liferay/frontend-js-react-web": "*",
 		"@liferay/frontend-js-state-web": "*",

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/common/BaseCard.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/common/BaseCard.tsx
@@ -21,6 +21,7 @@ const BaseCard: React.FC<IBaseCard> = ({
 	Preferences,
 	ariaLevel,
 	children,
+	className,
 	contentClassName,
 	description,
 	role,
@@ -28,7 +29,12 @@ const BaseCard: React.FC<IBaseCard> = ({
 	uppercaseTitle = true,
 }) => {
 	return (
-		<div className="cms-dashboard__base-card p-3 rounded-lg sheet">
+		<div
+			className={classNames(
+				'cms-dashboard__base-card p-3 rounded-lg sheet',
+				className
+			)}
+		>
 			<div className="cms-dashboard__base-card__header d-flex">
 				<div
 					aria-level={ariaLevel}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/performance/components/AssetConsumption.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/performance/components/AssetConsumption.tsx
@@ -9,6 +9,7 @@ import ClayIcon from '@clayui/icon';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {ClayPaginationBarWithBasicItems} from '@clayui/pagination-bar';
 import {toThousands} from '@liferay/analytics-reports-js-components-web';
+import {BarChart} from '@liferay/frontend-js-charts-web';
 import {sub} from 'frontend-js-web';
 import React, {useContext, useEffect, useMemo, useState} from 'react';
 
@@ -109,7 +110,22 @@ export function AssetConsumption() {
 		}
 
 		if (viewType === 'chart') {
-			return null;
+			return (
+				<BarChart
+					data={items.map(({count, title}) => ({
+						label:
+							title ||
+							sub(Liferay.Language.get('no-x'), groupByLabel),
+						value: count,
+					}))}
+					legend="none"
+					orientation="horizontal"
+					rounded
+					size="inline"
+					title={Liferay.Language.get('asset-consumption')}
+					track
+				/>
+			);
 		}
 
 		return (

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/performance/components/AssetConsumption.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/performance/components/AssetConsumption.tsx
@@ -46,7 +46,7 @@ export function AssetConsumption() {
 	const [loading, setLoading] = useState(true);
 	const [page, setPage] = useState(1);
 	const [pageSize, setPageSize] = useState(20);
-	const [viewType, setViewType] = useState<ViewType>('table');
+	const [viewType, setViewType] = useState<ViewType>('chart');
 
 	const depotEntryIds = useMemo(
 		() => (space.value === 'all' ? undefined : [space.value]),

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/performance/components/AudienceAndDistribution.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/performance/components/AudienceAndDistribution.tsx
@@ -111,6 +111,7 @@ function Card({
 					})}
 				/>
 			}
+			className="h-100"
 			description={description}
 			title={title}
 			uppercaseTitle={false}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/performance/components/AudienceAndDistribution.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/performance/components/AudienceAndDistribution.tsx
@@ -4,12 +4,14 @@
  */
 
 import ClayLayout from '@clayui/layout';
-import React, {useContext} from 'react';
+import {ChartState, PieChart} from '@liferay/frontend-js-charts-web';
+import React, {useContext, useEffect, useMemo, useState} from 'react';
 
 import {BaseCard} from '../../common/BaseCard';
 import {SectionHeader} from '../../common/SectionHeader';
 import {PerformanceContext} from '../PerformanceContext';
 import PerformanceService from '../PerformanceService';
+import {PerformanceMetric} from '../types';
 import {DownloadButton} from './DownloadButton';
 
 export function AudienceAndDistribution() {
@@ -67,7 +69,35 @@ function Card({
 }) {
 	const {range, space} = useContext(PerformanceContext);
 
-	const depotEntryIds = space.value === 'all' ? undefined : [space.value];
+	const [metric, setMetric] = useState<PerformanceMetric>();
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	const depotEntryIds = useMemo(
+		() => (space.value === 'all' ? undefined : [space.value]),
+		[space.value]
+	);
+
+	useEffect(() => {
+		async function fetchData() {
+			setLoading(true);
+
+			const {data, error} = await PerformanceService.getMetric({
+				depotEntryIds,
+				groupBy,
+				metricType: 'viewsMetric',
+				rangeKey: range.rangeKey,
+			});
+
+			setMetric(data ?? undefined);
+			setError(error);
+			setLoading(false);
+		}
+
+		fetchData();
+	}, [depotEntryIds, groupBy, range.rangeKey]);
+
+	const metrics = metric?.metrics ?? [];
 
 	return (
 		<BaseCard
@@ -84,6 +114,23 @@ function Card({
 			description={description}
 			title={title}
 			uppercaseTitle={false}
-		/>
+		>
+			<ChartState
+				empty={!loading && !error && !metrics.length}
+				error={error}
+				loading={loading}
+			>
+				{groupBy === 'categories' ? (
+					<PieChart
+						data={metrics.map(({value, valueKey}) => ({
+							label: valueKey,
+							value,
+						}))}
+						legend="table"
+						title=""
+					/>
+				) : null}
+			</ChartState>
+		</BaseCard>
 	);
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/performance/components/AudienceAndDistribution.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/performance/components/AudienceAndDistribution.tsx
@@ -4,7 +4,7 @@
  */
 
 import ClayLayout from '@clayui/layout';
-import {ChartState, PieChart} from '@liferay/frontend-js-charts-web';
+import {ChartState, MapChart, PieChart} from '@liferay/frontend-js-charts-web';
 import React, {useContext, useEffect, useMemo, useState} from 'react';
 
 import {BaseCard} from '../../common/BaseCard';
@@ -129,7 +129,17 @@ function Card({
 						legend="table"
 						title=""
 					/>
-				) : null}
+				) : (
+					<MapChart
+						data={metrics.map(({value, valueKey}) => ({
+							country: valueKey,
+							value,
+						}))}
+						legend="list"
+						title=""
+						variant="choropleth"
+					/>
+				)}
 			</ChartState>
 		</BaseCard>
 	);

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "b195a93ae64116d6e7cf5b16b58eb1b9e63b6ae1",
+	"@generated": "23f0ee3fb99ff23a7a956e5c7c321ee7227182b4",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -22,6 +22,9 @@
 			],
 			"@liferay/frontend-data-set-web/api": [
 				"../../../../../../../frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/js/api/api.ts"
+			],
+			"@liferay/frontend-js-charts-web": [
+				"../../../../../../../frontend-js/frontend-js-charts-web/src/main/resources/META-INF/resources/js/index.ts"
 			],
 			"@liferay/frontend-js-item-selector-web": [
 				"../../../../../../../frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/index.ts"
@@ -90,6 +93,9 @@
 		},
 		{
 			"path": "../../../../../../../frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-charts-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/tsconfig.json"

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/AudienceAndDistribution.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/AudienceAndDistribution.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+
+import {PerformanceContextProvider} from '../../../../src/main/resources/META-INF/resources/js/main_view/dashboard/performance/PerformanceContext';
+import PerformanceService from '../../../../src/main/resources/META-INF/resources/js/main_view/dashboard/performance/PerformanceService';
+import {AudienceAndDistribution} from '../../../../src/main/resources/META-INF/resources/js/main_view/dashboard/performance/components/AudienceAndDistribution';
+
+const renderComponent = () =>
+	render(
+		<PerformanceContextProvider>
+			<AudienceAndDistribution />
+		</PerformanceContextProvider>
+	);
+
+describe('AudienceAndDistribution', () => {
+	const {ResizeObserver} = window;
+
+	beforeAll(() => {
+		window.ResizeObserver = jest.fn().mockImplementation(() => ({
+			disconnect: jest.fn(),
+			observe: jest.fn(),
+			unobserve: jest.fn(),
+		}));
+	});
+
+	afterAll(() => {
+		window.ResizeObserver = ResizeObserver;
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('renders the categorization slices from the fetched metric', async () => {
+		jest.spyOn(PerformanceService, 'getMetric').mockImplementation(
+			async ({groupBy}) => ({
+				data: {
+					metricType: 'viewsMetric',
+					metrics:
+						groupBy === 'location'
+							? [{previousValue: 130, value: 162, valueKey: 'US'}]
+							: [
+									{
+										previousValue: 70000,
+										value: 83300,
+										valueKey: 'Sales',
+									},
+									{
+										previousValue: 15000,
+										value: 17500,
+										valueKey: 'Business',
+									},
+								],
+				},
+				error: null,
+			})
+		);
+
+		renderComponent();
+
+		expect(await screen.findByText('Sales')).toBeInTheDocument();
+		expect(screen.getByText('Business')).toBeInTheDocument();
+	});
+
+	it('renders the empty state when the metrics are empty', async () => {
+		jest.spyOn(PerformanceService, 'getMetric').mockResolvedValue({
+			data: {metricType: 'viewsMetric', metrics: []},
+			error: null,
+		});
+
+		renderComponent();
+
+		expect((await screen.findAllByText('no-data-available')).length).toBe(
+			2
+		);
+	});
+});

--- a/modules/apps/site/site-cms-site-initializer/test/tsconfig.json
+++ b/modules/apps/site/site-cms-site-initializer/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "6657802bdb19f9c8d1972d7fe62b244fdb61ba85",
+	"@generated": "19322937c50366a2242e182ed7eb0389c3146efb",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -22,6 +22,9 @@
 			],
 			"@liferay/frontend-data-set-web/api": [
 				"../../../frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/js/api/api.ts"
+			],
+			"@liferay/frontend-js-charts-web": [
+				"../../../frontend-js/frontend-js-charts-web/src/main/resources/META-INF/resources/js/index.ts"
 			],
 			"@liferay/frontend-js-item-selector-web": [
 				"../../../frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/index.ts"
@@ -92,6 +95,9 @@
 		},
 		{
 			"path": "../../../frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
+		{
+			"path": "../../../frontend-js/frontend-js-charts-web/src/main/resources/META-INF/resources/tsconfig.json"
 		},
 		{
 			"path": "../../../frontend-js/frontend-js-item-selector-web/src/main/resources/META-INF/resources/tsconfig.json"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97999

## What Is Being Fixed

The CMS performance dashboard rendered its Audience & Distribution and Asset Consumption sections without real chart visualizations, and did not use the standardized chart components now available in `@liferay/frontend-js-charts-web`.

## How It Is Being Fixed

The `@liferay/frontend-js-charts-web` dependency is added and its standardized components are wired into the performance dashboard. The Asset Consumption chart view now renders a horizontal bar chart and defaults to that view; Views by Categorization renders a donut pie chart; and Views by Location renders a choropleth map. Each chart is wrapped in the shared `ChartState` for loading, empty, and error handling, and is fed by the existing performance-metric endpoints. `BaseCard` now accepts a `className` so the two Audience & Distribution cards can be forced to equal height. Unit tests cover the new Audience & Distribution rendering.

## PR Check

**pr-check: PASS** — tested on `51ebf3c473b85a8348ef9786cb0eba444bff7527`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "51ebf3c473b85a8348ef9786cb0eba444bff7527"} -->
