### PR TITLE
LPD-98476 Add scope indicators to fragment sets

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/actions/updateFragments.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/actions/updateFragments.ts
@@ -20,11 +20,20 @@ export interface FragmentEntry {
 	type: FragmentEntryType;
 }
 
+export type ScopeType = 'design-library' | 'global' | 'site';
+
+export interface FragmentSetScope {
+	id: string;
+	label: string;
+	type: ScopeType;
+}
+
 export interface FragmentSet {
 	deprecated: boolean;
 	fragmentCollectionId: string;
 	fragmentEntries: Array<FragmentEntry | FragmentComposition>;
 	name: string;
+	scope?: FragmentSetScope;
 }
 
 export default function updateFragments({

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/FragmentsSidebar.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/FragmentsSidebar.js
@@ -159,6 +159,7 @@ export default function FragmentsSidebar() {
 					collectionId: collection.fragmentCollectionId,
 					deprecated: collection.deprecated,
 					label: collection.name,
+					scope: collection.scope,
 				})),
 				id: COLLECTION_IDS.fragments,
 				label: Liferay.Language.get('fragments'),

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/ScopeIndicator.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/ScopeIndicator.tsx
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayIcon from '@clayui/icon';
+import ClaySticker from '@clayui/sticker';
+import React from 'react';
+
+import {FragmentSetScope} from '../../../app/actions/updateFragments';
+
+const INDICATORS = {
+	'design-library': {
+		className: 'page-editor__scope-indicator--design-library',
+		symbol: 'books-brush',
+	},
+	'global': {
+		className: 'page-editor__scope-indicator--global',
+		symbol: 'globe-lines',
+	},
+} as const;
+
+export function ScopeIndicator({scope}: {scope?: FragmentSetScope}) {
+	if (!scope) {
+		return null;
+	}
+
+	const indicator = INDICATORS[scope.type as keyof typeof INDICATORS];
+
+	if (!indicator) {
+		return null;
+	}
+
+	const title =
+		scope.type === 'global'
+			? Liferay.Language.get('global-site')
+			: scope.label;
+
+	return (
+		<ClaySticker
+			className={`c-ml-1 flex-shrink-0 lfr-portal-tooltip page-editor__scope-indicator rounded ${indicator.className}`}
+			data-tooltip-align="top"
+			displayType="unstyled"
+			size="sm"
+			title={title}
+		>
+			<ClayIcon symbol={indicator.symbol} />
+		</ClaySticker>
+	);
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabCollection.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabCollection.js
@@ -14,6 +14,7 @@ import {HIGHLIGHTED_COLLECTION_ID} from '../../../app/config/constants/highlight
 import {LIST_ITEM_TYPES} from '../../../app/config/constants/listItemTypes';
 import {config} from '../../../app/config/index';
 import useKeyboardNavigation from '../hooks/useKeyboardNavigation';
+import {ScopeIndicator} from './ScopeIndicator';
 import TabItem from './TabItem';
 
 export default function TabCollection({
@@ -54,6 +55,7 @@ export default function TabCollection({
 			deprecated={collection.deprecated}
 			isSearchResult={isSearchResult}
 			open={open}
+			scope={collection.scope}
 			setOpen={setOpen}
 			title={collection.label}
 		>
@@ -135,6 +137,7 @@ function TabCollectionCollapse({
 	deprecated,
 	isSearchResult,
 	open,
+	scope,
 	setOpen,
 	title,
 }) {
@@ -171,6 +174,8 @@ function TabCollectionCollapse({
 			>
 				<span className="panel-title">
 					<span className="c-mr-2">{title}</span>
+
+					<ScopeIndicator scope={scope} />
 
 					{deprecated ? <FeatureIndicator type="deprecated" /> : null}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_Plugin.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_Plugin.scss
@@ -1,4 +1,5 @@
 @import 'FragmentsSidebar';
+@import 'ScopeIndicator';
 @import 'SearchResultsPanel';
 @import 'TabCollection';
 @import 'TabItem';

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_ScopeIndicator.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_ScopeIndicator.scss
@@ -1,0 +1,13 @@
+html#{$cadmin-selector} .cadmin {
+	.page-editor__scope-indicator {
+		&--design-library {
+			background-color: $cadmin-teal-l5;
+			color: $cadmin-teal;
+		}
+
+		&--global {
+			background-color: $cadmin-blue-l5;
+			color: $cadmin-blue;
+		}
+	}
+}

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/fragments_and_widgets/components/ScopeIndicator.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/fragments_and_widgets/components/ScopeIndicator.test.js
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {render} from '@testing-library/react';
+import React from 'react';
+
+import {ScopeIndicator} from '../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/ScopeIndicator';
+
+describe('ScopeIndicator', () => {
+	it('renders the global sticker with the global-site tooltip', () => {
+		const {container} = render(
+			<ScopeIndicator
+				scope={{id: '1', label: 'Global', type: 'global'}}
+			/>
+		);
+
+		const sticker = container.querySelector(
+			'.page-editor__scope-indicator--global'
+		);
+
+		expect(sticker).toBeInTheDocument();
+		expect(sticker).toHaveClass('lfr-portal-tooltip');
+		expect(sticker).toHaveAttribute(
+			'title',
+			Liferay.Language.get('global-site')
+		);
+		expect(
+			container.querySelector('.lexicon-icon-globe-lines')
+		).toBeInTheDocument();
+	});
+
+	it('renders the design library sticker with its name as tooltip', () => {
+		const {container} = render(
+			<ScopeIndicator
+				scope={{id: '2', label: 'Gerardo DL', type: 'design-library'}}
+			/>
+		);
+
+		const sticker = container.querySelector(
+			'.page-editor__scope-indicator--design-library'
+		);
+
+		expect(sticker).toBeInTheDocument();
+		expect(sticker).toHaveAttribute('title', 'Gerardo DL');
+		expect(
+			container.querySelector('.lexicon-icon-books-brush')
+		).toBeInTheDocument();
+	});
+
+	it('renders nothing for a regular site scope', () => {
+		const {container} = render(
+			<ScopeIndicator scope={{id: '3', label: 'My Site', type: 'site'}} />
+		);
+
+		expect(
+			container.querySelector('.page-editor__scope-indicator')
+		).not.toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98476

## What Is Being Fixed

The Components panel in the page editor does not indicate where each fragment
collection comes from. Collections can originate from the current site, the
global site, or a design library, but there is no visual cue for the scope of
each set.

## How It Is Being Fixed

An optional `scope` ({id, label, type}) is added to the `FragmentSet` type. A new
`ScopeIndicator` component renders a Clay sticker next to each collection name
based on the scope type: a blue globe for `global` and a teal books icon for
`design-library`. Regular site collections (and any collection without a scope)
render nothing.

The tooltip reuses the existing `global-site` language key for the global scope
and the design library's own name for design libraries. Colors come from the
Clay chart palette through a small SCSS class, mirroring the existing
design-library sticker pattern.

Because `scope` is optional, collections without it render no sticker, so the UI
behaves exactly as before until the backend starts sending the field.

## PR Check

**pr-check: PASS** — tested on `65887cc19cd22134189e981412abbc082a39e3bd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "65887cc19cd22134189e981412abbc082a39e3bd"} -->
