### PR TITLE
LPD-98857 Fix stray test log error and renamed theme references

### DIFF
--- a/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
+++ b/modules/apps/headless/headless-admin-fragment/headless-admin-fragment-test/src/testIntegration/java/com/liferay/headless/admin/fragment/resource/v1_0/test/FragmentSetResourceTest.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.FeatureFlagTestUtil;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -88,6 +89,9 @@ public class FragmentSetResourceTest extends BaseFragmentSetResourceTestCase {
 	@Override
 	public void setUp() throws Exception {
 		super.setUp();
+
+		FeatureFlagTestUtil.invokeFeatureFlagListeners(
+			TestPropsValues.getCompanyId(), true, "LPD-57283");
 
 		_depotEntry = _addDepotEntry(DepotConstants.TYPE_DESIGN_LIBRARY);
 	}

--- a/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/portlet/action/test/EditLayoutDesignMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/portlet/action/test/EditLayoutDesignMVCActionCommandTest.java
@@ -139,8 +139,7 @@ public class EditLayoutDesignMVCActionCommandTest {
 		MockActionRequest mockActionRequest = _getMockActionRequest(
 			draftLayout);
 
-		mockActionRequest.setParameter(
-			"regularThemeId", "dialect_WAR_dialecttheme");
+		mockActionRequest.setParameter("regularThemeId", "cms_WAR_cmstheme");
 
 		ReflectionTestUtil.invoke(
 			_mvcActionCommand, "_updateLayout",
@@ -158,8 +157,7 @@ public class EditLayoutDesignMVCActionCommandTest {
 
 		draftLayout = _layoutLocalService.getLayout(draftLayout.getPlid());
 
-		Assert.assertEquals(
-			"dialect_WAR_dialecttheme", draftLayout.getThemeId());
+		Assert.assertEquals("cms_WAR_cmstheme", draftLayout.getThemeId());
 
 		layout = _layoutLocalService.getLayout(layout.getPlid());
 
@@ -169,7 +167,7 @@ public class EditLayoutDesignMVCActionCommandTest {
 
 		layout = _layoutLocalService.getLayout(layout.getPlid());
 
-		Assert.assertEquals("dialect_WAR_dialecttheme", layout.getThemeId());
+		Assert.assertEquals("cms_WAR_cmstheme", layout.getThemeId());
 	}
 
 	@Test

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/util/test/DefaultStyleBookEntryUtilTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/util/test/DefaultStyleBookEntryUtilTest.java
@@ -138,7 +138,7 @@ public class DefaultStyleBookEntryUtilTest {
 
 		_layout = _layoutLocalService.updateLookAndFeel(
 			_group.getGroupId(), _layout.isPrivateLayout(),
-			_layout.getLayoutId(), _THEME_ID_DIALECT, "01", StringPool.BLANK);
+			_layout.getLayoutId(), _THEME_ID_CMS, "01", StringPool.BLANK);
 
 		Assert.assertNull(
 			DefaultStyleBookEntryUtil.getDefaultStyleBookEntry(_layout));
@@ -147,7 +147,7 @@ public class DefaultStyleBookEntryUtilTest {
 			_styleBookEntryLocalService.addStyleBookEntry(
 				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
 				_group.getGroupId(), true, null, RandomTestUtil.randomString(),
-				null, _THEME_ID_DIALECT, null);
+				null, _THEME_ID_CMS, null);
 
 		StyleBookEntry defaultStyleBookEntry =
 			DefaultStyleBookEntryUtil.getDefaultStyleBookEntry(_layout);
@@ -372,7 +372,7 @@ public class DefaultStyleBookEntryUtilTest {
 
 	private static final String _THEME_ID_CLASSIC = "classic_WAR_classictheme";
 
-	private static final String _THEME_ID_DIALECT = "dialect_WAR_dialecttheme";
+	private static final String _THEME_ID_CMS = "cms_WAR_cmstheme";
 
 	@Inject
 	private FrontendTokenDefinitionRegistry _frontendTokenDefinitionRegistry;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98857

## What Is Being Fixed

FragmentSetResourceTest emitted a NoSuchRoleException ("design library member") into the log because the Design Library roles are never created when the LPD-57283 feature flag is enabled only through the test rule. PortalLogAssertorTest flags stray errors like this. Separately, DefaultStyleBookEntryUtilTest and EditLayoutDesignMVCActionCommandTest still referenced the removed "dialect" theme.

## How It Is Being Fixed

FragmentSetResourceTest now invokes the LPD-57283 feature flag listener in setUp, which creates the Design Library roles before the design library depot entry is indexed, so DepotEntrySearchPermissionRoleContributor resolves the role instead of logging an error. DefaultStyleBookEntryUtilTest and EditLayoutDesignMVCActionCommandTest are updated to use the "cms" theme id in place of the removed "dialect" theme.

## Why Are There No Tests?

This PR only modifies existing integration tests to remove a stray log error and to follow a renamed theme; it contains no production code change, so no new tests are warranted.

## PR Check

**pr-check: PASS** — tested on `9f72c2e7a5b0d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "9f72c2e7a5b0d06ed6e94d0082419b9946e36122"} -->
