### PR TITLE
LPD-98455 Do not HTML-encode the embedded page URL

### DIFF
--- a/modules/apps/layout/layout-type-controller/layout-type-controller-embedded/src/main/resources/META-INF/resources/layout/init.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-embedded/src/main/resources/META-INF/resources/layout/init.jsp
@@ -13,7 +13,6 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 <%@ page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.model.Layout" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
-page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.UnicodeProperties" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %>
 

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-embedded/src/main/resources/META-INF/resources/layout/view/embedded_js.jspf
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-embedded/src/main/resources/META-INF/resources/layout/view/embedded_js.jspf
@@ -12,7 +12,7 @@ UnicodeProperties typeSettingsUnicodeProperties = layout.getTypeSettingsProperti
 <liferay-frontend:component
 	context='<%=
 		HashMapBuilder.<String, Object>put(
-			"url", HtmlUtil.escapeHREF(typeSettingsUnicodeProperties.getProperty("embeddedLayoutURL"))
+			"url", typeSettingsUnicodeProperties.getProperty("embeddedLayoutURL")
 		).build()
 	%>'
 	module="{embedded} from layout-type-controller-embedded"

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/embedded/internal/layout/type/controller/test/EmbeddedLayoutTypeControllerTest.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/embedded/internal/layout/type/controller/test/EmbeddedLayoutTypeControllerTest.java
@@ -1,0 +1,140 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.type.controller.embedded.internal.layout.type.controller.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
+import com.liferay.portal.kernel.model.LayoutTypeController;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.servlet.HttpMethods;
+import com.liferay.portal.kernel.servlet.taglib.aui.ScriptData;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.util.LayoutTypeControllerTracker;
+
+import java.io.StringWriter;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Rubén Pulido
+ */
+@RunWith(Arquillian.class)
+public class EmbeddedLayoutTypeControllerTest {
+
+	@ClassRule
+	@Rule
+	public static AggregateTestRule aggregateTestRule = new AggregateTestRule(
+		new LiferayIntegrationTestRule(),
+		PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_layout = LayoutTestUtil.addTypeEmbeddedLayout(_group.getGroupId());
+
+		_layoutTypeController =
+			LayoutTypeControllerTracker.getLayoutTypeController(
+				LayoutConstants.TYPE_EMBEDDED);
+	}
+
+	@Test
+	@TestInfo("LPD-98455")
+	public void testIncludeLayoutContent() throws Exception {
+		String queryString = StringBundler.concat(
+			"parameter1=", RandomTestUtil.randomString(),
+			"&parameter2=</script><script>alert(",
+			RandomTestUtil.randomString(), ")</script>");
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		_includeLayoutContent(
+			"http://example.com?" + queryString, mockHttpServletRequest);
+
+		StringWriter stringWriter = new StringWriter();
+
+		ScriptData scriptData = (ScriptData)mockHttpServletRequest.getAttribute(
+			WebKeys.AUI_SCRIPT_DATA);
+
+		scriptData.writeTo(stringWriter);
+
+		String content = String.valueOf(stringWriter.getBuffer());
+
+		Assert.assertTrue(
+			content,
+			content.contains(
+				StringUtil.replace(queryString, CharPool.SLASH, "\\/")));
+	}
+
+	private void _includeLayoutContent(
+			String embeddedLayoutURL,
+			MockHttpServletRequest mockHttpServletRequest)
+		throws Exception {
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			_layout.getTypeSettingsProperties();
+
+		typeSettingsUnicodeProperties.setProperty(
+			"embeddedLayoutURL", embeddedLayoutURL);
+
+		_layout.setTypeSettingsProperties(typeSettingsUnicodeProperties);
+
+		_layout = _layoutLocalService.updateLayout(_layout);
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY,
+			ContentLayoutTestUtil.getThemeDisplay(
+				_companyLocalService.fetchCompany(
+					TestPropsValues.getCompanyId()),
+				_group, _layout));
+
+		mockHttpServletRequest.setMethod(HttpMethods.GET);
+
+		_layoutTypeController.includeLayoutContent(
+			mockHttpServletRequest, new MockHttpServletResponse(), _layout);
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Layout _layout;
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
+
+	private LayoutTypeController _layoutTypeController;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98455

LPD associated to a fire LPP, please treat with priority.

## What Is Being Fixed

Embedded layout pages render their configured URL into a `liferay-frontend:component` context that is JSON-serialized into a `<script>` block. Since LPD-61035, the URL was wrapped in `HtmlUtil.escapeHREF(...)`, which HTML-entity-encodes it, so every `&` in the query string became `&amp;` and the embedded iframe received a corrupted URL. This is a regression of LPS-202245, reported by a customer as LPP-64709.

## How It Is Being Fixed

The `escapeHREF` wrapper is removed and the raw `embeddedLayoutURL` is passed into the component context, matching how URLs are handled across the portal: values placed in a component context are passed raw, and the JSON serializer is the escaping layer. The security property behind LPS-202245 is preserved by `JSONSerializerImpl`'s strict string encoding, which escapes `/` as `\/`, so a stored `</script>` renders as `<\/script>` and cannot break out of the script element. The now-unused `HtmlUtil` import is dropped from `init.jsp`. A new integration test stores a URL whose query string carries both a raw `&` and a `</script><script>...</script>` payload, then asserts the rendered script keeps the `&` intact and escapes the slashes, covering both the corruption fix and the no-breakout property.

## PR Check

**pr-check: PASS** — tested on `ac33c2e1c8908589631556ff6dd0832aa433d375`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "ac33c2e1c8908589631556ff6dd0832aa433d375"} -->
