### PR TITLE
LPD-95644 Improve element variations management in the page editor

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/UpdateLayoutPageTemplateStructureRelElementVariationMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/UpdateLayoutPageTemplateStructureRelElementVariationMVCActionCommandTest.java
@@ -1,0 +1,143 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.page.editor.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariation;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationLocalService;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Víctor Galán
+ */
+@RunWith(Arquillian.class)
+public class
+	UpdateLayoutPageTemplateStructureRelElementVariationMVCActionCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testProcessAction() throws Exception {
+		Group group = _groupLocalService.getGroup(TestPropsValues.getGroupId());
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(group);
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		_layoutPageTemplateStructureRelElementVariationLocalService.
+			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
+				externalReferenceCode, TestPropsValues.getUserId(),
+				group.getGroupId(), false, StringPool.FALSE,
+				Collections.emptyMap(), Collections.emptyMap(),
+				RandomTestUtil.randomString(), layout.getPlid(),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				new String[] {RandomTestUtil.randomString()},
+				ServiceContextTestUtil.getServiceContext(
+					group, TestPropsValues.getUserId()));
+
+		_mvcActionCommand.processAction(
+			_getMockLiferayPortletActionRequest(
+				true, externalReferenceCode, group, layout),
+			new MockLiferayPortletActionResponse());
+
+		LayoutPageTemplateStructureRelElementVariation
+			layoutPageTemplateStructureRelElementVariation =
+				_getLayoutPageTemplateStructureRelElementVariation(layout);
+
+		Assert.assertTrue(
+			layoutPageTemplateStructureRelElementVariation.isActive());
+
+		_mvcActionCommand.processAction(
+			_getMockLiferayPortletActionRequest(
+				false, externalReferenceCode, group, layout),
+			new MockLiferayPortletActionResponse());
+
+		layoutPageTemplateStructureRelElementVariation =
+			_getLayoutPageTemplateStructureRelElementVariation(layout);
+
+		Assert.assertFalse(
+			layoutPageTemplateStructureRelElementVariation.isActive());
+	}
+
+	private LayoutPageTemplateStructureRelElementVariation
+		_getLayoutPageTemplateStructureRelElementVariation(Layout layout) {
+
+		List<LayoutPageTemplateStructureRelElementVariation>
+			layoutPageTemplateStructureRelElementVariations =
+				_layoutPageTemplateStructureRelElementVariationLocalService.
+					getLayoutPageTemplateStructureRelElementVariations(
+						layout.getPlid());
+
+		return layoutPageTemplateStructureRelElementVariations.get(0);
+	}
+
+	private MockLiferayPortletActionRequest _getMockLiferayPortletActionRequest(
+		boolean active, String externalReferenceCode, Group group,
+		Layout layout) {
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			new MockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.addParameter(
+			"active", String.valueOf(active));
+		mockLiferayPortletActionRequest.addParameter(
+			"externalReferenceCode", externalReferenceCode);
+		mockLiferayPortletActionRequest.addParameter(
+			"plid", String.valueOf(layout.getPlid()));
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setScopeGroupId(group.getGroupId());
+
+		mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		return mockLiferayPortletActionRequest;
+	}
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private LayoutPageTemplateStructureRelElementVariationLocalService
+		_layoutPageTemplateStructureRelElementVariationLocalService;
+
+	@Inject(
+		filter = "mvc.command.name=/layout_content_page_editor/update_layout_page_template_structure_rel_element_variation"
+	)
+	private MVCActionCommand _mvcActionCommand;
+
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/EditElementVariationsDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/EditElementVariationsDisplayContext.java
@@ -130,6 +130,12 @@ public class EditElementVariationsDisplayContext {
 			_getActionURL(
 				"/layout_content_page_editor" +
 					"/update_segments_experience_audience_entry_rels")
+		).put(
+			"updateElementVariationURL",
+			_getActionURL(
+				"/layout_content_page_editor" +
+					"/update_layout_page_template_structure_rel_element" +
+						"_variation")
 		).build();
 	}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateLayoutPageTemplateStructureRelElementVariationMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateLayoutPageTemplateStructureRelElementVariationMVCActionCommand.java
@@ -1,0 +1,67 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.page.editor.web.internal.portlet.action;
+
+import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationService;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import jakarta.portlet.ActionRequest;
+import jakarta.portlet.ActionResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Víctor Galán
+ */
+@Component(
+	property = {
+		"jakarta.portlet.name=" + ContentPageEditorPortletKeys.CONTENT_PAGE_EDITOR_PORTLET,
+		"mvc.command.name=/layout_content_page_editor/update_layout_page_template_structure_rel_element_variation"
+	},
+	service = MVCActionCommand.class
+)
+public class
+	UpdateLayoutPageTemplateStructureRelElementVariationMVCActionCommand
+		extends BaseContentPageEditorTransactionalMVCActionCommand {
+
+	@Override
+	protected JSONObject doTransactionalCommand(
+			ActionRequest actionRequest, ActionResponse actionResponse)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		_layoutPageTemplateStructureRelElementVariationService.
+			updateLayoutPageTemplateStructureRelElementVariation(
+				ParamUtil.getString(actionRequest, "externalReferenceCode"),
+				themeDisplay.getScopeGroupId(),
+				ParamUtil.getLong(actionRequest, "plid"),
+				ParamUtil.getBoolean(actionRequest, "active"));
+
+		return _jsonFactory.createJSONObject();
+	}
+
+	@Override
+	protected boolean isLayoutLockRequired() {
+		return false;
+	}
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
+	private LayoutPageTemplateStructureRelElementVariationService
+		_layoutPageTemplateStructureRelElementVariationService;
+
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/AudiencePriority.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/AudiencePriority.tsx
@@ -30,9 +30,9 @@ export default function AudiencePriority({
 	const [openModal, setOpenModal] = useState(false);
 
 	return (
-		<div className="px-3">
+		<div className="mb-3 px-3">
 			<div className="align-items-center d-flex">
-				<span className="font-weight-bold">
+				<span className="font-weight-bold text-3">
 					{Liferay.Language.get('audiences-priority')}
 				</span>
 
@@ -47,7 +47,7 @@ export default function AudiencePriority({
 				/>
 			</div>
 
-			<div className="align-items-center d-flex flex-wrap mt-1 text-secondary">
+			<div className="align-items-center d-flex flex-wrap text-secondary">
 				{audiences.map((audience, index) => (
 					<React.Fragment key={audience.value}>
 						{index > 0 ? (

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
@@ -13,6 +13,7 @@ import React from 'react';
 
 import CodeEditorField from './CodeEditorField';
 import {Action, ElementVariation} from './elementVariationsReducer';
+import getAvailableAudiences from './getAvailableAudiences';
 import {EditableElementOption} from './getEditableElementOptions';
 
 type ElementVariationFormData = Pick<
@@ -22,6 +23,7 @@ type ElementVariationFormData = Pick<
 	| 'hide'
 	| 'html'
 	| 'js'
+	| 'key'
 	| 'name'
 	| 'targetElement'
 >;
@@ -32,6 +34,7 @@ interface Props {
 	dispatch: React.Dispatch<Action>;
 	editableElementOptions: EditableElementOption[];
 	elementVariation: ElementVariationFormData;
+	elementVariations: ElementVariation[];
 	languageId: string;
 	locales: Array<{id: string; label: string; symbol: string}>;
 	onCancel: () => void;
@@ -47,6 +50,7 @@ export default function ElementVariationForm({
 	dispatch,
 	editableElementOptions,
 	elementVariation,
+	elementVariations,
 	languageId,
 	locales,
 	onCancel,
@@ -70,6 +74,12 @@ export default function ElementVariationForm({
 	const selectedTargetElementItem = targetElementItems.find(
 		(targetElementItem) =>
 			targetElementItem.value === elementVariation.targetElement
+	);
+
+	const availableAudiences = getAvailableAudiences(
+		audiences,
+		elementVariations,
+		elementVariation
 	);
 
 	const translating = languageId !== defaultLanguageId;
@@ -253,7 +263,7 @@ export default function ElementVariationForm({
 											),
 									});
 								}}
-								sourceItems={audiences}
+								sourceItems={availableAudiences}
 							/>
 						</ClayForm.Group>
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
@@ -321,21 +321,6 @@ export default function ElementVariationForm({
 									description={Liferay.Language.get(
 										'changes-persist-in-the-preview.-reload-to-update'
 									)}
-									footer={
-										<ClayButton
-											className="mt-2"
-											displayType="secondary"
-											onClick={onReloadPreview}
-											size="sm"
-										>
-											<ClayIcon
-												className="mr-2"
-												symbol="reload"
-											/>
-
-											{Liferay.Language.get('reload')}
-										</ClayButton>
-									}
 									initialValue={
 										elementVariation.js[languageId] ?? ''
 									}
@@ -353,6 +338,18 @@ export default function ElementVariationForm({
 								/>
 							</>
 						)}
+
+						<div className="mb-4">
+							<ClayButton
+								displayType="secondary"
+								onClick={onReloadPreview}
+								size="xs"
+							>
+								<ClayIcon className="mr-2" symbol="reload" />
+
+								{Liferay.Language.get('reload')}
+							</ClayButton>
+						</div>
 
 						<ClayForm.Group className="my-4" small>
 							<ClayCheckbox

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
@@ -9,7 +9,7 @@ import ClayForm, {ClayCheckbox, ClayInput, ClayToggle} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayMultiSelect from '@clayui/multi-select';
 import {useId} from 'frontend-js-components-web';
-import React from 'react';
+import React, {useState} from 'react';
 
 import CodeEditorField from './CodeEditorField';
 import {Action, ElementVariation} from './elementVariationsReducer';
@@ -82,6 +82,15 @@ export default function ElementVariationForm({
 		elementVariation
 	);
 
+	const [errors, setErrors] = useState<{
+		audience?: boolean;
+		name?: boolean;
+		targetElement?: boolean;
+	}>({});
+
+	const clearError = (field: 'audience' | 'name' | 'targetElement') =>
+		setErrors((previousErrors) => ({...previousErrors, [field]: false}));
+
 	const translating = languageId !== defaultLanguageId;
 
 	const notLocalizableHint = translating ? (
@@ -134,7 +143,10 @@ export default function ElementVariationForm({
 			</div>
 
 			<div className="flex-grow-1 overflow-auto p-3">
-				<ClayForm.Group small>
+				<ClayForm.Group
+					className={errors.name ? 'has-error' : undefined}
+					small
+				>
 					<label htmlFor={nameId}>
 						{Liferay.Language.get('name')}
 
@@ -149,13 +161,21 @@ export default function ElementVariationForm({
 					<ClayInput
 						defaultValue={elementVariation.name}
 						id={nameId}
-						onBlur={(event) => onChange({name: event.target.value})}
+						onBlur={(event) => {
+							onChange({name: event.target.value});
+							clearError('name');
+						}}
 						readOnly={translating}
 						type="text"
 					/>
+
+					{errors.name ? <RequiredFieldFeedback /> : null}
 				</ClayForm.Group>
 
-				<ClayForm.Group small>
+				<ClayForm.Group
+					className={errors.targetElement ? 'has-error' : undefined}
+					small
+				>
 					<label htmlFor={targetElementId}>
 						{Liferay.Language.get('page-element')}
 
@@ -183,6 +203,8 @@ export default function ElementVariationForm({
 							onChange({
 								targetElement: targetElementItem?.value ?? '',
 							});
+
+							clearError('targetElement');
 						}}
 						selectedKey={selectedTargetElementItem?.key}
 					>
@@ -209,11 +231,18 @@ export default function ElementVariationForm({
 							</Option>
 						)}
 					</Picker>
+
+					{errors.targetElement ? <RequiredFieldFeedback /> : null}
 				</ClayForm.Group>
 
 				{elementVariation.targetElement ? (
 					<>
-						<ClayForm.Group small>
+						<ClayForm.Group
+							className={
+								errors.audience ? 'has-error' : undefined
+							}
+							small
+						>
 							<label htmlFor={audienceId}>
 								{Liferay.Language.get('audience')}
 
@@ -262,9 +291,13 @@ export default function ElementVariationForm({
 												(audience) => audience.value
 											),
 									});
+
+									clearError('audience');
 								}}
 								sourceItems={availableAudiences}
 							/>
+
+							{errors.audience ? <RequiredFieldFeedback /> : null}
 						</ClayForm.Group>
 
 						<ClayForm.Group className="align-items-center d-flex my-4">
@@ -390,12 +423,44 @@ export default function ElementVariationForm({
 				<ClayButton
 					className="ml-2"
 					displayType="primary"
-					onClick={onSave}
+					onClick={() => {
+						const nextErrors = {
+							audience:
+								Boolean(elementVariation.targetElement) &&
+								!elementVariation.audienceEntryERCs.length,
+							name: !elementVariation.name,
+							targetElement: !elementVariation.targetElement,
+						};
+
+						if (
+							nextErrors.audience ||
+							nextErrors.name ||
+							nextErrors.targetElement
+						) {
+							setErrors(nextErrors);
+
+							return;
+						}
+
+						onSave();
+					}}
 					size="sm"
 				>
 					{Liferay.Language.get('save')}
 				</ClayButton>
 			</div>
 		</>
+	);
+}
+
+function RequiredFieldFeedback() {
+	return (
+		<ClayForm.FeedbackGroup role="alert">
+			<ClayForm.FeedbackItem>
+				<ClayForm.FeedbackIndicator symbol="times-circle-full" />
+
+				{Liferay.Language.get('this-field-is-required')}
+			</ClayForm.FeedbackItem>
+		</ClayForm.FeedbackGroup>
 	);
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationService.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationService.ts
@@ -24,6 +24,13 @@ interface UpdateAudiencesPriorityParameters {
 	updateAudiencesPriorityURL: string;
 }
 
+interface UpdateElementVariationParameters {
+	active: boolean;
+	externalReferenceCode: string;
+	plid: number;
+	updateElementVariationURL: string;
+}
+
 export default {
 	addElementVariation({
 		addElementVariationURL,
@@ -72,6 +79,21 @@ export default {
 			body: {
 				audienceEntryERCs: JSON.stringify(audienceEntryERCs),
 				segmentsExperienceERC,
+			},
+		});
+	},
+
+	updateElementVariation({
+		active,
+		externalReferenceCode,
+		plid,
+		updateElementVariationURL,
+	}: UpdateElementVariationParameters) {
+		return serviceFetch<void>(updateElementVariationURL, {
+			body: {
+				active: String(active),
+				externalReferenceCode,
+				plid: String(plid),
 			},
 		});
 	},

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.scss
@@ -23,6 +23,7 @@
 	}
 
 	&__sidebar {
+		border-right: 0.5px solid $secondary;
 		width: 320px;
 	}
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
@@ -6,6 +6,7 @@
 import ClayButton from '@clayui/button';
 import {Option, Picker} from '@clayui/core';
 import ClayEmptyState from '@clayui/empty-state';
+import ClayIcon from '@clayui/icon';
 import {useId} from 'frontend-js-components-web';
 import React, {useReducer, useRef} from 'react';
 
@@ -126,7 +127,7 @@ function ElementVariations({
 	return (
 		<div className="d-flex element-variations flex-column">
 			<div className="d-flex element-variations__content flex-grow-1">
-				<div className="bg-white border-right d-flex element-variations__sidebar flex-column flex-shrink-0">
+				<div className="bg-white d-flex element-variations__sidebar flex-column flex-shrink-0">
 					{draftElementVariation ? (
 						<ElementVariationForm
 							audiences={audiences}
@@ -178,7 +179,7 @@ function ElementVariations({
 							</div>
 
 							<div className="flex-grow-1">
-								<div className="form-group p-3">
+								<div className="p-3">
 									<label htmlFor={experienceId}>
 										{Liferay.Language.get('experience')}
 									</label>
@@ -222,55 +223,9 @@ function ElementVariations({
 									}
 								/>
 
-								{experienceElementVariations.length ? (
-									<ElementVariationsList
-										audiences={audiences}
-										editableElementOptions={
-											editableElementOptions
-										}
-										elementVariations={
-											experienceElementVariations
-										}
-										onDeleteElementVariation={(
-											elementVariation
-										) =>
-											ElementVariationService.deleteElementVariation(
-												{
-													deleteElementVariationURL,
-													externalReferenceCode:
-														elementVariation.externalReferenceCode,
-													plid,
-												}
-											).then(() =>
-												dispatch({
-													key: elementVariation.key,
-													type: 'DELETE_ELEMENT_VARIATION',
-												})
-											)
-										}
-										onEditElementVariation={(key) =>
-											dispatch({
-												key,
-												type: 'EDIT_ELEMENT_VARIATION',
-											})
-										}
-									/>
-								) : (
-									<ClayEmptyState
-										className="mb-0 px-3"
-										description={Liferay.Language.get(
-											'you-can-create-page-elements-variations-based-on-audiences'
-										)}
-										imgSrc={`${Liferay.ThemeDisplay.getPathThemeImages()}/states/empty_state.svg`}
-										small
-										title={Liferay.Language.get(
-											'no-variations-yet'
-										)}
-									/>
-								)}
-
-								<div className="d-flex justify-content-center mt-2">
+								<div className="d-flex justify-content-start m-3">
 									<ClayButton
+										className="w-100"
 										displayType="secondary"
 										onClick={() =>
 											dispatch({
@@ -281,10 +236,63 @@ function ElementVariations({
 												type: 'CREATE_ELEMENT_VARIATION_DRAFT',
 											})
 										}
-										size="sm"
 									>
+										<ClayIcon
+											className="mr-2"
+											symbol="plus"
+										/>
+
 										{Liferay.Language.get('new-variation')}
 									</ClayButton>
+								</div>
+
+								<div className="border-top pt-3">
+									{experienceElementVariations.length ? (
+										<ElementVariationsList
+											audiences={audiences}
+											editableElementOptions={
+												editableElementOptions
+											}
+											elementVariations={
+												experienceElementVariations
+											}
+											onDeleteElementVariation={(
+												elementVariation
+											) =>
+												ElementVariationService.deleteElementVariation(
+													{
+														deleteElementVariationURL,
+														externalReferenceCode:
+															elementVariation.externalReferenceCode,
+														plid,
+													}
+												).then(() =>
+													dispatch({
+														key: elementVariation.key,
+														type: 'DELETE_ELEMENT_VARIATION',
+													})
+												)
+											}
+											onEditElementVariation={(key) =>
+												dispatch({
+													key,
+													type: 'EDIT_ELEMENT_VARIATION',
+												})
+											}
+										/>
+									) : (
+										<ClayEmptyState
+											className="mb-0 px-3"
+											description={Liferay.Language.get(
+												'you-can-create-page-elements-variations-based-on-audiences'
+											)}
+											imgSrc={`${Liferay.ThemeDisplay.getPathThemeImages()}/states/empty_state.svg`}
+											small
+											title={Liferay.Language.get(
+												'no-variations-yet'
+											)}
+										/>
+									)}
 								</div>
 							</div>
 						</>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
@@ -135,6 +135,7 @@ function ElementVariations({
 							dispatch={dispatch}
 							editableElementOptions={editableElementOptions}
 							elementVariation={draftElementVariation}
+							elementVariations={experienceElementVariations}
 							key={draftElementVariation.key}
 							languageId={languageId}
 							locales={locales}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
@@ -47,6 +47,7 @@ interface Props {
 	previewURL: string;
 	selectedSegmentsExperienceId: number;
 	updateAudiencesPriorityURL: string;
+	updateElementVariationURL: string;
 }
 
 export default function (props: Props) {
@@ -88,6 +89,7 @@ function ElementVariations({
 	previewURL,
 	selectedSegmentsExperienceId,
 	updateAudiencesPriorityURL,
+	updateElementVariationURL,
 }: Props) {
 	const experienceId = useId();
 
@@ -279,6 +281,25 @@ function ElementVariations({
 													key,
 													type: 'EDIT_ELEMENT_VARIATION',
 												})
+											}
+											onUpdateElementVariation={(
+												elementVariation
+											) =>
+												ElementVariationService.updateElementVariation(
+													{
+														active: !elementVariation.active,
+														externalReferenceCode:
+															elementVariation.externalReferenceCode,
+														plid,
+														updateElementVariationURL,
+													}
+												).then(() =>
+													dispatch({
+														active: !elementVariation.active,
+														key: elementVariation.key,
+														type: 'UPDATE_ELEMENT_VARIATION',
+													})
+												)
 											}
 										/>
 									) : (

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsList.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsList.tsx
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayButton from '@clayui/button';
+import {ClayDropDownWithItems} from '@clayui/drop-down';
+import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
 import ClayList from '@clayui/list';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
@@ -148,16 +151,16 @@ export default function ElementVariationsList({
 													)}
 												/>
 
-												<ClayList.QuickActionMenu.Item
-													onClick={() =>
-														onDeleteElementVariation(
-															elementVariation
-														)
+												<ElementVariationActions
+													elementVariation={
+														elementVariation
 													}
-													symbol="trash"
-													title={Liferay.Language.get(
-														'delete'
-													)}
+													onDeleteElementVariation={
+														onDeleteElementVariation
+													}
+													onEditElementVariation={
+														onEditElementVariation
+													}
 												/>
 											</ClayList.QuickActionMenu>
 										</ClayList.ItemField>
@@ -169,5 +172,51 @@ export default function ElementVariationsList({
 				)
 			)}
 		</>
+	);
+}
+
+interface ElementVariationActionsProps {
+	elementVariation: ElementVariation;
+	onDeleteElementVariation: (elementVariation: ElementVariation) => void;
+	onEditElementVariation: (key: string) => void;
+}
+
+function ElementVariationActions({
+	elementVariation,
+	onDeleteElementVariation,
+	onEditElementVariation,
+}: ElementVariationActionsProps) {
+	return (
+		<ClayDropDownWithItems
+			items={[
+				{
+					label: Liferay.Language.get('edit'),
+					onClick: () => onEditElementVariation(elementVariation.key),
+					symbolLeft: 'pencil',
+				},
+				{
+					label: elementVariation.active
+						? Liferay.Language.get('disable')
+						: Liferay.Language.get('enable'),
+					onClick: () => {},
+					symbolLeft: 'check-circle',
+				},
+				{
+					label: Liferay.Language.get('delete'),
+					onClick: () => onDeleteElementVariation(elementVariation),
+					symbolLeft: 'trash',
+				},
+			]}
+			trigger={
+				<ClayButton
+					aria-label={Liferay.Language.get('actions')}
+					className="component-action quick-action-item"
+					displayType="unstyled"
+					title={Liferay.Language.get('actions')}
+				>
+					<ClayIcon symbol="ellipsis-v" />
+				</ClayButton>
+			}
+		/>
 	);
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsList.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsList.tsx
@@ -135,6 +135,14 @@ export default function ElementVariationsList({
 															)}
 														</ClayLabel>
 													) : null}
+
+													{elementVariation.active ? null : (
+														<ClayLabel displayType="danger">
+															{Liferay.Language.get(
+																'inactive'
+															)}
+														</ClayLabel>
+													)}
 												</div>
 											</ClayList.ItemText>
 										</ClayList.ItemField>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsList.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsList.tsx
@@ -5,6 +5,7 @@
 
 import ClayLabel from '@clayui/label';
 import ClayList from '@clayui/list';
+import ClayLoadingIndicator from '@clayui/loading-indicator';
 import React from 'react';
 
 import {ElementVariation} from './elementVariationsReducer';
@@ -45,6 +46,10 @@ export default function ElementVariationsList({
 		},
 		{} as Record<string, ElementVariation[]>
 	);
+
+	if (!editableElementOptions.length) {
+		return <ClayLoadingIndicator className="mt-3" />;
+	}
 
 	return (
 		<>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsList.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsList.tsx
@@ -26,6 +26,7 @@ interface Props {
 	elementVariations: ElementVariation[];
 	onDeleteElementVariation: (elementVariation: ElementVariation) => void;
 	onEditElementVariation: (key: string) => void;
+	onUpdateElementVariation: (elementVariation: ElementVariation) => void;
 }
 
 export default function ElementVariationsList({
@@ -34,6 +35,7 @@ export default function ElementVariationsList({
 	elementVariations,
 	onDeleteElementVariation,
 	onEditElementVariation,
+	onUpdateElementVariation,
 }: Props) {
 	const groupedElementVariations = elementVariations.reduce(
 		(groupedElementVariations, elementVariation) => {
@@ -161,6 +163,9 @@ export default function ElementVariationsList({
 													onEditElementVariation={
 														onEditElementVariation
 													}
+													onUpdateElementVariation={
+														onUpdateElementVariation
+													}
 												/>
 											</ClayList.QuickActionMenu>
 										</ClayList.ItemField>
@@ -179,12 +184,14 @@ interface ElementVariationActionsProps {
 	elementVariation: ElementVariation;
 	onDeleteElementVariation: (elementVariation: ElementVariation) => void;
 	onEditElementVariation: (key: string) => void;
+	onUpdateElementVariation: (elementVariation: ElementVariation) => void;
 }
 
 function ElementVariationActions({
 	elementVariation,
 	onDeleteElementVariation,
 	onEditElementVariation,
+	onUpdateElementVariation,
 }: ElementVariationActionsProps) {
 	return (
 		<ClayDropDownWithItems
@@ -198,7 +205,7 @@ function ElementVariationActions({
 					label: elementVariation.active
 						? Liferay.Language.get('disable')
 						: Liferay.Language.get('enable'),
-					onClick: () => {},
+					onClick: () => onUpdateElementVariation(elementVariation),
 					symbolLeft: 'check-circle',
 				},
 				{

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/elementVariationsReducer.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/elementVariationsReducer.ts
@@ -47,6 +47,7 @@ export type Action =
 			type: 'SET_HIGHLIGHTED_TARGET_ELEMENT';
 	  }
 	| {languageId: string; type: 'SET_LANGUAGE_ID'}
+	| {active: boolean; key: string; type: 'UPDATE_ELEMENT_VARIATION'}
 	| {
 			properties: Partial<ElementVariation>;
 			type: 'UPDATE_ELEMENT_VARIATION_DRAFT';
@@ -190,6 +191,17 @@ export function reducer(state: State, action: Action): State {
 
 		case 'SET_LANGUAGE_ID':
 			return {...state, languageId: action.languageId};
+
+		case 'UPDATE_ELEMENT_VARIATION':
+			return {
+				...state,
+				elementVariations: state.elementVariations.map(
+					(elementVariation) =>
+						elementVariation.key === action.key
+							? {...elementVariation, active: action.active}
+							: elementVariation
+				),
+			};
 
 		case 'UPDATE_ELEMENT_VARIATION_DRAFT':
 			return {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/getAvailableAudiences.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/getAvailableAudiences.ts
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ElementVariation} from './elementVariationsReducer';
+
+export default function getAvailableAudiences(
+	audiences: Array<{label: string; value: string}>,
+	elementVariations: ElementVariation[],
+	elementVariation: Pick<ElementVariation, 'key' | 'targetElement'>
+): Array<{label: string; value: string}> {
+	const unavailableAudienceEntryERCs = new Set(
+		elementVariations
+			.filter(
+				(siblingElementVariation) =>
+					siblingElementVariation.key !== elementVariation.key &&
+					siblingElementVariation.targetElement ===
+						elementVariation.targetElement
+			)
+			.flatMap(
+				(siblingElementVariation) =>
+					siblingElementVariation.audienceEntryERCs
+			)
+	);
+
+	return audiences.filter(
+		(audience) => !unavailableAudienceEntryERCs.has(audience.value)
+	);
+}

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/ElementVariationForm.test.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/ElementVariationForm.test.tsx
@@ -23,6 +23,7 @@ const BASE_ELEMENT_VARIATION: ElementVariationProp = {
 	hide: false,
 	html: {},
 	js: {},
+	key: 'variation-1',
 	name: 'My Variation',
 	targetElement: '',
 };
@@ -60,6 +61,7 @@ function renderForm(
 					...BASE_ELEMENT_VARIATION,
 					...elementVariation,
 				}}
+				elementVariations={[]}
 				languageId="en_US"
 				locales={LOCALES}
 				onCancel={jest.fn()}

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/ElementVariationForm.test.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/ElementVariationForm.test.tsx
@@ -203,6 +203,81 @@ describe('ElementVariationForm', () => {
 		).toHaveLength(2);
 	});
 
+	it('shows a required error and blocks saving when no name is provided', async () => {
+		const onSave = jest.fn();
+
+		renderForm(
+			{
+				audienceEntryERCs: ['audience-1'],
+				name: '',
+				targetElement: '.title',
+			},
+			{onSave}
+		);
+
+		await userEvent.click(screen.getByText('save'));
+
+		expect(screen.getByText('this-field-is-required')).toBeInTheDocument();
+		expect(onSave).not.toHaveBeenCalled();
+	});
+
+	it('shows a required error and blocks saving when no page element is selected', async () => {
+		const onSave = jest.fn();
+
+		renderForm({targetElement: ''}, {onSave});
+
+		await userEvent.click(screen.getByText('save'));
+
+		expect(screen.getByText('this-field-is-required')).toBeInTheDocument();
+		expect(onSave).not.toHaveBeenCalled();
+	});
+
+	it('shows a required error and blocks saving when no audience is selected', async () => {
+		const onSave = jest.fn();
+
+		renderForm({targetElement: '.title'}, {onSave});
+
+		await userEvent.click(screen.getByText('save'));
+
+		expect(screen.getByText('this-field-is-required')).toBeInTheDocument();
+		expect(onSave).not.toHaveBeenCalled();
+	});
+
+	it('clears the required error when the offending field is updated', async () => {
+		renderForm({
+			audienceEntryERCs: ['audience-1'],
+			name: '',
+			targetElement: '.title',
+		});
+
+		await userEvent.click(screen.getByText('save'));
+
+		expect(screen.getByText('this-field-is-required')).toBeInTheDocument();
+
+		await userEvent.type(screen.getByLabelText('name'), 'New name');
+		await userEvent.tab();
+
+		expect(
+			screen.queryByText('this-field-is-required')
+		).not.toBeInTheDocument();
+	});
+
+	it('saves when an audience is selected', async () => {
+		const onSave = jest.fn();
+
+		renderForm(
+			{audienceEntryERCs: ['audience-1'], targetElement: '.title'},
+			{onSave}
+		);
+
+		await userEvent.click(screen.getByText('save'));
+
+		expect(
+			screen.queryByText('this-field-is-required')
+		).not.toBeInTheDocument();
+		expect(onSave).toHaveBeenCalledTimes(1);
+	});
+
 	it('has no accessibility violations', async () => {
 		const {container} = renderForm({targetElement: '.title'});
 

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/elementVariationsReducer.test.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/elementVariationsReducer.test.ts
@@ -239,6 +239,24 @@ describe('elementVariationsReducer', () => {
 			expect(state.elementVariations).toEqual([]);
 		});
 
+		it('updates the active flag on UPDATE_ELEMENT_VARIATION', () => {
+			const elementVariation = buildElementVariation({
+				active: true,
+				key: 'key-1',
+			});
+
+			const state = reducer(
+				buildState({elementVariations: [elementVariation]}),
+				{
+					active: false,
+					key: 'key-1',
+					type: 'UPDATE_ELEMENT_VARIATION',
+				}
+			);
+
+			expect(state.elementVariations[0].active).toBe(false);
+		});
+
 		it('clears the draft and resets the language on CANCEL_ELEMENT_VARIATION_DRAFT', () => {
 			const state = reducer(
 				buildState({

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/getAvailableAudiences.test.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/getAvailableAudiences.test.ts
@@ -1,0 +1,116 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ElementVariation} from '../../../../src/main/resources/META-INF/resources/page_editor/plugins/element_variations/elementVariationsReducer';
+import getAvailableAudiences from '../../../../src/main/resources/META-INF/resources/page_editor/plugins/element_variations/getAvailableAudiences';
+
+const AUDIENCES = [
+	{label: 'Audience A', value: 'audience-a'},
+	{label: 'Audience B', value: 'audience-b'},
+	{label: 'Audience C', value: 'audience-c'},
+];
+
+function createVariation(
+	overrides: Partial<ElementVariation> = {}
+): ElementVariation {
+	return {
+		active: true,
+		audienceEntryERCs: [],
+		externalReferenceCode: 'erc',
+		hide: false,
+		html: {},
+		js: {},
+		key: 'variation',
+		name: 'Variation',
+		segmentsExperienceERC: 'experience',
+		targetElement: '.title',
+		...overrides,
+	};
+}
+
+describe('getAvailableAudiences', () => {
+	it('removes audiences used by another variation on the same page element', () => {
+		const availableAudiences = getAvailableAudiences(
+			AUDIENCES,
+			[
+				createVariation({
+					audienceEntryERCs: ['audience-a'],
+					key: 'other',
+					targetElement: '.title',
+				}),
+			],
+			{key: 'draft', targetElement: '.title'}
+		);
+
+		expect(availableAudiences).toEqual([
+			{label: 'Audience B', value: 'audience-b'},
+			{label: 'Audience C', value: 'audience-c'},
+		]);
+	});
+
+	it('keeps audiences used by a variation on a different page element', () => {
+		const availableAudiences = getAvailableAudiences(
+			AUDIENCES,
+			[
+				createVariation({
+					audienceEntryERCs: ['audience-a'],
+					key: 'other',
+					targetElement: '.body',
+				}),
+			],
+			{key: 'draft', targetElement: '.title'}
+		);
+
+		expect(availableAudiences).toEqual(AUDIENCES);
+	});
+
+	it('keeps audiences used by the variation being edited', () => {
+		const availableAudiences = getAvailableAudiences(
+			AUDIENCES,
+			[
+				createVariation({
+					audienceEntryERCs: ['audience-a'],
+					key: 'draft',
+					targetElement: '.title',
+				}),
+			],
+			{key: 'draft', targetElement: '.title'}
+		);
+
+		expect(availableAudiences).toEqual(AUDIENCES);
+	});
+
+	it('removes audiences taken across several sibling variations', () => {
+		const availableAudiences = getAvailableAudiences(
+			AUDIENCES,
+			[
+				createVariation({
+					audienceEntryERCs: ['audience-a'],
+					key: 'other-1',
+					targetElement: '.title',
+				}),
+				createVariation({
+					audienceEntryERCs: ['audience-b'],
+					key: 'other-2',
+					targetElement: '.title',
+				}),
+			],
+			{key: 'draft', targetElement: '.title'}
+		);
+
+		expect(availableAudiences).toEqual([
+			{label: 'Audience C', value: 'audience-c'},
+		]);
+	});
+
+	it('returns every audience when there are no sibling variations', () => {
+		const availableAudiences = getAvailableAudiences(AUDIENCES, [], {
+			key: 'draft',
+			targetElement: '.title',
+		});
+
+		expect(availableAudiences).toEqual(AUDIENCES);
+	});
+});

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalService.java
@@ -384,6 +384,11 @@ public interface LayoutPageTemplateStructureRelElementVariationLocalService
 			LayoutPageTemplateStructureRelElementVariation
 				layoutPageTemplateStructureRelElementVariation);
 
+	public LayoutPageTemplateStructureRelElementVariation
+			updateLayoutPageTemplateStructureRelElementVariation(
+				String externalReferenceCode, long groupId, boolean active)
+		throws PortalException;
+
 	@Override
 	@Transactional(enabled = false)
 	public CTPersistence<LayoutPageTemplateStructureRelElementVariation>
@@ -403,4 +408,4 @@ public interface LayoutPageTemplateStructureRelElementVariationLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-473839327
+// LIFERAY-SERVICE-BUILDER-HASH:-1184717029

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceUtil.java
@@ -469,6 +469,16 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceUtil {
 				layoutPageTemplateStructureRelElementVariation);
 	}
 
+	public static LayoutPageTemplateStructureRelElementVariation
+			updateLayoutPageTemplateStructureRelElementVariation(
+				String externalReferenceCode, long groupId, boolean active)
+		throws PortalException {
+
+		return getService().
+			updateLayoutPageTemplateStructureRelElementVariation(
+				externalReferenceCode, groupId, active);
+	}
+
 	public static LayoutPageTemplateStructureRelElementVariationLocalService
 		getService() {
 
@@ -484,4 +494,4 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceUtil {
 					class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1355106791
+// LIFERAY-SERVICE-BUILDER-HASH:488687409

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper.java
@@ -529,6 +529,17 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper
 	}
 
 	@Override
+	public LayoutPageTemplateStructureRelElementVariation
+			updateLayoutPageTemplateStructureRelElementVariation(
+				String externalReferenceCode, long groupId, boolean active)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _layoutPageTemplateStructureRelElementVariationLocalService.
+			updateLayoutPageTemplateStructureRelElementVariation(
+				externalReferenceCode, groupId, active);
+	}
+
+	@Override
 	public BasePersistence<?> getBasePersistence() {
 		return _layoutPageTemplateStructureRelElementVariationLocalService.
 			getBasePersistence();
@@ -581,4 +592,4 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceWrapper
 		_layoutPageTemplateStructureRelElementVariationLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1148139206
+// LIFERAY-SERVICE-BUILDER-HASH:72931764

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationService.java
@@ -73,5 +73,11 @@ public interface LayoutPageTemplateStructureRelElementVariationService
 	 */
 	public String getOSGiServiceIdentifier();
 
+	public LayoutPageTemplateStructureRelElementVariation
+			updateLayoutPageTemplateStructureRelElementVariation(
+				String externalReferenceCode, long groupId, long plid,
+				boolean active)
+		throws PortalException;
+
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-967527342
+// LIFERAY-SERVICE-BUILDER-HASH:1285643008

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationServiceUtil.java
@@ -73,6 +73,17 @@ public class LayoutPageTemplateStructureRelElementVariationServiceUtil {
 		return getService().getOSGiServiceIdentifier();
 	}
 
+	public static LayoutPageTemplateStructureRelElementVariation
+			updateLayoutPageTemplateStructureRelElementVariation(
+				String externalReferenceCode, long groupId, long plid,
+				boolean active)
+		throws PortalException {
+
+		return getService().
+			updateLayoutPageTemplateStructureRelElementVariation(
+				externalReferenceCode, groupId, plid, active);
+	}
+
 	public static LayoutPageTemplateStructureRelElementVariationService
 		getService() {
 
@@ -86,4 +97,4 @@ public class LayoutPageTemplateStructureRelElementVariationServiceUtil {
 				LayoutPageTemplateStructureRelElementVariationService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1887344421
+// LIFERAY-SERVICE-BUILDER-HASH:-776365267

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateStructureRelElementVariationServiceWrapper.java
@@ -81,6 +81,18 @@ public class LayoutPageTemplateStructureRelElementVariationServiceWrapper
 	}
 
 	@Override
+	public LayoutPageTemplateStructureRelElementVariation
+			updateLayoutPageTemplateStructureRelElementVariation(
+				String externalReferenceCode, long groupId, long plid,
+				boolean active)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _layoutPageTemplateStructureRelElementVariationService.
+			updateLayoutPageTemplateStructureRelElementVariation(
+				externalReferenceCode, groupId, plid, active);
+	}
+
+	@Override
 	public LayoutPageTemplateStructureRelElementVariationService
 		getWrappedService() {
 
@@ -100,4 +112,4 @@ public class LayoutPageTemplateStructureRelElementVariationServiceWrapper
 		_layoutPageTemplateStructureRelElementVariationService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-622841873
+// LIFERAY-SERVICE-BUILDER-HASH:-1861794388

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/http/LayoutPageTemplateStructureRelElementVariationServiceHttp.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/http/LayoutPageTemplateStructureRelElementVariationServiceHttp.java
@@ -177,6 +177,51 @@ public class LayoutPageTemplateStructureRelElementVariationServiceHttp {
 		}
 	}
 
+	public static com.liferay.layout.page.template.model.
+		LayoutPageTemplateStructureRelElementVariation
+				updateLayoutPageTemplateStructureRelElementVariation(
+					HttpPrincipal httpPrincipal, String externalReferenceCode,
+					long groupId, long plid, boolean active)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				LayoutPageTemplateStructureRelElementVariationServiceUtil.class,
+				"updateLayoutPageTemplateStructureRelElementVariation",
+				_updateLayoutPageTemplateStructureRelElementVariationParameterTypes3);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, externalReferenceCode, groupId, plid, active);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.layout.page.template.model.
+				LayoutPageTemplateStructureRelElementVariation)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	private static Log _log = LogFactoryUtil.getLog(
 		LayoutPageTemplateStructureRelElementVariationServiceHttp.class);
 
@@ -194,6 +239,9 @@ public class LayoutPageTemplateStructureRelElementVariationServiceHttp {
 	private static final Class<?>[]
 		_getLayoutPageTemplateStructureRelElementVariationsParameterTypes2 =
 			new Class[] {long.class};
+	private static final Class<?>[]
+		_updateLayoutPageTemplateStructureRelElementVariationParameterTypes3 =
+			new Class[] {String.class, long.class, long.class, boolean.class};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1122815085
+// LIFERAY-SERVICE-BUILDER-HASH:1619289181

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationLocalServiceImpl.java
@@ -151,6 +151,26 @@ public class LayoutPageTemplateStructureRelElementVariationLocalServiceImpl
 			findByP_SEERC(plid, segmentsExperienceERC);
 	}
 
+	public LayoutPageTemplateStructureRelElementVariation
+			updateLayoutPageTemplateStructureRelElementVariation(
+				String externalReferenceCode, long groupId, boolean active)
+		throws PortalException {
+
+		LayoutPageTemplateStructureRelElementVariation
+			layoutPageTemplateStructureRelElementVariation =
+				layoutPageTemplateStructureRelElementVariationPersistence.
+					fetchByERC_G(externalReferenceCode, groupId);
+
+		if (layoutPageTemplateStructureRelElementVariation == null) {
+			return null;
+		}
+
+		layoutPageTemplateStructureRelElementVariation.setActive(active);
+
+		return layoutPageTemplateStructureRelElementVariationPersistence.update(
+			layoutPageTemplateStructureRelElementVariation);
+	}
+
 	private void _validate(
 			String[] audienceEntryERCs, String name, String targetElement)
 		throws PortalException {

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelElementVariationServiceImpl.java
@@ -73,6 +73,20 @@ public class LayoutPageTemplateStructureRelElementVariationServiceImpl
 			getLayoutPageTemplateStructureRelElementVariations(plid);
 	}
 
+	public LayoutPageTemplateStructureRelElementVariation
+			updateLayoutPageTemplateStructureRelElementVariation(
+				String externalReferenceCode, long groupId, long plid,
+				boolean active)
+		throws PortalException {
+
+		_layoutModelResourcePermission.check(
+			getPermissionChecker(), plid, ActionKeys.UPDATE);
+
+		return layoutPageTemplateStructureRelElementVariationLocalService.
+			updateLayoutPageTemplateStructureRelElementVariation(
+				externalReferenceCode, groupId, active);
+	}
+
 	@Reference(
 		target = "(model.class.name=com.liferay.portal.kernel.model.Layout)"
 	)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95644

## What Is Being Fixed

The element variations sidebar in the content page editor was missing management capabilities and polish. The list flickered the raw target element selector before resolving it to the editable name, variations could be created with the same audience on the same page element, there was no way to enable or disable a variation or tell which ones were inactive, and the variation form let you save with required fields empty.

## How It Is Being Fixed

The sidebar layout and styling are refined and the list shows a loading indicator while editable element names resolve, so the raw selector no longer flashes. The audience picker now filters out audiences already used by another variation on the same page element, preventing duplicates. Each variation gains an actions menu with edit, enable/disable, and delete; toggling the active status persists through a new update action command backed by a new service method, and inactive variations are flagged with a label. The variation form validates its required fields before saving, showing an inline error that clears as each field is corrected.

## PR Check

**pr-check: PASS** — tested on `6169b0dbac76ced3b7cda691c829638d73fa257c`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "6169b0dbac76ced3b7cda691c829638d73fa257c"} -->
