### PR TITLE
LPD-98088 Revert instanceable ID matching in language selector

### DIFF
--- a/modules/apps/site-navigation/site-navigation-language-web/src/main/java/com/liferay/site/navigation/language/web/internal/upgrade/registry/SiteNavigationLanguageWebUpgradeStepRegistrator.java
+++ b/modules/apps/site-navigation/site-navigation-language-web/src/main/java/com/liferay/site/navigation/language/web/internal/upgrade/registry/SiteNavigationLanguageWebUpgradeStepRegistrator.java
@@ -50,7 +50,7 @@ public class SiteNavigationLanguageWebUpgradeStepRegistrator
 				protected String[] getPortletIds() {
 					return new String[] {
 						SiteNavigationLanguagePortletKeys.
-							SITE_NAVIGATION_LANGUAGE + "%"
+							SITE_NAVIGATION_LANGUAGE
 					};
 				}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98088

## What Is Being Fixed

The instanceable ID matching added in LPD-98088 is no longer needed now that LPD-95995 has been reverted. The upgrade step was changed to match language selector portlet instance IDs with a "%" wildcard suffix; with LPD-95995 no longer in place, that broader match serves no purpose.

## How It Is Being Fixed

This reverts commit 6d427ceba967aa7de60ff8fa5dd8075d67981b8a. The upgrade step's getPortletIds() returns the plain SITE_NAVIGATION_LANGUAGE portlet key again instead of appending "%", restoring the exact-match behavior that preceded LPD-98088.

## Why Are There No Tests?

This is a straight revert of a previously merged commit; it restores the prior behavior and adds no new logic. No test changes are warranted.

## PR Check

**pr-check: PASS** — tested on `6465fea7d6a1ef4eb2a4b8e1ab8b25b7610a8aa4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "6465fea7d6a1ef4eb2a4b8e1ab8b25b7610a8aa4"} -->
