### PR TITLE
LPD-94450 Make the audience name field an accessible inline input

### DIFF
--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/AudienceBuilder.scss
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/AudienceBuilder.scss
@@ -77,6 +77,29 @@ $toolbar-height: 55px;
 	cursor: grab;
 }
 
+.audience-builder-name {
+	position: relative;
+
+	&::before {
+		background-color: var(--secondary-l0);
+		border-radius: 2px;
+		bottom: 0;
+		content: '';
+		left: 0;
+		position: absolute;
+		top: 0;
+		width: 2px;
+	}
+
+	&:focus-within::before {
+		background-color: transparent;
+	}
+
+	.form-control:not(:focus) {
+		border-color: transparent;
+	}
+}
+
 .audience-builder-rule {
 	border: 2px solid var(--secondary-l3);
 	border-left: 4px solid $indigo;

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/AudienceBuilder.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/AudienceBuilder.tsx
@@ -137,24 +137,26 @@ export default function AudienceBuilder({
 										</span>
 									</label>
 
-									<ClayInput
-										className="bg-white border-0 font-weight-semi-bold h-auto mb-0 p-0 text-8"
-										id={`${namespace}name`}
-										maxLength={NAME_MAX_LENGTH}
-										name={`${namespace}name`}
-										onChange={(event) =>
-											dispatch({
-												name: event.target.value,
-												type: 'SET_NAME',
-											})
-										}
-										placeholder={Liferay.Language.get(
-											'new-audience'
-										)}
-										required
-										type="text"
-										value={state.name}
-									/>
+									<div className="audience-builder-name">
+										<ClayInput
+											className="bg-white font-weight-semi-bold h-auto mb-0 text-8"
+											id={`${namespace}name`}
+											maxLength={NAME_MAX_LENGTH}
+											name={`${namespace}name`}
+											onChange={(event) =>
+												dispatch({
+													name: event.target.value,
+													type: 'SET_NAME',
+												})
+											}
+											placeholder={Liferay.Language.get(
+												'new-audience'
+											)}
+											required
+											type="text"
+											value={state.name}
+										/>
+									</div>
 								</ClayForm.Group>
 
 								<GeneralSettings


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94450

## What Is Being Fixed

The Audience Builder name field rendered as a borderless input disguised as a heading, using the `border-0` utility that also removed the focus outline, so a keyboard user got no visible focus indicator (WCAG 2.4.7 Focus Visible). It also lacked the inline-title affordance the projects (CMP) screens use, so it did not read as an editable field.

## How It Is Being Fixed

The field now matches the inline title input the CMP "New Project" and "New Task" screens use. That input is the built-in `INPUTS-inline-text-input` fragment from the "Inputs" fragment collection, wired to the object title field in the CMP display-page templates. The fragment is FreeMarker plus vanilla JS driven by the page-editor Form container, so it cannot be imported into the audiences React app; its CSS and behavior were replicated instead. The input is wrapped in an `.audience-builder-name` container that draws a 2px left accent bar via a `::before` pseudo-element, and the border is hidden only at rest (`.form-control:not(:focus)`) so Clay's focus ring returns on focus. The accent-bar color uses the theme-aware `var(--secondary-l0)` token rather than the fragment's raw hex.

Styles matched from:

- Fragment styles and markup: `modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/inline-text-input/index.css` and `index.html`
- CMP name/title input usage: `modules/apps/site-initializer/site-initializer-cmp/src/main/resources/site-initializer/layout-page-templates/display-page-templates/project-edit/page-definition.json` (and `task-edit/page-definition.json`), which bind `INPUTS-inline-text-input` to the object `title` field

## Why Are There No Tests?

The change is presentation-only (a CSS accent bar and focus ring). The name field's behavior is already covered by the existing @LPD-94450 Playwright tests in audiences.spec.ts, and asserting computed border/background styles would be brittle. Verified visually with before/after screenshots.

## PR Check

**pr-check: PASS** — tested on `be539eabb230edd361fd5867156c70012de299b9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "be539eabb230edd361fd5867156c70012de299b9"} -->
