### PR TITLE
LPD-98541 Block compositions from unconnected Design Library fragments

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/manager/test/FragmentCollectionManagerTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/manager/test/FragmentCollectionManagerTest.java
@@ -233,7 +233,7 @@ public class FragmentCollectionManagerTest {
 
 	private void _testGetGroupIds(long[] expectedGroupIds) throws Exception {
 		long[] groupIds = ReflectionTestUtil.invoke(
-			_fragmentCollectionManager, "_getGroupIds",
+			_fragmentCollectionManager, "getGroupIds",
 			new Class<?>[] {long.class, long.class, long.class},
 			_group.getCompanyId(), _company.getGroupId(), _group.getGroupId());
 

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/ValidateFragmentCompositionMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/ValidateFragmentCompositionMVCActionCommandTest.java
@@ -6,14 +6,21 @@
 package com.liferay.layout.content.page.editor.web.internal.portlet.action.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.constants.FragmentConstants;
+import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
+import com.liferay.fragment.service.FragmentEntryLocalService;
 import com.liferay.layout.provider.LayoutStructureProvider;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.layout.util.constants.LayoutDataItemTypeConstants;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.feature.flag.constants.FeatureFlagConstants;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
@@ -33,6 +40,11 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ScopeUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.props.test.util.PropsTemporarySwapper;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -40,6 +52,8 @@ import com.liferay.segments.service.SegmentsExperienceLocalService;
 
 import jakarta.portlet.ActionRequest;
 import jakarta.portlet.ActionResponse;
+
+import java.util.Collections;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -130,6 +144,78 @@ public class ValidateFragmentCompositionMVCActionCommandTest {
 		_testValidateFragmentComposition(containerItemId, true);
 	}
 
+	@Test
+	@TestInfo("LPD-98541")
+	public void testValidateFragmentCompositionWithDesignLibraryFragment()
+		throws Exception {
+
+		DepotEntry depotEntry = _addDesignLibraryDepotEntry();
+
+		String itemId = _addContainerWithFragmentEntry(depotEntry.getGroupId());
+
+		try (PropsTemporarySwapper propsTemporarySwapper =
+				new PropsTemporarySwapper(
+					FeatureFlagConstants.getKey("LPD-57283"),
+					Boolean.TRUE.toString())) {
+
+			_testValidateFragmentComposition(itemId, false);
+
+			_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+				depotEntry.getDepotEntryId(), _group.getGroupId());
+
+			_testValidateFragmentComposition(itemId, true);
+		}
+
+		try (PropsTemporarySwapper propsTemporarySwapper =
+				new PropsTemporarySwapper(
+					FeatureFlagConstants.getKey("LPD-57283"),
+					Boolean.FALSE.toString())) {
+
+			_testValidateFragmentComposition(itemId, false);
+		}
+	}
+
+	private String _addContainerWithFragmentEntry(long groupId)
+		throws Exception {
+
+		FragmentEntry fragmentEntry =
+			_fragmentEntryLocalService.addFragmentEntry(
+				null, TestPropsValues.getUserId(), groupId, 0,
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), false, "{fieldSets: []}", null,
+				0, false, false, FragmentConstants.TYPE_COMPONENT, null,
+				WorkflowConstants.STATUS_APPROVED,
+				ServiceContextTestUtil.getServiceContext(
+					groupId, TestPropsValues.getUserId()));
+
+		JSONObject addItemJSONObject = ContentLayoutTestUtil.addItemToLayout(
+			"{}", LayoutDataItemTypeConstants.TYPE_CONTAINER, _draftLayout,
+			_layoutStructureProvider, _segmentsExperienceId);
+
+		String containerItemId = addItemJSONObject.getString("addedItemId");
+
+		ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+			null, fragmentEntry.getCss(), fragmentEntry.getConfiguration(),
+			fragmentEntry.getExternalReferenceCode(),
+			ScopeUtil.getItemScopeExternalReferenceCode(
+				fragmentEntry.getGroupId(), _group.getGroupId()),
+			fragmentEntry.getHtml(), fragmentEntry.getJs(), _draftLayout,
+			fragmentEntry.getFragmentEntryKey(), fragmentEntry.getType(),
+			containerItemId, 0, _segmentsExperienceId);
+
+		return containerItemId;
+	}
+
+	private DepotEntry _addDesignLibraryDepotEntry() throws Exception {
+		return _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			Collections.emptyMap(), DepotConstants.TYPE_DESIGN_LIBRARY,
+			_serviceContext);
+	}
+
 	private void _testValidateFragmentComposition(String itemId, boolean valid)
 		throws Exception {
 
@@ -160,10 +246,19 @@ public class ValidateFragmentCompositionMVCActionCommandTest {
 	@Inject
 	private CompanyLocalService _companyLocalService;
 
+	@Inject
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
 	private Layout _draftLayout;
 
 	@Inject
 	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
+
+	@Inject
+	private FragmentEntryLocalService _fragmentEntryLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FragmentCollectionManager.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FragmentCollectionManager.java
@@ -109,7 +109,7 @@ public class FragmentCollectionManager {
 
 		List<FragmentCollection> fragmentCollections =
 			_fragmentCollectionService.getFragmentCollections(
-				_getGroupIds(
+				getGroupIds(
 					themeDisplay.getCompanyId(),
 					themeDisplay.getCompanyGroupId(), groupId));
 
@@ -227,6 +227,24 @@ public class FragmentCollectionManager {
 		}
 
 		return allFragmentCollectionMapsList;
+	}
+
+	public long[] getGroupIds(long companyId, long companyGroupId, long groupId)
+		throws PortalException {
+
+		long[] groupIds = {companyGroupId, groupId, CompanyConstants.SYSTEM};
+
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-57283")) {
+			return groupIds;
+		}
+
+		return ArrayUtil.append(
+			groupIds,
+			TransformUtil.transformToLongArray(
+				_depotEntryLocalService.getGroupConnectedDepotEntries(
+					groupId, DepotConstants.TYPE_DESIGN_LIBRARY,
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+				DepotEntry::getGroupId));
 	}
 
 	public Map<String, List<Map<String, Object>>> getLayoutElementMapsListMap(
@@ -523,25 +541,6 @@ public class FragmentCollectionManager {
 		}
 
 		return fragmentEntryKey + StringPool.POUND + group.getGroupKey();
-	}
-
-	private long[] _getGroupIds(
-			long companyId, long companyGroupId, long groupId)
-		throws PortalException {
-
-		long[] groupIds = {companyGroupId, groupId, CompanyConstants.SYSTEM};
-
-		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-57283")) {
-			return groupIds;
-		}
-
-		return ArrayUtil.append(
-			groupIds,
-			TransformUtil.transformToLongArray(
-				_depotEntryLocalService.getGroupConnectedDepotEntries(
-					groupId, DepotConstants.TYPE_DESIGN_LIBRARY,
-					QueryUtil.ALL_POS, QueryUtil.ALL_POS),
-				DepotEntry::getGroupId));
 	}
 
 	private Map<String, Object> _getScopeMap(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentCompositionMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentCompositionMVCActionCommand.java
@@ -13,6 +13,7 @@ import com.liferay.fragment.service.FragmentCollectionService;
 import com.liferay.fragment.service.FragmentCompositionService;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.layout.content.page.editor.web.internal.constants.ContentPageEditorConstants;
+import com.liferay.layout.content.page.editor.web.internal.manager.FragmentCollectionManager;
 import com.liferay.layout.content.page.editor.web.internal.util.layout.structure.LayoutStructureUtil;
 import com.liferay.layout.page.template.serializer.LayoutStructureItemJSONSerializer;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -66,6 +67,10 @@ public class AddFragmentCompositionMVCActionCommand
 			actionRequest, "segmentsExperienceId");
 
 		if (LayoutStructureUtil.hasMissingFragmentEntryFragmentEntryLinks(
+				_fragmentCollectionManager.getGroupIds(
+					themeDisplay.getCompanyId(),
+					themeDisplay.getCompanyGroupId(),
+					themeDisplay.getScopeGroupId()),
 				itemId,
 				LayoutStructureUtil.getLayoutStructure(
 					themeDisplay.getScopeGroupId(), themeDisplay.getPlid(),
@@ -200,6 +205,9 @@ public class AddFragmentCompositionMVCActionCommand
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private FragmentCollectionManager _fragmentCollectionManager;
 
 	@Reference
 	private FragmentCollectionService _fragmentCollectionService;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/ValidateFragmentCompositionMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/ValidateFragmentCompositionMVCActionCommand.java
@@ -6,6 +6,7 @@
 package com.liferay.layout.content.page.editor.web.internal.portlet.action;
 
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
+import com.liferay.layout.content.page.editor.web.internal.manager.FragmentCollectionManager;
 import com.liferay.layout.content.page.editor.web.internal.util.layout.structure.LayoutStructureUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -18,6 +19,7 @@ import jakarta.portlet.ActionRequest;
 import jakarta.portlet.ActionResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Georgel Pop
@@ -42,6 +44,10 @@ public class ValidateFragmentCompositionMVCActionCommand
 
 		boolean hasMissingFragmentEntry =
 			LayoutStructureUtil.hasMissingFragmentEntryFragmentEntryLinks(
+				_fragmentCollectionManager.getGroupIds(
+					themeDisplay.getCompanyId(),
+					themeDisplay.getCompanyGroupId(),
+					themeDisplay.getScopeGroupId()),
 				ParamUtil.getString(actionRequest, "itemId"),
 				LayoutStructureUtil.getLayoutStructure(
 					themeDisplay.getScopeGroupId(), themeDisplay.getPlid(),
@@ -49,5 +55,8 @@ public class ValidateFragmentCompositionMVCActionCommand
 
 		return JSONUtil.put("valid", !hasMissingFragmentEntry);
 	}
+
+	@Reference
+	private FragmentCollectionManager _fragmentCollectionManager;
 
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/layout/structure/LayoutStructureUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/layout/structure/LayoutStructureUtil.java
@@ -23,6 +23,7 @@ import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.List;
@@ -112,7 +113,7 @@ public class LayoutStructureUtil {
 	}
 
 	public static boolean hasMissingFragmentEntryFragmentEntryLinks(
-		String itemId, LayoutStructure layoutStructure) {
+		long[] groupIds, String itemId, LayoutStructure layoutStructure) {
 
 		LayoutStructureItem layoutStructureItem =
 			layoutStructure.getLayoutStructureItem(itemId);
@@ -122,7 +123,8 @@ public class LayoutStructureUtil {
 		}
 
 		return _hasMissingFragmentEntryFragmentEntryLinks(
-			layoutStructureItem.getChildrenItemIds(), layoutStructure);
+			groupIds, layoutStructureItem.getChildrenItemIds(),
+			layoutStructure);
 	}
 
 	public static JSONObject updateLayoutPageTemplateData(
@@ -145,14 +147,15 @@ public class LayoutStructureUtil {
 	}
 
 	private static boolean _hasMissingFragmentEntryFragmentEntryLinks(
-		List<String> itemIds, LayoutStructure layoutStructure) {
+		long[] groupIds, List<String> itemIds,
+		LayoutStructure layoutStructure) {
 
 		for (String itemId : itemIds) {
 			LayoutStructureItem layoutStructureItem =
 				layoutStructure.getLayoutStructureItem(itemId);
 
 			if (_hasMissingFragmentEntryFragmentEntryLinks(
-					layoutStructureItem.getChildrenItemIds(),
+					groupIds, layoutStructureItem.getChildrenItemIds(),
 					layoutStructure)) {
 
 				return true;
@@ -175,6 +178,10 @@ public class LayoutStructureUtil {
 			FragmentEntry fragmentEntry = getFragmentEntry(fragmentEntryLink);
 
 			if (fragmentEntry != null) {
+				if (!ArrayUtil.contains(groupIds, fragmentEntry.getGroupId())) {
+					return true;
+				}
+
 				continue;
 			}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98541

## What Is Being Fixed

Fragment compositions could reference fragments from a Design Library that was not connected (scoped) to the current site. When such a composition was added or validated on the site, the fragment entry link resolved through the depot even though the site had no relationship to that Design Library, effectively pulling in cross-site content the site never opted into.

## How It Is Being Fixed

`FragmentCollectionManager.getGroupIds` (promoted from private) returns the set of group IDs whose fragments the current site actually reaches: its own group, the company group, `CompanyConstants.SYSTEM`, and any Design Library depot that has a `DepotEntryGroupRel` with the site. `LayoutStructureUtil.hasMissingFragmentEntryFragmentEntryLinks` now takes this array and flags any fragment link whose `groupId` is not in the set. Both `AddFragmentCompositionMVCActionCommand` and `ValidateFragmentCompositionMVCActionCommand` compute the group set and pass it in, so composition addition and validation both reject fragments from unconnected Design Libraries. Integration coverage: `FragmentCollectionManagerTest.testGetGroupIds` exercises the resolver directly across the `LPD-57283` feature-flag boundary, and `ValidateFragmentCompositionMVCActionCommandTest.testValidateFragmentCompositionWithDesignLibraryFragment` asserts the MVC action returns invalid when the depot is unconnected and valid once a `DepotEntryGroupRel` is added.

## PR Check

**pr-check: PASS** — tested on `926a41473d85610845b772073397d77eb8910961`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "926a41473d85610845b772073397d77eb8910961"} -->
