### PR TITLE
LPD-88395 Gate fragment resources on MANAGE_FRAGMENT_ENTRIES, not DL

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCollectionServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCollectionServiceImpl.java
@@ -197,6 +197,10 @@ public class FragmentCollectionServiceImpl
 			String externalReferenceCode, long groupId)
 		throws PortalException {
 
+		_portletResourcePermission.check(
+			getPermissionChecker(), groupId,
+			FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
+
 		return fragmentCollectionLocalService.
 			getFragmentCollectionByExternalReferenceCode(
 				externalReferenceCode, groupId);

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentCollectionServicePermissionTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentCollectionServicePermissionTest.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -204,6 +205,36 @@ public class FragmentCollectionServicePermissionTest {
 
 		_fragmentCollectionService.fetchFragmentCollection(
 			fragmentCollection.getFragmentCollectionId());
+	}
+
+	@Test(expected = PrincipalException.MustHavePermission.class)
+	@TestInfo("LPD-88395")
+	public void testGetFragmentCollectionByExternalReferenceCodeWithoutPermissions()
+		throws Exception {
+
+		FragmentCollection fragmentCollection =
+			FragmentTestUtil.addFragmentCollection(_group.getGroupId());
+
+		UserTestUtil.setUser(_user);
+
+		_fragmentCollectionService.getFragmentCollectionByExternalReferenceCode(
+			fragmentCollection.getExternalReferenceCode(), _group.getGroupId());
+	}
+
+	@Test
+	@TestInfo("LPD-88395")
+	public void testGetFragmentCollectionByExternalReferenceCodeWithPermissions()
+		throws Exception {
+
+		FragmentCollection fragmentCollection =
+			FragmentTestUtil.addFragmentCollection(_group.getGroupId());
+
+		_setRolePermissions(FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
+
+		UserTestUtil.setUser(_user);
+
+		_fragmentCollectionService.getFragmentCollectionByExternalReferenceCode(
+			fragmentCollection.getExternalReferenceCode(), _group.getGroupId());
 	}
 
 	@Test(expected = PrincipalException.MustHavePermission.class)

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentResourceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.headless.admin.fragment.internal.resource.v1_0;
 
+import com.liferay.fragment.constants.FragmentActionKeys;
 import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.constants.FragmentPortletKeys;
 import com.liferay.fragment.exception.RequiredFragmentEntryVersionException;
@@ -31,8 +32,11 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.UserConstants;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -129,6 +133,10 @@ public class FragmentResourceImpl extends BaseFragmentResourceImpl {
 			true, true, contextCompany.getCompanyId(),
 			siteExternalReferenceCode);
 
+		if (!_hasManageFragmentEntriesPermission(groupId)) {
+			return Page.of(Collections.emptyList());
+		}
+
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionService.
 				getFragmentCollectionByExternalReferenceCode(
@@ -147,12 +155,15 @@ public class FragmentResourceImpl extends BaseFragmentResourceImpl {
 
 		EnabledUtil.checkEnabled(contextCompany);
 
-		return _getFragmentsPage(
-			filter, 0,
-			GroupUtil.getGroupId(
-				true, true, contextCompany.getCompanyId(),
-				siteExternalReferenceCode),
-			pagination);
+		long groupId = GroupUtil.getGroupId(
+			true, true, contextCompany.getCompanyId(),
+			siteExternalReferenceCode);
+
+		if (!_hasManageFragmentEntriesPermission(groupId)) {
+			return Page.of(Collections.emptyList());
+		}
+
+		return _getFragmentsPage(filter, 0, groupId, pagination);
 	}
 
 	@Override
@@ -313,6 +324,8 @@ public class FragmentResourceImpl extends BaseFragmentResourceImpl {
 				searchContext.setAttribute("headListable", Boolean.TRUE);
 				searchContext.setCompanyId(contextCompany.getCompanyId());
 				searchContext.setGroupIds(new long[] {groupId});
+				searchContext.setUserId(UserConstants.USER_ID_DEFAULT);
+				searchContext.setVulcanCheckPermissions(false);
 			},
 			null,
 			document -> {
@@ -396,6 +409,12 @@ public class FragmentResourceImpl extends BaseFragmentResourceImpl {
 				(Object[])FieldTypeUtil.toInternalFieldTypes(
 					formFragment.getFieldTypes()))
 		).toString();
+	}
+
+	private boolean _hasManageFragmentEntriesPermission(long groupId) {
+		return _portletResourcePermission.contains(
+			PermissionThreadLocal.getPermissionChecker(), groupId,
+			FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
 	}
 
 	private Fragment _toFragment(FragmentEntry fragmentEntry) throws Exception {
@@ -539,5 +558,10 @@ public class FragmentResourceImpl extends BaseFragmentResourceImpl {
 
 	@Reference
 	private Language _language;
+
+	@Reference(
+		target = "(resource.name=" + FragmentConstants.RESOURCE_NAME + ")"
+	)
+	private PortletResourcePermission _portletResourcePermission;
 
 }

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentSetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentSetResourceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.headless.admin.fragment.resource.v1_0.FragmentSetResource;
 import com.liferay.headless.common.spi.util.GroupUtil;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.UserConstants;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
@@ -186,6 +187,10 @@ public class FragmentSetResourceImpl
 			true, true, contextCompany.getCompanyId(),
 			siteExternalReferenceCode);
 
+		if (!_hasManageFragmentEntriesPermission(groupId)) {
+			return Page.of(Collections.emptyList());
+		}
+
 		return _search(
 			filter, groupId, pagination,
 			_getSiteActionsUnsafeFunction(groupId, siteExternalReferenceCode));
@@ -331,6 +336,8 @@ public class FragmentSetResourceImpl
 			searchContext -> {
 				searchContext.setCompanyId(contextCompany.getCompanyId());
 				searchContext.setGroupIds(new long[] {groupId});
+				searchContext.setUserId(UserConstants.USER_ID_DEFAULT);
+				searchContext.setVulcanCheckPermissions(false);
 			},
 			null,
 			document -> _toFragmentSet(

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentSetResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/FragmentSetResourceImpl.java
@@ -122,6 +122,10 @@ public class FragmentSetResourceImpl
 			contextCompany.getCompanyId(), designLibraryExternalReferenceCode,
 			DepotConstants.TYPE_DESIGN_LIBRARY);
 
+		if (!_hasManageFragmentEntriesPermission(groupId)) {
+			return Page.of(Collections.emptyList());
+		}
+
 		return _search(
 			filter, groupId, pagination,
 			_getDesignLibraryActionsUnsafeFunction(

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/ResourceFileResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/ResourceFileResourceImpl.java
@@ -203,7 +203,7 @@ public class ResourceFileResourceImpl extends BaseResourceFileResourceImpl {
 			true, true, contextCompany.getCompanyId(),
 			siteExternalReferenceCode);
 
-		Folder folder = _dlAppService.getFolderByExternalReferenceCode(
+		Folder folder = _dlAppLocalService.getFolderByExternalReferenceCode(
 			resourceFolderExternalReferenceCode, groupId);
 
 		ResourceFolderUtil.checkResourceFolder(

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/ResourceFileResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/ResourceFileResourceImpl.java
@@ -109,10 +109,7 @@ public class ResourceFileResourceImpl extends BaseResourceFileResourceImpl {
 			true, true, contextCompany.getCompanyId(),
 			siteExternalReferenceCode);
 
-		if (!_portletResourcePermission.contains(
-				PermissionThreadLocal.getPermissionChecker(), groupId,
-				FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES)) {
-
+		if (!_hasManageFragmentEntriesPermission(groupId)) {
 			return Page.of(Collections.emptyList());
 		}
 
@@ -162,10 +159,7 @@ public class ResourceFileResourceImpl extends BaseResourceFileResourceImpl {
 			true, true, contextCompany.getCompanyId(),
 			siteExternalReferenceCode);
 
-		if (!_portletResourcePermission.contains(
-				PermissionThreadLocal.getPermissionChecker(), groupId,
-				FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES)) {
-
+		if (!_hasManageFragmentEntriesPermission(groupId)) {
 			return Page.of(Collections.emptyList());
 		}
 
@@ -241,9 +235,7 @@ public class ResourceFileResourceImpl extends BaseResourceFileResourceImpl {
 		long groupId = GroupUtil.getStagingAwareGroupId(
 			true, contextCompany.getCompanyId(), siteExternalReferenceCode);
 
-		_portletResourcePermission.check(
-			PermissionThreadLocal.getPermissionChecker(), groupId,
-			FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
+		_checkManageFragmentEntriesPermission(groupId);
 
 		return _addResourceFile(
 			_getOrAddFragmentCollection(groupId, resourceFile), groupId,
@@ -266,9 +258,7 @@ public class ResourceFileResourceImpl extends BaseResourceFileResourceImpl {
 				groupId, resourceFileExternalReferenceCode);
 
 		if (dlFileEntry == null) {
-			_portletResourcePermission.check(
-				PermissionThreadLocal.getPermissionChecker(), groupId,
-				FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
+			_checkManageFragmentEntriesPermission(groupId);
 
 			resourceFile.setExternalReferenceCode(
 				() -> resourceFileExternalReferenceCode);
@@ -333,6 +323,14 @@ public class ResourceFileResourceImpl extends BaseResourceFileResourceImpl {
 					contextAcceptLanguage.getPreferredLocale(),
 					"a-file-url-reference-with-content-is-required"));
 		}
+	}
+
+	private void _checkManageFragmentEntriesPermission(long groupId)
+		throws Exception {
+
+		_portletResourcePermission.check(
+			PermissionThreadLocal.getPermissionChecker(), groupId,
+			FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
 	}
 
 	private void _checkName(String name) {
@@ -426,6 +424,12 @@ public class ResourceFileResourceImpl extends BaseResourceFileResourceImpl {
 		serviceContext.setAddGuestPermissions(true);
 
 		return serviceContext;
+	}
+
+	private boolean _hasManageFragmentEntriesPermission(long groupId) {
+		return _portletResourcePermission.contains(
+			PermissionThreadLocal.getPermissionChecker(), groupId,
+			FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
 	}
 
 	private byte[] _toByteArray(FileURLReference fileURLReference)

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/ResourceFileResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/ResourceFileResourceImpl.java
@@ -223,10 +223,6 @@ public class ResourceFileResourceImpl extends BaseResourceFileResourceImpl {
 		long groupId = GroupUtil.getStagingAwareGroupId(
 			true, contextCompany.getCompanyId(), siteExternalReferenceCode);
 
-		_portletResourcePermission.check(
-			PermissionThreadLocal.getPermissionChecker(), groupId,
-			FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
-
 		return _addResourceFile(
 			_fragmentCollectionService.
 				getFragmentCollectionByExternalReferenceCode(

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/ResourceFileResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/ResourceFileResourceImpl.java
@@ -10,7 +10,6 @@ import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLVersionNumberIncrease;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
-import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.fragment.constants.FragmentActionKeys;
@@ -81,11 +80,12 @@ public class ResourceFileResourceImpl extends BaseResourceFileResourceImpl {
 
 		EnabledUtil.checkEnabled(contextCompany);
 
-		FileEntry fileEntry = _dlAppService.getFileEntryByExternalReferenceCode(
-			resourceFileExternalReferenceCode,
-			GroupUtil.getStagingAwareGroupId(
-				true, contextCompany.getCompanyId(),
-				siteExternalReferenceCode));
+		FileEntry fileEntry =
+			_dlAppLocalService.getFileEntryByExternalReferenceCode(
+				resourceFileExternalReferenceCode,
+				GroupUtil.getStagingAwareGroupId(
+					true, contextCompany.getCompanyId(),
+					siteExternalReferenceCode));
 
 		_checkResourceFile(fileEntry);
 
@@ -138,11 +138,12 @@ public class ResourceFileResourceImpl extends BaseResourceFileResourceImpl {
 
 		EnabledUtil.checkEnabled(contextCompany);
 
-		FileEntry fileEntry = _dlAppService.getFileEntryByExternalReferenceCode(
-			resourceFileExternalReferenceCode,
-			GroupUtil.getGroupId(
-				true, true, contextCompany.getCompanyId(),
-				siteExternalReferenceCode));
+		FileEntry fileEntry =
+			_dlAppLocalService.getFileEntryByExternalReferenceCode(
+				resourceFileExternalReferenceCode,
+				GroupUtil.getGroupId(
+					true, true, contextCompany.getCompanyId(),
+					siteExternalReferenceCode));
 
 		_checkResourceFile(fileEntry);
 
@@ -278,7 +279,7 @@ public class ResourceFileResourceImpl extends BaseResourceFileResourceImpl {
 		}
 
 		_checkResourceFile(
-			_dlAppService.getFileEntry(dlFileEntry.getFileEntryId()));
+			_dlAppLocalService.getFileEntry(dlFileEntry.getFileEntryId()));
 
 		_checkName(resourceFile.getName());
 
@@ -409,7 +410,7 @@ public class ResourceFileResourceImpl extends BaseResourceFileResourceImpl {
 			},
 			null,
 			document -> _toResourceFile(
-				_dlAppService.getFileEntry(
+				_dlAppLocalService.getFileEntry(
 					GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK)))));
 	}
 
@@ -470,9 +471,6 @@ public class ResourceFileResourceImpl extends BaseResourceFileResourceImpl {
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;
-
-	@Reference
-	private DLAppService _dlAppService;
 
 	@Reference
 	private DLFileEntryLocalService _dlFileEntryLocalService;

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/ResourceFileResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/ResourceFileResourceImpl.java
@@ -29,6 +29,7 @@ import com.liferay.headless.admin.site.dto.v1_0.util.URLUtil;
 import com.liferay.headless.common.spi.util.GroupUtil;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.model.UserConstants;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
@@ -404,6 +405,7 @@ public class ResourceFileResourceImpl extends BaseResourceFileResourceImpl {
 				searchContext.setCompanyId(contextCompany.getCompanyId());
 				searchContext.setFolderIds(folderIds);
 				searchContext.setGroupIds(new long[] {groupId});
+				searchContext.setUserId(UserConstants.USER_ID_DEFAULT);
 				searchContext.setVulcanCheckPermissions(false);
 			},
 			null,

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/ResourceFolderResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/ResourceFolderResourceImpl.java
@@ -6,7 +6,7 @@
 package com.liferay.headless.admin.fragment.internal.resource.v1_0;
 
 import com.liferay.document.library.kernel.model.DLFolder;
-import com.liferay.document.library.kernel.service.DLAppService;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.fragment.constants.FragmentActionKeys;
 import com.liferay.fragment.constants.FragmentConstants;
@@ -66,7 +66,7 @@ public class ResourceFolderResourceImpl extends BaseResourceFolderResourceImpl {
 
 		EnabledUtil.checkEnabled(contextCompany);
 
-		Folder folder = _dlAppService.getFolderByExternalReferenceCode(
+		Folder folder = _dlAppLocalService.getFolderByExternalReferenceCode(
 			resourceFolderExternalReferenceCode,
 			GroupUtil.getStagingAwareGroupId(
 				true, contextCompany.getCompanyId(),
@@ -75,7 +75,7 @@ public class ResourceFolderResourceImpl extends BaseResourceFolderResourceImpl {
 		ResourceFolderUtil.checkResourceFolder(
 			_dlFolderLocalService.getDLFolder(folder.getFolderId()));
 
-		_dlAppService.deleteFolder(folder.getFolderId());
+		_dlAppLocalService.deleteFolder(folder.getFolderId());
 	}
 
 	@Override
@@ -124,7 +124,7 @@ public class ResourceFolderResourceImpl extends BaseResourceFolderResourceImpl {
 
 		EnabledUtil.checkEnabled(contextCompany);
 
-		Folder folder = _dlAppService.getFolderByExternalReferenceCode(
+		Folder folder = _dlAppLocalService.getFolderByExternalReferenceCode(
 			resourceFolderExternalReferenceCode,
 			GroupUtil.getGroupId(
 				true, true, contextCompany.getCompanyId(),
@@ -150,7 +150,7 @@ public class ResourceFolderResourceImpl extends BaseResourceFolderResourceImpl {
 			true, true, contextCompany.getCompanyId(),
 			siteExternalReferenceCode);
 
-		Folder folder = _dlAppService.getFolderByExternalReferenceCode(
+		Folder folder = _dlAppLocalService.getFolderByExternalReferenceCode(
 			resourceFolderExternalReferenceCode, groupId);
 
 		ResourceFolderUtil.checkResourceFolder(
@@ -264,9 +264,9 @@ public class ResourceFolderResourceImpl extends BaseResourceFolderResourceImpl {
 
 		ResourceFolderUtil.checkResourceFolder(dlFolder);
 
-		Folder folder = _dlAppService.updateFolder(
-			dlFolder.getFolderId(), resourceFolder.getName(),
-			dlFolder.getDescription(),
+		Folder folder = _dlAppLocalService.updateFolder(
+			dlFolder.getFolderId(), dlFolder.getParentFolderId(),
+			resourceFolder.getName(), dlFolder.getDescription(),
 			ServiceContextUtil.getServiceContext(
 				contextCompany.getCompanyId(), resourceFolder.getDateCreated(),
 				groupId, contextHttpServletRequest,
@@ -398,7 +398,7 @@ public class ResourceFolderResourceImpl extends BaseResourceFolderResourceImpl {
 		new ResourceFolderEntityModel();
 
 	@Reference
-	private DLAppService _dlAppService;
+	private DLAppLocalService _dlAppLocalService;
 
 	@Reference
 	private DLFolderLocalService _dlFolderLocalService;

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/ResourceFolderResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/ResourceFolderResourceImpl.java
@@ -226,6 +226,8 @@ public class ResourceFolderResourceImpl extends BaseResourceFolderResourceImpl {
 		long groupId = GroupUtil.getStagingAwareGroupId(
 			true, contextCompany.getCompanyId(), siteExternalReferenceCode);
 
+		_checkManageFragmentEntriesPermission(groupId);
+
 		return _toResourceFolder(
 			_addDLFolder(
 				_getOrAddFragmentCollection(groupId, resourceFolder), groupId,
@@ -249,6 +251,8 @@ public class ResourceFolderResourceImpl extends BaseResourceFolderResourceImpl {
 				resourceFolderExternalReferenceCode, groupId);
 
 		if (dlFolder == null) {
+			_checkManageFragmentEntriesPermission(groupId);
+
 			resourceFolder.setExternalReferenceCode(
 				() -> resourceFolderExternalReferenceCode);
 
@@ -282,6 +286,14 @@ public class ResourceFolderResourceImpl extends BaseResourceFolderResourceImpl {
 			contextHttpServletRequest,
 			contextAcceptLanguage.getPreferredLocale(), resourceFolder,
 			contextUser.getUserId());
+	}
+
+	private void _checkManageFragmentEntriesPermission(long groupId)
+		throws Exception {
+
+		_portletResourcePermission.check(
+			PermissionThreadLocal.getPermissionChecker(), groupId,
+			FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
 	}
 
 	private FragmentCollection _getOrAddFragmentCollection(

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/ResourceFolderResourceImpl.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/ResourceFolderResourceImpl.java
@@ -95,10 +95,7 @@ public class ResourceFolderResourceImpl extends BaseResourceFolderResourceImpl {
 			true, true, contextCompany.getCompanyId(),
 			siteExternalReferenceCode);
 
-		if (!_portletResourcePermission.contains(
-				PermissionThreadLocal.getPermissionChecker(), groupId,
-				FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES)) {
-
+		if (!_hasManageFragmentEntriesPermission(groupId)) {
 			return Page.of(Collections.emptyList());
 		}
 
@@ -172,10 +169,7 @@ public class ResourceFolderResourceImpl extends BaseResourceFolderResourceImpl {
 			true, true, contextCompany.getCompanyId(),
 			siteExternalReferenceCode);
 
-		if (!_portletResourcePermission.contains(
-				PermissionThreadLocal.getPermissionChecker(), groupId,
-				FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES)) {
-
+		if (!_hasManageFragmentEntriesPermission(groupId)) {
 			return Page.of(Collections.emptyList());
 		}
 
@@ -380,6 +374,12 @@ public class ResourceFolderResourceImpl extends BaseResourceFolderResourceImpl {
 			document -> _toResourceFolder(
 				_dlFolderLocalService.getDLFolder(
 					GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK)))));
+	}
+
+	private boolean _hasManageFragmentEntriesPermission(long groupId) {
+		return _portletResourcePermission.contains(
+			PermissionThreadLocal.getPermissionChecker(), groupId,
+			FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
 	}
 
 	private ResourceFolder _toResourceFolder(DLFolder dlFolder)

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/util/ResourceFolderUtil.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-impl/src/main/java/com/liferay/headless/admin/fragment/internal/resource/v1_0/util/ResourceFolderUtil.java
@@ -7,7 +7,7 @@ package com.liferay.headless.admin.fragment.internal.resource.v1_0.util;
 
 import com.liferay.document.library.kernel.exception.NoSuchFolderException;
 import com.liferay.document.library.kernel.model.DLFolder;
-import com.liferay.document.library.kernel.service.DLAppServiceUtil;
+import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.document.library.kernel.service.DLFolderLocalServiceUtil;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.service.FragmentCollectionServiceUtil;
@@ -48,8 +48,8 @@ public class ResourceFolderUtil {
 		serviceContext.setAddGroupPermissions(true);
 		serviceContext.setAddGuestPermissions(true);
 
-		Folder folder = DLAppServiceUtil.addFolder(
-			resourceFolder.getExternalReferenceCode(),
+		Folder folder = DLAppLocalServiceUtil.addFolder(
+			resourceFolder.getExternalReferenceCode(), userId,
 			parentDLFolder.getRepositoryId(), parentDLFolder.getFolderId(),
 			resourceFolder.getName(), StringPool.BLANK, serviceContext);
 

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
@@ -182,7 +182,7 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 	@Override
 	@Test
-	@TestInfo("LPD-95281")
+	@TestInfo({"LPD-88395", "LPD-95281"})
 	public void testDeleteSiteFragment() throws Exception {
 		super.testDeleteSiteFragment();
 
@@ -191,11 +191,13 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		_testDeleteSiteFragment(true, true);
 		_testDeleteSiteFragmentNonexistent();
 		_testDeleteSiteFragmentWithFormFragment();
+		_testDeleteSiteFragmentWithoutPermissionsProblemException();
+		_testDeleteSiteFragmentWithPermissions();
 	}
 
 	@Override
 	@Test
-	@TestInfo({"LPD-88489", "LPD-95281"})
+	@TestInfo({"LPD-88395", "LPD-88489", "LPD-95281"})
 	public void testGetSiteFragment() throws Exception {
 		super.testGetSiteFragment();
 
@@ -205,6 +207,8 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		_testGetSiteFragmentFragmentSet();
 		_testGetSiteFragmentThumbnailURLReference();
 		_testGetSiteFragmentWithFormFragment();
+		_testGetSiteFragmentWithoutPermissionsProblemException();
+		_testGetSiteFragmentWithPermissions();
 	}
 
 	@Override
@@ -233,7 +237,7 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 	@Override
 	@Test
-	@TestInfo({"LPD-88489", "LPD-95281"})
+	@TestInfo({"LPD-88395", "LPD-88489", "LPD-95281"})
 	public void testPostSiteFragment() throws Exception {
 		super.testPostSiteFragment();
 
@@ -264,11 +268,13 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		_testPostSiteFragmentThumbnailURLReferenceURLUnreachableProblemException();
 		_testPostSiteFragmentThumbnailURLReferenceURLUnsupportedProtocolProblemException();
 		_testPostSiteFragmentWithFormFragment();
+		_testPostSiteFragmentWithoutPermissionsProblemException();
+		_testPostSiteFragmentWithPermissions();
 	}
 
 	@Override
 	@Test
-	@TestInfo("LPD-95281")
+	@TestInfo({"LPD-88395", "LPD-95281"})
 	public void testPostSiteFragmentSetFragment() throws Exception {
 		super.testPostSiteFragmentSetFragment();
 
@@ -284,11 +290,13 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		_testPostSiteFragmentSetFragmentFragmentSetNonexisting();
 		_testPostSiteFragmentSetFragmentFragmentSetNull();
 		_testPostSiteFragmentSetFragmentWithFormFragment();
+		_testPostSiteFragmentSetFragmentWithoutPermissionsProblemException();
+		_testPostSiteFragmentSetFragmentWithPermissions();
 	}
 
 	@Override
 	@Test
-	@TestInfo({"LPD-88489", "LPD-95281"})
+	@TestInfo({"LPD-88395", "LPD-88489", "LPD-95281"})
 	public void testPutSiteFragment() throws Exception {
 		_testPutSiteFragmentBatch();
 		_testPutSiteFragmentCreateApproved();
@@ -323,6 +331,8 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		_testPutSiteFragmentUpdateThumbnailURLReferenceURL();
 		_testPutSiteFragmentUpdateTypeProblemException();
 		_testPutSiteFragmentWithFormFragment();
+		_testPutSiteFragmentWithoutPermissionsProblemException();
+		_testPutSiteFragmentWithPermissions();
 	}
 
 	@Override
@@ -1253,6 +1263,37 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		Assert.assertTrue(fragmentEntryVersions.isEmpty());
 	}
 
+	private void _testDeleteSiteFragmentWithoutPermissionsProblemException()
+		throws Exception {
+
+		Fragment fragment = _postSiteFragmentSetFragment(
+			_randomFragment(true, true, _fragmentCollection));
+
+		try {
+			_userWithoutPermissionsFragmentResource.deleteSiteFragment(
+				testGroup.getExternalReferenceCode(),
+				fragment.getExternalReferenceCode());
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("FORBIDDEN", problem.getStatus());
+		}
+	}
+
+	private void _testDeleteSiteFragmentWithPermissions() throws Exception {
+		Fragment fragment = _postSiteFragmentSetFragment(
+			_randomFragment(true, true, _fragmentCollection));
+
+		assertHttpResponseStatusCode(
+			204,
+			_userWithPermissionsFragmentResource.deleteSiteFragmentHttpResponse(
+				testGroup.getExternalReferenceCode(),
+				fragment.getExternalReferenceCode()));
+	}
+
 	private void _testGetSiteFragment(boolean approved, boolean draft)
 		throws Exception {
 
@@ -1521,6 +1562,40 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 			fragmentResource.getSiteFragment(
 				testGroup.getExternalReferenceCode(),
 				fragment.getExternalReferenceCode()));
+	}
+
+	private void _testGetSiteFragmentWithoutPermissionsProblemException()
+		throws Exception {
+
+		Fragment fragment = _postSiteFragmentSetFragment(
+			_randomFragment(true, true, _fragmentCollection));
+
+		try {
+			_userWithoutPermissionsFragmentResource.getSiteFragment(
+				testGroup.getExternalReferenceCode(),
+				fragment.getExternalReferenceCode());
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("NOT_FOUND", problem.getStatus());
+		}
+	}
+
+	private void _testGetSiteFragmentWithPermissions() throws Exception {
+		Fragment postFragment = _postSiteFragmentSetFragment(
+			_randomFragment(true, true, _fragmentCollection));
+
+		Fragment getFragment =
+			_userWithPermissionsFragmentResource.getSiteFragment(
+				testGroup.getExternalReferenceCode(),
+				postFragment.getExternalReferenceCode());
+
+		Assert.assertEquals(
+			postFragment.getExternalReferenceCode(),
+			getFragment.getExternalReferenceCode());
 	}
 
 	private void _testPostFragmentApproved(
@@ -2071,6 +2146,41 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 			_postSiteFragmentSetFragment(_randomFormFragment(fieldTypes)));
 	}
 
+	private void _testPostSiteFragmentSetFragmentWithoutPermissionsProblemException()
+		throws Exception {
+
+		try {
+			_userWithoutPermissionsFragmentResource.postSiteFragmentSetFragment(
+				testGroup.getExternalReferenceCode(),
+				_fragmentCollection.getExternalReferenceCode(),
+				_randomFragment(true, true, _fragmentCollection));
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("FORBIDDEN", problem.getStatus());
+		}
+	}
+
+	private void _testPostSiteFragmentSetFragmentWithPermissions()
+		throws Exception {
+
+		Fragment fragment = _randomFragment(
+			true, true, RandomTestUtil.randomString(), _fragmentCollection,
+			null);
+
+		Fragment postFragment =
+			_userWithPermissionsFragmentResource.postSiteFragmentSetFragment(
+				testGroup.getExternalReferenceCode(),
+				_fragmentCollection.getExternalReferenceCode(), fragment);
+
+		Assert.assertEquals(
+			fragment.getExternalReferenceCode(),
+			postFragment.getExternalReferenceCode());
+	}
+
 	private void _testPostSiteFragmentThumbnailURLReferenceExternalReferenceCode()
 		throws Exception {
 
@@ -2280,6 +2390,37 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		_assertProblemException(
 			"the-form-fragment-field-types-are-invalid",
 			() -> _postSiteFragment(_randomFormFragment(fieldTypes)));
+	}
+
+	private void _testPostSiteFragmentWithoutPermissionsProblemException()
+		throws Exception {
+
+		try {
+			_userWithoutPermissionsFragmentResource.postSiteFragment(
+				testGroup.getExternalReferenceCode(),
+				_randomFragment(true, true, _fragmentCollection));
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("FORBIDDEN", problem.getStatus());
+		}
+	}
+
+	private void _testPostSiteFragmentWithPermissions() throws Exception {
+		Fragment fragment = _randomFragment(
+			true, true, RandomTestUtil.randomString(), _fragmentCollection,
+			null);
+
+		Fragment postFragment =
+			_userWithPermissionsFragmentResource.postSiteFragment(
+				testGroup.getExternalReferenceCode(), fragment);
+
+		Assert.assertEquals(
+			fragment.getExternalReferenceCode(),
+			postFragment.getExternalReferenceCode());
 	}
 
 	private void _testPutFragment(
@@ -3023,6 +3164,36 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 			() -> fragmentResource.putSiteFragment(
 				testGroup.getExternalReferenceCode(),
 				formFragment.getExternalReferenceCode(), formFragment));
+	}
+
+	private void _testPutSiteFragmentWithoutPermissionsProblemException()
+		throws Exception {
+
+		try {
+			_userWithoutPermissionsFragmentResource.putSiteFragment(
+				testGroup.getExternalReferenceCode(),
+				RandomTestUtil.randomString(),
+				_randomFragment(true, true, _fragmentCollection));
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("FORBIDDEN", problem.getStatus());
+		}
+	}
+
+	private void _testPutSiteFragmentWithPermissions() throws Exception {
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		Fragment putFragment =
+			_userWithPermissionsFragmentResource.putSiteFragment(
+				testGroup.getExternalReferenceCode(), externalReferenceCode,
+				_randomFragment(true, true, _fragmentCollection));
+
+		Assert.assertEquals(
+			externalReferenceCode, putFragment.getExternalReferenceCode());
 	}
 
 	private FragmentSet _toFragmentSet(FragmentCollection fragmentCollection) {

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentResourceTest.java
@@ -7,6 +7,8 @@ package com.liferay.headless.admin.fragment.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.test.util.LazyReferencingTestUtil;
+import com.liferay.fragment.constants.FragmentActionKeys;
+import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.model.FragmentEntryVersion;
@@ -38,7 +40,10 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Repository;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -50,6 +55,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
@@ -159,6 +165,10 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		super.setUp();
 
 		_fragmentCollection = _addFragmentCollection();
+		_userWithoutPermissionsFragmentResource =
+			_getUserWithoutPermissionsFragmentResource();
+		_userWithPermissionsFragmentResource =
+			_getUserWithPermissionsFragmentResource();
 	}
 
 	@Override
@@ -199,20 +209,26 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 	@Override
 	@Test
+	@TestInfo("LPD-88395")
 	public void testGetSiteFragmentSetFragmentsPage() throws Exception {
 		super.testGetSiteFragmentSetFragmentsPage();
 
 		_testGetSiteFragmentSetFragmentsPageWithNonexistentFragmentSet();
+		_testGetSiteFragmentSetFragmentsPageWithoutPermissions();
+		_testGetSiteFragmentSetFragmentsPageWithPermissions();
 		_testGetSiteFragmentSetFragmentsPageWithStatus();
 	}
 
 	@Override
 	@Test
+	@TestInfo("LPD-88395")
 	public void testGetSiteFragmentsPage() throws Exception {
 		super.testGetSiteFragmentsPage();
 
 		_testGetSiteFragmentsPageWithFilter();
 		_testGetSiteFragmentsPageWithFragmentSets();
+		_testGetSiteFragmentsPageWithoutPermissions();
+		_testGetSiteFragmentsPageWithPermissions();
 	}
 
 	@Override
@@ -780,6 +796,53 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		return null;
 	}
 
+	private FragmentResource _getUserWithoutPermissionsFragmentResource()
+		throws Exception {
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(testCompany, password);
+
+		_userLocalService.addGroupUser(
+			testGroup.getGroupId(), user.getUserId());
+
+		return FragmentResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	private FragmentResource _getUserWithPermissionsFragmentResource()
+		throws Exception {
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(testCompany, password);
+
+		Role role = RoleTestUtil.addRole(
+			RandomTestUtil.randomString(), RoleConstants.TYPE_REGULAR,
+			FragmentConstants.RESOURCE_NAME, ResourceConstants.SCOPE_GROUP,
+			String.valueOf(testGroup.getGroupId()),
+			FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user.getUserId());
+
+		return FragmentResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
 	private void _populateFragment(Fragment fragment) {
 		if ((fragment instanceof FormFragment formFragment) &&
 			(formFragment.getFieldTypes() == null)) {
@@ -1255,6 +1318,40 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		}
 	}
 
+	private void _testGetSiteFragmentSetFragmentsPageWithoutPermissions()
+		throws Exception {
+
+		_postSiteFragmentSetFragment(
+			_randomFragment(true, true, _fragmentCollection),
+			_fragmentCollection.getExternalReferenceCode());
+
+		Page<Fragment> page =
+			_userWithoutPermissionsFragmentResource.
+				getSiteFragmentSetFragmentsPage(
+					testGroup.getExternalReferenceCode(),
+					_fragmentCollection.getExternalReferenceCode(),
+					Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
+	}
+
+	private void _testGetSiteFragmentSetFragmentsPageWithPermissions()
+		throws Exception {
+
+		Fragment fragment = _postSiteFragmentSetFragment(
+			_randomFragment(true, true, _fragmentCollection),
+			_fragmentCollection.getExternalReferenceCode());
+
+		Page<Fragment> page =
+			_userWithPermissionsFragmentResource.
+				getSiteFragmentSetFragmentsPage(
+					testGroup.getExternalReferenceCode(),
+					_fragmentCollection.getExternalReferenceCode(),
+					Pagination.of(1, 10));
+
+		assertContains(fragment, (List<Fragment>)page.getItems());
+	}
+
 	private void _testGetSiteFragmentSetFragmentsPageWithStatus()
 		throws Exception {
 
@@ -1350,6 +1447,38 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 		assertContains(approvedFragment2, items);
 		assertContains(draftFragment1, items);
 		assertContains(draftFragment2, items);
+	}
+
+	private void _testGetSiteFragmentsPageWithoutPermissions()
+		throws Exception {
+
+		_postSiteFragmentSetFragment(
+			_randomFragment(true, true, _fragmentCollection),
+			_fragmentCollection.getExternalReferenceCode());
+
+		Page<Fragment> page =
+			_userWithoutPermissionsFragmentResource.getSiteFragmentsPage(
+				testGroup.getExternalReferenceCode(), null,
+				Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
+	}
+
+	private void _testGetSiteFragmentsPageWithPermissions() throws Exception {
+		Fragment fragment = _postSiteFragmentSetFragment(
+			_randomFragment(true, true, _fragmentCollection),
+			_fragmentCollection.getExternalReferenceCode());
+
+		Page<Fragment> page =
+			_userWithPermissionsFragmentResource.getSiteFragmentsPage(
+				testGroup.getExternalReferenceCode(), null,
+				Pagination.of(1, 1));
+
+		page = _userWithPermissionsFragmentResource.getSiteFragmentsPage(
+			testGroup.getExternalReferenceCode(), null,
+			Pagination.of(1, (int)page.getTotalCount()));
+
+		assertContains(fragment, (List<Fragment>)page.getItems());
 	}
 
 	private void _testGetSiteFragmentThumbnailURLReference() throws Exception {
@@ -2973,5 +3102,8 @@ public class FragmentResourceTest extends BaseFragmentResourceTestCase {
 
 	@Inject
 	private UserLocalService _userLocalService;
+
+	private FragmentResource _userWithoutPermissionsFragmentResource;
+	private FragmentResource _userWithPermissionsFragmentResource;
 
 }

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -129,6 +129,7 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 
 	@Override
 	@Test
+	@TestInfo("LPD-88395")
 	public void testDeleteSiteFragmentSet() throws Exception {
 		super.testDeleteSiteFragmentSet();
 
@@ -144,6 +145,9 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 				fetchFragmentCollectionByExternalReferenceCode(
 					fragmentSet.getExternalReferenceCode(),
 					testGroup.getGroupId()));
+
+		_testDeleteSiteFragmentSetWithoutPermissionsProblemException();
+		_testDeleteSiteFragmentSetWithPermissions();
 	}
 
 	@Override
@@ -184,6 +188,7 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 
 	@Override
 	@Test
+	@TestInfo("LPD-88395")
 	public void testPostSiteFragmentSet() throws Exception {
 		FragmentSet randomFragmentSet = randomFragmentSet();
 
@@ -232,10 +237,13 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 				testGroup.getExternalReferenceCode(), invalidNameFragmentSet));
 
 		_testPostSiteFragmentSetBatch();
+		_testPostSiteFragmentSetWithoutPermissionsProblemException();
+		_testPostSiteFragmentSetWithPermissions();
 	}
 
 	@Override
 	@Test
+	@TestInfo("LPD-88395")
 	public void testPutSiteFragmentSet() throws Exception {
 		FragmentSet fragmentSet = randomFragmentSet();
 
@@ -323,6 +331,8 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 
 		_testPutSiteFragmentSetBatch();
 		_testPutSiteFragmentSetWithDates();
+		_testPutSiteFragmentSetWithoutPermissionsProblemException();
+		_testPutSiteFragmentSetWithPermissions();
 	}
 
 	@Override
@@ -683,6 +693,38 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 				RandomTestUtil.randomString()));
 	}
 
+	private void _testDeleteSiteFragmentSetWithoutPermissionsProblemException()
+		throws Exception {
+
+		FragmentSet fragmentSet = testGetSiteFragmentSetsPage_addFragmentSet(
+			testGroup.getExternalReferenceCode(), randomFragmentSet());
+
+		try {
+			_userWithoutPermissionsFragmentSetResource.deleteSiteFragmentSet(
+				testGroup.getExternalReferenceCode(),
+				fragmentSet.getExternalReferenceCode());
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("FORBIDDEN", problem.getStatus());
+		}
+	}
+
+	private void _testDeleteSiteFragmentSetWithPermissions() throws Exception {
+		FragmentSet fragmentSet = testGetSiteFragmentSetsPage_addFragmentSet(
+			testGroup.getExternalReferenceCode(), randomFragmentSet());
+
+		assertHttpResponseStatusCode(
+			204,
+			_userWithPermissionsFragmentSetResource.
+				deleteSiteFragmentSetHttpResponse(
+					testGroup.getExternalReferenceCode(),
+					fragmentSet.getExternalReferenceCode()));
+	}
+
 	private void _testGetDesignLibraryFragmentSetActions() throws Exception {
 		Group group = _depotEntry.getGroup();
 
@@ -856,6 +898,34 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 		_assertFragmentCollection(fragmentSet2, irrelevantGroup);
 	}
 
+	private void _testPostSiteFragmentSetWithoutPermissionsProblemException()
+		throws Exception {
+
+		try {
+			_userWithoutPermissionsFragmentSetResource.postSiteFragmentSet(
+				testGroup.getExternalReferenceCode(), randomFragmentSet());
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("FORBIDDEN", problem.getStatus());
+		}
+	}
+
+	private void _testPostSiteFragmentSetWithPermissions() throws Exception {
+		FragmentSet fragmentSet = randomFragmentSet();
+
+		FragmentSet postFragmentSet =
+			_userWithPermissionsFragmentSetResource.postSiteFragmentSet(
+				testGroup.getExternalReferenceCode(), fragmentSet);
+
+		Assert.assertEquals(
+			fragmentSet.getExternalReferenceCode(),
+			postFragmentSet.getExternalReferenceCode());
+	}
+
 	private void _testPutSiteFragmentSetBatch() throws Exception {
 		FragmentSet fragmentSet1 = testPutSiteFragmentSet_addFragmentSet();
 		FragmentSet fragmentSet2 = testPutSiteFragmentSet_addFragmentSet();
@@ -919,6 +989,35 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 		Assert.assertEquals(date, putFragmentSet.getDateCreated());
 		Assert.assertEquals(
 			fragmentSet.getDateModified(), putFragmentSet.getDateModified());
+	}
+
+	private void _testPutSiteFragmentSetWithoutPermissionsProblemException()
+		throws Exception {
+
+		try {
+			_userWithoutPermissionsFragmentSetResource.putSiteFragmentSet(
+				testGroup.getExternalReferenceCode(),
+				RandomTestUtil.randomString(), randomFragmentSet());
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("FORBIDDEN", problem.getStatus());
+		}
+	}
+
+	private void _testPutSiteFragmentSetWithPermissions() throws Exception {
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		FragmentSet putFragmentSet =
+			_userWithPermissionsFragmentSetResource.putSiteFragmentSet(
+				testGroup.getExternalReferenceCode(), externalReferenceCode,
+				randomFragmentSet());
+
+		Assert.assertEquals(
+			externalReferenceCode, putFragmentSet.getExternalReferenceCode());
 	}
 
 	private JSONObject _waitForExportFinish(

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -9,12 +9,16 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.fragment.constants.FragmentActionKeys;
+import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.exception.DuplicateFragmentCollectionKeyException;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.service.FragmentCollectionLocalService;
 import com.liferay.headless.admin.fragment.client.dto.v1_0.FragmentSet;
 import com.liferay.headless.admin.fragment.client.pagination.Page;
+import com.liferay.headless.admin.fragment.client.pagination.Pagination;
 import com.liferay.headless.admin.fragment.client.problem.Problem;
+import com.liferay.headless.admin.fragment.client.resource.v1_0.FragmentSetResource;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -22,21 +26,29 @@ import com.liferay.portal.kernel.feature.flag.constants.FeatureFlagConstants;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.Validator;
@@ -90,6 +102,10 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 		super.setUp();
 
 		_depotEntry = _addDepotEntry(DepotConstants.TYPE_DESIGN_LIBRARY);
+		_userWithoutPermissionsFragmentSetResource =
+			_getUserWithoutPermissionsFragmentSetResource();
+		_userWithPermissionsFragmentSetResource =
+			_getUserWithPermissionsFragmentSetResource();
 	}
 
 	@Override
@@ -146,37 +162,24 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 
 	@Override
 	@Test
+	@TestInfo("LPD-88395")
 	public void testGetSiteFragmentSet() throws Exception {
 		super.testGetSiteFragmentSet();
 
 		_testGetSiteFragmentSetActions();
+		_testGetSiteFragmentSetWithoutPermissions();
+		_testGetSiteFragmentSetWithPermissions();
 	}
 
 	@Override
 	@Test
+	@TestInfo("LPD-88395")
 	public void testGetSiteFragmentSetsPage() throws Exception {
 		super.testGetSiteFragmentSetsPage();
 
-		FragmentSet nonmarketplaceFragmentSet = randomFragmentSet();
-
-		nonmarketplaceFragmentSet.setMarketplace(false);
-
-		nonmarketplaceFragmentSet = testGetSiteFragmentSetsPage_addFragmentSet(
-			testGroup.getExternalReferenceCode(), nonmarketplaceFragmentSet);
-
-		FragmentSet marketplaceFragmentSet = randomFragmentSet();
-
-		marketplaceFragmentSet.setMarketplace(true);
-
-		marketplaceFragmentSet = testGetSiteFragmentSetsPage_addFragmentSet(
-			testGroup.getExternalReferenceCode(), marketplaceFragmentSet);
-
-		_assertGetSiteFragmentSetsPageWithFilter(
-			nonmarketplaceFragmentSet, "marketplace eq false",
-			marketplaceFragmentSet);
-		_assertGetSiteFragmentSetsPageWithFilter(
-			marketplaceFragmentSet, "marketplace eq true",
-			nonmarketplaceFragmentSet);
+		_testGetSiteFragmentSetsPage();
+		_testGetSiteFragmentSetsPageWithoutPermissions();
+		_testGetSiteFragmentSetsPageWithPermissions();
 	}
 
 	@Override
@@ -556,6 +559,53 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 		}
 	}
 
+	private FragmentSetResource _getUserWithoutPermissionsFragmentSetResource()
+		throws Exception {
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(testCompany, password);
+
+		_userLocalService.addGroupUser(
+			testGroup.getGroupId(), user.getUserId());
+
+		return FragmentSetResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	private FragmentSetResource _getUserWithPermissionsFragmentSetResource()
+		throws Exception {
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(testCompany, password);
+
+		Role role = RoleTestUtil.addRole(
+			RandomTestUtil.randomString(), RoleConstants.TYPE_REGULAR,
+			FragmentConstants.RESOURCE_NAME, ResourceConstants.SCOPE_GROUP,
+			String.valueOf(testGroup.getGroupId()),
+			FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user.getUserId());
+
+		return FragmentSetResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
 	private void _testBatchEngineDeleteImportTask() throws Exception {
 		FragmentSet fragmentSet1 = testPostSiteFragmentSet_addFragmentSet(
 			randomFragmentSet());
@@ -665,6 +715,93 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 				"/sites/", testGroup.getExternalReferenceCode(),
 				"/fragment-sets/", postFragmentSet.getExternalReferenceCode()),
 			"delete", "get", "replace");
+	}
+
+	private void _testGetSiteFragmentSetsPage() throws Exception {
+		FragmentSet nonmarketplaceFragmentSet = randomFragmentSet();
+
+		nonmarketplaceFragmentSet.setMarketplace(false);
+
+		nonmarketplaceFragmentSet = testGetSiteFragmentSetsPage_addFragmentSet(
+			testGroup.getExternalReferenceCode(), nonmarketplaceFragmentSet);
+
+		FragmentSet marketplaceFragmentSet = randomFragmentSet();
+
+		marketplaceFragmentSet.setMarketplace(true);
+
+		marketplaceFragmentSet = testGetSiteFragmentSetsPage_addFragmentSet(
+			testGroup.getExternalReferenceCode(), marketplaceFragmentSet);
+
+		_assertGetSiteFragmentSetsPageWithFilter(
+			nonmarketplaceFragmentSet, "marketplace eq false",
+			marketplaceFragmentSet);
+		_assertGetSiteFragmentSetsPageWithFilter(
+			marketplaceFragmentSet, "marketplace eq true",
+			nonmarketplaceFragmentSet);
+	}
+
+	private void _testGetSiteFragmentSetsPageWithoutPermissions()
+		throws Exception {
+
+		testGetSiteFragmentSetsPage_addFragmentSet(
+			testGroup.getExternalReferenceCode(), randomFragmentSet());
+
+		Page<FragmentSet> page =
+			_userWithoutPermissionsFragmentSetResource.getSiteFragmentSetsPage(
+				testGroup.getExternalReferenceCode(), null,
+				Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
+	}
+
+	private void _testGetSiteFragmentSetsPageWithPermissions()
+		throws Exception {
+
+		FragmentSet fragmentSet = testGetSiteFragmentSetsPage_addFragmentSet(
+			testGroup.getExternalReferenceCode(), randomFragmentSet());
+
+		Page<FragmentSet> page =
+			_userWithPermissionsFragmentSetResource.getSiteFragmentSetsPage(
+				testGroup.getExternalReferenceCode(), null,
+				Pagination.of(1, 1));
+
+		page = _userWithPermissionsFragmentSetResource.getSiteFragmentSetsPage(
+			testGroup.getExternalReferenceCode(), null,
+			Pagination.of(1, (int)page.getTotalCount()));
+
+		assertContains(fragmentSet, (List<FragmentSet>)page.getItems());
+	}
+
+	private void _testGetSiteFragmentSetWithoutPermissions() throws Exception {
+		FragmentSet fragmentSet = testGetSiteFragmentSetsPage_addFragmentSet(
+			testGroup.getExternalReferenceCode(), randomFragmentSet());
+
+		try {
+			_userWithoutPermissionsFragmentSetResource.getSiteFragmentSet(
+				testGroup.getExternalReferenceCode(),
+				fragmentSet.getExternalReferenceCode());
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("NOT_FOUND", problem.getStatus());
+		}
+	}
+
+	private void _testGetSiteFragmentSetWithPermissions() throws Exception {
+		FragmentSet fragmentSet = testGetSiteFragmentSetsPage_addFragmentSet(
+			testGroup.getExternalReferenceCode(), randomFragmentSet());
+
+		FragmentSet getFragmentSet =
+			_userWithPermissionsFragmentSetResource.getSiteFragmentSet(
+				testGroup.getExternalReferenceCode(),
+				fragmentSet.getExternalReferenceCode());
+
+		Assert.assertEquals(
+			fragmentSet.getExternalReferenceCode(),
+			getFragmentSet.getExternalReferenceCode());
 	}
 
 	private void _testPostSiteFragmentSetBatch() throws Exception {
@@ -839,5 +976,11 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 
 	@Inject
 	private Language _language;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+	private FragmentSetResource _userWithoutPermissionsFragmentSetResource;
+	private FragmentSetResource _userWithPermissionsFragmentSetResource;
 
 }

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -7,6 +7,7 @@ package com.liferay.headless.admin.fragment.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.constants.FragmentActionKeys;
@@ -31,6 +32,8 @@ import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.test.TestInfo;
@@ -102,6 +105,8 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 		super.setUp();
 
 		_depotEntry = _addDepotEntry(DepotConstants.TYPE_DESIGN_LIBRARY);
+		_designLibraryOwnerFragmentSetResource =
+			_getDesignLibraryOwnerFragmentSetResource();
 		_userWithoutPermissionsFragmentSetResource =
 			_getUserWithoutPermissionsFragmentSetResource();
 		_userWithPermissionsDesignLibraryFragmentSetResource =
@@ -166,6 +171,7 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 	public void testGetDesignLibraryFragmentSetsPage() throws Exception {
 		super.testGetDesignLibraryFragmentSetsPage();
 
+		_testGetDesignLibraryFragmentSetsPageAsDesignLibraryOwner();
 		_testGetDesignLibraryFragmentSetsPageWithoutPermissions();
 		_testGetDesignLibraryFragmentSetsPageWithPermissions();
 	}
@@ -575,6 +581,36 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 		}
 	}
 
+	private FragmentSetResource _getDesignLibraryOwnerFragmentSetResource()
+		throws Exception {
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(testCompany, password);
+
+		Group group = _depotEntry.getGroup();
+
+		_userLocalService.addGroupUser(group.getGroupId(), user.getUserId());
+
+		Role role = _roleLocalService.getRole(
+			testCompany.getCompanyId(),
+			DepotRolesConstants.ASSET_LIBRARY_OWNER);
+
+		_userGroupRoleLocalService.addUserGroupRoles(
+			user.getUserId(), group.getGroupId(),
+			new long[] {role.getRoleId()});
+
+		return FragmentSetResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
 	private FragmentSetResource _getUserWithoutPermissionsFragmentSetResource()
 		throws Exception {
 
@@ -777,6 +813,22 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 				"/design-libraries/", group.getExternalReferenceCode(),
 				"/fragment-sets/", fragmentSet.getExternalReferenceCode()),
 			"delete", "get");
+	}
+
+	private void _testGetDesignLibraryFragmentSetsPageAsDesignLibraryOwner()
+		throws Exception {
+
+		FragmentSet fragmentSet = _addDesignLibraryFragmentSet(
+			randomFragmentSet(), _depotEntry.getGroup());
+
+		Page<FragmentSet> page =
+			_designLibraryOwnerFragmentSetResource.
+				getDesignLibraryFragmentSetsPage(
+					_depotEntry.getGroup(
+					).getExternalReferenceCode(),
+					null, Pagination.of(1, 10));
+
+		assertContains(fragmentSet, (List<FragmentSet>)page.getItems());
 	}
 
 	private void _testGetDesignLibraryFragmentSetsPageWithoutPermissions()
@@ -1141,6 +1193,8 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;
 
+	private FragmentSetResource _designLibraryOwnerFragmentSetResource;
+
 	@Inject
 	private FragmentCollectionLocalService _fragmentCollectionLocalService;
 
@@ -1149,6 +1203,12 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 
 	@Inject
 	private Language _language;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private UserGroupRoleLocalService _userGroupRoleLocalService;
 
 	@Inject
 	private UserLocalService _userLocalService;

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -104,6 +104,8 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 		_depotEntry = _addDepotEntry(DepotConstants.TYPE_DESIGN_LIBRARY);
 		_userWithoutPermissionsFragmentSetResource =
 			_getUserWithoutPermissionsFragmentSetResource();
+		_userWithPermissionsDesignLibraryFragmentSetResource =
+			_getUserWithPermissionsDesignLibraryFragmentSetResource();
 		_userWithPermissionsFragmentSetResource =
 			_getUserWithPermissionsFragmentSetResource();
 	}
@@ -160,8 +162,12 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 
 	@Override
 	@Test
+	@TestInfo("LPD-88395")
 	public void testGetDesignLibraryFragmentSetsPage() throws Exception {
 		super.testGetDesignLibraryFragmentSetsPage();
+
+		_testGetDesignLibraryFragmentSetsPageWithoutPermissions();
+		_testGetDesignLibraryFragmentSetsPageWithPermissions();
 	}
 
 	@Override
@@ -590,6 +596,35 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 		).build();
 	}
 
+	private FragmentSetResource
+			_getUserWithPermissionsDesignLibraryFragmentSetResource()
+		throws Exception {
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(testCompany, password);
+
+		Group group = _depotEntry.getGroup();
+
+		Role role = RoleTestUtil.addRole(
+			RandomTestUtil.randomString(), RoleConstants.TYPE_REGULAR,
+			FragmentConstants.RESOURCE_NAME, ResourceConstants.SCOPE_GROUP,
+			String.valueOf(group.getGroupId()),
+			FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user.getUserId());
+
+		return FragmentSetResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
 	private FragmentSetResource _getUserWithPermissionsFragmentSetResource()
 		throws Exception {
 
@@ -742,6 +777,45 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 				"/design-libraries/", group.getExternalReferenceCode(),
 				"/fragment-sets/", fragmentSet.getExternalReferenceCode()),
 			"delete", "get");
+	}
+
+	private void _testGetDesignLibraryFragmentSetsPageWithoutPermissions()
+		throws Exception {
+
+		_addDesignLibraryFragmentSet(
+			randomFragmentSet(), _depotEntry.getGroup());
+
+		Page<FragmentSet> page =
+			_userWithoutPermissionsFragmentSetResource.
+				getDesignLibraryFragmentSetsPage(
+					_depotEntry.getGroup(
+					).getExternalReferenceCode(),
+					null, Pagination.of(1, 10));
+
+		Assert.assertEquals(0, page.getTotalCount());
+	}
+
+	private void _testGetDesignLibraryFragmentSetsPageWithPermissions()
+		throws Exception {
+
+		FragmentSet fragmentSet = _addDesignLibraryFragmentSet(
+			randomFragmentSet(), _depotEntry.getGroup());
+
+		Page<FragmentSet> page =
+			_userWithPermissionsDesignLibraryFragmentSetResource.
+				getDesignLibraryFragmentSetsPage(
+					_depotEntry.getGroup(
+					).getExternalReferenceCode(),
+					null, Pagination.of(1, 1));
+
+		page =
+			_userWithPermissionsDesignLibraryFragmentSetResource.
+				getDesignLibraryFragmentSetsPage(
+					_depotEntry.getGroup(
+					).getExternalReferenceCode(),
+					null, Pagination.of(1, (int)page.getTotalCount()));
+
+		assertContains(fragmentSet, (List<FragmentSet>)page.getItems());
 	}
 
 	private void _testGetSiteFragmentSetActions() throws Exception {
@@ -1080,6 +1154,8 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 	private UserLocalService _userLocalService;
 
 	private FragmentSetResource _userWithoutPermissionsFragmentSetResource;
+	private FragmentSetResource
+		_userWithPermissionsDesignLibraryFragmentSetResource;
 	private FragmentSetResource _userWithPermissionsFragmentSetResource;
 
 }

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/ResourceFileResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/ResourceFileResourceTest.java
@@ -650,15 +650,15 @@ public class ResourceFileResourceTest extends BaseResourceFileResourceTestCase {
 	private ResourceFileResource _getUserWithPermissionsResourceFileResource()
 		throws Exception {
 
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(testCompany, password);
+
 		Role role = RoleTestUtil.addRole(
 			RandomTestUtil.randomString(), RoleConstants.TYPE_REGULAR,
 			FragmentConstants.RESOURCE_NAME, ResourceConstants.SCOPE_GROUP,
 			String.valueOf(testGroup.getGroupId()),
 			FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
-
-		String password = RandomTestUtil.randomString();
-
-		User user = UserTestUtil.addUser(testCompany, password);
 
 		_userLocalService.addRoleUser(role.getRoleId(), user.getUserId());
 

--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/ResourceFolderResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/ResourceFolderResourceTest.java
@@ -7,6 +7,8 @@ package com.liferay.headless.admin.fragment.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.test.util.LazyReferencingTestUtil;
+import com.liferay.fragment.constants.FragmentActionKeys;
+import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.service.FragmentCollectionLocalService;
 import com.liferay.headless.admin.fragment.client.dto.v1_0.FragmentSet;
@@ -24,16 +26,21 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Repository;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
@@ -83,35 +90,27 @@ public class ResourceFolderResourceTest
 	public void setUp() throws Exception {
 		super.setUp();
 
-		String password = RandomTestUtil.randomString();
-
-		User user = UserTestUtil.addUser(testCompany, password);
-
-		_resourceFolderResource = ResourceFolderResource.builder(
-		).authentication(
-			user.getEmailAddress(), password
-		).endpoint(
-			testCompany.getVirtualHostname(),
-			PortalUtil.getPortalServerPort(false), "http"
-		).locale(
-			LocaleUtil.getDefault()
-		).build();
+		_userWithoutPermissionsResourceFolderResource =
+			_getUserWithoutPermissionsResourceFolderResource();
+		_userWithPermissionsResourceFolderResource =
+			_getUserWithPermissionsResourceFolderResource();
 	}
 
 	@Override
 	@Test
-	@TestInfo("LPD-88489")
+	@TestInfo({"LPD-88395", "LPD-88489"})
 	public void testDeleteSiteResourceFolder() throws Exception {
 		super.testDeleteSiteResourceFolder();
 
 		_testDeleteSiteResourceFolderChildResourceFolder();
 		_testDeleteSiteResourceFolderPortletFolderProblemException();
 		_testDeleteSiteResourceFolderWithoutPermissionsProblemException();
+		_testDeleteSiteResourceFolderWithPermissions();
 	}
 
 	@Override
 	@Test
-	@TestInfo("LPD-88489")
+	@TestInfo({"LPD-88395", "LPD-88489"})
 	public void testGetSiteFragmentSetResourceFoldersPage() throws Exception {
 		super.testGetSiteFragmentSetResourceFoldersPage();
 
@@ -119,11 +118,12 @@ public class ResourceFolderResourceTest
 		_testGetSiteFragmentSetResourceFoldersPageEmpty();
 		_testGetSiteFragmentSetResourceFoldersPageFragmentSetNonexistentProblemException();
 		_testGetSiteFragmentSetResourceFoldersPageWithoutPermissions();
+		_testGetSiteFragmentSetResourceFoldersPageWithPermissions();
 	}
 
 	@Override
 	@Test
-	@TestInfo("LPD-88489")
+	@TestInfo({"LPD-88395", "LPD-88489"})
 	public void testGetSiteResourceFolder() throws Exception {
 		super.testGetSiteResourceFolder();
 
@@ -132,11 +132,12 @@ public class ResourceFolderResourceTest
 		_testGetSiteResourceFolderPortletFolderProblemException();
 		_testGetSiteResourceFolderResourceFolderNonexistentProblemException();
 		_testGetSiteResourceFolderWithoutPermissionsProblemException();
+		_testGetSiteResourceFolderWithPermissions();
 	}
 
 	@Override
 	@Test
-	@TestInfo("LPD-88489")
+	@TestInfo({"LPD-88395", "LPD-88489"})
 	public void testGetSiteResourceFolderResourceFoldersPage()
 		throws Exception {
 
@@ -146,31 +147,34 @@ public class ResourceFolderResourceTest
 		_testGetSiteResourceFolderResourceFoldersPageEmpty();
 		_testGetSiteResourceFolderResourceFoldersPageResourceFolderNonexistentProblemException();
 		_testGetSiteResourceFolderResourceFoldersPageWithoutPermissionsProblemException();
+		_testGetSiteResourceFolderResourceFoldersPageWithPermissions();
 	}
 
 	@Override
 	@Test
-	@TestInfo("LPD-88489")
+	@TestInfo({"LPD-88395", "LPD-88489"})
 	public void testGetSiteResourceFoldersPage() throws Exception {
 		super.testGetSiteResourceFoldersPage();
 
 		_testGetSiteResourceFoldersPage();
 		_testGetSiteResourceFoldersPagePortletFolder();
 		_testGetSiteResourceFoldersPageWithoutPermissions();
+		_testGetSiteResourceFoldersPageWithPermissions();
 	}
 
 	@Override
 	@Test
-	@TestInfo("LPD-88489")
+	@TestInfo({"LPD-88395", "LPD-88489"})
 	public void testPostSiteFragmentSetResourceFolder() throws Exception {
 		super.testPostSiteFragmentSetResourceFolder();
 
 		_testPostSiteFragmentSetResourceFolderWithoutPermissionsProblemException();
+		_testPostSiteFragmentSetResourceFolderWithPermissions();
 	}
 
 	@Override
 	@Test
-	@TestInfo("LPD-88489")
+	@TestInfo({"LPD-88395", "LPD-88489"})
 	public void testPostSiteResourceFolder() throws Exception {
 		super.testPostSiteResourceFolder();
 
@@ -191,16 +195,18 @@ public class ResourceFolderResourceTest
 		_testPostSiteResourceFolderParentResourceFolderPortletFolderLazyReferencingProblemException();
 		_testPostSiteResourceFolderParentResourceFolderPortletFolderProblemException();
 		_testPostSiteResourceFolderWithoutPermissionsProblemException();
+		_testPostSiteResourceFolderWithPermissions();
 	}
 
 	@Override
 	@Test
-	@TestInfo("LPD-88489")
+	@TestInfo({"LPD-88395", "LPD-88489"})
 	public void testPutSiteResourceFolder() throws Exception {
 		_testPutSiteResourceFolder();
 		_testPutSiteResourceFolderParentResourceFolderExternalReferenceCode();
 		_testPutSiteResourceFolderPortletFolderProblemException();
 		_testPutSiteResourceFolderWithoutPermissionsProblemException();
+		_testPutSiteResourceFolderWithPermissions();
 	}
 
 	@Override
@@ -469,6 +475,55 @@ public class ResourceFolderResourceTest
 			siteExternalReferenceCode, externalReferenceCode);
 	}
 
+	private ResourceFolderResource
+			_getUserWithoutPermissionsResourceFolderResource()
+		throws Exception {
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(testCompany, password);
+
+		_userLocalService.addGroupUser(
+			testGroup.getGroupId(), user.getUserId());
+
+		return ResourceFolderResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	private ResourceFolderResource
+			_getUserWithPermissionsResourceFolderResource()
+		throws Exception {
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(testCompany, password);
+
+		Role role = RoleTestUtil.addRole(
+			RandomTestUtil.randomString(), RoleConstants.TYPE_REGULAR,
+			FragmentConstants.RESOURCE_NAME, ResourceConstants.SCOPE_GROUP,
+			String.valueOf(testGroup.getGroupId()),
+			FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
+
+		_userLocalService.addRoleUser(role.getRoleId(), user.getUserId());
+
+		return ResourceFolderResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
 	private ResourceFolder _postSiteResourceFolder(
 			ResourceFolder parentResourceFolder)
 		throws Exception {
@@ -585,9 +640,10 @@ public class ResourceFolderResourceTest
 				testGroup.getExternalReferenceCode(), randomResourceFolder());
 
 		try {
-			_resourceFolderResource.deleteSiteResourceFolder(
-				testGroup.getExternalReferenceCode(),
-				resourceFolder.getExternalReferenceCode());
+			_userWithoutPermissionsResourceFolderResource.
+				deleteSiteResourceFolder(
+					testGroup.getExternalReferenceCode(),
+					resourceFolder.getExternalReferenceCode());
 
 			Assert.fail();
 		}
@@ -596,6 +652,21 @@ public class ResourceFolderResourceTest
 
 			Assert.assertEquals("FORBIDDEN", problem.getStatus());
 		}
+	}
+
+	private void _testDeleteSiteResourceFolderWithPermissions()
+		throws Exception {
+
+		ResourceFolder resourceFolder =
+			resourceFolderResource.postSiteResourceFolder(
+				testGroup.getExternalReferenceCode(), randomResourceFolder());
+
+		assertHttpResponseStatusCode(
+			204,
+			_userWithPermissionsResourceFolderResource.
+				deleteSiteResourceFolderHttpResponse(
+					testGroup.getExternalReferenceCode(),
+					resourceFolder.getExternalReferenceCode()));
 	}
 
 	private void _testGetSiteFragmentSetResourceFoldersPage() throws Exception {
@@ -662,12 +733,36 @@ public class ResourceFolderResourceTest
 				fragmentCollection.getExternalReferenceCode()));
 
 		Page<ResourceFolder> page =
-			_resourceFolderResource.getSiteFragmentSetResourceFoldersPage(
-				testGroup.getExternalReferenceCode(),
-				fragmentCollection.getExternalReferenceCode(),
-				Pagination.of(1, 10));
+			_userWithoutPermissionsResourceFolderResource.
+				getSiteFragmentSetResourceFoldersPage(
+					testGroup.getExternalReferenceCode(),
+					fragmentCollection.getExternalReferenceCode(),
+					Pagination.of(1, 10));
 
 		Assert.assertEquals(0, page.getTotalCount());
+	}
+
+	private void _testGetSiteFragmentSetResourceFoldersPageWithPermissions()
+		throws Exception {
+
+		FragmentCollection fragmentCollection = _addFragmentCollection(
+			testGroup.getGroupId());
+
+		ResourceFolder resourceFolder =
+			resourceFolderResource.postSiteFragmentSetResourceFolder(
+				testGroup.getExternalReferenceCode(),
+				fragmentCollection.getExternalReferenceCode(),
+				_randomResourceFolder(
+					fragmentCollection.getExternalReferenceCode()));
+
+		Page<ResourceFolder> page =
+			_userWithPermissionsResourceFolderResource.
+				getSiteFragmentSetResourceFoldersPage(
+					testGroup.getExternalReferenceCode(),
+					fragmentCollection.getExternalReferenceCode(),
+					Pagination.of(1, 10));
+
+		assertContains(resourceFolder, (List<ResourceFolder>)page.getItems());
 	}
 
 	private void _testGetSiteResourceFolderFragmentSet() throws Exception {
@@ -840,10 +935,11 @@ public class ResourceFolderResourceTest
 			fragmentCollection.getExternalReferenceCode());
 
 		try {
-			_resourceFolderResource.getSiteResourceFolderResourceFoldersPage(
-				testGroup.getExternalReferenceCode(),
-				resourceFolder.getExternalReferenceCode(),
-				Pagination.of(1, 10));
+			_userWithoutPermissionsResourceFolderResource.
+				getSiteResourceFolderResourceFoldersPage(
+					testGroup.getExternalReferenceCode(),
+					resourceFolder.getExternalReferenceCode(),
+					Pagination.of(1, 10));
 
 			Assert.fail();
 		}
@@ -852,6 +948,29 @@ public class ResourceFolderResourceTest
 
 			Assert.assertEquals("NOT_FOUND", problem.getStatus());
 		}
+	}
+
+	private void _testGetSiteResourceFolderResourceFoldersPageWithPermissions()
+		throws Exception {
+
+		FragmentCollection fragmentCollection = _addFragmentCollection(
+			testGroup.getGroupId());
+
+		ResourceFolder resourceFolder = _postSiteResourceFolder(
+			fragmentCollection.getExternalReferenceCode());
+
+		ResourceFolder childResourceFolder = _postSiteResourceFolder(
+			resourceFolder);
+
+		Page<ResourceFolder> page =
+			_userWithPermissionsResourceFolderResource.
+				getSiteResourceFolderResourceFoldersPage(
+					testGroup.getExternalReferenceCode(),
+					resourceFolder.getExternalReferenceCode(),
+					Pagination.of(1, 10));
+
+		assertContains(
+			childResourceFolder, (List<ResourceFolder>)page.getItems());
 	}
 
 	private void _testGetSiteResourceFoldersPage() throws Exception {
@@ -937,11 +1056,36 @@ public class ResourceFolderResourceTest
 			testGroup.getExternalReferenceCode(), randomResourceFolder());
 
 		Page<ResourceFolder> page =
-			_resourceFolderResource.getSiteResourceFoldersPage(
-				testGroup.getExternalReferenceCode(), null,
-				Pagination.of(1, 10));
+			_userWithoutPermissionsResourceFolderResource.
+				getSiteResourceFoldersPage(
+					testGroup.getExternalReferenceCode(), null,
+					Pagination.of(1, 10));
 
 		Assert.assertEquals(0, page.getTotalCount());
+	}
+
+	private void _testGetSiteResourceFoldersPageWithPermissions()
+		throws Exception {
+
+		FragmentCollection fragmentCollection = _addFragmentCollection(
+			testGroup.getGroupId());
+
+		ResourceFolder resourceFolder = _postSiteResourceFolder(
+			fragmentCollection.getExternalReferenceCode());
+
+		Page<ResourceFolder> page =
+			_userWithPermissionsResourceFolderResource.
+				getSiteResourceFoldersPage(
+					testGroup.getExternalReferenceCode(), null,
+					Pagination.of(1, 1));
+
+		page =
+			_userWithPermissionsResourceFolderResource.
+				getSiteResourceFoldersPage(
+					testGroup.getExternalReferenceCode(), null,
+					Pagination.of(1, (int)page.getTotalCount()));
+
+		assertContains(resourceFolder, (List<ResourceFolder>)page.getItems());
 	}
 
 	private void _testGetSiteResourceFolderWithoutPermissionsProblemException()
@@ -952,7 +1096,7 @@ public class ResourceFolderResourceTest
 				testGroup.getExternalReferenceCode(), randomResourceFolder());
 
 		try {
-			_resourceFolderResource.getSiteResourceFolder(
+			_userWithoutPermissionsResourceFolderResource.getSiteResourceFolder(
 				testGroup.getExternalReferenceCode(),
 				resourceFolder.getExternalReferenceCode());
 
@@ -963,6 +1107,21 @@ public class ResourceFolderResourceTest
 
 			Assert.assertEquals("NOT_FOUND", problem.getStatus());
 		}
+	}
+
+	private void _testGetSiteResourceFolderWithPermissions() throws Exception {
+		ResourceFolder resourceFolder =
+			resourceFolderResource.postSiteResourceFolder(
+				testGroup.getExternalReferenceCode(), randomResourceFolder());
+
+		ResourceFolder getResourceFolder =
+			_userWithPermissionsResourceFolderResource.getSiteResourceFolder(
+				testGroup.getExternalReferenceCode(),
+				resourceFolder.getExternalReferenceCode());
+
+		Assert.assertEquals(
+			resourceFolder.getExternalReferenceCode(),
+			getResourceFolder.getExternalReferenceCode());
 	}
 
 	private void _testPostSiteFragmentSetResourceFolderWithoutPermissionsProblemException()
@@ -977,9 +1136,11 @@ public class ResourceFolderResourceTest
 		resourceFolder.setName(RandomTestUtil.randomString());
 
 		try {
-			_resourceFolderResource.postSiteFragmentSetResourceFolder(
-				testGroup.getExternalReferenceCode(),
-				fragmentCollection.getExternalReferenceCode(), resourceFolder);
+			_userWithoutPermissionsResourceFolderResource.
+				postSiteFragmentSetResourceFolder(
+					testGroup.getExternalReferenceCode(),
+					fragmentCollection.getExternalReferenceCode(),
+					resourceFolder);
 
 			Assert.fail();
 		}
@@ -988,6 +1149,27 @@ public class ResourceFolderResourceTest
 
 			Assert.assertEquals("FORBIDDEN", problem.getStatus());
 		}
+	}
+
+	private void _testPostSiteFragmentSetResourceFolderWithPermissions()
+		throws Exception {
+
+		FragmentCollection fragmentCollection = _addFragmentCollection(
+			testGroup.getGroupId());
+
+		ResourceFolder resourceFolder = _randomResourceFolder(
+			fragmentCollection.getExternalReferenceCode());
+
+		ResourceFolder postResourceFolder =
+			_userWithPermissionsResourceFolderResource.
+				postSiteFragmentSetResourceFolder(
+					testGroup.getExternalReferenceCode(),
+					fragmentCollection.getExternalReferenceCode(),
+					resourceFolder);
+
+		Assert.assertEquals(
+			resourceFolder.getExternalReferenceCode(),
+			postResourceFolder.getExternalReferenceCode());
 	}
 
 	private void _testPostSiteResourceFolder() throws Exception {
@@ -1493,8 +1675,10 @@ public class ResourceFolderResourceTest
 		throws Exception {
 
 		try {
-			_resourceFolderResource.postSiteResourceFolder(
-				testGroup.getExternalReferenceCode(), randomResourceFolder());
+			_userWithoutPermissionsResourceFolderResource.
+				postSiteResourceFolder(
+					testGroup.getExternalReferenceCode(),
+					randomResourceFolder());
 
 			Assert.fail();
 		}
@@ -1503,6 +1687,22 @@ public class ResourceFolderResourceTest
 
 			Assert.assertEquals("FORBIDDEN", problem.getStatus());
 		}
+	}
+
+	private void _testPostSiteResourceFolderWithPermissions() throws Exception {
+		FragmentCollection fragmentCollection = _addFragmentCollection(
+			testGroup.getGroupId());
+
+		ResourceFolder resourceFolder = _randomResourceFolder(
+			fragmentCollection.getExternalReferenceCode());
+
+		ResourceFolder postResourceFolder =
+			_userWithPermissionsResourceFolderResource.postSiteResourceFolder(
+				testGroup.getExternalReferenceCode(), resourceFolder);
+
+		Assert.assertEquals(
+			resourceFolder.getExternalReferenceCode(),
+			postResourceFolder.getExternalReferenceCode());
 	}
 
 	private void _testPutSiteResourceFolder() throws Exception {
@@ -1656,7 +1856,7 @@ public class ResourceFolderResourceTest
 		resourceFolder.setName(RandomTestUtil.randomString());
 
 		try {
-			_resourceFolderResource.putSiteResourceFolder(
+			_userWithoutPermissionsResourceFolderResource.putSiteResourceFolder(
 				testGroup.getExternalReferenceCode(),
 				resourceFolder.getExternalReferenceCode(), resourceFolder);
 
@@ -1667,6 +1867,23 @@ public class ResourceFolderResourceTest
 
 			Assert.assertEquals("FORBIDDEN", problem.getStatus());
 		}
+	}
+
+	private void _testPutSiteResourceFolderWithPermissions() throws Exception {
+		FragmentCollection fragmentCollection = _addFragmentCollection(
+			testGroup.getGroupId());
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		ResourceFolder putResourceFolder =
+			_userWithPermissionsResourceFolderResource.putSiteResourceFolder(
+				testGroup.getExternalReferenceCode(), externalReferenceCode,
+				_randomResourceFolder(
+					fragmentCollection.getExternalReferenceCode()));
+
+		Assert.assertEquals(
+			externalReferenceCode,
+			putResourceFolder.getExternalReferenceCode());
 	}
 
 	private FragmentSet _toFragmentSet(String externalReferenceCode) {
@@ -1710,6 +1927,11 @@ public class ResourceFolderResourceTest
 	@Inject
 	private Language _language;
 
-	private ResourceFolderResource _resourceFolderResource;
+	@Inject
+	private UserLocalService _userLocalService;
+
+	private ResourceFolderResource
+		_userWithoutPermissionsResourceFolderResource;
+	private ResourceFolderResource _userWithPermissionsResourceFolderResource;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88395

## What Is Being Fixed

The headless-admin-fragment permission model let callers reach fragments, fragment sets, resource files, and resource folders in groups they cannot manage, because enforcement was inconsistent. `FragmentCollectionService.getFragmentCollectionByExternalReferenceCode` was the only fragment collection read that did not check `MANAGE_FRAGMENT_ENTRIES`; the site fragments, site fragment set fragments, site fragment sets, and design library fragment sets listings returned entries from groups the requesting user cannot manage; resource folder writes did not check `MANAGE_FRAGMENT_ENTRIES` at all; and resource folder and file operations went through the remote `DLAppService`, coupling access to the document library permission model on top of `MANAGE_FRAGMENT_ENTRIES`. The resource file search also filtered results by the requesting user rather than by the fragment permission.

## How It Is Being Fixed

`MANAGE_FRAGMENT_ENTRIES` becomes the single authority for reading and writing these resources. The by-external-reference-code getter now checks it in the service, closing the gap for every caller including the JSON web service tunnel. The fragment, fragment set, and design library fragment set listings return an empty page for users without the permission, and the searches run with the permission pre-filter disabled and as the default user, since fragment collections define no VIEW action. Resource folder writes check `MANAGE_FRAGMENT_ENTRIES` explicitly, and resource folder and file operations now use the local `DLAppLocalService` so the fragment permission is the only authority, with reads still gated through the `getFragmentCollection` getter. Integration tests cover the gated read at the service layer and the with and without permission scenarios across the fragment, fragment set, resource folder, and design library endpoints, including a design library owner reading the fragment sets.

## PR Check

**pr-check: PASS** — tested on `bcfd4acceef1717608926b22f37949c1df12b3fa`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "bcfd4acceef1717608926b22f37949c1df12b3fa"} -->
