### PR TITLE
LPD-98540 Surface Design Library fragments in the Page Editor

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/manager/test/FragmentCollectionManagerTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/manager/test/FragmentCollectionManagerTest.java
@@ -6,28 +6,50 @@
 package com.liferay.layout.content.page.editor.web.internal.manager.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.portal.kernel.feature.flag.constants.FeatureFlagConstants;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.props.test.util.PropsTemporarySwapper;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,6 +67,56 @@ public class FragmentCollectionManagerTest {
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_company = _companyLocalService.getCompany(
+			TestPropsValues.getCompanyId());
+
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	@TestInfo("LPD-98540")
+	public void testGetGroupIds() throws Exception {
+		DepotEntry assetLibraryDepotEntry = _addDepotEntry(
+			DepotConstants.TYPE_ASSET_LIBRARY);
+
+		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+			assetLibraryDepotEntry.getDepotEntryId(), _group.getGroupId());
+
+		DepotEntry designLibraryDepotEntry = _addDepotEntry(
+			DepotConstants.TYPE_DESIGN_LIBRARY);
+
+		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+			designLibraryDepotEntry.getDepotEntryId(), _group.getGroupId());
+
+		_addDepotEntry(DepotConstants.TYPE_DESIGN_LIBRARY);
+
+		try (PropsTemporarySwapper propsTemporarySwapper =
+				new PropsTemporarySwapper(
+					FeatureFlagConstants.getKey("LPD-57283"),
+					Boolean.FALSE.toString())) {
+
+			_testGetGroupIds(
+				new long[] {
+					_company.getGroupId(), _group.getGroupId(),
+					CompanyConstants.SYSTEM
+				});
+		}
+
+		try (PropsTemporarySwapper propsTemporarySwapper =
+				new PropsTemporarySwapper(
+					FeatureFlagConstants.getKey("LPD-57283"),
+					Boolean.TRUE.toString())) {
+
+			_testGetGroupIds(
+				new long[] {
+					_company.getGroupId(), designLibraryDepotEntry.getGroupId(),
+					_group.getGroupId(), CompanyConstants.SYSTEM
+				});
+		}
+	}
 
 	@Test
 	@TestInfo("LPS-162848")
@@ -127,11 +199,90 @@ public class FragmentCollectionManagerTest {
 		}
 	}
 
+	@Test
+	@TestInfo("LPD-98540")
+	public void testGetScopeMap() throws Exception {
+		DepotEntry designLibraryDepotEntry = _addDepotEntry(
+			DepotConstants.TYPE_DESIGN_LIBRARY);
+
+		_testGetScopeMap("design-library", designLibraryDepotEntry.getGroup());
+
+		_testGetScopeMap("global", _company.getGroup());
+		_testGetScopeMap("site", _group);
+
+		Assert.assertNull(
+			_invokeGetScopeMap(CompanyConstants.SYSTEM, new HashMap<>()));
+	}
+
+	private DepotEntry _addDepotEntry(int type) throws Exception {
+		return _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			Collections.emptyMap(), type,
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private Map<String, Object> _invokeGetScopeMap(
+		long groupId, Map<Long, Map<String, Object>> scopeMaps) {
+
+		return ReflectionTestUtil.invoke(
+			_fragmentCollectionManager, "_getScopeMap",
+			new Class<?>[] {long.class, long.class, Locale.class, Map.class},
+			_company.getGroupId(), groupId, LocaleUtil.getDefault(), scopeMaps);
+	}
+
+	private void _testGetGroupIds(long[] expectedGroupIds) throws Exception {
+		long[] groupIds = ReflectionTestUtil.invoke(
+			_fragmentCollectionManager, "_getGroupIds",
+			new Class<?>[] {long.class, long.class, long.class},
+			_group.getCompanyId(), _company.getGroupId(), _group.getGroupId());
+
+		Assert.assertTrue(
+			Arrays.toString(groupIds),
+			ArrayUtil.containsAll(groupIds, expectedGroupIds));
+		Assert.assertEquals(
+			Arrays.toString(groupIds), expectedGroupIds.length,
+			groupIds.length);
+	}
+
+	private void _testGetScopeMap(String expectedType, Group group)
+		throws Exception {
+
+		Map<Long, Map<String, Object>> scopeMaps = new HashMap<>();
+
+		Map<String, Object> scopeMap = _invokeGetScopeMap(
+			group.getGroupId(), scopeMaps);
+
+		Assert.assertEquals(
+			String.valueOf(group.getGroupId()), scopeMap.get("id"));
+		Assert.assertEquals(
+			group.getDescriptiveName(LocaleUtil.getDefault()),
+			scopeMap.get("label"));
+		Assert.assertEquals(expectedType, scopeMap.get("type"));
+		Assert.assertSame(
+			scopeMap, _invokeGetScopeMap(group.getGroupId(), scopeMaps));
+	}
+
+	private Company _company;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
 	@Inject(
 		filter = "component.name=com.liferay.layout.content.page.editor.web.internal.manager.FragmentCollectionManager",
 		type = Inject.NoType.class
 	)
 	private Object _fragmentCollectionManager;
+
+	@DeleteAfterTestRun
+	private Group _group;
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FragmentCollectionManager.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FragmentCollectionManager.java
@@ -63,6 +63,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -112,6 +113,8 @@ public class FragmentCollectionManager {
 					themeDisplay.getCompanyId(),
 					themeDisplay.getCompanyGroupId(), groupId));
 
+		Map<Long, Map<String, Object>> scopeMapsByGroupId = new HashMap<>();
+
 		for (FragmentCollection fragmentCollection : fragmentCollections) {
 			if (!includeSystem &&
 				(fragmentCollection.getGroupId() !=
@@ -153,6 +156,12 @@ public class FragmentCollectionManager {
 					"fragmentEntries", fragmentEntryMapsList
 				).put(
 					"name", fragmentCollection.getName()
+				).put(
+					"scope",
+					_getScopeMap(
+						themeDisplay.getCompanyGroupId(),
+						fragmentCollection.getGroupId(),
+						themeDisplay.getLocale(), scopeMapsByGroupId)
 				).build());
 		}
 
@@ -533,6 +542,40 @@ public class FragmentCollectionManager {
 					groupId, DepotConstants.TYPE_DESIGN_LIBRARY,
 					QueryUtil.ALL_POS, QueryUtil.ALL_POS),
 				DepotEntry::getGroupId));
+	}
+
+	private Map<String, Object> _getScopeMap(
+			long companyGroupId, long groupId, Locale locale,
+			Map<Long, Map<String, Object>> scopeMaps)
+		throws PortalException {
+
+		if ((groupId > 0) && !scopeMaps.containsKey(groupId)) {
+			Group group = _groupLocalService.getGroup(groupId);
+
+			scopeMaps.put(
+				groupId,
+				HashMapBuilder.<String, Object>put(
+					"id", String.valueOf(groupId)
+				).put(
+					"label", group.getDescriptiveName(locale)
+				).put(
+					"type", _getScopeType(companyGroupId, group)
+				).build());
+		}
+
+		return scopeMaps.get(groupId);
+	}
+
+	private String _getScopeType(long companyGroupId, Group group) {
+		if (group.getGroupId() == companyGroupId) {
+			return "global";
+		}
+
+		if (group.isDepot()) {
+			return "design-library";
+		}
+
+		return "site";
 	}
 
 	private List<Map<String, Object>> _getSortedFragmentCollectionMapsList(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FragmentCollectionManager.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FragmentCollectionManager.java
@@ -100,10 +100,7 @@ public class FragmentCollectionManager {
 
 		List<FragmentCollection> fragmentCollections =
 			_fragmentCollectionService.getFragmentCollections(
-				new long[] {
-					themeDisplay.getCompanyGroupId(), groupId,
-					CompanyConstants.SYSTEM
-				});
+				_getGroupIds(themeDisplay.getCompanyGroupId(), groupId));
 
 		for (FragmentCollection fragmentCollection : fragmentCollections) {
 			if (!includeSystem &&
@@ -507,6 +504,10 @@ public class FragmentCollectionManager {
 		}
 
 		return fragmentEntryKey + StringPool.POUND + group.getGroupKey();
+	}
+
+	private long[] _getGroupIds(long companyGroupId, long groupId) {
+		return new long[] {companyGroupId, groupId, CompanyConstants.SYSTEM};
 	}
 
 	private List<Map<String, Object>> _getSortedFragmentCollectionMapsList(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FragmentCollectionManager.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FragmentCollectionManager.java
@@ -5,6 +5,9 @@
 
 package com.liferay.layout.content.page.editor.web.internal.manager;
 
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.contributor.FragmentCollectionContributor;
 import com.liferay.fragment.contributor.FragmentCollectionContributorRegistry;
@@ -27,6 +30,9 @@ import com.liferay.layout.util.PortalPreferencesUtil;
 import com.liferay.layout.util.structure.DropZoneLayoutStructureItem;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactory;
@@ -41,6 +47,7 @@ import com.liferay.portal.kernel.portlet.PortletPreferencesFactory;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -71,10 +78,11 @@ import org.osgi.service.component.annotations.Reference;
 public class FragmentCollectionManager {
 
 	public List<Map<String, Object>> getFragmentCollectionMapsList(
-		long groupId, HttpServletRequest httpServletRequest,
-		boolean includeEmpty, boolean includeSystem,
-		DropZoneLayoutStructureItem masterDropZoneLayoutStructureItem,
-		ThemeDisplay themeDisplay) {
+			long groupId, HttpServletRequest httpServletRequest,
+			boolean includeEmpty, boolean includeSystem,
+			DropZoneLayoutStructureItem masterDropZoneLayoutStructureItem,
+			ThemeDisplay themeDisplay)
+		throws PortalException {
 
 		List<Map<String, Object>> allFragmentCollectionMapsList =
 			new ArrayList<>();
@@ -100,7 +108,9 @@ public class FragmentCollectionManager {
 
 		List<FragmentCollection> fragmentCollections =
 			_fragmentCollectionService.getFragmentCollections(
-				_getGroupIds(themeDisplay.getCompanyGroupId(), groupId));
+				_getGroupIds(
+					themeDisplay.getCompanyId(),
+					themeDisplay.getCompanyGroupId(), groupId));
 
 		for (FragmentCollection fragmentCollection : fragmentCollections) {
 			if (!includeSystem &&
@@ -506,8 +516,23 @@ public class FragmentCollectionManager {
 		return fragmentEntryKey + StringPool.POUND + group.getGroupKey();
 	}
 
-	private long[] _getGroupIds(long companyGroupId, long groupId) {
-		return new long[] {companyGroupId, groupId, CompanyConstants.SYSTEM};
+	private long[] _getGroupIds(
+			long companyId, long companyGroupId, long groupId)
+		throws PortalException {
+
+		long[] groupIds = {companyGroupId, groupId, CompanyConstants.SYSTEM};
+
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-57283")) {
+			return groupIds;
+		}
+
+		return ArrayUtil.append(
+			groupIds,
+			TransformUtil.transformToLongArray(
+				_depotEntryLocalService.getGroupConnectedDepotEntries(
+					groupId, DepotConstants.TYPE_DESIGN_LIBRARY,
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+				DepotEntry::getGroupId));
 	}
 
 	private List<Map<String, Object>> _getSortedFragmentCollectionMapsList(
@@ -692,6 +717,9 @@ public class FragmentCollectionManager {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		FragmentCollectionManager.class);
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Reference
 	private FragmentCollectionContributorRegistry


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98540

## What Is Being Fixed

When editing a page, the Content Page Editor only surfaces fragment collections from the current site and company scope. Fragment collections defined in Design Library depots connected to the site are not offered, so authors cannot reuse them from the editor.

## How It Is Being Fixed

`FragmentCollectionManager` now folds the group ids of every connected Design Library depot into the scope set used to look up fragment collections, gated by feature flag `LPD-57283`. A new `_getGroupIds` helper centralizes the resolution, and the fragment collection maps carry a scope value so consumers can tell site, company, and Design Library entries apart. An integration test exercises the scope resolution against a site with a connected Design Library depot.

## PR Check

**pr-check: PASS** — tested on `c7a8d8f73b6bb0ee59e302624c5b73435738102f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c7a8d8f73b6bb0ee59e302624c5b73435738102f"} -->
