### PR TITLE
LPD-98159 Support nested rule groups with grouped conditions

### DIFF
--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/ConditionsPanel.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/ConditionsPanel.tsx
@@ -36,6 +36,7 @@ import {
 } from '../types';
 import {DropZone, getDropPosition} from '../util/getDropPosition';
 import {canGroupNode} from '../util/tree/canGroupNode';
+import {flattenRules} from '../util/tree/flattenRules';
 import {isGroup} from '../util/tree/isGroup';
 import RuleRow from './RuleRow';
 
@@ -51,6 +52,7 @@ interface RenderContext {
 	dispatch: Dispatch<Action>;
 	getItemProps: (index: number) => NavigationItemProps;
 	iconColorsByKey: Record<string, string>;
+	ruleIndexById: Map<string, number>;
 }
 
 function toMovementItems(
@@ -117,8 +119,14 @@ export default function ConditionsPanel({
 
 	const movementSource = useMovementSource();
 
+	const ruleIndexById = useMemo(
+		() =>
+			new Map(flattenRules(root).map((rule, index) => [rule.id, index])),
+		[root]
+	);
+
 	const {getItemProps} = useKeyboardNavigation({
-		itemCount: root.items.filter((node) => !isGroup(node)).length,
+		itemCount: ruleIndexById.size,
 	});
 
 	const keyboardMovementItems = toMovementItems(
@@ -152,6 +160,7 @@ export default function ConditionsPanel({
 		dispatch,
 		getItemProps,
 		iconColorsByKey,
+		ruleIndexById,
 	};
 
 	return (
@@ -216,6 +225,7 @@ function GroupItems({context, group, path}: GroupItemsProps) {
 		dispatch,
 		getItemProps,
 		iconColorsByKey,
+		ruleIndexById,
 	} = context;
 
 	const topLevel = !path.length;
@@ -246,10 +256,6 @@ function GroupItems({context, group, path}: GroupItemsProps) {
 		<>
 			{group.items.map((node, index) => {
 				const nodePath = [...path, index];
-
-				const ruleIndex = group.items
-					.slice(0, index)
-					.filter((item) => !isGroup(item)).length;
 
 				return (
 					<Fragment key={node.id}>
@@ -282,11 +288,9 @@ function GroupItems({context, group, path}: GroupItemsProps) {
 								iconColor={iconColorsByKey[node.attribute]}
 								index={index}
 								movable={topLevel}
-								navigationProps={
-									topLevel
-										? getItemProps(ruleIndex)
-										: undefined
-								}
+								navigationProps={getItemProps(
+									ruleIndexById.get(node.id) ?? 0
+								)}
 								onAddRule={handleAddRule}
 								onChange={(rule) =>
 									dispatch({

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/ConditionsPanel.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/ConditionsPanel.tsx
@@ -325,7 +325,7 @@ function GroupItems({context, group, path}: GroupItemsProps) {
 									dispatch({
 										nodeId,
 										targetId: node.id,
-										type: 'MOVE_GROUP',
+										type: 'MOVE_RULE_INTO_NEW_GROUP',
 									})
 								}
 								onMoveRule={handleMoveRule}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/ConditionsPanel.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/ConditionsPanel.tsx
@@ -23,17 +23,13 @@ import {DROP_POSITIONS} from '../constants/dropPositions';
 import useKeyboardNavigation, {
 	NavigationItemProps,
 } from '../hooks/useKeyboardNavigation';
-import {useMovementSource} from '../keyboard_movement/KeyboardMovementContext';
-import KeyboardMovementManager, {
-	MovementItem,
-} from '../keyboard_movement/KeyboardMovementManager';
-import {Action} from '../reducer';
 import {
-	AudiencesCriteria,
-	AudiencesCriteriaType,
-	CriteriaNode,
-	Group,
-} from '../types';
+	useMovementSource,
+	useMovementTarget,
+} from '../keyboard_movement/KeyboardMovementContext';
+import KeyboardMovementManager from '../keyboard_movement/KeyboardMovementManager';
+import {Action} from '../reducer';
+import {AudiencesCriteria, AudiencesCriteriaType, Group} from '../types';
 import {DropZone, getDropPosition} from '../util/getDropPosition';
 import {canGroupNode} from '../util/tree/canGroupNode';
 import {flattenRules} from '../util/tree/flattenRules';
@@ -55,27 +51,25 @@ interface RenderContext {
 	ruleIndexById: Map<string, number>;
 }
 
-function toMovementItems(
-	items: CriteriaNode[],
-	audiencesCriteriasByKey: Record<string, AudiencesCriteria>
-): MovementItem[] {
-	return items.map((node) => {
+function collectNodeNames(
+	group: Group,
+	audiencesCriteriasByKey: Record<string, AudiencesCriteria>,
+	namesById: Record<string, string> = {}
+): Record<string, string> {
+	group.items.forEach((node) => {
 		if (isGroup(node)) {
-			return {
-				icon: 'folder',
-				id: node.id,
-				name: Liferay.Language.get('group'),
-			};
+			namesById[node.id] = Liferay.Language.get('group');
+
+			collectNodeNames(node, audiencesCriteriasByKey, namesById);
 		}
-
-		const audiencesCriteria = audiencesCriteriasByKey[node.attribute];
-
-		return {
-			icon: audiencesCriteria?.icon ?? '',
-			id: node.id,
-			name: audiencesCriteria?.label ?? node.attribute,
-		};
+		else {
+			namesById[node.id] =
+				audiencesCriteriasByKey[node.attribute]?.label ??
+				node.attribute;
+		}
 	});
+
+	return namesById;
 }
 
 export default function ConditionsPanel({
@@ -129,9 +123,9 @@ export default function ConditionsPanel({
 		itemCount: ruleIndexById.size,
 	});
 
-	const keyboardMovementItems = toMovementItems(
-		root.items,
-		audiencesCriteriasByKey
+	const namesById = useMemo(
+		() => collectNodeNames(root, audiencesCriteriasByKey),
+		[audiencesCriteriasByKey, root]
 	);
 
 	const [{canDrop, isOver}, drop] = useDrop<
@@ -168,8 +162,8 @@ export default function ConditionsPanel({
 			{movementSource ? (
 				<KeyboardMovementManager
 					dispatch={dispatch}
-					items={keyboardMovementItems}
-					nodes={root.items}
+					namesById={namesById}
+					root={root}
 					source={movementSource}
 				/>
 			) : null}
@@ -228,8 +222,6 @@ function GroupItems({context, group, path}: GroupItemsProps) {
 		ruleIndexById,
 	} = context;
 
-	const topLevel = !path.length;
-
 	const handleAddRule = (
 		audiencesCriteria: AudiencesCriteria,
 		insertIndex?: number
@@ -287,7 +279,6 @@ function GroupItems({context, group, path}: GroupItemsProps) {
 								canGroup={canGroupNode(nodePath)}
 								iconColor={iconColorsByKey[node.attribute]}
 								index={index}
-								movable={topLevel}
 								navigationProps={getItemProps(
 									ruleIndexById.get(node.id) ?? 0
 								)}
@@ -367,9 +358,13 @@ function GroupRow({
 }: GroupRowProps) {
 	const {dispatch} = context;
 
+	const movementTarget = useMovementTarget();
+
 	const groupRef = useRef<HTMLDivElement | null>(null);
 
 	const [dropPosition, setDropPosition] = useState<DropZone | null>(null);
+
+	const isMovementTarget = movementTarget.nodeId === group.id;
 
 	const [{isOver}, dropRef] = useDrop<RowDragItem, void, {isOver: boolean}>({
 		accept: [DRAG_TYPES.ATTRIBUTE, DRAG_TYPES.RULE],
@@ -416,11 +411,16 @@ function GroupRow({
 				'audience-builder-group border overflow-hidden rounded',
 				{
 					'audience-builder-group--drop-bottom':
-						isOver && dropPosition === DROP_POSITIONS.bottom,
+						(isOver && dropPosition === DROP_POSITIONS.bottom) ||
+						(isMovementTarget &&
+							movementTarget.position === DROP_POSITIONS.bottom),
 					'audience-builder-group--drop-top':
-						isOver && dropPosition === DROP_POSITIONS.top,
+						(isOver && dropPosition === DROP_POSITIONS.top) ||
+						(isMovementTarget &&
+							movementTarget.position === DROP_POSITIONS.top),
 				}
 			)}
+			data-keyboard-movement-id={group.id}
 			ref={setGroupRef}
 			role="group"
 		>

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
@@ -69,13 +69,13 @@ export default function RuleRow({
 	const isMovementTarget =
 		Boolean(movementSource) && movementTarget.nodeId === rule.id;
 
-	const isMovementTargetBottomPosition =
+	const isMovementTargetBottom =
 		isMovementTarget && movementTarget.position === DROP_POSITIONS.bottom;
 
-	const isMovementTargetGroupPosition =
+	const isMovementTargetGroup =
 		isMovementTarget && movementTarget.position === 'group';
 
-	const isMovementTargetTopPosition =
+	const isMovementTargetTop =
 		isMovementTarget && movementTarget.position === DROP_POSITIONS.top;
 
 	const [{isDragging}, dragRef, dragPreviewRef] = useDrag<
@@ -151,11 +151,11 @@ export default function RuleRow({
 			<ErrorRuleRow
 				dropBottom={
 					(isOver && dropPosition === DROP_POSITIONS.bottom) ||
-					isMovementTargetBottomPosition
+					isMovementTargetBottom
 				}
 				dropTop={
 					(isOver && dropPosition === DROP_POSITIONS.top) ||
-					isMovementTargetTopPosition
+					isMovementTargetTop
 				}
 				navigationProps={navigationProps}
 				nodeId={rule.id}
@@ -180,13 +180,13 @@ export default function RuleRow({
 						isDragging || isMovementSource,
 					'audience-builder-rule--drop-bottom':
 						(isOver && dropPosition === DROP_POSITIONS.bottom) ||
-						isMovementTargetBottomPosition,
+						isMovementTargetBottom,
 					'audience-builder-rule--drop-group':
 						(isOver && dropPosition === 'group') ||
-						isMovementTargetGroupPosition,
+						isMovementTargetGroup,
 					'audience-builder-rule--drop-top':
 						(isOver && dropPosition === DROP_POSITIONS.top) ||
-						isMovementTargetTopPosition,
+						isMovementTargetTop,
 				}
 			)}
 			data-keyboard-movement-id={rule.id}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
@@ -73,7 +73,7 @@ export default function RuleRow({
 		isMovementTarget && movementTarget.position === DROP_POSITIONS.bottom;
 
 	const isMovementTargetGroup =
-		isMovementTarget && movementTarget.position === 'group';
+		isMovementTarget && movementTarget.position === 'middle';
 
 	const isMovementTargetTop =
 		isMovementTarget && movementTarget.position === DROP_POSITIONS.top;
@@ -115,14 +115,14 @@ export default function RuleRow({
 				dropZone === DROP_POSITIONS.bottom ? index + 1 : index;
 
 			if ('audiencesCriteria' in item) {
-				if (dropZone === 'group') {
+				if (dropZone === 'middle') {
 					onGroup(item.audiencesCriteria);
 				}
 				else {
 					onAddRule(item.audiencesCriteria, insertIndex);
 				}
 			}
-			else if (dropZone === 'group') {
+			else if (dropZone === 'middle') {
 				onMoveGroup(item.id);
 			}
 			else {
@@ -182,7 +182,7 @@ export default function RuleRow({
 						(isOver && dropPosition === DROP_POSITIONS.bottom) ||
 						isMovementTargetBottom,
 					'audience-builder-rule--drop-group':
-						(isOver && dropPosition === 'group') ||
+						(isOver && dropPosition === 'middle') ||
 						isMovementTargetGroup,
 					'audience-builder-rule--drop-top':
 						(isOver && dropPosition === DROP_POSITIONS.top) ||

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
@@ -30,7 +30,6 @@ interface IProps {
 	canGroup: boolean;
 	iconColor: string;
 	index: number;
-	movable: boolean;
 	navigationProps?: NavigationItemProps;
 	onAddRule: (audiencesCriteria: AudiencesCriteria, index?: number) => void;
 	onChange: (rule: Rule) => void;
@@ -47,7 +46,6 @@ export default function RuleRow({
 	canGroup,
 	iconColor,
 	index,
-	movable,
 	navigationProps,
 	onAddRule,
 	onChange,
@@ -66,10 +64,10 @@ export default function RuleRow({
 	const movementTarget = useMovementTarget();
 	const setMovementSource = useSetMovementSource();
 
-	const isMovementSource = movable && movementSource?.ruleId === rule.id;
+	const isMovementSource = movementSource?.ruleId === rule.id;
 
 	const isMovementTarget =
-		movable && Boolean(movementSource) && movementTarget.index === index;
+		Boolean(movementSource) && movementTarget.nodeId === rule.id;
 
 	const isMovementTargetBottomPosition =
 		isMovementTarget && movementTarget.position === DROP_POSITIONS.bottom;
@@ -146,6 +144,7 @@ export default function RuleRow({
 					isMovementTargetTopPosition
 				}
 				navigationProps={navigationProps}
+				nodeId={rule.id}
 				onDelete={onDelete}
 				rowRef={setRowRef}
 			/>
@@ -175,6 +174,7 @@ export default function RuleRow({
 						isMovementTargetTopPosition,
 				}
 			)}
+			data-keyboard-movement-id={rule.id}
 			onFocus={navigationProps?.onFocus}
 			onKeyDown={navigationProps?.onKeyDown}
 			ref={setRowRef}
@@ -188,7 +188,7 @@ export default function RuleRow({
 					className="audience-builder-grip text-secondary"
 					displayType="secondary"
 					onClick={(event) => {
-						if (movable && event.detail === 0) {
+						if (event.detail === 0) {
 							setMovementSource({
 								icon: audiencesCriteria.icon,
 								name: label,
@@ -303,6 +303,7 @@ interface ErrorRuleRowProps {
 	dropBottom: boolean;
 	dropTop: boolean;
 	navigationProps?: NavigationItemProps;
+	nodeId: string;
 	onDelete: () => void;
 	rowRef: (node: HTMLDivElement | null) => void;
 }
@@ -311,6 +312,7 @@ function ErrorRuleRow({
 	dropBottom,
 	dropTop,
 	navigationProps,
+	nodeId,
 	onDelete,
 	rowRef,
 }: ErrorRuleRowProps) {
@@ -326,6 +328,7 @@ function ErrorRuleRow({
 					'audience-builder-rule--drop-top': dropTop,
 				}
 			)}
+			data-keyboard-movement-id={nodeId}
 			onFocus={navigationProps?.onFocus}
 			onKeyDown={navigationProps?.onKeyDown}
 			ref={rowRef}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
@@ -91,6 +91,17 @@ export default function RuleRow({
 		dragPreviewRef(getEmptyImage(), {captureDraggingState: true});
 	}, [dragPreviewRef]);
 
+	useEffect(() => {
+		dropItemRef.current
+			?.querySelectorAll<HTMLElement>('[role="combobox"]')
+			.forEach((element) =>
+				element.setAttribute(
+					'tabindex',
+					String(navigationProps?.tabIndex ?? 0)
+				)
+			);
+	});
+
 	const [{isOver}, dropRef] = useDrop<RowDragItem, void, {isOver: boolean}>({
 		accept: [DRAG_TYPES.ATTRIBUTE, DRAG_TYPES.RULE],
 		canDrop: (item) => !('id' in item) || item.id !== rule.id,
@@ -232,6 +243,7 @@ export default function RuleRow({
 					inputType={inputType}
 					onChange={(value) => onChange({...rule, value})}
 					options={options}
+					tabIndex={navigationProps?.tabIndex ?? 0}
 					type={type}
 					value={rule.value}
 				/>
@@ -245,6 +257,7 @@ export default function RuleRow({
 					onClick={onDuplicate}
 					size="sm"
 					symbol="copy"
+					tabIndex={navigationProps?.tabIndex ?? 0}
 					title={Liferay.Language.get('duplicate')}
 				/>
 
@@ -255,6 +268,7 @@ export default function RuleRow({
 					onClick={onDelete}
 					size="sm"
 					symbol="times-circle"
+					tabIndex={navigationProps?.tabIndex ?? 0}
 					title={Liferay.Language.get('delete')}
 				/>
 			</div>
@@ -266,6 +280,7 @@ interface RuleValueFieldProps {
 	inputType: AudiencesCriteria['inputType'];
 	onChange: (value: string) => void;
 	options: AudiencesCriteria['options'];
+	tabIndex: number;
 	type: AudiencesCriteria['type'];
 	value: string;
 }
@@ -274,6 +289,7 @@ function RuleValueField({
 	inputType,
 	onChange,
 	options,
+	tabIndex,
 	type,
 	value,
 }: RuleValueFieldProps) {
@@ -297,6 +313,7 @@ function RuleValueField({
 			className="form-control-sm text-3"
 			onChange={(event) => onChange(event.target.value)}
 			placeholder={inputType === 'date' ? 'YYYY-MM-DD' : undefined}
+			tabIndex={tabIndex}
 			type={type === 'number' ? 'number' : 'text'}
 			value={value}
 		/>
@@ -356,6 +373,7 @@ function ErrorRuleRow({
 				onClick={onDelete}
 				size="sm"
 				symbol="times-circle"
+				tabIndex={navigationProps?.tabIndex ?? 0}
 				title={Liferay.Language.get('delete')}
 			/>
 		</div>

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
@@ -91,6 +91,10 @@ export default function RuleRow({
 		dragPreviewRef(getEmptyImage(), {captureDraggingState: true});
 	}, [dragPreviewRef]);
 
+	// Clay's Picker forces tabindex="0" on its combobox trigger and ignores the
+	// tabindex prop, so mirror the roving value onto it to keep inactive rows
+	// out of the tab order.
+
 	useEffect(() => {
 		dropItemRef.current
 			?.querySelectorAll<HTMLElement>('[role="combobox"]')
@@ -100,7 +104,7 @@ export default function RuleRow({
 					String(navigationProps?.tabIndex ?? 0)
 				)
 			);
-	});
+	}, [navigationProps?.tabIndex]);
 
 	const [{isOver}, dropRef] = useDrop<RowDragItem, void, {isOver: boolean}>({
 		accept: [DRAG_TYPES.ATTRIBUTE, DRAG_TYPES.RULE],

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
@@ -72,6 +72,9 @@ export default function RuleRow({
 	const isMovementTargetBottomPosition =
 		isMovementTarget && movementTarget.position === DROP_POSITIONS.bottom;
 
+	const isMovementTargetGroupPosition =
+		isMovementTarget && movementTarget.position === 'group';
+
 	const isMovementTargetTopPosition =
 		isMovementTarget && movementTarget.position === DROP_POSITIONS.top;
 
@@ -168,7 +171,8 @@ export default function RuleRow({
 						(isOver && dropPosition === DROP_POSITIONS.bottom) ||
 						isMovementTargetBottomPosition,
 					'audience-builder-rule--drop-group':
-						isOver && dropPosition === 'group',
+						(isOver && dropPosition === 'group') ||
+						isMovementTargetGroupPosition,
 					'audience-builder-rule--drop-top':
 						(isOver && dropPosition === DROP_POSITIONS.top) ||
 						isMovementTargetTopPosition,

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/constants/keyboardCodes.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/constants/keyboardCodes.ts
@@ -14,3 +14,5 @@ export const ENTER_KEY_CODE = 'Enter';
 export const ESCAPE_KEY_CODE = 'Escape';
 
 export const HOME_KEY_CODE = 'Home';
+
+export const SPACE_KEY_CODE = 'Space';

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/DragPreviewWrapper.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/DragPreviewWrapper.tsx
@@ -13,13 +13,13 @@ export default function DragPreviewWrapper() {
 	const target = useMovementTarget();
 
 	const alignment = useMemo(() => {
-		if (!source || target.index === null || !target.position) {
+		if (!source || !target.nodeId || !target.position) {
 			return undefined;
 		}
 
-		const element = document.querySelectorAll<HTMLElement>(
-			'.audience-builder-rule'
-		)[target.index];
+		const element = document.querySelector<HTMLElement>(
+			`[data-keyboard-movement-id="${target.nodeId}"]`
+		);
 
 		if (!element) {
 			return undefined;

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/DragPreviewWrapper.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/DragPreviewWrapper.tsx
@@ -13,7 +13,12 @@ export default function DragPreviewWrapper() {
 	const target = useMovementTarget();
 
 	const alignment = useMemo(() => {
-		if (!source || !target.nodeId || !target.position) {
+		if (
+			!source ||
+			!target.nodeId ||
+			!target.position ||
+			target.position === 'group'
+		) {
 			return undefined;
 		}
 

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/DragPreviewWrapper.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/DragPreviewWrapper.tsx
@@ -13,12 +13,7 @@ export default function DragPreviewWrapper() {
 	const target = useMovementTarget();
 
 	const alignment = useMemo(() => {
-		if (
-			!source ||
-			!target.nodeId ||
-			!target.position ||
-			target.position === 'group'
-		) {
+		if (!source || !target.nodeId || !target.position) {
 			return undefined;
 		}
 

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementContext.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementContext.tsx
@@ -6,8 +6,8 @@
 import {ScreenReaderAnnouncer} from '@liferay/layout-js-components-web';
 import React, {useCallback, useContext, useRef, useState} from 'react';
 
-import {DropPosition} from '../constants/dropPositions';
 import {AudiencesCriteria} from '../types';
+import {DropZone} from '../util/getDropPosition';
 
 export interface MovementSource {
 	audiencesCriteria?: AudiencesCriteria;
@@ -18,7 +18,7 @@ export interface MovementSource {
 
 export interface MovementTarget {
 	nodeId: string | null;
-	position: DropPosition | null;
+	position: DropZone | null;
 }
 
 interface KeyboardMovementContextValue {

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementContext.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementContext.tsx
@@ -17,7 +17,7 @@ export interface MovementSource {
 }
 
 export interface MovementTarget {
-	index: number | null;
+	nodeId: string | null;
 	position: DropPosition | null;
 }
 
@@ -30,7 +30,7 @@ interface KeyboardMovementContextValue {
 }
 
 const INITIAL_TARGET: MovementTarget = {
-	index: null,
+	nodeId: null,
 	position: null,
 };
 

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementManager.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementManager.tsx
@@ -16,7 +16,8 @@ import {
 	HOME_KEY_CODE,
 } from '../constants/keyboardCodes';
 import {Action} from '../reducer';
-import {CriteriaNode} from '../types';
+import {Group} from '../types';
+import {MoveTarget, getMoveTargets} from '../util/getMoveTargets';
 import {
 	MovementSource,
 	MovementTarget,
@@ -26,35 +27,17 @@ import {
 	useSetMovementText,
 } from './KeyboardMovementContext';
 
-const ACTION_TYPES = {
-	add: 'add',
-	move: 'move',
-} as const;
-
-const DIRECTIONS = {
-	down: 'down',
-	up: 'up',
-} as const;
-
-type Direction = keyof typeof DIRECTIONS;
-
-export interface MovementItem {
-	icon: string;
-	id: string;
-	name: string;
-}
-
 interface Props {
 	dispatch: Dispatch<Action>;
-	items: MovementItem[];
-	nodes: CriteriaNode[];
+	namesById: Record<string, string>;
+	root: Group;
 	source: MovementSource;
 }
 
 export default function KeyboardMovementManager({
 	dispatch,
-	items,
-	nodes,
+	namesById,
+	root,
 	source,
 }: Props) {
 	const disableMovement = useDisableKeyboardMovement();
@@ -62,12 +45,28 @@ export default function KeyboardMovementManager({
 	const setText = useSetMovementText();
 	const target = useMovementTarget();
 
+	const targets = getMoveTargets(root);
+
+	const currentIndex = targets.findIndex(
+		(moveTarget) =>
+			moveTarget.nodeId === target.nodeId &&
+			moveTarget.position === target.position
+	);
+
+	const sourceIndex = source.ruleId
+		? targets.findIndex(
+				(moveTarget) =>
+					moveTarget.nodeId === source.ruleId &&
+					moveTarget.position === DROP_POSITIONS.top
+			)
+		: -1;
+
 	useEffect(() => {
-		if (target.index !== null) {
+		if (target.nodeId !== null) {
 			return;
 		}
 
-		if (!items.length) {
+		if (!targets.length) {
 			if (!source.ruleId && source.audiencesCriteria) {
 				dispatch({
 					audiencesCriteria: source.audiencesCriteria,
@@ -83,7 +82,7 @@ export default function KeyboardMovementManager({
 			return;
 		}
 
-		setTarget(getInitialTarget(source, nodes));
+		setTarget(toMovementTarget(getInitialTarget(targets, sourceIndex)));
 
 		setText(
 			Liferay.Language.get(
@@ -93,54 +92,30 @@ export default function KeyboardMovementManager({
 	}, [
 		disableMovement,
 		dispatch,
-		items,
-		nodes,
 		setTarget,
 		setText,
 		source,
+		sourceIndex,
 		target,
+		targets,
 	]);
 
 	useEffect(() => {
 		const executeAction = () => {
-			if (target.index === null || !target.position) {
+			const moveTarget = targets[currentIndex];
+
+			if (!moveTarget) {
 				return;
 			}
 
-			const insertionIndex =
-				target.position === DROP_POSITIONS.bottom
-					? target.index + 1
-					: target.index;
-
-			const actionType = source.ruleId
-				? ACTION_TYPES.move
-				: ACTION_TYPES.add;
-
-			if (actionType === ACTION_TYPES.add) {
-				if (!source.audiencesCriteria) {
-					return;
-				}
-
-				dispatch({
-					audiencesCriteria: source.audiencesCriteria,
-					index: insertionIndex,
-					type: 'ADD_RULE',
-				});
-			}
-			else {
-				const sourceIndex = nodes.findIndex(
-					(node) => node.id === source.ruleId
-				);
-
-				if (sourceIndex === -1) {
-					disableMovement();
-
-					return;
-				}
+			if (source.ruleId) {
+				const sourceTarget = targets[sourceIndex];
 
 				if (
-					insertionIndex === sourceIndex ||
-					insertionIndex === sourceIndex + 1
+					sourceTarget &&
+					moveTarget.groupId === sourceTarget.groupId &&
+					(moveTarget.index === sourceTarget.index ||
+						moveTarget.index === sourceTarget.index + 1)
 				) {
 					setText('');
 
@@ -149,43 +124,46 @@ export default function KeyboardMovementManager({
 					return;
 				}
 
-				const nextNodes = [...nodes];
-
-				const [movedNode] = nextNodes.splice(sourceIndex, 1);
-
-				nextNodes.splice(
-					insertionIndex > sourceIndex
-						? insertionIndex - 1
-						: insertionIndex,
-					0,
-					movedNode
-				);
-
-				dispatch({items: nextNodes, type: 'REORDER_RULES'});
+				dispatch({
+					nodeId: source.ruleId,
+					targetGroupId: moveTarget.groupId,
+					targetIndex: moveTarget.index,
+					type: 'MOVE_RULE',
+				});
+			}
+			else if (source.audiencesCriteria) {
+				dispatch({
+					audiencesCriteria: source.audiencesCriteria,
+					groupPath: moveTarget.groupPath,
+					index: moveTarget.index,
+					type: 'ADD_RULE',
+				});
 			}
 
 			setText(
 				sub(Liferay.Language.get('x-placed-on-x-of-x'), [
 					source.name,
-					target.position,
-					items[target.index].name,
+					moveTarget.position,
+					namesById[moveTarget.nodeId] ?? '',
 				])
 			);
 
 			disableMovement();
 		};
 
-		const moveTarget = (nextTarget: MovementTarget | null) => {
-			if (!nextTarget || nextTarget.index === null) {
+		const moveTo = (nextIndex: number) => {
+			const moveTarget = targets[nextIndex];
+
+			if (!moveTarget) {
 				return;
 			}
 
-			setTarget(nextTarget);
+			setTarget(toMovementTarget(moveTarget));
 
 			setText(
 				sub(Liferay.Language.get('targeting-x-of-x'), [
-					nextTarget.position,
-					items[nextTarget.index].name,
+					moveTarget.position,
+					namesById[moveTarget.nodeId] ?? '',
 				])
 			);
 		};
@@ -195,18 +173,13 @@ export default function KeyboardMovementManager({
 			event.stopPropagation();
 
 			if (event.code === ARROW_DOWN_KEY_CODE) {
-				moveTarget(
-					getNextTarget(target, DIRECTIONS.down, items.length)
-				);
+				moveTo(currentIndex + 1);
 			}
 			else if (event.code === ARROW_UP_KEY_CODE) {
-				moveTarget(getNextTarget(target, DIRECTIONS.up, items.length));
+				moveTo(currentIndex - 1);
 			}
 			else if (event.code === END_KEY_CODE) {
-				moveTarget({
-					index: items.length - 1,
-					position: DROP_POSITIONS.bottom,
-				});
+				moveTo(targets.length - 1);
 			}
 			else if (event.code === ENTER_KEY_CODE) {
 				executeAction();
@@ -217,7 +190,7 @@ export default function KeyboardMovementManager({
 				disableMovement();
 			}
 			else if (event.code === HOME_KEY_CODE) {
-				moveTarget({index: 0, position: DROP_POSITIONS.top});
+				moveTo(0);
 			}
 		};
 
@@ -229,50 +202,17 @@ export default function KeyboardMovementManager({
 	return null;
 }
 
-export function getInitialTarget(
-	source: MovementSource,
-	nodes: CriteriaNode[]
-): MovementTarget {
-	if (source.ruleId) {
-		return {
-			index: nodes.findIndex((node) => node.id === source.ruleId),
-			position: DROP_POSITIONS.bottom,
-		};
+function getInitialTarget(
+	targets: MoveTarget[],
+	sourceIndex: number
+): MoveTarget {
+	if (sourceIndex !== -1) {
+		return targets[sourceIndex + 1] ?? targets[sourceIndex];
 	}
 
-	return {index: nodes.length - 1, position: DROP_POSITIONS.bottom};
+	return targets[targets.length - 1];
 }
 
-export function getNextTarget(
-	target: MovementTarget,
-	direction: Direction,
-	itemsCount: number
-): MovementTarget | null {
-	const {index, position} = target;
-
-	if (index === null || !position) {
-		return null;
-	}
-
-	if (direction === DIRECTIONS.down) {
-		if (position === DROP_POSITIONS.top) {
-			return {index, position: DROP_POSITIONS.bottom};
-		}
-
-		if (index < itemsCount - 1) {
-			return {index: index + 1, position: DROP_POSITIONS.bottom};
-		}
-
-		return null;
-	}
-
-	if (position === DROP_POSITIONS.bottom) {
-		if (index === 0) {
-			return {index: 0, position: DROP_POSITIONS.top};
-		}
-
-		return {index: index - 1, position: DROP_POSITIONS.bottom};
-	}
-
-	return null;
+function toMovementTarget(moveTarget: MoveTarget): MovementTarget {
+	return {nodeId: moveTarget.nodeId, position: moveTarget.position};
 }

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementManager.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementManager.tsx
@@ -14,6 +14,7 @@ import {
 	ENTER_KEY_CODE,
 	ESCAPE_KEY_CODE,
 	HOME_KEY_CODE,
+	SPACE_KEY_CODE,
 } from '../constants/keyboardCodes';
 import {Action} from '../reducer';
 import {Group} from '../types';
@@ -208,7 +209,10 @@ export default function KeyboardMovementManager({
 			else if (event.code === END_KEY_CODE) {
 				moveTo(targets.length - 1);
 			}
-			else if (event.code === ENTER_KEY_CODE) {
+			else if (
+				event.code === ENTER_KEY_CODE ||
+				event.code === SPACE_KEY_CODE
+			) {
 				executeAction();
 			}
 			else if (event.code === ESCAPE_KEY_CODE) {

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementManager.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementManager.tsx
@@ -17,6 +17,7 @@ import {
 } from '../constants/keyboardCodes';
 import {Action} from '../reducer';
 import {Group} from '../types';
+import {DropZone} from '../util/getDropPosition';
 import {MoveTarget, getMoveTargets} from '../util/getMoveTargets';
 import {
 	MovementSource,
@@ -169,7 +170,7 @@ export default function KeyboardMovementManager({
 			setText(
 				sub(Liferay.Language.get('x-placed-on-x-of-x'), [
 					source.name,
-					moveTarget.position,
+					getPositionLabel(moveTarget.position),
 					namesById[moveTarget.nodeId] ?? '',
 				])
 			);
@@ -188,7 +189,7 @@ export default function KeyboardMovementManager({
 
 			setText(
 				sub(Liferay.Language.get('targeting-x-of-x'), [
-					moveTarget.position,
+					getPositionLabel(moveTarget.position),
 					namesById[moveTarget.nodeId] ?? '',
 				])
 			);
@@ -226,6 +227,18 @@ export default function KeyboardMovementManager({
 	});
 
 	return null;
+}
+
+function getPositionLabel(position: DropZone): string {
+	if (position === 'group') {
+		return Liferay.Language.get('group');
+	}
+
+	if (position === DROP_POSITIONS.top) {
+		return Liferay.Language.get('top');
+	}
+
+	return Liferay.Language.get('bottom');
 }
 
 function getInitialTarget(

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementManager.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementManager.tsx
@@ -4,7 +4,7 @@
  */
 
 import {sub} from 'frontend-js-web';
-import {Dispatch, useEffect} from 'react';
+import {Dispatch, useEffect, useMemo} from 'react';
 
 import {DROP_POSITIONS} from '../constants/dropPositions';
 import {
@@ -45,7 +45,15 @@ export default function KeyboardMovementManager({
 	const setText = useSetMovementText();
 	const target = useMovementTarget();
 
-	const targets = getMoveTargets(root);
+	const targets = useMemo(
+		() =>
+			getMoveTargets(root).filter(
+				(moveTarget) =>
+					moveTarget.position !== 'group' ||
+					moveTarget.nodeId !== source.ruleId
+			),
+		[root, source.ruleId]
+	);
 
 	const currentIndex = targets.findIndex(
 		(moveTarget) =>
@@ -109,35 +117,53 @@ export default function KeyboardMovementManager({
 			}
 
 			if (source.ruleId) {
-				const sourceTarget = targets[sourceIndex];
-
-				if (
-					sourceTarget &&
-					moveTarget.groupId === sourceTarget.groupId &&
-					(moveTarget.index === sourceTarget.index ||
-						moveTarget.index === sourceTarget.index + 1)
-				) {
-					setText('');
-
-					disableMovement();
-
-					return;
+				if (moveTarget.position === 'group') {
+					dispatch({
+						nodeId: source.ruleId,
+						targetId: moveTarget.nodeId,
+						type: 'MOVE_GROUP',
+					});
 				}
+				else {
+					const sourceTarget = targets[sourceIndex];
 
-				dispatch({
-					nodeId: source.ruleId,
-					targetGroupId: moveTarget.groupId,
-					targetIndex: moveTarget.index,
-					type: 'MOVE_RULE',
-				});
+					if (
+						sourceTarget &&
+						moveTarget.groupId === sourceTarget.groupId &&
+						(moveTarget.index === sourceTarget.index ||
+							moveTarget.index === sourceTarget.index + 1)
+					) {
+						setText('');
+
+						disableMovement();
+
+						return;
+					}
+
+					dispatch({
+						nodeId: source.ruleId,
+						targetGroupId: moveTarget.groupId,
+						targetIndex: moveTarget.index,
+						type: 'MOVE_RULE',
+					});
+				}
 			}
 			else if (source.audiencesCriteria) {
-				dispatch({
-					audiencesCriteria: source.audiencesCriteria,
-					groupPath: moveTarget.groupPath,
-					index: moveTarget.index,
-					type: 'ADD_RULE',
-				});
+				if (moveTarget.position === 'group') {
+					dispatch({
+						audiencesCriteria: source.audiencesCriteria,
+						targetId: moveTarget.nodeId,
+						type: 'ADD_GROUP',
+					});
+				}
+				else {
+					dispatch({
+						audiencesCriteria: source.audiencesCriteria,
+						groupPath: moveTarget.groupPath,
+						index: moveTarget.index,
+						type: 'ADD_RULE',
+					});
+				}
 			}
 
 			setText(

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementManager.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementManager.tsx
@@ -51,7 +51,7 @@ export default function KeyboardMovementManager({
 		() =>
 			getMoveTargets(root).filter(
 				(moveTarget) =>
-					moveTarget.position !== 'group' ||
+					moveTarget.position !== 'middle' ||
 					moveTarget.nodeId !== source.ruleId
 			),
 		[root, source.ruleId]
@@ -119,7 +119,7 @@ export default function KeyboardMovementManager({
 			}
 
 			if (source.ruleId) {
-				if (moveTarget.position === 'group') {
+				if (moveTarget.position === 'middle') {
 					dispatch({
 						nodeId: source.ruleId,
 						targetId: moveTarget.nodeId,
@@ -151,7 +151,7 @@ export default function KeyboardMovementManager({
 				}
 			}
 			else if (source.audiencesCriteria) {
-				if (moveTarget.position === 'group') {
+				if (moveTarget.position === 'middle') {
 					dispatch({
 						audiencesCriteria: source.audiencesCriteria,
 						targetId: moveTarget.nodeId,
@@ -234,7 +234,7 @@ export default function KeyboardMovementManager({
 }
 
 function getPositionLabel(position: DropZone): string {
-	if (position === 'group') {
+	if (position === 'middle') {
 		return Liferay.Language.get('group');
 	}
 

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementManager.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementManager.tsx
@@ -111,7 +111,7 @@ export default function KeyboardMovementManager({
 	]);
 
 	useEffect(() => {
-		const executeAction = () => {
+		const confirmPlacement = () => {
 			const moveTarget = targets[currentIndex];
 
 			if (!moveTarget) {
@@ -213,7 +213,7 @@ export default function KeyboardMovementManager({
 				event.code === ENTER_KEY_CODE ||
 				event.code === SPACE_KEY_CODE
 			) {
-				executeAction();
+				confirmPlacement();
 			}
 			else if (event.code === ESCAPE_KEY_CODE) {
 				setText('');

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementManager.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementManager.tsx
@@ -123,7 +123,7 @@ export default function KeyboardMovementManager({
 					dispatch({
 						nodeId: source.ruleId,
 						targetId: moveTarget.nodeId,
-						type: 'MOVE_GROUP',
+						type: 'MOVE_RULE_INTO_NEW_GROUP',
 					});
 				}
 				else {

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/reducer.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/reducer.ts
@@ -15,8 +15,8 @@ import {addRule} from './util/tree/addRule';
 import {deleteEmptyGroups} from './util/tree/deleteEmptyGroups';
 import {deleteRule} from './util/tree/deleteRule';
 import {duplicateRule} from './util/tree/duplicateRule';
-import {moveGroup} from './util/tree/moveGroup';
 import {moveRule} from './util/tree/moveRule';
+import {moveRuleIntoNewGroup} from './util/tree/moveRuleIntoNewGroup';
 import {parseRootGroup} from './util/tree/parseRootGroup';
 import {reorderGroup} from './util/tree/reorderGroup';
 import {serializeGroup} from './util/tree/serializeGroup';
@@ -48,7 +48,7 @@ export type Action =
 			targetIndex: number;
 			type: 'MOVE_RULE';
 	  }
-	| {nodeId: string; targetId: string; type: 'MOVE_GROUP'}
+	| {nodeId: string; targetId: string; type: 'MOVE_RULE_INTO_NEW_GROUP'}
 	| {conjunction: string; groupPath?: number[]; type: 'SET_CONJUNCTION'}
 	| {externalReferenceCode: string; type: 'SET_EXTERNAL_REFERENCE_CODE'}
 	| {groupPath?: number[]; items: CriteriaNode[]; type: 'REORDER_RULES'}
@@ -114,10 +114,14 @@ export function reducer(state: State, action: Action): State {
 			};
 		case 'DUPLICATE_RULE':
 			return {...state, root: duplicateRule(state.root, action.path)};
-		case 'MOVE_GROUP':
+		case 'MOVE_RULE_INTO_NEW_GROUP':
 			return {
 				...state,
-				root: moveGroup(state.root, action.nodeId, action.targetId),
+				root: moveRuleIntoNewGroup(
+					state.root,
+					action.nodeId,
+					action.targetId
+				),
 			};
 		case 'MOVE_RULE':
 			return {

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/getDropPosition.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/getDropPosition.ts
@@ -8,7 +8,7 @@ import {DropTargetMonitor} from 'react-dnd';
 
 import {DROP_POSITIONS, DropPosition} from '../constants/dropPositions';
 
-export type DropZone = DropPosition | 'group';
+export type DropZone = DropPosition | 'middle';
 
 export function getDropPosition(
 	ref: React.RefObject<HTMLElement>,
@@ -41,5 +41,5 @@ export function getDropPosition(
 		return DROP_POSITIONS.bottom;
 	}
 
-	return 'group';
+	return 'middle';
 }

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/getMoveTargets.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/getMoveTargets.ts
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {DROP_POSITIONS, DropPosition} from '../constants/dropPositions';
+import {DROP_POSITIONS} from '../constants/dropPositions';
 import {Group} from '../types';
+import {DropZone} from './getDropPosition';
+import {canGroupNode} from './tree/canGroupNode';
 import {isGroup} from './tree/isGroup';
 
 export interface MoveTarget {
@@ -12,7 +14,7 @@ export interface MoveTarget {
 	groupPath: number[];
 	index: number;
 	nodeId: string;
-	position: DropPosition;
+	position: DropZone;
 }
 
 export function getMoveTargets(root: Group): MoveTarget[] {
@@ -30,6 +32,15 @@ export function getMoveTargets(root: Group): MoveTarget[] {
 
 			if (isGroup(node)) {
 				collectTargets(node, [...groupPath, index]);
+			}
+			else if (canGroupNode([...groupPath, index])) {
+				targets.push({
+					groupId: group.id,
+					groupPath,
+					index,
+					nodeId: node.id,
+					position: 'group',
+				});
 			}
 
 			if (index === group.items.length - 1) {

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/getMoveTargets.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/getMoveTargets.ts
@@ -39,7 +39,7 @@ export function getMoveTargets(root: Group): MoveTarget[] {
 					groupPath,
 					index,
 					nodeId: node.id,
-					position: 'group',
+					position: 'middle',
 				});
 			}
 

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/getMoveTargets.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/getMoveTargets.ts
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {DROP_POSITIONS, DropPosition} from '../constants/dropPositions';
+import {Group} from '../types';
+import {isGroup} from './tree/isGroup';
+
+export interface MoveTarget {
+	groupId: string;
+	groupPath: number[];
+	index: number;
+	nodeId: string;
+	position: DropPosition;
+}
+
+export function getMoveTargets(root: Group): MoveTarget[] {
+	const targets: MoveTarget[] = [];
+
+	const collectTargets = (group: Group, groupPath: number[]) => {
+		group.items.forEach((node, index) => {
+			targets.push({
+				groupId: group.id,
+				groupPath,
+				index,
+				nodeId: node.id,
+				position: DROP_POSITIONS.top,
+			});
+
+			if (isGroup(node)) {
+				collectTargets(node, [...groupPath, index]);
+			}
+
+			if (index === group.items.length - 1) {
+				targets.push({
+					groupId: group.id,
+					groupPath,
+					index: index + 1,
+					nodeId: node.id,
+					position: DROP_POSITIONS.bottom,
+				});
+			}
+		});
+	};
+
+	collectTargets(root, []);
+
+	return targets;
+}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/tree/addGroup.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/tree/addGroup.ts
@@ -7,7 +7,6 @@ import {AudiencesCriteria, Group} from '../../types';
 import {createRule} from './createRule';
 import {findParent} from './findParent';
 import {insertIntoGroup} from './insertIntoGroup';
-import {unwrapRedundantGroups} from './unwrapRedundantGroups';
 import {wrapNode} from './wrapNode';
 
 export function addGroup(
@@ -24,5 +23,5 @@ export function addGroup(
 		return insertIntoGroup(root, parent.id, rule, 1);
 	}
 
-	return unwrapRedundantGroups(wrapNode(root, targetId, rule, conjunction));
+	return wrapNode(root, targetId, rule, conjunction);
 }

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/tree/flattenRules.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/tree/flattenRules.ts
@@ -1,0 +1,13 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Group, Rule} from '../../types';
+import {isGroup} from './isGroup';
+
+export function flattenRules(group: Group): Rule[] {
+	return group.items.flatMap((node) =>
+		isGroup(node) ? flattenRules(node) : [node]
+	);
+}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/tree/moveRuleIntoNewGroup.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/tree/moveRuleIntoNewGroup.ts
@@ -12,7 +12,7 @@ import {insertIntoGroup} from './insertIntoGroup';
 import {unwrapRedundantGroups} from './unwrapRedundantGroups';
 import {wrapNode} from './wrapNode';
 
-export function moveGroup(
+export function moveRuleIntoNewGroup(
 	root: Group,
 	nodeId: string,
 	targetId: string,

--- a/modules/apps/audiences/audiences-web/test/js/AudienceBuilder.test.tsx
+++ b/modules/apps/audiences/audiences-web/test/js/AudienceBuilder.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import '@testing-library/jest-dom';
-import {fireEvent, render, screen, within} from '@testing-library/react';
+import {render, screen, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -113,7 +113,7 @@ describe('AudienceBuilder', () => {
 				)
 			).toBeInTheDocument();
 
-			await userEvent.keyboard('{ArrowUp}');
+			await userEvent.keyboard('{ArrowUp}{ArrowUp}');
 
 			expect(
 				container.querySelector('.audience-builder-rule')
@@ -184,7 +184,9 @@ describe('AudienceBuilder', () => {
 				/>
 			);
 
-			fireEvent.click(screen.getAllByTitle('move-x')[0]);
+			screen.getAllByTitle('move-x')[0].focus();
+
+			await userEvent.keyboard('{Enter}');
 
 			await userEvent.keyboard('{ArrowDown}{Enter}');
 
@@ -208,14 +210,97 @@ describe('AudienceBuilder', () => {
 				/>
 			);
 
-			fireEvent.click(screen.getByTitle('move-x'));
+			screen.getByTitle('move-x').focus();
 
-			await userEvent.keyboard('{ArrowUp}{ArrowUp}{Enter}');
+			await userEvent.keyboard('{Enter}');
+
+			await userEvent.keyboard('{ArrowUp}{ArrowUp}{ArrowUp}{Enter}');
 
 			expect(getSerializedRuleAttributes(container)).toEqual([
 				'age',
 				'removed',
 			]);
+		});
+
+		it('moves a nested condition out of its group', async () => {
+			const {container} = render(
+				<AudienceBuilder
+					audiencesCriteriaTypes={AUDIENCES_CRITERIA_TYPES}
+					rulesGroup={{
+						conjunction: 'AND',
+						rules: [
+							{attribute: 'age', operator: 'gt', value: '18'},
+							{
+								conjunction: 'OR',
+								rules: [
+									{
+										attribute: 'city',
+										operator: 'eq',
+										value: 'Madrid',
+									},
+									{
+										attribute: 'country',
+										operator: 'eq',
+										value: 'ES',
+									},
+								],
+							},
+						],
+					}}
+				/>
+			);
+
+			screen.getAllByTitle('move-x')[1].focus();
+
+			await userEvent.keyboard('{Enter}');
+
+			await userEvent.keyboard(
+				'{ArrowUp}{ArrowUp}{ArrowUp}{ArrowUp}{Enter}'
+			);
+
+			expect(getSerializedRuleAttributes(container)).toEqual([
+				'city',
+				'age',
+				'country',
+			]);
+		});
+
+		it('groups two conditions with the keyboard', async () => {
+			const {container} = render(
+				<AudienceBuilder
+					audiencesCriteriaTypes={AUDIENCES_CRITERIA_TYPES}
+					rulesGroup={{
+						conjunction: 'AND',
+						rules: [
+							{attribute: 'age', operator: 'gt', value: '18'},
+							{
+								attribute: 'city',
+								operator: 'eq',
+								value: 'Madrid',
+							},
+							{attribute: 'country', operator: 'eq', value: 'ES'},
+						],
+					}}
+				/>
+			);
+
+			screen.getAllByTitle('move-x')[0].focus();
+
+			await userEvent.keyboard('{Enter}');
+
+			await userEvent.keyboard('{ArrowDown}{Enter}');
+
+			const input =
+				container.querySelector<HTMLInputElement>('input[name="json"]');
+
+			const serializedCriteria = JSON.parse(input!.value);
+
+			expect(
+				serializedCriteria.rules[0].rules.map(
+					(rule: {attribute: string}) => rule.attribute
+				)
+			).toEqual(['city', 'age']);
+			expect(serializedCriteria.rules[1].attribute).toBe('country');
 		});
 
 		it('cancels the movement with escape', async () => {
@@ -236,7 +321,9 @@ describe('AudienceBuilder', () => {
 				/>
 			);
 
-			fireEvent.click(screen.getAllByTitle('move-x')[0]);
+			screen.getAllByTitle('move-x')[0].focus();
+
+			await userEvent.keyboard('{Enter}');
 
 			await userEvent.keyboard('{ArrowDown}{Escape}');
 

--- a/modules/apps/audiences/audiences-web/test/js/AudienceBuilder.test.tsx
+++ b/modules/apps/audiences/audiences-web/test/js/AudienceBuilder.test.tsx
@@ -196,6 +196,36 @@ describe('AudienceBuilder', () => {
 			]);
 		});
 
+		it('commits the movement with space', async () => {
+			const {container} = render(
+				<AudienceBuilder
+					audiencesCriteriaTypes={AUDIENCES_CRITERIA_TYPES}
+					rulesGroup={{
+						conjunction: 'AND',
+						rules: [
+							{attribute: 'age', operator: 'gt', value: '18'},
+							{
+								attribute: 'city',
+								operator: 'eq',
+								value: 'Madrid',
+							},
+						],
+					}}
+				/>
+			);
+
+			screen.getAllByTitle('move-x')[0].focus();
+
+			await userEvent.keyboard('{Enter}');
+
+			await userEvent.keyboard('{ArrowDown}[Space]');
+
+			expect(getSerializedRuleAttributes(container)).toEqual([
+				'city',
+				'age',
+			]);
+		});
+
 		it('reorders a condition above a removed-criteria error row', async () => {
 			const {container} = render(
 				<AudienceBuilder

--- a/modules/apps/audiences/audiences-web/test/js/components/ConditionsPanel.test.tsx
+++ b/modules/apps/audiences/audiences-web/test/js/components/ConditionsPanel.test.tsx
@@ -156,4 +156,51 @@ describe('ConditionsPanel', () => {
 			type: 'DELETE_RULE',
 		});
 	});
+
+	it('keeps only the current row in the tab order', () => {
+		renderConditionsPanel({
+			items: [
+				{attribute: 'age', id: 'rule-age', operator: 'gt', value: '18'},
+				{
+					attribute: 'city',
+					id: 'rule-city',
+					operator: 'eq',
+					value: 'Madrid',
+				},
+			],
+		});
+
+		const deleteButtons = screen.getAllByLabelText('delete');
+
+		expect(deleteButtons[0]).toHaveAttribute('tabindex', '0');
+		expect(deleteButtons[1]).toHaveAttribute('tabindex', '-1');
+	});
+
+	it('navigates into a nested group with arrow keys', async () => {
+		renderConditionsPanel({
+			items: [
+				{attribute: 'age', id: 'rule-age', operator: 'gt', value: '18'},
+				{
+					conjunction: 'OR',
+					id: 'group-nested',
+					items: [
+						{
+							attribute: 'city',
+							id: 'rule-city',
+							operator: 'eq',
+							value: 'Madrid',
+						},
+					],
+				},
+			],
+		});
+
+		const rows = screen.getAllByRole('menuitem');
+
+		rows[0].focus();
+
+		await userEvent.keyboard('{ArrowDown}');
+
+		expect(rows[1]).toHaveFocus();
+	});
 });

--- a/modules/apps/audiences/audiences-web/test/js/util/getMoveTargets.test.ts
+++ b/modules/apps/audiences/audiences-web/test/js/util/getMoveTargets.test.ts
@@ -41,12 +41,12 @@ describe('getMoveTargets', () => {
 			)
 		).toEqual([
 			'age:top:root:0',
-			'age:group:root:0',
+			'age:middle:root:0',
 			'group:top:root:1',
 			'city:top:group:0',
-			'city:group:group:0',
+			'city:middle:group:0',
 			'country:top:group:1',
-			'country:group:group:1',
+			'country:middle:group:1',
 			'country:bottom:group:2',
 			'group:bottom:root:2',
 		]);
@@ -68,9 +68,9 @@ describe('getMoveTargets', () => {
 			)
 		).toEqual([
 			'age:top',
-			'age:group',
+			'age:middle',
 			'city:top',
-			'city:group',
+			'city:middle',
 			'city:bottom',
 		]);
 	});

--- a/modules/apps/audiences/audiences-web/test/js/util/getMoveTargets.test.ts
+++ b/modules/apps/audiences/audiences-web/test/js/util/getMoveTargets.test.ts
@@ -1,0 +1,110 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Group} from '../../../src/main/resources/META-INF/resources/js/types';
+import {getMoveTargets} from '../../../src/main/resources/META-INF/resources/js/util/getMoveTargets';
+
+describe('getMoveTargets', () => {
+	it('lists insertion targets across nested groups in visual order', () => {
+		const root: Group = {
+			conjunction: 'AND',
+			id: 'root',
+			items: [
+				{attribute: 'age', id: 'age', operator: 'gt', value: '18'},
+				{
+					conjunction: 'OR',
+					id: 'group',
+					items: [
+						{
+							attribute: 'city',
+							id: 'city',
+							operator: 'eq',
+							value: 'A',
+						},
+						{
+							attribute: 'country',
+							id: 'country',
+							operator: 'eq',
+							value: 'B',
+						},
+					],
+				},
+			],
+		};
+
+		expect(
+			getMoveTargets(root).map(
+				(target) =>
+					`${target.nodeId}:${target.position}:${target.groupId}:${target.index}`
+			)
+		).toEqual([
+			'age:top:root:0',
+			'age:group:root:0',
+			'group:top:root:1',
+			'city:top:group:0',
+			'city:group:group:0',
+			'country:top:group:1',
+			'country:group:group:1',
+			'country:bottom:group:2',
+			'group:bottom:root:2',
+		]);
+	});
+
+	it('includes a group target for each rule within the depth limit', () => {
+		const root: Group = {
+			conjunction: 'AND',
+			id: 'root',
+			items: [
+				{attribute: 'age', id: 'age', operator: 'gt', value: '18'},
+				{attribute: 'city', id: 'city', operator: 'eq', value: 'A'},
+			],
+		};
+
+		expect(
+			getMoveTargets(root).map(
+				(target) => `${target.nodeId}:${target.position}`
+			)
+		).toEqual([
+			'age:top',
+			'age:group',
+			'city:top',
+			'city:group',
+			'city:bottom',
+		]);
+	});
+
+	it('omits the group target for a rule at the max depth', () => {
+		const root: Group = {
+			conjunction: 'AND',
+			id: 'root',
+			items: [
+				{
+					conjunction: 'AND',
+					id: 'group-1',
+					items: [
+						{
+							conjunction: 'AND',
+							id: 'group-2',
+							items: [
+								{
+									attribute: 'age',
+									id: 'age',
+									operator: 'gt',
+									value: '18',
+								},
+							],
+						},
+					],
+				},
+			],
+		};
+
+		expect(
+			getMoveTargets(root)
+				.filter((target) => target.nodeId === 'age')
+				.map((target) => target.position)
+		).toEqual(['top', 'bottom']);
+	});
+});

--- a/modules/apps/audiences/audiences-web/test/js/util/tree.test.ts
+++ b/modules/apps/audiences/audiences-web/test/js/util/tree.test.ts
@@ -17,6 +17,7 @@ import {createRule} from '../../../src/main/resources/META-INF/resources/js/util
 import {deleteEmptyGroups} from '../../../src/main/resources/META-INF/resources/js/util/tree/deleteEmptyGroups';
 import {deleteRule} from '../../../src/main/resources/META-INF/resources/js/util/tree/deleteRule';
 import {duplicateRule} from '../../../src/main/resources/META-INF/resources/js/util/tree/duplicateRule';
+import {flattenRules} from '../../../src/main/resources/META-INF/resources/js/util/tree/flattenRules';
 import {isGroup} from '../../../src/main/resources/META-INF/resources/js/util/tree/isGroup';
 import {moveGroup} from '../../../src/main/resources/META-INF/resources/js/util/tree/moveGroup';
 import {moveRule} from '../../../src/main/resources/META-INF/resources/js/util/tree/moveRule';
@@ -415,6 +416,24 @@ describe('tree', () => {
 			expect(group.conjunction).toBe('AND');
 			expect(group.items).toHaveLength(0);
 			expect(group.id).toEqual(expect.stringMatching(/^group-/));
+		});
+	});
+
+	describe('flattenRules', () => {
+		it('lists rules in depth-first render order', () => {
+			const ageRule = createRule(AGE);
+			const countryRule = createRule(COUNTRY);
+			const nestedRule = createRule(AGE);
+			const root = createGroup('AND', [
+				ageRule,
+				createGroup('OR', [countryRule, nestedRule]),
+			]);
+
+			expect(flattenRules(root).map((rule) => rule.id)).toEqual([
+				ageRule.id,
+				countryRule.id,
+				nestedRule.id,
+			]);
 		});
 	});
 });

--- a/modules/apps/audiences/audiences-web/test/js/util/tree.test.ts
+++ b/modules/apps/audiences/audiences-web/test/js/util/tree.test.ts
@@ -19,8 +19,8 @@ import {deleteRule} from '../../../src/main/resources/META-INF/resources/js/util
 import {duplicateRule} from '../../../src/main/resources/META-INF/resources/js/util/tree/duplicateRule';
 import {flattenRules} from '../../../src/main/resources/META-INF/resources/js/util/tree/flattenRules';
 import {isGroup} from '../../../src/main/resources/META-INF/resources/js/util/tree/isGroup';
-import {moveGroup} from '../../../src/main/resources/META-INF/resources/js/util/tree/moveGroup';
 import {moveRule} from '../../../src/main/resources/META-INF/resources/js/util/tree/moveRule';
+import {moveRuleIntoNewGroup} from '../../../src/main/resources/META-INF/resources/js/util/tree/moveRuleIntoNewGroup';
 import {parseRootGroup} from '../../../src/main/resources/META-INF/resources/js/util/tree/parseRootGroup';
 import {reorderGroup} from '../../../src/main/resources/META-INF/resources/js/util/tree/reorderGroup';
 import {serializeGroup} from '../../../src/main/resources/META-INF/resources/js/util/tree/serializeGroup';
@@ -357,14 +357,18 @@ describe('tree', () => {
 		});
 	});
 
-	describe('moveGroup', () => {
+	describe('moveRuleIntoNewGroup', () => {
 		it('groups the target rule and the moved rule together', () => {
 			const ageRule = createRule(AGE);
 			const countryRule = createRule(COUNTRY);
 			const keepRule = createRule(AGE);
 			const root = createGroup('AND', [ageRule, countryRule, keepRule]);
 
-			const grouped = moveGroup(root, ageRule.id, countryRule.id);
+			const grouped = moveRuleIntoNewGroup(
+				root,
+				ageRule.id,
+				countryRule.id
+			);
 
 			expect(grouped.items).toHaveLength(2);
 
@@ -383,7 +387,11 @@ describe('tree', () => {
 			const countryRule = createRule(COUNTRY);
 			const root = createGroup('OR', [ageRule, countryRule]);
 
-			const result = moveGroup(root, ageRule.id, countryRule.id);
+			const result = moveRuleIntoNewGroup(
+				root,
+				ageRule.id,
+				countryRule.id
+			);
 
 			expect(result.conjunction).toBe('OR');
 			expect(result.items).toHaveLength(2);
@@ -397,7 +405,9 @@ describe('tree', () => {
 			const ageRule = createRule(AGE);
 			const root = createGroup('AND', [ageRule]);
 
-			expect(moveGroup(root, ageRule.id, ageRule.id)).toBe(root);
+			expect(moveRuleIntoNewGroup(root, ageRule.id, ageRule.id)).toBe(
+				root
+			);
 		});
 	});
 

--- a/modules/test/playwright/pages/audiences-web/AudiencesPage.ts
+++ b/modules/test/playwright/pages/audiences-web/AudiencesPage.ts
@@ -26,6 +26,32 @@ export class AudiencesPage {
 		this.valueInput = page.getByLabel('Value');
 	}
 
+	async addCondition(attributeIndex: number) {
+		const attribute = this.page
+			.getByRole('menuitem', {name: /^Add /})
+			.nth(attributeIndex);
+
+		const ruleCount = await this.page
+			.locator('.audience-builder-rule')
+			.count();
+
+		// The first attribute drops immediately; later ones pick up then drop.
+
+		await attribute.press('Enter');
+
+		if (ruleCount) {
+			await expect(attribute).toHaveClass(
+				/audience-builder-attribute--dragging/
+			);
+
+			await attribute.press('Enter');
+		}
+
+		await expect(this.page.locator('.audience-builder-rule')).toHaveCount(
+			ruleCount + 1
+		);
+	}
+
 	async createAudience({
 		attributeName,
 		name,
@@ -99,5 +125,20 @@ export class AudiencesPage {
 
 	async goto() {
 		await this.page.goto(PORTLET_URLS.audiences);
+	}
+
+	async openNewAudience() {
+		await this.goto();
+
+		await this.newAudienceButton.click();
+
+		await expect(this.page.getByText('No Criteria Yet')).toBeVisible();
+
+		await expect(
+			this.page
+				.locator('.c-empty-state', {hasText: 'No Criteria Yet'})
+				.locator('img')
+				.first()
+		).toBeVisible();
 	}
 }

--- a/modules/test/playwright/tests/audiences-web/main/audiences.spec.ts
+++ b/modules/test/playwright/tests/audiences-web/main/audiences.spec.ts
@@ -6,6 +6,7 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {audiencesPagesTest} from '../../../fixtures/audiencesPagesTest';
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
@@ -17,6 +18,7 @@ import {waitForAlert} from '../../../utils/waitForAlert';
 
 const test = mergeTests(
 	apiHelpersTest,
+	audiencesPagesTest,
 	dataApiHelpersTest,
 	featureFlagsTest({
 		'LPD-85746': {enabled: true},
@@ -367,5 +369,118 @@ test(
 		await expect(
 			page.locator('tr').filter({hasText: audienceName})
 		).toHaveCount(0);
+	}
+);
+
+test(
+	'Groups, navigates, keeps the conjunction independent, caps nesting, and unwraps',
+	{
+		tag: '@LPD-98159',
+	},
+	async ({audiencesPage, page}) => {
+		const attributes = page.locator('.audience-builder-attribute');
+		const groups = page.locator('.audience-builder-group');
+		const rules = page.locator('.audience-builder-rule');
+
+		await audiencesPage.openNewAudience();
+
+		await audiencesPage.addCondition(0);
+		await audiencesPage.addCondition(1);
+		await audiencesPage.addCondition(0);
+
+		// Pick the first condition up and drop it onto the second to group them
+
+		await page
+			.getByRole('button', {name: /^Move /})
+			.first()
+			.press('Enter');
+
+		await expect(
+			page.locator('.audience-builder-rule--dragging')
+		).toBeVisible();
+
+		await page.keyboard.press('ArrowDown');
+		await page.keyboard.press('Enter');
+
+		await expect(groups).toHaveCount(1);
+		await expect(groups.locator('.audience-builder-rule')).toHaveCount(2);
+		await expect(rules).toHaveCount(3);
+
+		// Arrow navigation reaches the rules nested inside the group
+
+		await rules.last().focus();
+
+		await page.keyboard.press('ArrowUp');
+
+		await expect(
+			groups.locator('.audience-builder-rule').last()
+		).toBeFocused();
+
+		// Tabbing past a condition's last action leaves the list
+
+		await rules.last().getByLabel('Delete').focus();
+
+		await page.keyboard.press('Tab');
+
+		await expect(
+			page.getByRole('menu', {name: 'Conditions'}).locator(':focus')
+		).toHaveCount(0);
+
+		// The new group defaults to All
+
+		await expect(groups.getByLabel('Conjunction')).toContainText('All');
+
+		// Switching the root to Any leaves the nested group on All
+
+		const rootConjunction = page.getByLabel('Conjunction').first();
+
+		await rootConjunction.click();
+
+		await page.getByRole('option', {exact: true, name: 'Any'}).click();
+
+		await expect(rootConjunction).toContainText('Any');
+		await expect(groups.getByLabel('Conjunction')).toContainText('All');
+
+		// Dropping onto a rule inside the group nests a third level
+
+		await expect(async () => {
+			await attributes
+				.first()
+				.dragTo(
+					groups.first().locator('.audience-builder-rule').first()
+				);
+
+			await expect(groups).toHaveCount(2);
+		}).toPass();
+
+		// A drop inside the deepest group adds a sibling but no fourth level
+
+		const beforeCount = await rules.count();
+
+		await expect(async () => {
+			await attributes
+				.first()
+				.dragTo(
+					groups.last().locator('.audience-builder-rule').first()
+				);
+
+			await expect(rules).toHaveCount(beforeCount + 1);
+		}).toPass();
+
+		await expect(groups).toHaveCount(2);
+
+		// Deleting conditions unwraps the groups back down to two rules
+
+		while ((await rules.count()) > 2) {
+			await groups
+				.last()
+				.locator('.audience-builder-rule')
+				.first()
+				.getByLabel('Delete')
+				.click();
+		}
+
+		await expect(groups).toHaveCount(0);
+		await expect(rules).toHaveCount(2);
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98159

## What Is Being Fixed

The Audience Builder only supported a flat list of conditions joined by one conjunction, so users could not express nested logic such as "A AND (B OR C)". There was also no way to group conditions or rearrange them with the keyboard, which left the builder inaccessible to keyboard and screen-reader users.

## How It Is Being Fixed

Adds a nested condition tree model to the Audience Builder and the UI to operate it. Conditions can be grouped and nested up to a depth limit, and moved across groups with both drag-and-drop and the keyboard. Keyboard movement lets a user pick up a condition, arrow through every valid drop target across nested groups, and confirm the placement with Enter or Space, announcing each step to screen readers. Roving navigation was extended so the arrow keys reach conditions inside nested groups, and tabbing leaves the list as a single stop. The drop position that forms a group is named "middle" to match the shared drag-preview vocabulary, which also restores the preview while grouping, and the group-forming move action is named MOVE_RULE_INTO_NEW_GROUP to distinguish it from relocating a condition. A no-op group unwrap was removed from the add path, and the Clay Picker tabindex workaround that keeps inactive rows out of the tab order is scoped and documented.

## PR Check

**pr-check: PASS** — tested on `ec81ba0c2b2f6de7b7c205974be2cf34299d9858`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ec81ba0c2b2f6de7b7c205974be2cf34299d9858"} -->
