### PR TITLE
LPD-98697 Prevent URL configuration field crash when value is undefined

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment_configuration_fields/URLField.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment_configuration_fields/URLField.js
@@ -27,7 +27,7 @@ const SOURCE_OPTIONS = [
 	},
 ];
 
-export default function URLField({field, onValueSelect, value}) {
+export default function URLField({field, onValueSelect, value = {}}) {
 	const [nextHref, setNextHref] = useControlledState(value.href || '');
 
 	const [source, setSource] = useState(SOURCE_OPTION_MANUAL);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98697

## What Is Being Fixed

The URLField fragment configuration component destructures value.href, but the
value prop can be undefined when the field has no stored configuration. When
that happens the component throws and the URL configuration field is unusable,
as exercised by the "Allows using a configuration of type url" test.

## How It Is Being Fixed

Default the value prop to an empty object in URLField, so reading value.href
yields an empty string instead of throwing when no configuration is stored.

## Why Are There No Tests?

The existing Playwright test "General Configuration > Allows using a
configuration of type url" (fragmentConfiguration.spec.ts) already covers this
flow; this one-line guard makes that test pass, so no new test is added.

## PR Check

**pr-check: PASS** — tested on `e2f861685a79563190d29bb97b77f0e3eeba1083`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "e2f861685a79563190d29bb97b77f0e3eeba1083"} -->
