### PR TITLE
LPD-98538 Block propagation and usages for Design Library fragments

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
@@ -981,10 +981,14 @@ public class FragmentEntryLocalServiceImpl
 	private void _propagateChanges(FragmentEntry fragmentEntry)
 		throws PortalException {
 
+		Group group = _groupLocalService.getGroup(fragmentEntry.getGroupId());
+
+		if (group.isDepot()) {
+			return;
+		}
+
 		ActionableDynamicQuery actionableDynamicQuery =
 			_fragmentEntryLinkLocalService.getActionableDynamicQuery();
-
-		Group group = _groupLocalService.getGroup(fragmentEntry.getGroupId());
 
 		actionableDynamicQuery.setAddCriteriaMethod(
 			dynamicQuery -> {

--- a/modules/apps/fragment/fragment-test/build.gradle
+++ b/modules/apps/fragment/fragment-test/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-api")
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
 	testIntegrationImplementation project(":apps:configuration-admin:configuration-admin-api")
+	testIntegrationImplementation project(":apps:depot:depot-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
@@ -6,24 +6,35 @@
 package com.liferay.fragment.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.fragment.configuration.FragmentServiceConfiguration;
 import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.exception.DuplicateFragmentEntryExternalReferenceCodeException;
 import com.liferay.fragment.exception.NoSuchEntryException;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.fragment.service.FragmentEntryLocalService;
 import com.liferay.fragment.test.util.FragmentEntryTestUtil;
 import com.liferay.fragment.test.util.FragmentTestUtil;
 import com.liferay.fragment.util.comparator.FragmentEntryCreateDateComparator;
 import com.liferay.fragment.util.comparator.FragmentEntryNameComparator;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -31,18 +42,24 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ScopeUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
 
 import java.sql.Timestamp;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assert;
@@ -61,7 +78,9 @@ public class FragmentEntryLocalServiceTest {
 	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {
@@ -210,6 +229,7 @@ public class FragmentEntryLocalServiceTest {
 	}
 
 	@Test
+	@TestInfo("LPD-98538")
 	public void testUpdateFragmentEntry() throws Exception {
 		_testUpdateFragmentEntryFragmentCollectionId();
 		_testUpdateFragmentEntryName();
@@ -219,6 +239,36 @@ public class FragmentEntryLocalServiceTest {
 		_testUpdateFragmentEntryWithCacheable();
 		_testUpdateFragmentEntryWithHtmlWithAmpersand();
 		_testUpdateFragmentEntryWithPreviewFileEntryId();
+		_testUpdateFragmentEntryWithPropagateChanges();
+	}
+
+	private FragmentEntry _addFragmentEntry(long groupId) throws Exception {
+		FragmentCollection fragmentCollection =
+			FragmentTestUtil.addFragmentCollection(groupId);
+
+		return FragmentEntryTestUtil.addFragmentEntry(
+			fragmentCollection.getFragmentCollectionId());
+	}
+
+	private FragmentEntryLink _addFragmentEntryLink(
+			FragmentEntry fragmentEntry, Layout layout,
+			long segmentsExperienceId)
+		throws Exception {
+
+		FragmentEntryLink fragmentEntryLink =
+			ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+				null, fragmentEntry.getCss(), fragmentEntry.getConfiguration(),
+				fragmentEntry.getExternalReferenceCode(),
+				ScopeUtil.getItemScopeExternalReferenceCode(
+					fragmentEntry.getGroupId(), layout.getGroupId()),
+				fragmentEntry.getHtml(), fragmentEntry.getJs(), layout,
+				fragmentEntry.getFragmentEntryKey(), fragmentEntry.getType(),
+				null, 0, segmentsExperienceId);
+
+		Assert.assertEquals(
+			fragmentEntry.getHtml(), fragmentEntryLink.getHtml());
+
+		return fragmentEntryLink;
 	}
 
 	private void _assertCopyFragmentEntry(
@@ -236,6 +286,16 @@ public class FragmentEntryLocalServiceTest {
 			fragmentEntry.getStatus(), copyFragmentEntry.getStatus());
 		Assert.assertEquals(
 			fragmentEntry.getType(), copyFragmentEntry.getType());
+	}
+
+	private void _assertFragmentEntryLinkHTML(
+		long fragmentEntryLinkId, String html) {
+
+		FragmentEntryLink fragmentEntryLink =
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				fragmentEntryLinkId);
+
+		Assert.assertEquals(html, fragmentEntryLink.getHtml());
 	}
 
 	private String _read(String fileName) throws Exception {
@@ -1226,7 +1286,90 @@ public class FragmentEntryLocalServiceTest {
 			previewFileEntryId + 1, fragmentEntry.getPreviewFileEntryId());
 	}
 
+	private void _testUpdateFragmentEntryWithPropagateChanges()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		long segmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				draftLayout.getPlid());
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			Collections.emptyMap(), DepotConstants.TYPE_DESIGN_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
+
+		FragmentEntry depotFragmentEntry = _addFragmentEntry(
+			depotEntry.getGroupId());
+
+		FragmentEntryLink depotFragmentEntryLink = _addFragmentEntryLink(
+			depotFragmentEntry, draftLayout, segmentsExperienceId);
+
+		FragmentEntry siteFragmentEntry = _addFragmentEntry(
+			_group.getGroupId());
+
+		FragmentEntryLink siteFragmentEntryLink = _addFragmentEntryLink(
+			siteFragmentEntry, draftLayout, segmentsExperienceId);
+
+		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
+
+		String originalHTML = depotFragmentEntry.getHtml();
+
+		String updatedHTML = RandomTestUtil.randomString();
+
+		_updateFragmentEntriesWithPropagateChanges(
+			updatedHTML, depotFragmentEntry, siteFragmentEntry);
+
+		_assertFragmentEntryLinkHTML(
+			depotFragmentEntryLink.getFragmentEntryLinkId(), originalHTML);
+		_assertFragmentEntryLinkHTML(
+			siteFragmentEntryLink.getFragmentEntryLinkId(), updatedHTML);
+	}
+
+	private void _updateFragmentEntriesWithPropagateChanges(
+			String html, FragmentEntry... fragmentEntries)
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						FragmentServiceConfiguration.class.getName(),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"propagateChanges", true
+						).build())) {
+
+			for (FragmentEntry fragmentEntry : fragmentEntries) {
+				FragmentEntry updatedFragmentEntry =
+					_fragmentEntryLocalService.updateFragmentEntry(
+						TestPropsValues.getUserId(),
+						fragmentEntry.getFragmentEntryId(),
+						fragmentEntry.getFragmentCollectionId(),
+						fragmentEntry.getName(), fragmentEntry.getCss(), html,
+						fragmentEntry.getJs(), false,
+						fragmentEntry.getConfiguration(),
+						fragmentEntry.getIcon(),
+						fragmentEntry.getPreviewFileEntryId(), false,
+						fragmentEntry.getTypeOptions(),
+						WorkflowConstants.STATUS_APPROVED);
+
+				Assert.assertEquals(html, updatedFragmentEntry.getHtml());
+			}
+		}
+	}
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
 	private FragmentCollection _fragmentCollection;
+
+	@Inject
+	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
 
 	@Inject
 	private FragmentEntryLocalService _fragmentEntryLocalService;
@@ -1236,6 +1379,9 @@ public class FragmentEntryLocalServiceTest {
 
 	@Inject
 	private Language _language;
+
+	@Inject
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
 
 	private FragmentCollection _updatedFragmentCollection;
 

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProvider.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProvider.java
@@ -11,6 +11,7 @@ import com.liferay.fragment.constants.FragmentPortletKeys;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.web.internal.configuration.FragmentPortletConfiguration;
 import com.liferay.fragment.web.internal.security.permission.resource.FragmentPermission;
+import com.liferay.fragment.web.internal.util.DesignLibraryUtil;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.item.selector.ItemSelector;
@@ -139,7 +140,9 @@ public class BasicFragmentEntryActionDropdownItemsProvider {
 							hasManageFragmentEntriesPermission &&
 							!_fragmentEntry.isReadOnly() &&
 							(_fragmentEntry.getGroupId() !=
-								_themeDisplay.getCompanyGroupId()),
+								_themeDisplay.getCompanyGroupId()) &&
+							!DesignLibraryUtil.isDesignLibraryScope(
+								_themeDisplay.getScopeGroup()),
 						_getViewFragmentEntryUsagesActionUnsafeConsumer()
 					).build());
 				dropdownGroupItem.setSeparator(true);

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProviderTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProviderTest.java
@@ -51,6 +51,30 @@ public class BasicFragmentEntryActionDropdownItemsProviderTest
 	}
 
 	@Test
+	@TestInfo("LPD-63087")
+	public void testGetActionDropdownItemsForMarketplaceFragmentEntry()
+		throws Exception {
+
+		setUpFragmentPermission(true);
+
+		Mockito.when(
+			_fragmentEntry.isMarketplace()
+		).thenReturn(
+			true
+		);
+
+		BasicFragmentEntryActionDropdownItemsProvider
+			basicFragmentEntryActionDropdownItemsProvider =
+				new BasicFragmentEntryActionDropdownItemsProvider(
+					_fragmentEntry, renderRequest, renderResponse);
+
+		assertDropdownItemsInCorrectOrder(
+			basicFragmentEntryActionDropdownItemsProvider.
+				getActionDropdownItems(),
+			"rename", "view-site-usages", "move", "delete");
+	}
+
+	@Test
 	@TestInfo({"LPS-122082", "LPS-122641"})
 	public void testGetActionDropdownItemsForReactFragmentEntry()
 		throws Exception {
@@ -136,30 +160,6 @@ public class BasicFragmentEntryActionDropdownItemsProviderTest
 				"edit", "change-thumbnail", "rename", "mark-as-cacheable",
 				"export", "make-a-copy", "move", "delete");
 		}
-	}
-
-	@Test
-	@TestInfo("LPD-63087")
-	public void testGetActionDropdownItemsForMarketplaceFragmentEntry()
-		throws Exception {
-
-		setUpFragmentPermission(true);
-
-		Mockito.when(
-			_fragmentEntry.isMarketplace()
-		).thenReturn(
-			true
-		);
-
-		BasicFragmentEntryActionDropdownItemsProvider
-			basicFragmentEntryActionDropdownItemsProvider =
-				new BasicFragmentEntryActionDropdownItemsProvider(
-					_fragmentEntry, renderRequest, renderResponse);
-
-		assertDropdownItemsInCorrectOrder(
-			basicFragmentEntryActionDropdownItemsProvider.
-				getActionDropdownItems(),
-			"rename", "view-site-usages", "move", "delete");
 	}
 
 	@Test

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProviderTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProviderTest.java
@@ -6,13 +6,17 @@
 package com.liferay.fragment.web.internal.servlet.taglib.util;
 
 import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.web.internal.util.DesignLibraryUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 /**
@@ -82,6 +86,56 @@ public class BasicFragmentEntryActionDropdownItemsProviderTest
 			basicFragmentEntryActionDropdownItemsProvider.
 				getActionDropdownItems(),
 			"edit", "make-a-copy");
+	}
+
+	@Test
+	@TestInfo("LPD-98538")
+	public void testGetActionDropdownItemsForSiteScopedFragmentEntry()
+		throws Exception {
+
+		setUpFragmentPermission(true);
+		_setUpFragmentEntry(false, false, false);
+
+		Mockito.when(
+			_fragmentEntry.getGroupId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		BasicFragmentEntryActionDropdownItemsProvider
+			basicFragmentEntryActionDropdownItemsProvider =
+				new BasicFragmentEntryActionDropdownItemsProvider(
+					_fragmentEntry, renderRequest, renderResponse);
+
+		try (MockedStatic<DesignLibraryUtil> designLibraryUtilMockedStatic =
+				Mockito.mockStatic(DesignLibraryUtil.class)) {
+
+			designLibraryUtilMockedStatic.when(
+				() -> DesignLibraryUtil.isDesignLibraryScope(
+					Mockito.nullable(Group.class))
+			).thenReturn(
+				false
+			);
+
+			assertDropdownItemsInCorrectOrder(
+				basicFragmentEntryActionDropdownItemsProvider.
+					getActionDropdownItems(),
+				"edit", "change-thumbnail", "rename", "mark-as-cacheable",
+				"view-usages", "export", "make-a-copy", "move", "delete");
+
+			designLibraryUtilMockedStatic.when(
+				() -> DesignLibraryUtil.isDesignLibraryScope(
+					Mockito.nullable(Group.class))
+			).thenReturn(
+				true
+			);
+
+			assertDropdownItemsInCorrectOrder(
+				basicFragmentEntryActionDropdownItemsProvider.
+					getActionDropdownItems(),
+				"edit", "change-thumbnail", "rename", "mark-as-cacheable",
+				"export", "make-a-copy", "move", "delete");
+		}
 	}
 
 	@Test

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProviderTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProviderTest.java
@@ -140,7 +140,7 @@ public class BasicFragmentEntryActionDropdownItemsProviderTest
 
 	@Test
 	@TestInfo("LPD-63087")
-	public void testGetActionDropdownItemstForMarketplaceFragmentEntry()
+	public void testGetActionDropdownItemsForMarketplaceFragmentEntry()
 		throws Exception {
 
 		setUpFragmentPermission(true);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98538

## What Is Being Fixed

Design Library fragment entries were being treated like site-level fragments in two flows. The propagate-changes background job walked the fragment entry links of a depot's fragments across every site, and the "View Usages" action on the fragment card was still surfaced when the fragment lived in a Design Library scope where the site-usages view does not apply.

## How It Is Being Fixed

`FragmentEntryLocalServiceImpl._propagateChanges` now returns early when the fragment entry belongs to a depot group, so propagation stops for Design Libraries by construction. `BasicFragmentEntryActionDropdownItemsProvider` also excludes the "View Usages" action when the current scope is a Design Library, gated by `DesignLibraryUtil.isDesignLibraryScope(...)`. Integration coverage in `FragmentEntryLocalServiceTest` verifies both a depot fragment entry link and a site fragment entry link, asserting only the site link is propagated; the unit test in `BasicFragmentEntryActionDropdownItemsProviderTest` asserts the "View Usages" action toggles as expected across scopes.

## PR Check

**pr-check: PASS** — tested on `009eaba9dc497d0614d4884854ea05809ead16f2`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "009eaba9dc497d0614d4884854ea05809ead16f2"} -->
