### PR TITLE
LPD-96532 Show a specific error for too many asset categories

### DIFF
--- a/modules/apps/info/info-api/bnd.bnd
+++ b/modules/apps/info/info-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Info API
 Bundle-SymbolicName: com.liferay.info.api
-Bundle-Version: 38.11.1
+Bundle-Version: 38.12.0
 Export-Package:\
 	com.liferay.info.collection.provider,\
 	com.liferay.info.constants,\

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/exception/InfoFormValidationException.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/exception/InfoFormValidationException.java
@@ -39,6 +39,39 @@ public class InfoFormValidationException extends InfoFormException {
 			locale, "x-an-error-occurred", HtmlUtil.escape(fieldLabel), false);
 	}
 
+	public static class AssetTooManyCategories
+		extends InfoFormValidationException {
+
+		public AssetTooManyCategories(
+			AssetCategoryException assetCategoryException,
+			AssetVocabulary assetVocabulary) {
+
+			_assetCategoryException = assetCategoryException;
+			_assetVocabulary = assetVocabulary;
+		}
+
+		public AssetCategoryException getAssetCategoryException() {
+			return _assetCategoryException;
+		}
+
+		public AssetVocabulary getAssetVocabulary() {
+			return _assetVocabulary;
+		}
+
+		@Override
+		public String getLocalizedMessage(Locale locale) {
+			return LanguageUtil.format(
+				locale, "you-cannot-select-more-than-one-category-for-x",
+				(_assetVocabulary != null) ?
+					HtmlUtil.escape(_assetVocabulary.getTitle(locale)) :
+						StringPool.BLANK);
+		}
+
+		private final AssetCategoryException _assetCategoryException;
+		private final AssetVocabulary _assetVocabulary;
+
+	}
+
 	public static class BlockedEmailAddressDomain
 		extends InvalidInfoFieldValue {
 
@@ -429,39 +462,6 @@ public class InfoFormValidationException extends InfoFormException {
 		private final List<CustomValidation> _customValidations =
 			new ArrayList<>();
 		private final String _message;
-
-	}
-
-	public static class TooManyAssetCategories
-		extends InfoFormValidationException {
-
-		public TooManyAssetCategories(
-			AssetCategoryException assetCategoryException,
-			AssetVocabulary assetVocabulary) {
-
-			_assetCategoryException = assetCategoryException;
-			_assetVocabulary = assetVocabulary;
-		}
-
-		public AssetCategoryException getAssetCategoryException() {
-			return _assetCategoryException;
-		}
-
-		public AssetVocabulary getAssetVocabulary() {
-			return _assetVocabulary;
-		}
-
-		@Override
-		public String getLocalizedMessage(Locale locale) {
-			return LanguageUtil.format(
-				locale, "you-cannot-select-more-than-one-category-for-x",
-				(_assetVocabulary != null) ?
-					HtmlUtil.escape(_assetVocabulary.getTitle(locale)) :
-						StringPool.BLANK);
-		}
-
-		private final AssetCategoryException _assetCategoryException;
-		private final AssetVocabulary _assetVocabulary;
 
 	}
 

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/exception/InfoFormValidationException.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/exception/InfoFormValidationException.java
@@ -432,6 +432,39 @@ public class InfoFormValidationException extends InfoFormException {
 
 	}
 
+	public static class TooManyAssetCategories
+		extends InfoFormValidationException {
+
+		public TooManyAssetCategories(
+			AssetCategoryException assetCategoryException,
+			AssetVocabulary assetVocabulary) {
+
+			_assetCategoryException = assetCategoryException;
+			_assetVocabulary = assetVocabulary;
+		}
+
+		public AssetCategoryException getAssetCategoryException() {
+			return _assetCategoryException;
+		}
+
+		public AssetVocabulary getAssetVocabulary() {
+			return _assetVocabulary;
+		}
+
+		@Override
+		public String getLocalizedMessage(Locale locale) {
+			return LanguageUtil.format(
+				locale, "you-cannot-select-more-than-one-category-for-x",
+				(_assetVocabulary != null) ?
+					HtmlUtil.escape(_assetVocabulary.getTitle(locale)) :
+						StringPool.BLANK);
+		}
+
+		private final AssetCategoryException _assetCategoryException;
+		private final AssetVocabulary _assetVocabulary;
+
+	}
+
 	public static class UniqueValueConstraintViolation
 		extends InfoFormValidationException {
 

--- a/modules/apps/info/info-api/src/main/resources/com/liferay/info/exception/packageinfo
+++ b/modules/apps/info/info-api/src/main/resources/com/liferay/info/exception/packageinfo
@@ -1,1 +1,1 @@
-version 6.6.0
+version 6.7.0

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandler.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandler.java
@@ -55,7 +55,7 @@ public class ObjectEntryInfoItemExceptionRequestHandler {
 			else if (assetCategoryException.getType() ==
 						AssetCategoryException.TOO_MANY_CATEGORIES) {
 
-				throw new InfoFormValidationException.TooManyAssetCategories(
+				throw new InfoFormValidationException.AssetTooManyCategories(
 					assetCategoryException,
 					assetCategoryException.getVocabulary());
 			}

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandler.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandler.java
@@ -52,6 +52,13 @@ public class ObjectEntryInfoItemExceptionRequestHandler {
 					assetCategoryException,
 					assetCategoryException.getVocabulary());
 			}
+			else if (assetCategoryException.getType() ==
+						AssetCategoryException.TOO_MANY_CATEGORIES) {
+
+				throw new InfoFormValidationException.TooManyAssetCategories(
+					assetCategoryException,
+					assetCategoryException.getVocabulary());
+			}
 		}
 
 		if (exception instanceof ModelListenerException) {

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandlerTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandlerTest.java
@@ -8,6 +8,7 @@ package com.liferay.object.web.internal.info.item.handler;
 import com.liferay.asset.kernel.exception.AssetCategoryException;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.info.exception.InfoFormValidationException;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import org.junit.Assert;
@@ -28,6 +29,7 @@ public class ObjectEntryInfoItemExceptionRequestHandlerTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
+	@TestInfo("LPD-96532")
 	public void testHandleInfoFormException() throws Exception {
 		_testHandleInfoFormExceptionWhenAssetCategoryExceptionTypeIsAtLeastOneCategory();
 		_testHandleInfoFormExceptionWhenAssetCategoryExceptionTypeIsTooManyCategories();

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandlerTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandlerTest.java
@@ -1,0 +1,82 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.web.internal.info.item.handler;
+
+import com.liferay.asset.kernel.exception.AssetCategoryException;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.info.exception.InfoFormValidationException;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Jan Brychta
+ */
+public class ObjectEntryInfoItemExceptionRequestHandlerTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testHandleInfoFormException() throws Exception {
+		_testHandleInfoFormExceptionWhenAssetCategoryExceptionTypeIsAtLeastOneCategory();
+		_testHandleInfoFormExceptionWhenAssetCategoryExceptionTypeIsTooManyCategories();
+	}
+
+	private void _testHandleInfoFormExceptionWhenAssetCategoryExceptionTypeIsAtLeastOneCategory()
+		throws Exception {
+
+		AssetVocabulary assetVocabulary = Mockito.mock(AssetVocabulary.class);
+
+		try {
+			ObjectEntryInfoItemExceptionRequestHandler.handleInfoFormException(
+				new AssetCategoryException(
+					assetVocabulary,
+					AssetCategoryException.AT_LEAST_ONE_CATEGORY),
+				0, null, null);
+
+			Assert.fail();
+		}
+		catch (InfoFormValidationException.RequiredAssetCategory
+					infoFormValidationException) {
+
+			Assert.assertSame(
+				assetVocabulary,
+				infoFormValidationException.getAssetVocabulary());
+		}
+	}
+
+	private void _testHandleInfoFormExceptionWhenAssetCategoryExceptionTypeIsTooManyCategories()
+		throws Exception {
+
+		AssetVocabulary assetVocabulary = Mockito.mock(AssetVocabulary.class);
+
+		try {
+			ObjectEntryInfoItemExceptionRequestHandler.handleInfoFormException(
+				new AssetCategoryException(
+					assetVocabulary,
+					AssetCategoryException.TOO_MANY_CATEGORIES),
+				0, null, null);
+
+			Assert.fail();
+		}
+		catch (InfoFormValidationException.TooManyAssetCategories
+					infoFormValidationException) {
+
+			Assert.assertSame(
+				assetVocabulary,
+				infoFormValidationException.getAssetVocabulary());
+		}
+	}
+
+}

--- a/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandlerTest.java
+++ b/modules/apps/object/object-web/src/test/java/com/liferay/object/web/internal/info/item/handler/ObjectEntryInfoItemExceptionRequestHandlerTest.java
@@ -72,7 +72,7 @@ public class ObjectEntryInfoItemExceptionRequestHandlerTest {
 
 			Assert.fail();
 		}
-		catch (InfoFormValidationException.TooManyAssetCategories
+		catch (InfoFormValidationException.AssetTooManyCategories
 					infoFormValidationException) {
 
 			Assert.assertSame(

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorToolbar.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/content_editor/components/ContentEditorToolbar.tsx
@@ -198,7 +198,7 @@ export default function ContentEditorToolbar({
 
 		sessionStorage.removeItem(SUCCESS_MESSAGE_SESSION_KEY);
 
-		if (getForm()?.querySelector('.form-group.has-error')) {
+		if (getForm()?.querySelector('.alert-danger, .form-group.has-error')) {
 			return;
 		}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96532

## What Is Being Fixed

When a vocabulary had "Allow multiple categories" disabled and a user tried to publish content through the CMS section, CardinalityAssetEntryValidator threw AssetCategoryException with TOO_MANY_CATEGORIES. ObjectEntryInfoItemExceptionRequestHandler only handled AT_LEAST_ONE_CATEGORY and fell through to a generic InfoFormException, causing the frontend to show "An error occurred while sending the form information." instead of a message identifying the actual problem. Additionally, the success toast was incorrectly shown alongside the error, because ContentEditorToolbar only checked for field-level .form-group.has-error elements, while this form-level error renders as .alert-danger.

## How It Is Being Fixed

The handler now maps TOO_MANY_CATEGORIES to a new InfoFormValidationException.AssetTooManyCategories, which formats the vocabulary name into the error message. The check in ContentEditorToolbar is extended to also cover .alert-danger so the success toast no longer appears alongside a form-level error. The new public API on info-api required a baseline version bump, and the exception handler test was annotated with @TestInfo. The last commit, renaming the exception class so Asset leads the identifier instead of being embedded after a qualifier, was made per Brian Chan's review recommendation that info-api is outside the asset-* module realm and needs the identifier to read unambiguously.

## PR Check

**pr-check: PASS** — tested on `3144970c008fb3e20d2ad4f59e565921e16d5065`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "3144970c008fb3e20d2ad4f59e565921e16d5065"} -->
