### PR TITLE
LPD-97443 Fix NPE staging a widget page converted to a content page

### DIFF
--- a/modules/apps/layout/layout-page-template-service/bnd.bnd
+++ b/modules/apps/layout/layout-page-template-service/bnd.bnd
@@ -5,6 +5,6 @@ Import-Package:\
 	com.liferay.layout.page.template.util.comparator,\
 	\
 	*
-Liferay-Require-SchemaVersion: 6.1.0
+Liferay-Require-SchemaVersion: 6.2.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/registry/LayoutPageTemplateServiceUpgradeStepRegistrator.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/registry/LayoutPageTemplateServiceUpgradeStepRegistrator.java
@@ -266,6 +266,13 @@ public class LayoutPageTemplateServiceUpgradeStepRegistrator
 			LayoutPageTemplateStructureRelElementVariationAudienceEntryRelTable.
 				create(),
 			LayoutPageTemplateStructureRelElementVariationTable.create());
+
+		registry.register(
+			"6.1.0", "6.2.0",
+			new com.liferay.layout.page.template.internal.upgrade.v6_2_0.
+				LayoutPageTemplateStructureRelUpgradeProcess(
+					_layoutLocalService, _segmentsExperienceLocalService,
+					_userLocalService));
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v6_2_0/LayoutPageTemplateStructureRelUpgradeProcess.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v6_2_0/LayoutPageTemplateStructureRelUpgradeProcess.java
@@ -1,0 +1,179 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.internal.upgrade.v6_2_0;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.segments.constants.SegmentsExperienceConstants;
+import com.liferay.segments.model.SegmentsExperience;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Balázs Sáfrány-Kovalik
+ */
+public class LayoutPageTemplateStructureRelUpgradeProcess
+	extends UpgradeProcess {
+
+	public LayoutPageTemplateStructureRelUpgradeProcess(
+		LayoutLocalService layoutLocalService,
+		SegmentsExperienceLocalService segmentsExperienceLocalService,
+		UserLocalService userLocalService) {
+
+		_layoutLocalService = layoutLocalService;
+		_segmentsExperienceLocalService = segmentsExperienceLocalService;
+		_userLocalService = userLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select distinct LayoutPageTemplateStructure.",
+					"layoutPageTemplateStructureId, ",
+					"LayoutPageTemplateStructure.companyId, ",
+					"LayoutPageTemplateStructure.plid, ",
+					"LayoutPageTemplateStructure.userId from ",
+					"LayoutPageTemplateStructure inner join ",
+					"LayoutPageTemplateStructureRel on ",
+					"LayoutPageTemplateStructureRel.",
+					"layoutPageTemplateStructureId = ",
+					"LayoutPageTemplateStructure.",
+					"layoutPageTemplateStructureId where ",
+					"LayoutPageTemplateStructureRel.segmentsExperienceId = 0"));
+
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				_repairLayoutPageTemplateStructureRels(
+					resultSet.getLong("layoutPageTemplateStructureId"),
+					resultSet.getLong("companyId"), resultSet.getLong("plid"),
+					resultSet.getLong("userId"));
+			}
+		}
+	}
+
+	private void _deleteLayoutPageTemplateStructureRel(
+			long layoutPageTemplateStructureId)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"delete from LayoutPageTemplateStructureRel where ",
+					"layoutPageTemplateStructureId = ? and ",
+					"segmentsExperienceId = 0"))) {
+
+			preparedStatement.setLong(1, layoutPageTemplateStructureId);
+
+			preparedStatement.executeUpdate();
+		}
+	}
+
+	private long _getDefaultSegmentsExperienceId(
+			long companyId, long plid, long userId)
+		throws Exception {
+
+		long segmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				plid);
+
+		if (segmentsExperienceId != SegmentsExperienceConstants.ID_DEFAULT) {
+			return segmentsExperienceId;
+		}
+
+		User user = _userLocalService.fetchUser(userId);
+
+		if (user == null) {
+			userId = _userLocalService.getGuestUserId(companyId);
+		}
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.addDefaultSegmentsExperience(
+				null, userId, plid, new ServiceContext());
+
+		return segmentsExperience.getSegmentsExperienceId();
+	}
+
+	private boolean _hasLayoutPageTemplateStructureRel(
+			long layoutPageTemplateStructureId, long segmentsExperienceId)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select layoutPageTemplateStructureRelId from ",
+					"LayoutPageTemplateStructureRel where ",
+					"layoutPageTemplateStructureId = ? and ",
+					"segmentsExperienceId = ?"))) {
+
+			preparedStatement.setLong(1, layoutPageTemplateStructureId);
+			preparedStatement.setLong(2, segmentsExperienceId);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				return resultSet.next();
+			}
+		}
+	}
+
+	private void _repairLayoutPageTemplateStructureRels(
+			long layoutPageTemplateStructureId, long companyId, long plid,
+			long userId)
+		throws Exception {
+
+		Layout layout = _layoutLocalService.fetchLayout(plid);
+
+		if (layout == null) {
+			_deleteLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructureId);
+
+			return;
+		}
+
+		long segmentsExperienceId = _getDefaultSegmentsExperienceId(
+			companyId, plid, userId);
+
+		if (_hasLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructureId, segmentsExperienceId)) {
+
+			_deleteLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructureId);
+		}
+		else {
+			_updateLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructureId, segmentsExperienceId);
+		}
+	}
+
+	private void _updateLayoutPageTemplateStructureRel(
+			long layoutPageTemplateStructureId, long segmentsExperienceId)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"update LayoutPageTemplateStructureRel set ",
+					"segmentsExperienceId = ? where ",
+					"layoutPageTemplateStructureId = ? and ",
+					"segmentsExperienceId = 0"))) {
+
+			preparedStatement.setLong(1, segmentsExperienceId);
+			preparedStatement.setLong(2, layoutPageTemplateStructureId);
+
+			preparedStatement.executeUpdate();
+		}
+	}
+
+	private final LayoutLocalService _layoutLocalService;
+	private final SegmentsExperienceLocalService
+		_segmentsExperienceLocalService;
+	private final UserLocalService _userLocalService;
+
+}

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelLocalServiceImpl.java
@@ -5,8 +5,10 @@
 
 package com.liferay.layout.page.template.service.impl;
 
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRel;
 import com.liferay.layout.page.template.service.base.LayoutPageTemplateStructureRelLocalServiceBaseImpl;
+import com.liferay.layout.page.template.service.persistence.LayoutPageTemplateStructurePersistence;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.SystemEventConstants;
@@ -15,6 +17,9 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.segments.constants.SegmentsExperienceConstants;
+import com.liferay.segments.model.SegmentsExperience;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
 
 import java.util.Date;
 import java.util.List;
@@ -40,6 +45,10 @@ public class LayoutPageTemplateStructureRelLocalServiceImpl
 		throws PortalException {
 
 		User user = _userLocalService.getUser(userId);
+
+		segmentsExperienceId = _getSegmentsExperienceId(
+			layoutPageTemplateStructureId, segmentsExperienceId, userId,
+			serviceContext);
 
 		long layoutPageTemplateStructureRelId = counterLocalService.increment();
 
@@ -170,6 +179,42 @@ public class LayoutPageTemplateStructureRelLocalServiceImpl
 		return layoutPageTemplateStructureRelPersistence.update(
 			layoutPageTemplateStructureRel);
 	}
+
+	private long _getSegmentsExperienceId(
+			long layoutPageTemplateStructureId, long segmentsExperienceId,
+			long userId, ServiceContext serviceContext)
+		throws PortalException {
+
+		if (segmentsExperienceId != SegmentsExperienceConstants.ID_DEFAULT) {
+			return segmentsExperienceId;
+		}
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_layoutPageTemplateStructurePersistence.findByPrimaryKey(
+				layoutPageTemplateStructureId);
+
+		segmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				layoutPageTemplateStructure.getPlid());
+
+		if (segmentsExperienceId != SegmentsExperienceConstants.ID_DEFAULT) {
+			return segmentsExperienceId;
+		}
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.addDefaultSegmentsExperience(
+				null, userId, layoutPageTemplateStructure.getPlid(),
+				serviceContext);
+
+		return segmentsExperience.getSegmentsExperienceId();
+	}
+
+	@Reference
+	private LayoutPageTemplateStructurePersistence
+		_layoutPageTemplateStructurePersistence;
+
+	@Reference
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/exportimport/test/LayoutPageTemplateStructureRelExportImportTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/exportimport/test/LayoutPageTemplateStructureRelExportImportTest.java
@@ -14,6 +14,9 @@ import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.exportimport.test.util.lar.BaseExportImportTestCase;
 import com.liferay.journal.model.JournalArticle;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureServiceUtil;
 import com.liferay.layout.provider.LayoutStructureProvider;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
@@ -47,6 +50,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.segments.constants.SegmentsExperienceConstants;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
 
 import org.junit.After;
@@ -380,6 +384,45 @@ public class LayoutPageTemplateStructureRelExportImportTest
 			guestGroup.getExternalReferenceCode());
 	}
 
+	@Test
+	@TestInfo("LPD-97443")
+	public void testImportedLayoutPageTemplateStructureRelHasDefaultSegmentsExperience()
+		throws Exception {
+
+		exportImportLayouts(
+			new long[] {layout.getLayoutId()}, getImportParameterMap());
+
+		importedLayout = _layoutLocalService.getLayoutByExternalReferenceCode(
+			layout.getExternalReferenceCode(), importedGroup.getGroupId());
+
+		long defaultSegmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				importedLayout.getPlid());
+
+		Assert.assertNotEquals(
+			SegmentsExperienceConstants.ID_DEFAULT,
+			defaultSegmentsExperienceId);
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_layoutPageTemplateStructureLocalService.
+				fetchLayoutPageTemplateStructure(
+					importedGroup.getGroupId(), importedLayout.getPlid());
+
+		Assert.assertNull(
+			_layoutPageTemplateStructureRelLocalService.
+				fetchLayoutPageTemplateStructureRel(
+					layoutPageTemplateStructure.
+						getLayoutPageTemplateStructureId(),
+					SegmentsExperienceConstants.ID_DEFAULT));
+
+		Assert.assertNotNull(
+			_layoutPageTemplateStructureRelLocalService.
+				fetchLayoutPageTemplateStructureRel(
+					layoutPageTemplateStructure.
+						getLayoutPageTemplateStructureId(),
+					defaultSegmentsExperienceId));
+	}
+
 	private AssetListEntry _addAssetListEntry(Group group) throws Exception {
 		return _assetListEntryLocalService.addAssetListEntry(
 			null, TestPropsValues.getUserId(), group.getGroupId(),
@@ -659,6 +702,14 @@ public class LayoutPageTemplateStructureRelExportImportTest
 
 	@Inject
 	private LayoutLocalService _layoutLocalService;
+
+	@Inject
+	private LayoutPageTemplateStructureLocalService
+		_layoutPageTemplateStructureLocalService;
+
+	@Inject
+	private LayoutPageTemplateStructureRelLocalService
+		_layoutPageTemplateStructureRelLocalService;
 
 	@Inject
 	private LayoutStructureProvider _layoutStructureProvider;

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v6_2_0/test/LayoutPageTemplateStructureRelUpgradeProcessTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v6_2_0/test/LayoutPageTemplateStructureRelUpgradeProcessTest.java
@@ -1,0 +1,218 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.internal.upgrade.v6_2_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRel;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelLocalService;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.version.Version;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+import com.liferay.segments.constants.SegmentsExperienceConstants;
+import com.liferay.segments.model.SegmentsExperience;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
+import com.liferay.segments.test.util.SegmentsTestUtil;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Balázs Sáfrány-Kovalik
+ */
+@RunWith(Arquillian.class)
+public class LayoutPageTemplateStructureRelUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testUpgradeDeletesRedundantOrphanedLayoutPageTemplateStructureRel()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_fetchLayoutPageTemplateStructure(draftLayout);
+
+		long defaultSegmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				draftLayout.getPlid());
+
+		SegmentsExperience segmentsExperience =
+			SegmentsTestUtil.addSegmentsExperience(
+				_group.getGroupId(), draftLayout.getPlid());
+
+		_layoutPageTemplateStructureRelLocalService.
+			addLayoutPageTemplateStructureRel(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				layoutPageTemplateStructure.getLayoutPageTemplateStructureId(),
+				segmentsExperience.getSegmentsExperienceId(), StringPool.BLANK,
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId()));
+
+		_orphanLayoutPageTemplateStructureRel(
+			layoutPageTemplateStructure,
+			segmentsExperience.getSegmentsExperienceId());
+
+		Assert.assertNotNull(
+			_fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure,
+				SegmentsExperienceConstants.ID_DEFAULT));
+
+		_runUpgrade();
+
+		Assert.assertNull(
+			_fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure,
+				SegmentsExperienceConstants.ID_DEFAULT));
+
+		Assert.assertNotNull(
+			_fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure, defaultSegmentsExperienceId));
+	}
+
+	@Test
+	public void testUpgradeReassignsOrphanedLayoutPageTemplateStructureRelToDefaultExperience()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_fetchLayoutPageTemplateStructure(draftLayout);
+
+		long defaultSegmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				draftLayout.getPlid());
+
+		LayoutPageTemplateStructureRel defaultLayoutPageTemplateStructureRel =
+			_fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure, defaultSegmentsExperienceId);
+
+		String data = defaultLayoutPageTemplateStructureRel.getData();
+
+		_orphanLayoutPageTemplateStructureRel(
+			layoutPageTemplateStructure, defaultSegmentsExperienceId);
+
+		Assert.assertNull(
+			_fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure, defaultSegmentsExperienceId));
+
+		_runUpgrade();
+
+		Assert.assertNull(
+			_fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure,
+				SegmentsExperienceConstants.ID_DEFAULT));
+
+		LayoutPageTemplateStructureRel layoutPageTemplateStructureRel =
+			_fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure, defaultSegmentsExperienceId);
+
+		Assert.assertNotNull(layoutPageTemplateStructureRel);
+		Assert.assertEquals(data, layoutPageTemplateStructureRel.getData());
+	}
+
+	private LayoutPageTemplateStructure _fetchLayoutPageTemplateStructure(
+		Layout layout) {
+
+		return _layoutPageTemplateStructureLocalService.
+			fetchLayoutPageTemplateStructure(
+				layout.getGroupId(), layout.getPlid());
+	}
+
+	private LayoutPageTemplateStructureRel _fetchLayoutPageTemplateStructureRel(
+		LayoutPageTemplateStructure layoutPageTemplateStructure,
+		long segmentsExperienceId) {
+
+		return _layoutPageTemplateStructureRelLocalService.
+			fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure.getLayoutPageTemplateStructureId(),
+				segmentsExperienceId);
+	}
+
+	private void _orphanLayoutPageTemplateStructureRel(
+		LayoutPageTemplateStructure layoutPageTemplateStructure,
+		long segmentsExperienceId) {
+
+		LayoutPageTemplateStructureRel layoutPageTemplateStructureRel =
+			_fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure, segmentsExperienceId);
+
+		layoutPageTemplateStructureRel.setSegmentsExperienceId(
+			SegmentsExperienceConstants.ID_DEFAULT);
+
+		_layoutPageTemplateStructureRelLocalService.
+			updateLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructureRel);
+	}
+
+	private void _runUpgrade() throws Exception {
+		UpgradeProcess[] upgradeProcesses = UpgradeTestUtil.getUpgradeSteps(
+			_upgradeStepRegistrator, new Version(6, 2, 0));
+
+		upgradeProcesses[0].upgrade();
+
+		_entityCache.clearCache();
+
+		_multiVMPool.clear();
+	}
+
+	@Inject
+	private EntityCache _entityCache;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private LayoutPageTemplateStructureLocalService
+		_layoutPageTemplateStructureLocalService;
+
+	@Inject
+	private LayoutPageTemplateStructureRelLocalService
+		_layoutPageTemplateStructureRelLocalService;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	@Inject
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.layout.page.template.internal.upgrade.registry.LayoutPageTemplateServiceUpgradeStepRegistrator))"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateStructureRelLocalServiceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateStructureRelLocalServiceTest.java
@@ -1,0 +1,107 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRel;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelLocalService;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.segments.constants.SegmentsExperienceConstants;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Balázs Sáfrány-Kovalik
+ */
+@RunWith(Arquillian.class)
+public class LayoutPageTemplateStructureRelLocalServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testAddLayoutPageTemplateStructureRelReassignsDefaultSegmentsExperienceId()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_layoutPageTemplateStructureLocalService.
+				fetchLayoutPageTemplateStructure(
+					draftLayout.getGroupId(), draftLayout.getPlid());
+
+		_segmentsExperienceLocalService.deleteSegmentsExperiences(
+			draftLayout.getGroupId(), draftLayout.getPlid());
+
+		Assert.assertEquals(
+			SegmentsExperienceConstants.ID_DEFAULT,
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				draftLayout.getPlid()));
+
+		LayoutPageTemplateStructureRel layoutPageTemplateStructureRel =
+			_layoutPageTemplateStructureRelLocalService.
+				addLayoutPageTemplateStructureRel(
+					TestPropsValues.getUserId(), _group.getGroupId(),
+					layoutPageTemplateStructure.
+						getLayoutPageTemplateStructureId(),
+					SegmentsExperienceConstants.ID_DEFAULT, StringPool.BLANK,
+					ServiceContextTestUtil.getServiceContext(
+						_group.getGroupId(), TestPropsValues.getUserId()));
+
+		Assert.assertNotEquals(
+			SegmentsExperienceConstants.ID_DEFAULT,
+			layoutPageTemplateStructureRel.getSegmentsExperienceId());
+		Assert.assertEquals(
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				draftLayout.getPlid()),
+			layoutPageTemplateStructureRel.getSegmentsExperienceId());
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private LayoutPageTemplateStructureLocalService
+		_layoutPageTemplateStructureLocalService;
+
+	@Inject
+	private LayoutPageTemplateStructureRelLocalService
+		_layoutPageTemplateStructureRelLocalService;
+
+	@Inject
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
+
+}

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceCopyLayoutContentTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceCopyLayoutContentTest.java
@@ -35,6 +35,7 @@ import com.liferay.layout.model.LayoutClassedModelUsage;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRel;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariation;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryService;
@@ -815,6 +816,46 @@ public class LayoutLocalServiceCopyLayoutContentTest {
 		Assert.assertEquals(
 			draftFragmentEntryLink2.getEditableValues(),
 			updatedFragmentEntryLink2.getEditableValues());
+	}
+
+	@Test
+	public void testCopyLayoutContentToWidgetPageCreatesValidSegmentsExperience()
+		throws Exception {
+
+		Layout sourceLayout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout targetLayout = LayoutTestUtil.addTypePortletLayout(
+			_group.getGroupId(), StringPool.BLANK);
+
+		Assert.assertNull(
+			_layoutPageTemplateStructureLocalService.
+				fetchLayoutPageTemplateStructure(
+					targetLayout.getGroupId(), targetLayout.getPlid()));
+
+		_layoutLocalService.copyLayoutContent(sourceLayout, targetLayout);
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_layoutPageTemplateStructureLocalService.
+				fetchLayoutPageTemplateStructure(
+					targetLayout.getGroupId(), targetLayout.getPlid());
+
+		List<LayoutPageTemplateStructureRel> layoutPageTemplateStructureRels =
+			_layoutPageTemplateStructureRelLocalService.
+				getLayoutPageTemplateStructureRels(
+					layoutPageTemplateStructure.
+						getLayoutPageTemplateStructureId());
+
+		Assert.assertEquals(
+			layoutPageTemplateStructureRels.toString(), 1,
+			layoutPageTemplateStructureRels.size());
+
+		LayoutPageTemplateStructureRel layoutPageTemplateStructureRel =
+			layoutPageTemplateStructureRels.get(0);
+
+		Assert.assertEquals(
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				targetLayout.getPlid()),
+			layoutPageTemplateStructureRel.getSegmentsExperienceId());
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97443

## What Is Being Fixed

Publishing a page through staging threw a NullPointerException ("Cannot invoke com.liferay.portal.kernel.model.ClassedModel.getModelClassName() because classedModel is null") when the page had been created as a widget page and later converted to a content page. The conversion left the page's LayoutPageTemplateStructureRel with a segmentsExperienceId of 0 — the deprecated ID_DEFAULT value — for which no SegmentsExperience row exists, so the publish path dereferenced a null model.

## How It Is Being Fixed

The fix has 2 parts, prevention and repair. For prevention, addLayoutPageTemplateStructureRel — the single chokepoint every structure rel creation funnels through — now resolves the layout's default experience whenever a rel is requested with the ID_DEFAULT (0) value, materializing a real default experience when none exists yet, so a rel is never persisted with 0. For repair, a v6_2_0 upgrade process re-points existing orphaned 0-rels onto the materialized default experience, deleting a 0-rel that is redundant with an existing default rel and deleting one whose layout no longer exists.

Coverage is added at every level the invariant must hold: the service guard itself, the widget-to-content conversion, an export/import round-trip, and the repair upgrade.

## PR Check

**pr-check: PASS** — tested on `5aa0bad6211f5a0e3947b5f3ef91de912ec2f98b`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "5aa0bad6211f5a0e3947b5f3ef91de912ec2f98b"} -->
