### PR TITLE
LPD-98300 Enable LPD-17564 feature flag in elementVariations test

### DIFF
--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/elementVariations.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/elementVariations.spec.ts
@@ -22,6 +22,7 @@ const test = mergeTests(
 	audiencesPagesTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
+		'LPD-17564': {enabled: true},
 		'LPD-85746': {enabled: true},
 	}),
 	isolatedSiteTest,


### PR DESCRIPTION
Enables the `LPD-17564` feature flag in the `elementVariations` Playwright test (`layout-content-page-editor-web`) so the test runs with that flag turned on.

**pr-check: PASS** — tested on `9cd5438e742cd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
