### PR TITLE
LPD-98539 Reject Fragment Composition addition into a Design Library

### DIFF
--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/exception/FragmentCompositionGroupIdException.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/exception/FragmentCompositionGroupIdException.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+package com.liferay.fragment.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class FragmentCompositionGroupIdException extends PortalException {
+
+	public FragmentCompositionGroupIdException() {
+	}
+
+	public FragmentCompositionGroupIdException(String msg) {
+		super(msg);
+	}
+
+	public FragmentCompositionGroupIdException(String msg, Throwable throwable) {
+		super(msg, throwable);
+	}
+
+	public FragmentCompositionGroupIdException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/exception/FragmentCompositionGroupIdException.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/exception/FragmentCompositionGroupIdException.java
@@ -2,6 +2,7 @@
  * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
+
 package com.liferay.fragment.exception;
 
 import com.liferay.portal.kernel.exception.PortalException;
@@ -18,7 +19,9 @@ public class FragmentCompositionGroupIdException extends PortalException {
 		super(msg);
 	}
 
-	public FragmentCompositionGroupIdException(String msg, Throwable throwable) {
+	public FragmentCompositionGroupIdException(
+		String msg, Throwable throwable) {
+
 		super(msg, throwable);
 	}
 

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCompositionLocalService.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCompositionLocalService.java
@@ -428,4 +428,4 @@ public interface FragmentCompositionLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1302643829
+// LIFERAY-SERVICE-BUILDER-HASH:550365415

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/exception/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.11.0
+version 1.12.0

--- a/modules/apps/fragment/fragment-service/service.xml
+++ b/modules/apps/fragment/fragment-service/service.xml
@@ -376,6 +376,7 @@
 		<exception>DuplicateFragmentEntryKey</exception>
 		<exception>FragmentCollectionName</exception>
 		<exception>FragmentCompositionDescription</exception>
+		<exception>FragmentCompositionGroupId</exception>
 		<exception>FragmentCompositionName</exception>
 		<exception>FragmentEntryConfiguration</exception>
 		<exception>FragmentEntryContent</exception>

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCompositionLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCompositionLocalServiceImpl.java
@@ -7,6 +7,7 @@ package com.liferay.fragment.service.impl;
 
 import com.liferay.fragment.exception.DuplicateFragmentCompositionKeyException;
 import com.liferay.fragment.exception.FragmentCompositionDescriptionException;
+import com.liferay.fragment.exception.FragmentCompositionGroupIdException;
 import com.liferay.fragment.exception.FragmentCompositionNameException;
 import com.liferay.fragment.internal.util.FragmentCompositionKeyUtil;
 import com.liferay.fragment.model.FragmentComposition;
@@ -17,12 +18,14 @@ import com.liferay.portal.aop.AopService;
 import com.liferay.portal.dao.orm.custom.sql.CustomSQL;
 import com.liferay.portal.kernel.dao.orm.WildcardMode;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -57,6 +60,8 @@ public class FragmentCompositionLocalServiceImpl
 		throws PortalException {
 
 		// Fragment composition
+
+		_validateGroupId(groupId);
 
 		User user = _userLocalService.getUser(userId);
 
@@ -411,6 +416,14 @@ public class FragmentCompositionLocalServiceImpl
 		}
 	}
 
+	private void _validateGroupId(long groupId) throws PortalException {
+		Group group = _groupLocalService.getGroup(groupId);
+
+		if (group.isDepot()) {
+			throw new FragmentCompositionGroupIdException();
+		}
+	}
+
 	private void _validateName(String name) throws PortalException {
 		if (Validator.isNull(name)) {
 			throw new FragmentCompositionNameException("Name must not be null");
@@ -434,6 +447,9 @@ public class FragmentCompositionLocalServiceImpl
 
 	@Reference
 	private CustomSQL _customSQL;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private PortletFileRepository _portletFileRepository;

--- a/modules/apps/fragment/fragment-test/build.gradle
+++ b/modules/apps/fragment/fragment-test/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-api")
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
 	testIntegrationImplementation project(":apps:configuration-admin:configuration-admin-api")
+	testIntegrationImplementation project(":apps:depot:depot-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/importer/test/FragmentsImporterTest.java
@@ -6,6 +6,9 @@
 package com.liferay.fragment.importer.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.configuration.FragmentServiceConfiguration;
 import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.constants.FragmentExportImportConstants;
@@ -35,12 +38,15 @@ import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ScopeUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.URLUtil;
@@ -57,6 +63,7 @@ import java.io.InputStream;
 import java.net.URL;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
@@ -196,6 +203,44 @@ public class FragmentsImporterTest {
 		Assert.assertEquals(
 			"{SimpleInputField} from @liferay/fragment-impl/api",
 			fieldSetJSONObject.getString("customComponentModule"));
+	}
+
+	@Test
+	@TestInfo("LPD-98539")
+	public void testImportFragmentEntriesIntoDesignLibrarySkipsCompositions()
+		throws Exception {
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			Collections.emptyMap(), DepotConstants.TYPE_DESIGN_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
+
+		List<FragmentsImporterResultEntry> fragmentsImporterResultEntries =
+			_fragmentsImporter.importFragmentEntries(
+				_user.getUserId(), depotEntry.getGroupId(), 0, _file,
+				FragmentsImportStrategy.DO_NOT_OVERWRITE, false);
+
+		_assertFragmentsImporterResultEntries(
+			ListUtil.filter(
+				fragmentsImporterResultEntries,
+				fragmentsImporterResultEntry -> Objects.equals(
+					fragmentsImporterResultEntry.getType(),
+					FragmentsImporterResultEntry.Type.COMPOSITION)),
+			FragmentsImporterResultEntry.Status.INVALID,
+			FragmentsImporterResultEntry.Type.COMPOSITION);
+		_assertFragmentsImporterResultEntries(
+			ListUtil.filter(
+				fragmentsImporterResultEntries,
+				fragmentsImporterResultEntry -> ArrayUtil.contains(
+					new String[] {
+						"Fragment", "Fragment With Icon",
+						"Input Fragment With Type Options"
+					},
+					fragmentsImporterResultEntry.getName())),
+			FragmentsImporterResultEntry.Status.IMPORTED,
+			FragmentsImporterResultEntry.Type.FRAGMENT);
 	}
 
 	@Test
@@ -726,6 +771,27 @@ public class FragmentsImporterTest {
 		}
 	}
 
+	private void _assertFragmentsImporterResultEntries(
+		List<FragmentsImporterResultEntry> fragmentsImporterResultEntries,
+		FragmentsImporterResultEntry.Status status,
+		FragmentsImporterResultEntry.Type type) {
+
+		Assert.assertFalse(
+			fragmentsImporterResultEntries.toString(),
+			fragmentsImporterResultEntries.isEmpty());
+
+		for (FragmentsImporterResultEntry fragmentsImporterResultEntry :
+				fragmentsImporterResultEntries) {
+
+			Assert.assertEquals(
+				fragmentsImporterResultEntry.toString(), status,
+				fragmentsImporterResultEntry.getStatus());
+			Assert.assertEquals(
+				fragmentsImporterResultEntry.toString(), type,
+				fragmentsImporterResultEntry.getType());
+		}
+	}
+
 	private void _deleteFragmentCollections(
 			List<FragmentCollection> fragmentCollections)
 		throws Exception {
@@ -1014,6 +1080,10 @@ public class FragmentsImporterTest {
 		_PATH_DEPENDENCIES + "resources-collection/";
 
 	private Bundle _bundle;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
 	private File _file;
 
 	@Inject

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentCompositionLocalServiceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentCompositionLocalServiceTest.java
@@ -6,7 +6,11 @@
 package com.liferay.fragment.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.exception.DuplicateFragmentCompositionExternalReferenceCodeException;
+import com.liferay.fragment.exception.FragmentCompositionGroupIdException;
 import com.liferay.fragment.exception.FragmentCompositionNameException;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentComposition;
@@ -15,6 +19,7 @@ import com.liferay.fragment.test.util.FragmentTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -22,6 +27,8 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -29,6 +36,8 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PersistenceTestRule;
 import com.liferay.portal.test.rule.TransactionalTestRule;
+
+import java.util.Collections;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -77,6 +86,27 @@ public class FragmentCompositionLocalServiceTest {
 		Assert.assertTrue(
 			Validator.isNotNull(
 				fragmentComposition.getExternalReferenceCode()));
+	}
+
+	@Test(expected = FragmentCompositionGroupIdException.class)
+	@TestInfo("LPD-98539")
+	public void testAddFragmentCompositionInDesignLibrary() throws Exception {
+		DepotEntry designLibraryDepotEntry =
+			_depotEntryLocalService.addDepotEntry(
+				HashMapBuilder.put(
+					LocaleUtil.getDefault(), RandomTestUtil.randomString()
+				).build(),
+				Collections.emptyMap(), DepotConstants.TYPE_DESIGN_LIBRARY,
+				ServiceContextTestUtil.getServiceContext());
+
+		_fragmentCompositionLocalService.addFragmentComposition(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			designLibraryDepotEntry.getGroupId(),
+			_fragmentCollection.getFragmentCollectionId(),
+			StringUtil.randomId(), RandomTestUtil.randomString(),
+			StringPool.BLANK, StringPool.BLANK, 0,
+			WorkflowConstants.STATUS_APPROVED,
+			ServiceContextTestUtil.getServiceContext());
 	}
 
 	@Test(
@@ -173,6 +203,9 @@ public class FragmentCompositionLocalServiceTest {
 			_updatedFragmentCollection.getFragmentCollectionId(),
 			fragmentCompositionByPrimaryKey.getFragmentCollectionId());
 	}
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	private FragmentCollection _fragmentCollection;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98539

## What Is Being Fixed

Fragment Compositions could be added to a Design Library depot, but Design Libraries are meant to expose atomic fragments across sites, not whole compositions built on top of those fragments. Both `FragmentCompositionLocalService.addFragmentComposition` and the `FragmentsImporter` accepted them silently, so a composition landed inside the Design Library and started leaking into every consumer site.

## How It Is Being Fixed

`FragmentCompositionLocalServiceImpl` now rejects any addition when the target group is a depot, throwing the new `FragmentCompositionGroupIdException` declared through Service Builder in `service.xml`. `FragmentsImporter` skips composition entries when the destination is a Design Library, so an existing import bundle keeps flowing for its atomic fragments without failing the whole run. Integration coverage: `FragmentCompositionLocalServiceTest` asserts the exception at the service layer, and `FragmentsImporterTest` asserts the composition is silently skipped during a Design Library import while atomic fragments still import.

## PR Check

**pr-check: PASS** — tested on `324f74bd5f578b02e180a5d1b69a09f2cf515a69`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "324f74bd5f578b02e180a5d1b69a09f2cf515a69"} -->
