### PR TITLE
LPD-98455 Do not HTML-encode the embedded page URL

### DIFF
--- a/modules/apps/layout/layout-type-controller/layout-type-controller-embedded/src/main/resources/META-INF/resources/layout/init.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-embedded/src/main/resources/META-INF/resources/layout/init.jsp
@@ -13,6 +13,7 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 <%@ page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.model.Layout" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
+page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.UnicodeProperties" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %>
 

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-embedded/src/main/resources/META-INF/resources/layout/init.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-embedded/src/main/resources/META-INF/resources/layout/init.jsp
@@ -13,7 +13,6 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 <%@ page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.model.Layout" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
-page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.UnicodeProperties" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %>
 

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-embedded/src/main/resources/META-INF/resources/layout/view/embedded_js.jspf
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-embedded/src/main/resources/META-INF/resources/layout/view/embedded_js.jspf
@@ -12,7 +12,7 @@ UnicodeProperties typeSettingsUnicodeProperties = layout.getTypeSettingsProperti
 <liferay-frontend:component
 	context='<%=
 		HashMapBuilder.<String, Object>put(
-			"url", HtmlUtil.escapeHREF(typeSettingsUnicodeProperties.getProperty("embeddedLayoutURL"))
+			"url", typeSettingsUnicodeProperties.getProperty("embeddedLayoutURL")
 		).build()
 	%>'
 	module="{embedded} from layout-type-controller-embedded"

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-embedded/src/main/resources/META-INF/resources/layout/view/embedded_js.jspf
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-embedded/src/main/resources/META-INF/resources/layout/view/embedded_js.jspf
@@ -12,7 +12,7 @@ UnicodeProperties typeSettingsUnicodeProperties = layout.getTypeSettingsProperti
 <liferay-frontend:component
 	context='<%=
 		HashMapBuilder.<String, Object>put(
-			"url", typeSettingsUnicodeProperties.getProperty("embeddedLayoutURL")
+			"url", HtmlUtil.escapeJSLink(typeSettingsUnicodeProperties.getProperty("embeddedLayoutURL"))
 		).build()
 	%>'
 	module="{embedded} from layout-type-controller-embedded"

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/embedded/internal/layout/type/controller/test/EmbeddedLayoutTypeControllerTest.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/embedded/internal/layout/type/controller/test/EmbeddedLayoutTypeControllerTest.java
@@ -82,6 +82,16 @@ public class EmbeddedLayoutTypeControllerTest {
 			content,
 			content.contains(
 				StringUtil.replace(queryString, CharPool.SLASH, "\\/")));
+
+		String randomString = RandomTestUtil.randomString();
+
+		content = _includeLayoutContent(
+			"javascript:alert(" + randomString + ")");
+
+		Assert.assertFalse(
+			content, content.contains("javascript:alert(" + randomString));
+		Assert.assertTrue(
+			content, content.contains("javascript%3aalert(" + randomString));
 	}
 
 	private String _includeLayoutContent(String embeddedLayoutURL)

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/embedded/internal/layout/type/controller/test/EmbeddedLayoutTypeControllerTest.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/embedded/internal/layout/type/controller/test/EmbeddedLayoutTypeControllerTest.java
@@ -76,7 +76,8 @@ public class EmbeddedLayoutTypeControllerTest {
 			RandomTestUtil.randomString(), ")</script>");
 
 		String content = _includeLayoutContent(
-			"http://example.com?" + queryString);
+			StringBundler.concat(
+				"http://", RandomTestUtil.randomString(), "?", queryString));
 
 		Assert.assertTrue(
 			content,

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/embedded/internal/layout/type/controller/test/EmbeddedLayoutTypeControllerTest.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/embedded/internal/layout/type/controller/test/EmbeddedLayoutTypeControllerTest.java
@@ -75,20 +75,8 @@ public class EmbeddedLayoutTypeControllerTest {
 			"&parameter2=</script><script>alert(",
 			RandomTestUtil.randomString(), ")</script>");
 
-		MockHttpServletRequest mockHttpServletRequest =
-			new MockHttpServletRequest();
-
-		_includeLayoutContent(
-			"http://example.com?" + queryString, mockHttpServletRequest);
-
-		StringWriter stringWriter = new StringWriter();
-
-		ScriptData scriptData = (ScriptData)mockHttpServletRequest.getAttribute(
-			WebKeys.AUI_SCRIPT_DATA);
-
-		scriptData.writeTo(stringWriter);
-
-		String content = String.valueOf(stringWriter.getBuffer());
+		String content = _includeLayoutContent(
+			"http://example.com?" + queryString);
 
 		Assert.assertTrue(
 			content,
@@ -96,9 +84,7 @@ public class EmbeddedLayoutTypeControllerTest {
 				StringUtil.replace(queryString, CharPool.SLASH, "\\/")));
 	}
 
-	private void _includeLayoutContent(
-			String embeddedLayoutURL,
-			MockHttpServletRequest mockHttpServletRequest)
+	private String _includeLayoutContent(String embeddedLayoutURL)
 		throws Exception {
 
 		UnicodeProperties typeSettingsUnicodeProperties =
@@ -111,17 +97,25 @@ public class EmbeddedLayoutTypeControllerTest {
 
 		_layout = _layoutLocalService.updateLayout(_layout);
 
-		mockHttpServletRequest.setAttribute(
-			WebKeys.THEME_DISPLAY,
-			ContentLayoutTestUtil.getThemeDisplay(
+		MockHttpServletRequest mockHttpServletRequest =
+			ContentLayoutTestUtil.getMockHttpServletRequest(
 				_companyLocalService.fetchCompany(
 					TestPropsValues.getCompanyId()),
-				_group, _layout));
+				_group, _layout);
 
 		mockHttpServletRequest.setMethod(HttpMethods.GET);
 
 		_layoutTypeController.includeLayoutContent(
 			mockHttpServletRequest, new MockHttpServletResponse(), _layout);
+
+		ScriptData scriptData = (ScriptData)mockHttpServletRequest.getAttribute(
+			WebKeys.AUI_SCRIPT_DATA);
+
+		StringWriter stringWriter = new StringWriter();
+
+		scriptData.writeTo(stringWriter);
+
+		return String.valueOf(stringWriter.getBuffer());
 	}
 
 	@Inject

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/embedded/internal/layout/type/controller/test/EmbeddedLayoutTypeControllerTest.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/embedded/internal/layout/type/controller/test/EmbeddedLayoutTypeControllerTest.java
@@ -1,0 +1,140 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.type.controller.embedded.internal.layout.type.controller.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
+import com.liferay.portal.kernel.model.LayoutTypeController;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.servlet.HttpMethods;
+import com.liferay.portal.kernel.servlet.taglib.aui.ScriptData;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.util.LayoutTypeControllerTracker;
+
+import java.io.StringWriter;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Rubén Pulido
+ */
+@RunWith(Arquillian.class)
+public class EmbeddedLayoutTypeControllerTest {
+
+	@ClassRule
+	@Rule
+	public static AggregateTestRule aggregateTestRule = new AggregateTestRule(
+		new LiferayIntegrationTestRule(),
+		PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_layout = LayoutTestUtil.addTypeEmbeddedLayout(_group.getGroupId());
+
+		_layoutTypeController =
+			LayoutTypeControllerTracker.getLayoutTypeController(
+				LayoutConstants.TYPE_EMBEDDED);
+	}
+
+	@Test
+	@TestInfo("LPD-98455")
+	public void testIncludeLayoutContent() throws Exception {
+		String queryString = StringBundler.concat(
+			"parameter1=", RandomTestUtil.randomString(),
+			"&parameter2=</script><script>alert(",
+			RandomTestUtil.randomString(), ")</script>");
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		_includeLayoutContent(
+			"http://example.com?" + queryString, mockHttpServletRequest);
+
+		StringWriter stringWriter = new StringWriter();
+
+		ScriptData scriptData = (ScriptData)mockHttpServletRequest.getAttribute(
+			WebKeys.AUI_SCRIPT_DATA);
+
+		scriptData.writeTo(stringWriter);
+
+		String content = String.valueOf(stringWriter.getBuffer());
+
+		Assert.assertTrue(
+			content,
+			content.contains(
+				StringUtil.replace(queryString, CharPool.SLASH, "\\/")));
+	}
+
+	private void _includeLayoutContent(
+			String embeddedLayoutURL,
+			MockHttpServletRequest mockHttpServletRequest)
+		throws Exception {
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			_layout.getTypeSettingsProperties();
+
+		typeSettingsUnicodeProperties.setProperty(
+			"embeddedLayoutURL", embeddedLayoutURL);
+
+		_layout.setTypeSettingsProperties(typeSettingsUnicodeProperties);
+
+		_layout = _layoutLocalService.updateLayout(_layout);
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY,
+			ContentLayoutTestUtil.getThemeDisplay(
+				_companyLocalService.fetchCompany(
+					TestPropsValues.getCompanyId()),
+				_group, _layout));
+
+		mockHttpServletRequest.setMethod(HttpMethods.GET);
+
+		_layoutTypeController.includeLayoutContent(
+			mockHttpServletRequest, new MockHttpServletResponse(), _layout);
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Layout _layout;
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
+
+	private LayoutTypeController _layoutTypeController;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98455

## What Is Being Fixed

The embedded page URL was HTML-encoded before being written into the iframe src, so a URL containing special characters was corrupted — an ampersand became `&amp;`, and `</script>` in a query string became `&lt;\/script&gt;`, leaving the browser to load a broken address. The encoding was redundant because the URL is serialized into JSON inside a script element, where the JSON serializer already escapes quotes, backslashes, and forward slashes, so a stored `</script>` renders as `<\/script>` and cannot close the element.

## How It Is Being Fixed

The `HtmlUtil.escapeHREF()` call is removed from `embedded_js.jspf` so the URL is no longer HTML-encoded. Because `escapeHREF()` also had the side effect of percent-encoding the colon of a `javascript:` URL — the only thing stopping a stored `javascript:alert(...)` from executing when `embedded.js` assigns it to `iframe.src` — the URL is routed through `HtmlUtil.escapeJSLink()` instead, which neutralizes the `javascript:` scheme without HTML-encoding anything else. An integration test covers both cases: a `</script>` breakout in a query string is slash-escaped, and a `javascript:` scheme URL is defused to `javascript%3a`.

## PR Check

**pr-check: PASS** (scoped to the LPD-98455 change) — tested on `60b103363784da40d459fdcd32f8df3781a44b68`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| JSP Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "60b103363784da40d459fdcd32f8df3781a44b68"} -->
