### PR TITLE
LPD-98894 Improve element variations panel error and state handling

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/AudiencePriority.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/AudiencePriority.tsx
@@ -5,6 +5,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayIcon from '@clayui/icon';
+import {openToast} from 'frontend-js-components-web';
 import React, {useState} from 'react';
 
 import AudiencesPriorityModal from './AudiencesPriorityModal';
@@ -81,7 +82,16 @@ export default function AudiencePriority({
 							),
 							segmentsExperienceERC,
 							updateAudiencesPriorityURL,
-						}).then(() => setAudiences(orderedAudiences))
+						})
+							.then(() => setAudiences(orderedAudiences))
+							.catch(() =>
+								openToast({
+									message: Liferay.Language.get(
+										'an-unexpected-error-occurred'
+									),
+									type: 'danger',
+								})
+							)
 					}
 				/>
 			) : null}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationForm.tsx
@@ -215,6 +215,7 @@ export default function ElementVariationForm({
 							);
 
 							onChange({
+								audienceEntryERCs: [],
 								targetElement: targetElementItem?.value ?? '',
 							});
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
@@ -8,7 +8,7 @@ import {Option, Picker} from '@clayui/core';
 import ClayEmptyState from '@clayui/empty-state';
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
-import {useId} from 'frontend-js-components-web';
+import {openToast, useId} from 'frontend-js-components-web';
 import React, {useReducer, useRef} from 'react';
 
 import {initializeConfig} from '../../app/config/index';
@@ -56,6 +56,13 @@ export default function (props: Props) {
 	initializeConfig({portletNamespace: props.portletNamespace} as Config);
 
 	return <ElementVariations {...props} />;
+}
+
+function showErrorToast() {
+	openToast({
+		message: Liferay.Language.get('an-unexpected-error-occurred'),
+		type: 'danger',
+	});
 }
 
 function getOrderedAudiences(
@@ -175,11 +182,13 @@ function ElementVariations({
 									addElementVariationURL,
 									elementVariation: draftElementVariation,
 									plid,
-								}).then(() =>
-									dispatch({
-										type: 'SAVE_ELEMENT_VARIATION_DRAFT',
-									})
-								)
+								})
+									.then(() =>
+										dispatch({
+											type: 'SAVE_ELEMENT_VARIATION_DRAFT',
+										})
+									)
+									.catch(showErrorToast)
 							}
 						/>
 					) : (
@@ -305,12 +314,14 @@ function ElementVariations({
 															elementVariation.externalReferenceCode,
 														plid,
 													}
-												).then(() =>
-													dispatch({
-														key: elementVariation.key,
-														type: 'DELETE_ELEMENT_VARIATION',
-													})
 												)
+													.then(() =>
+														dispatch({
+															key: elementVariation.key,
+															type: 'DELETE_ELEMENT_VARIATION',
+														})
+													)
+													.catch(showErrorToast)
 											}
 											onEditElementVariation={(key) =>
 												dispatch({
@@ -329,13 +340,15 @@ function ElementVariations({
 														plid,
 														updateElementVariationURL,
 													}
-												).then(() =>
-													dispatch({
-														active: !elementVariation.active,
-														key: elementVariation.key,
-														type: 'UPDATE_ELEMENT_VARIATION',
-													})
 												)
+													.then(() =>
+														dispatch({
+															active: !elementVariation.active,
+															key: elementVariation.key,
+															type: 'UPDATE_ELEMENT_VARIATION',
+														})
+													)
+													.catch(showErrorToast)
 											}
 										/>
 									) : (

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
@@ -151,7 +151,9 @@ function ElementVariations({
 							audiences={audiences}
 							defaultLanguageId={defaultLanguageId}
 							dispatch={dispatch}
-							editableElementOptions={editableElementOptions}
+							editableElementOptions={
+								editableElementOptions ?? []
+							}
 							elementVariation={draftElementVariation}
 							elementVariations={experienceElementVariations}
 							key={draftElementVariation.key}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsList.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsList.tsx
@@ -22,7 +22,7 @@ function hasValueInAnyLanguage(
 
 interface Props {
 	audiences: Array<{label: string; value: string}>;
-	editableElementOptions: EditableElementOption[];
+	editableElementOptions: EditableElementOption[] | null;
 	elementVariations: ElementVariation[];
 	onDeleteElementVariation: (elementVariation: ElementVariation) => void;
 	onEditElementVariation: (key: string) => void;
@@ -52,7 +52,7 @@ export default function ElementVariationsList({
 		{} as Record<string, ElementVariation[]>
 	);
 
-	if (!editableElementOptions.length) {
+	if (!editableElementOptions) {
 		return <ClayLoadingIndicator className="mt-3" />;
 	}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/elementVariationsReducer.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/elementVariationsReducer.ts
@@ -23,7 +23,7 @@ export interface ElementVariation {
 export interface State {
 	defaultLanguageId: string;
 	draftElementVariation: ElementVariation | null;
-	editableElementOptions: EditableElementOption[];
+	editableElementOptions: EditableElementOption[] | null;
 	elementVariations: ElementVariation[];
 	experienceKey: string;
 	highlightedTargetElement: string | null;
@@ -98,7 +98,7 @@ export function createInitialState({
 	return {
 		defaultLanguageId,
 		draftElementVariation: null,
-		editableElementOptions: [],
+		editableElementOptions: null,
 		elementVariations: elementVariations.map((elementVariation) => ({
 			...elementVariation,
 			hide: elementVariation.hide === 'true',

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/elementVariationsReducer.test.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/plugins/element_variations/elementVariationsReducer.test.ts
@@ -71,7 +71,7 @@ describe('elementVariationsReducer', () => {
 			).toEqual({
 				defaultLanguageId: 'en_US',
 				draftElementVariation: null,
-				editableElementOptions: [],
+				editableElementOptions: null,
 				elementVariations: [],
 				experienceKey: '',
 				highlightedTargetElement: null,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98894

## What Is Being Fixed

The element variations panel silently dropped service failures: a failed add, delete, enable/disable, or audiences priority save gave the author no feedback and left the UI looking successful. Two state edge cases compounded this. Switching the target element kept the previously selected audiences, so a combination that is invalid for the new target could linger and be submitted. And the variations list treated an empty editable element options array as a loading state, so on a page whose editable elements were all removed the saved variations stayed hidden behind a permanent spinner and could not be disabled or deleted.

## How It Is Being Fixed

The four ElementVariationService call sites now chain a catch handler that surfaces the generic "An unexpected error occurred" danger toast, following the page rules convention; the backend action commands already return the error in the response body, so the rejection only needed consuming. The target element picker resets the audience selection alongside the target change. The editable element options are now null until the preview iframe reports, so the list shows the loading indicator only while genuinely loading and renders the variations when the page has no editable elements; the form keeps its non-null contract through a coalesce.

## Why Are There No Tests?

The state model change is covered by the updated reducer unit test, and the module's full Jest suite passes. The toast handlers and the audience reset are thin UI wiring over existing utilities; dedicated coverage for the error paths is deferred to the upcoming error handling story.

## PR Check

**pr-check: PASS** — tested on `bd2c8bfc74341666fa344f3ddf38a97a905a56da`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "bd2c8bfc74341666fa344f3ddf38a97a905a56da"} -->
