### PR TITLE
LPD-98300 Enable LPS-178052 feature flag in elementVariations test

### DIFF
--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/elementVariations.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/elementVariations.spec.ts
@@ -23,6 +23,7 @@ const test = mergeTests(
 	dataApiHelpersTest,
 	featureFlagsTest({
 		'LPD-85746': {enabled: true},
+		'LPS-178052': {enabled: true},
 	}),
 	isolatedSiteTest,
 	loginTest(),


### PR DESCRIPTION
Enables the  feature flag in the  Playwright test () so the test runs with the segments/experiences flag it depends on.

Supersedes #18739, which enabled the wrong flag () and was closed without merging.