### PR TITLE
LPD-95007 Return typed errors from the shared page utilities

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/DisplayPageTemplateFolderUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/DisplayPageTemplateFolderUtil.java
@@ -9,6 +9,7 @@ import com.liferay.headless.admin.site.dto.v1_0.DisplayPageTemplateFolder;
 import com.liferay.headless.common.spi.service.context.ServiceContextBuilder;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateCollectionTypeConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
+import com.liferay.layout.page.template.exception.InvalidLayoutPageTemplateCollectionTypeException;
 import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
 import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionServiceUtil;
 import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
@@ -103,7 +104,7 @@ public class DisplayPageTemplateFolderUtil {
 				LayoutPageTemplateCollectionTypeConstants.DISPLAY_PAGE,
 				parentLayoutPageTemplateCollection.getType())) {
 
-			throw new IllegalArgumentException(
+			throw new InvalidLayoutPageTemplateCollectionTypeException(
 				"The parent display page template folder type does not match " +
 					"the display page type");
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/DisplayPageTemplateFolderUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/DisplayPageTemplateFolderUtil.java
@@ -11,7 +11,6 @@ import com.liferay.layout.page.template.constants.LayoutPageTemplateCollectionTy
 import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
 import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionServiceUtil;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.Validator;
@@ -88,8 +87,8 @@ public class DisplayPageTemplateFolderUtil {
 						getExternalReferenceCode())) {
 
 				throw new IllegalArgumentException(
-					"The parent display page template folder external " +
-						"reference codes do not match");
+					"The provided external reference code does not point to " +
+						"the parent display page template folder");
 			}
 
 			parentLayoutPageTemplateCollection =
@@ -104,14 +103,9 @@ public class DisplayPageTemplateFolderUtil {
 				LayoutPageTemplateCollectionTypeConstants.DISPLAY_PAGE,
 				parentLayoutPageTemplateCollection.getType())) {
 
-			String externalReferenceCode =
-				displayPageTemplateFolder.
-					getParentDisplayPageTemplateFolderExternalReferenceCode();
-
 			throw new IllegalArgumentException(
-				StringBundler.concat(
-					"The external reference code \"", externalReferenceCode,
-					"\" does not point to a display page template folder"));
+				"The parent display page template folder type does not match " +
+					"the display page type");
 		}
 
 		return parentLayoutPageTemplateCollection.

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/DisplayPageTemplateFolderUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/DisplayPageTemplateFolderUtil.java
@@ -11,6 +11,7 @@ import com.liferay.layout.page.template.constants.LayoutPageTemplateCollectionTy
 import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
 import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionServiceUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.lazy.referencing.LazyReferencingThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.Validator;
@@ -86,7 +87,9 @@ public class DisplayPageTemplateFolderUtil {
 					parentDisplayPageTemplateFolder.
 						getExternalReferenceCode())) {
 
-				throw new UnsupportedOperationException();
+				throw new IllegalArgumentException(
+					"The parent display page template folder external " +
+						"reference codes do not match");
 			}
 
 			parentLayoutPageTemplateCollection =
@@ -101,7 +104,14 @@ public class DisplayPageTemplateFolderUtil {
 				LayoutPageTemplateCollectionTypeConstants.DISPLAY_PAGE,
 				parentLayoutPageTemplateCollection.getType())) {
 
-			throw new UnsupportedOperationException();
+			String externalReferenceCode =
+				displayPageTemplateFolder.
+					getParentDisplayPageTemplateFolderExternalReferenceCode();
+
+			throw new IllegalArgumentException(
+				StringBundler.concat(
+					"The external reference code \"", externalReferenceCode,
+					"\" does not point to a display page template folder"));
 		}
 
 		return parentLayoutPageTemplateCollection.

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageExperienceUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageExperienceUtil.java
@@ -11,7 +11,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
-import com.liferay.segments.exception.DefaultSegmentsExperienceSegmentException;
+import com.liferay.segments.exception.DefaultSegmentsExperienceException;
 import com.liferay.segments.exception.DuplicateSegmentsExperienceKeyException;
 import com.liferay.segments.model.SegmentsExperience;
 
@@ -103,7 +103,7 @@ public class PageExperienceUtil {
 		}
 
 		if (defaultPageExperience.getSegmentItemExternalReference() != null) {
-			throw new DefaultSegmentsExperienceSegmentException();
+			throw new DefaultSegmentsExperienceException();
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageExperienceUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageExperienceUtil.java
@@ -6,9 +6,13 @@
 package com.liferay.headless.admin.site.internal.resource.v1_0.util;
 
 import com.liferay.headless.admin.site.dto.v1_0.PageExperience;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
+import com.liferay.segments.exception.DefaultSegmentsExperienceSegmentException;
+import com.liferay.segments.exception.DuplicateSegmentsExperienceKeyException;
 import com.liferay.segments.model.SegmentsExperience;
 
 import java.util.HashSet;
@@ -24,7 +28,7 @@ public class PageExperienceUtil {
 		PageExperience[] pageExperiences) {
 
 		if (ArrayUtil.isEmpty(pageExperiences)) {
-			throw new UnsupportedOperationException();
+			throw new IllegalArgumentException("A page experience is required");
 		}
 
 		for (PageExperience pageExperience : pageExperiences) {
@@ -36,17 +40,22 @@ public class PageExperienceUtil {
 			}
 		}
 
-		throw new UnsupportedOperationException();
+		throw new IllegalArgumentException(
+			"A default page experience is required");
 	}
 
 	public static void validatePageExperiences(
-		SegmentsExperience defaultSegmentsExperience,
-		PageExperience[] pageExperiences) {
+			SegmentsExperience defaultSegmentsExperience,
+			PageExperience[] pageExperiences)
+		throws PortalException {
 
-		if ((defaultSegmentsExperience == null) ||
-			ArrayUtil.isEmpty(pageExperiences)) {
+		if (defaultSegmentsExperience == null) {
+			throw new IllegalArgumentException(
+				"The default page experience does not exist");
+		}
 
-			throw new UnsupportedOperationException();
+		if (ArrayUtil.isEmpty(pageExperiences)) {
+			throw new IllegalArgumentException("A page experience is required");
 		}
 
 		Set<String> pageExperienceKeys = new HashSet<>(pageExperiences.length);
@@ -54,8 +63,14 @@ public class PageExperienceUtil {
 		PageExperience defaultPageExperience = null;
 
 		for (PageExperience pageExperience : pageExperiences) {
+			if (Validator.isNull(pageExperience.getKey())) {
+				throw new IllegalArgumentException(
+					"A page experience key is required");
+			}
+
 			if (!pageExperienceKeys.add(pageExperience.getKey())) {
-				throw new UnsupportedOperationException();
+				throw new DuplicateSegmentsExperienceKeyException(
+					pageExperience.getKey());
 			}
 
 			if (Objects.equals(
@@ -66,15 +81,29 @@ public class PageExperienceUtil {
 			}
 		}
 
-		if ((defaultPageExperience == null) ||
-			!StringUtil.equals(
-				defaultSegmentsExperience.getExternalReferenceCode(),
-				defaultPageExperience.getExternalReferenceCode()) ||
-			((defaultPageExperience.getPriority() != null) &&
-			 (defaultPageExperience.getPriority() != 0)) ||
-			(defaultPageExperience.getSegmentItemExternalReference() != null)) {
+		if (defaultPageExperience == null) {
+			throw new IllegalArgumentException(
+				"A default page experience is required");
+		}
 
-			throw new UnsupportedOperationException();
+		if ((defaultPageExperience.getPriority() != null) &&
+			(defaultPageExperience.getPriority() != 0)) {
+
+			throw new IllegalArgumentException(
+				"The default page experience must have a priority of 0");
+		}
+
+		if (!StringUtil.equals(
+				defaultSegmentsExperience.getExternalReferenceCode(),
+				defaultPageExperience.getExternalReferenceCode())) {
+
+			throw new IllegalArgumentException(
+				"The external reference code does not match the target " +
+					"page's experience external reference code");
+		}
+
+		if (defaultPageExperience.getSegmentItemExternalReference() != null) {
+			throw new DefaultSegmentsExperienceSegmentException();
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
@@ -129,8 +129,9 @@ public class PageSpecificationUtil {
 					getDraftContentPageSpecificationExternalReferenceCode())) {
 
 			throw new IllegalArgumentException(
-				"The draft and published page specifications have mismatched " +
-					"external reference codes");
+				"The draft page specification's external reference code does " +
+					"not match the published page specification's draft " +
+						"external reference code");
 		}
 
 		return new PageSpecification[] {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/PageSpecificationUtil.java
@@ -41,7 +41,8 @@ public class PageSpecificationUtil {
 		}
 
 		if (pageSpecifications.length != 1) {
-			throw new UnsupportedOperationException();
+			throw new IllegalArgumentException(
+				"Exactly one page specification is required");
 		}
 
 		PageSpecification pageSpecification = pageSpecifications[0];
@@ -55,7 +56,8 @@ public class PageSpecificationUtil {
 				pageSpecification.getStatus(),
 				PageSpecification.Status.APPROVED)) {
 
-			throw new UnsupportedOperationException();
+			throw new IllegalArgumentException(
+				"The page specification is invalid or has not been approved");
 		}
 
 		return pageSpecification;
@@ -69,7 +71,8 @@ public class PageSpecificationUtil {
 		}
 
 		if (pageSpecifications.length != 2) {
-			throw new UnsupportedOperationException();
+			throw new IllegalArgumentException(
+				"Exactly two page specifications are required");
 		}
 
 		PageSpecification[] sortedContentPageSpecifications =
@@ -96,7 +99,8 @@ public class PageSpecificationUtil {
 		}
 
 		if (pageSpecifications.length != 2) {
-			throw new UnsupportedOperationException();
+			throw new IllegalArgumentException(
+				"Exactly two page specifications are required");
 		}
 
 		ContentPageSpecification draftContentPageSpecification;
@@ -124,7 +128,9 @@ public class PageSpecificationUtil {
 				publishedContentPageSpecification.
 					getDraftContentPageSpecificationExternalReferenceCode())) {
 
-			throw new UnsupportedOperationException();
+			throw new IllegalArgumentException(
+				"The draft and published page specifications have mismatched " +
+					"external reference codes");
 		}
 
 		return new PageSpecification[] {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/SegmentsExperienceUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/SegmentsExperienceUtil.java
@@ -46,7 +46,8 @@ public class SegmentsExperienceUtil {
 		throws Exception {
 
 		if (!Objects.equals(layout.getType(), LayoutConstants.TYPE_CONTENT)) {
-			throw new UnsupportedOperationException();
+			throw new IllegalArgumentException(
+				"Only site pages can define additional page experiences");
 		}
 
 		SegmentsEntryReference segmentsEntryReference =
@@ -145,7 +146,8 @@ public class SegmentsExperienceUtil {
 
 	public static void validateSegmentsExperienceLayout(Layout layout) {
 		if (!Objects.equals(layout.getType(), LayoutConstants.TYPE_CONTENT)) {
-			throw new UnsupportedOperationException();
+			throw new IllegalArgumentException(
+				"Only site pages can define additional page experiences");
 		}
 
 		long plid = layout.getPlid();
@@ -159,7 +161,8 @@ public class SegmentsExperienceUtil {
 				fetchLayoutPageTemplateEntryByPlid(plid);
 
 		if (layoutPageTemplateEntry != null) {
-			throw new UnsupportedOperationException();
+			throw new IllegalArgumentException(
+				"Only site pages can define additional page experiences");
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/SegmentsExperienceUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/SegmentsExperienceUtil.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
+import com.liferay.segments.exception.SegmentsExperienceLayoutException;
 import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.service.SegmentsEntryLocalServiceUtil;
@@ -46,7 +47,7 @@ public class SegmentsExperienceUtil {
 		throws Exception {
 
 		if (!Objects.equals(layout.getType(), LayoutConstants.TYPE_CONTENT)) {
-			throw new IllegalArgumentException(
+			throw new SegmentsExperienceLayoutException(
 				"Only site pages can define additional page experiences");
 		}
 
@@ -144,9 +145,11 @@ public class SegmentsExperienceUtil {
 			).build());
 	}
 
-	public static void validateSegmentsExperienceLayout(Layout layout) {
+	public static void validateSegmentsExperienceLayout(Layout layout)
+		throws Exception {
+
 		if (!Objects.equals(layout.getType(), LayoutConstants.TYPE_CONTENT)) {
-			throw new IllegalArgumentException(
+			throw new SegmentsExperienceLayoutException(
 				"Only site pages can define additional page experiences");
 		}
 
@@ -161,7 +164,7 @@ public class SegmentsExperienceUtil {
 				fetchLayoutPageTemplateEntryByPlid(plid);
 
 		if (layoutPageTemplateEntry != null) {
-			throw new IllegalArgumentException(
+			throw new SegmentsExperienceLayoutException(
 				"Only site pages can define additional page experiences");
 		}
 	}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/SegmentsExperienceUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/SegmentsExperienceUtil.java
@@ -47,8 +47,7 @@ public class SegmentsExperienceUtil {
 		throws Exception {
 
 		if (!Objects.equals(layout.getType(), LayoutConstants.TYPE_CONTENT)) {
-			throw new SegmentsExperienceLayoutException(
-				"Only site pages can define additional page experiences");
+			throw new SegmentsExperienceLayoutException();
 		}
 
 		SegmentsEntryReference segmentsEntryReference =
@@ -149,8 +148,7 @@ public class SegmentsExperienceUtil {
 		throws Exception {
 
 		if (!Objects.equals(layout.getType(), LayoutConstants.TYPE_CONTENT)) {
-			throw new SegmentsExperienceLayoutException(
-				"Only site pages can define additional page experiences");
+			throw new SegmentsExperienceLayoutException();
 		}
 
 		long plid = layout.getPlid();
@@ -164,8 +162,7 @@ public class SegmentsExperienceUtil {
 				fetchLayoutPageTemplateEntryByPlid(plid);
 
 		if (layoutPageTemplateEntry != null) {
-			throw new SegmentsExperienceLayoutException(
-				"Only site pages can define additional page experiences");
+			throw new SegmentsExperienceLayoutException();
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/DefaultSegmentsExperienceExceptionProblemMapper.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/DefaultSegmentsExperienceExceptionProblemMapper.java
@@ -7,7 +7,7 @@ package com.liferay.headless.admin.site.internal.vulcan.problem;
 
 import com.liferay.portal.vulcan.problem.Problem;
 import com.liferay.portal.vulcan.problem.ProblemMapper;
-import com.liferay.segments.exception.DefaultSegmentsExperienceSegmentException;
+import com.liferay.segments.exception.DefaultSegmentsExperienceException;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -15,17 +15,16 @@ import org.osgi.service.component.annotations.Component;
  * @author Javier Moral
  */
 @Component(service = ProblemMapper.class)
-public class DefaultSegmentsExperienceSegmentExceptionProblemMapper
-	implements ProblemMapper<DefaultSegmentsExperienceSegmentException> {
+public class DefaultSegmentsExperienceExceptionProblemMapper
+	implements ProblemMapper<DefaultSegmentsExperienceException> {
 
 	@Override
 	public Problem getProblem(
-		DefaultSegmentsExperienceSegmentException
-			defaultSegmentsExperienceSegmentException) {
+		DefaultSegmentsExperienceException defaultSegmentsExperienceException) {
 
 		return ProblemUtil.getProblem(
 			"The default page experience cannot reference a segment",
-			Problem.Status.CONFLICT, defaultSegmentsExperienceSegmentException);
+			Problem.Status.CONFLICT, defaultSegmentsExperienceException);
 	}
 
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/DefaultSegmentsExperienceSegmentExceptionProblemMapper.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/DefaultSegmentsExperienceSegmentExceptionProblemMapper.java
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.vulcan.problem;
+
+import com.liferay.portal.vulcan.problem.Problem;
+import com.liferay.portal.vulcan.problem.ProblemMapper;
+import com.liferay.segments.exception.DefaultSegmentsExperienceSegmentException;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Javier Moral
+ */
+@Component(service = ProblemMapper.class)
+public class DefaultSegmentsExperienceSegmentExceptionProblemMapper
+	implements ProblemMapper<DefaultSegmentsExperienceSegmentException> {
+
+	@Override
+	public Problem getProblem(
+		DefaultSegmentsExperienceSegmentException
+			defaultSegmentsExperienceSegmentException) {
+
+		return ProblemUtil.getProblem(
+			"The default page experience cannot reference a segment",
+			Problem.Status.CONFLICT, defaultSegmentsExperienceSegmentException);
+	}
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/DuplicateSegmentsExperienceKeyExceptionProblemMapper.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/DuplicateSegmentsExperienceKeyExceptionProblemMapper.java
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.vulcan.problem;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.vulcan.problem.Problem;
+import com.liferay.portal.vulcan.problem.ProblemMapper;
+import com.liferay.segments.exception.DuplicateSegmentsExperienceKeyException;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Javier Moral
+ */
+@Component(service = ProblemMapper.class)
+public class DuplicateSegmentsExperienceKeyExceptionProblemMapper
+	implements ProblemMapper<DuplicateSegmentsExperienceKeyException> {
+
+	@Override
+	public Problem getProblem(
+		DuplicateSegmentsExperienceKeyException
+			duplicateSegmentsExperienceKeyException) {
+
+		String segmentsExperienceKey =
+			duplicateSegmentsExperienceKeyException.getSegmentsExperienceKey();
+
+		String message = "A page experience with the same key already exists";
+
+		if (Validator.isNotNull(segmentsExperienceKey)) {
+			message = StringBundler.concat(
+				"A page experience with key ", segmentsExperienceKey,
+				" already exists");
+		}
+
+		return ProblemUtil.getProblem(
+			message, Problem.Status.CONFLICT,
+			duplicateSegmentsExperienceKeyException);
+	}
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/DuplicateSegmentsExperienceKeyExceptionProblemMapper.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/DuplicateSegmentsExperienceKeyExceptionProblemMapper.java
@@ -5,7 +5,6 @@
 
 package com.liferay.headless.admin.site.internal.vulcan.problem;
 
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.problem.Problem;
 import com.liferay.portal.vulcan.problem.ProblemMapper;
@@ -31,9 +30,9 @@ public class DuplicateSegmentsExperienceKeyExceptionProblemMapper
 		String message = "A page experience with the same key already exists";
 
 		if (Validator.isNotNull(segmentsExperienceKey)) {
-			message = StringBundler.concat(
-				"A page experience with key ", segmentsExperienceKey,
-				" already exists");
+			message =
+				"A page experience with key " + segmentsExperienceKey +
+					" already exists";
 		}
 
 		return ProblemUtil.getProblem(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/InvalidLayoutPageTemplateCollectionTypeExceptionProblemMapper.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/InvalidLayoutPageTemplateCollectionTypeExceptionProblemMapper.java
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.vulcan.problem;
+
+import com.liferay.layout.page.template.exception.InvalidLayoutPageTemplateCollectionTypeException;
+import com.liferay.portal.vulcan.problem.Problem;
+import com.liferay.portal.vulcan.problem.ProblemMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Alberto Chaparro
+ */
+@Component(service = ProblemMapper.class)
+public class InvalidLayoutPageTemplateCollectionTypeExceptionProblemMapper
+	implements ProblemMapper<InvalidLayoutPageTemplateCollectionTypeException> {
+
+	@Override
+	public Problem getProblem(
+		InvalidLayoutPageTemplateCollectionTypeException
+			invalidLayoutPageTemplateCollectionTypeException) {
+
+		return ProblemUtil.getProblem(
+			Problem.Status.BAD_REQUEST,
+			invalidLayoutPageTemplateCollectionTypeException);
+	}
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/SegmentsExperienceLayoutExceptionProblemMapper.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/SegmentsExperienceLayoutExceptionProblemMapper.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.vulcan.problem;
+
+import com.liferay.portal.vulcan.problem.Problem;
+import com.liferay.portal.vulcan.problem.ProblemMapper;
+import com.liferay.segments.exception.SegmentsExperienceLayoutException;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Alberto Chaparro
+ */
+@Component(service = ProblemMapper.class)
+public class SegmentsExperienceLayoutExceptionProblemMapper
+	implements ProblemMapper<SegmentsExperienceLayoutException> {
+
+	@Override
+	public Problem getProblem(
+		SegmentsExperienceLayoutException segmentsExperienceLayoutException) {
+
+		return ProblemUtil.getProblem(
+			Problem.Status.BAD_REQUEST, segmentsExperienceLayoutException);
+	}
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/SegmentsExperienceLayoutExceptionProblemMapper.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/SegmentsExperienceLayoutExceptionProblemMapper.java
@@ -23,6 +23,7 @@ public class SegmentsExperienceLayoutExceptionProblemMapper
 		SegmentsExperienceLayoutException segmentsExperienceLayoutException) {
 
 		return ProblemUtil.getProblem(
+			"Only site pages can define additional page experiences",
 			Problem.Status.BAD_REQUEST, segmentsExperienceLayoutException);
 	}
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/SegmentsExperienceNameExceptionProblemMapper.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/SegmentsExperienceNameExceptionProblemMapper.java
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.vulcan.problem;
+
+import com.liferay.portal.vulcan.problem.Problem;
+import com.liferay.portal.vulcan.problem.ProblemMapper;
+import com.liferay.segments.exception.SegmentsExperienceNameException;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Javier Moral
+ */
+@Component(service = ProblemMapper.class)
+public class SegmentsExperienceNameExceptionProblemMapper
+	implements ProblemMapper<SegmentsExperienceNameException> {
+
+	@Override
+	public Problem getProblem(
+		SegmentsExperienceNameException segmentsExperienceNameException) {
+
+		return ProblemUtil.getProblem(
+			"A name in the site's default language is required for each page " +
+				"experience",
+			Problem.Status.BAD_REQUEST, segmentsExperienceNameException);
+	}
+
+}

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/exception/InvalidLayoutPageTemplateCollectionTypeException.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/exception/InvalidLayoutPageTemplateCollectionTypeException.java
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Javier Moral
+ */
+public class InvalidLayoutPageTemplateCollectionTypeException
+	extends PortalException {
+
+	public InvalidLayoutPageTemplateCollectionTypeException() {
+	}
+
+	public InvalidLayoutPageTemplateCollectionTypeException(String msg) {
+		super(msg);
+	}
+
+	public InvalidLayoutPageTemplateCollectionTypeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public InvalidLayoutPageTemplateCollectionTypeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateCollectionLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateCollectionLocalServiceImpl.java
@@ -5,7 +5,10 @@
 
 package com.liferay.layout.page.template.service.impl;
 
+import com.liferay.layout.page.template.constants.LayoutPageTemplateCollectionTypeConstants;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
 import com.liferay.layout.page.template.exception.DuplicateLayoutPageTemplateCollectionException;
+import com.liferay.layout.page.template.exception.InvalidLayoutPageTemplateCollectionTypeException;
 import com.liferay.layout.page.template.exception.LayoutPageTemplateCollectionGroupIdException;
 import com.liferay.layout.page.template.exception.LayoutPageTemplateCollectionLayoutPageTemplateCollectionKeyException;
 import com.liferay.layout.page.template.exception.LayoutPageTemplateCollectionNameException;
@@ -73,6 +76,8 @@ public class LayoutPageTemplateCollectionLocalServiceImpl
 		User user = _userLocalService.getUser(userId);
 
 		_validate(groupId, name, parentLayoutPageTemplateCollectionId, type);
+		_validateParentLayoutPageTemplateCollectionType(
+			parentLayoutPageTemplateCollectionId, type);
 
 		if (Validator.isNull(layoutPageTemplateCollectionKey)) {
 			layoutPageTemplateCollectionKey =
@@ -568,6 +573,33 @@ public class LayoutPageTemplateCollectionLocalServiceImpl
 		if (layoutPageTemplateCollection != null) {
 			throw new LayoutPageTemplateCollectionLayoutPageTemplateCollectionKeyException.MustNotBeDuplicate(
 				groupId, layoutPageTemplateCollectionKey, type);
+		}
+	}
+
+	private void _validateParentLayoutPageTemplateCollectionType(
+			long parentLayoutPageTemplateCollectionId, int type)
+		throws PortalException {
+
+		if ((type != LayoutPageTemplateCollectionTypeConstants.DISPLAY_PAGE) ||
+			(parentLayoutPageTemplateCollectionId ==
+				LayoutPageTemplateConstants.
+					PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT)) {
+
+			return;
+		}
+
+		LayoutPageTemplateCollection parentLayoutPageTemplateCollection =
+			layoutPageTemplateCollectionPersistence.fetchByPrimaryKey(
+				parentLayoutPageTemplateCollectionId);
+
+		if ((parentLayoutPageTemplateCollection == null) ||
+			(parentLayoutPageTemplateCollection.getType() !=
+				LayoutPageTemplateCollectionTypeConstants.DISPLAY_PAGE)) {
+
+			throw new InvalidLayoutPageTemplateCollectionTypeException(
+				"Parent layout page template collection " +
+					parentLayoutPageTemplateCollectionId +
+						" must be of type display page");
 		}
 	}
 

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateCollectionLocalServiceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateCollectionLocalServiceTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateCollectionTypeConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
 import com.liferay.layout.page.template.exception.DuplicateLayoutPageTemplateCollectionExternalReferenceCodeException;
+import com.liferay.layout.page.template.exception.InvalidLayoutPageTemplateCollectionTypeException;
 import com.liferay.layout.page.template.exception.LayoutPageTemplateCollectionGroupIdException;
 import com.liferay.layout.page.template.exception.LayoutPageTemplateCollectionLayoutPageTemplateCollectionKeyException;
 import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
@@ -183,6 +184,30 @@ public class LayoutPageTemplateCollectionLocalServiceTest {
 				"Layout page template collection key ",
 				layoutPageTemplateCollectionKey,
 				" must have fewer than 75 characters"));
+	}
+
+	@Test(expected = InvalidLayoutPageTemplateCollectionTypeException.class)
+	public void testAddLayoutPageTemplateCollectionWithInvalidParentType()
+		throws Exception {
+
+		LayoutPageTemplateCollection layoutPageTemplateCollection =
+			_layoutPageTemplateCollectionLocalService.
+				addLayoutPageTemplateCollection(
+					null, TestPropsValues.getUserId(), _group.getGroupId(),
+					LayoutPageTemplateConstants.
+						PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
+					null, RandomTestUtil.randomString(), null,
+					LayoutPageTemplateCollectionTypeConstants.BASIC,
+					_serviceContext);
+
+		_layoutPageTemplateCollectionLocalService.
+			addLayoutPageTemplateCollection(
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
+				layoutPageTemplateCollection.
+					getLayoutPageTemplateCollectionId(),
+				null, RandomTestUtil.randomString(), null,
+				LayoutPageTemplateCollectionTypeConstants.DISPLAY_PAGE,
+				_serviceContext);
 	}
 
 	@Test

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/exception/DefaultSegmentsExperienceException.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/exception/DefaultSegmentsExperienceException.java
@@ -10,22 +10,20 @@ import com.liferay.portal.kernel.exception.PortalException;
 /**
  * @author Javier Moral
  */
-public class DefaultSegmentsExperienceSegmentException extends PortalException {
+public class DefaultSegmentsExperienceException extends PortalException {
 
-	public DefaultSegmentsExperienceSegmentException() {
+	public DefaultSegmentsExperienceException() {
 	}
 
-	public DefaultSegmentsExperienceSegmentException(String msg) {
+	public DefaultSegmentsExperienceException(String msg) {
 		super(msg);
 	}
 
-	public DefaultSegmentsExperienceSegmentException(
-		String msg, Throwable throwable) {
-
+	public DefaultSegmentsExperienceException(String msg, Throwable throwable) {
 		super(msg, throwable);
 	}
 
-	public DefaultSegmentsExperienceSegmentException(Throwable throwable) {
+	public DefaultSegmentsExperienceException(Throwable throwable) {
 		super(throwable);
 	}
 

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/exception/DefaultSegmentsExperienceSegmentException.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/exception/DefaultSegmentsExperienceSegmentException.java
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.segments.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Javier Moral
+ */
+public class DefaultSegmentsExperienceSegmentException extends PortalException {
+
+	public DefaultSegmentsExperienceSegmentException() {
+	}
+
+	public DefaultSegmentsExperienceSegmentException(String msg) {
+		super(msg);
+	}
+
+	public DefaultSegmentsExperienceSegmentException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DefaultSegmentsExperienceSegmentException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/exception/DuplicateSegmentsExperienceKeyException.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/exception/DuplicateSegmentsExperienceKeyException.java
@@ -12,6 +12,9 @@ import com.liferay.portal.kernel.exception.PortalException;
  */
 public class DuplicateSegmentsExperienceKeyException extends PortalException {
 
+	public DuplicateSegmentsExperienceKeyException() {
+	}
+
 	public DuplicateSegmentsExperienceKeyException(
 		String segmentsExperienceKey) {
 
@@ -20,10 +23,20 @@ public class DuplicateSegmentsExperienceKeyException extends PortalException {
 		_segmentsExperienceKey = segmentsExperienceKey;
 	}
 
+	public DuplicateSegmentsExperienceKeyException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateSegmentsExperienceKeyException(Throwable throwable) {
+		super(throwable);
+	}
+
 	public String getSegmentsExperienceKey() {
 		return _segmentsExperienceKey;
 	}
 
-	private final String _segmentsExperienceKey;
+	private String _segmentsExperienceKey;
 
 }

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/exception/DuplicateSegmentsExperienceKeyException.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/exception/DuplicateSegmentsExperienceKeyException.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.segments.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Javier Moral
+ */
+public class DuplicateSegmentsExperienceKeyException extends PortalException {
+
+	public DuplicateSegmentsExperienceKeyException(
+		String segmentsExperienceKey) {
+
+		super("Duplicate segments experience key " + segmentsExperienceKey);
+
+		_segmentsExperienceKey = segmentsExperienceKey;
+	}
+
+	public String getSegmentsExperienceKey() {
+		return _segmentsExperienceKey;
+	}
+
+	private final String _segmentsExperienceKey;
+
+}

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/exception/SegmentsExperienceLayoutException.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/exception/SegmentsExperienceLayoutException.java
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.segments.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Javier Moral
+ */
+public class SegmentsExperienceLayoutException extends PortalException {
+
+	public SegmentsExperienceLayoutException(long plid) {
+		super(
+			"Additional segments experiences can only be added to content " +
+				"page layouts that are not page templates, plid: " + plid);
+	}
+
+}

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/exception/SegmentsExperienceLayoutException.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/exception/SegmentsExperienceLayoutException.java
@@ -12,10 +12,19 @@ import com.liferay.portal.kernel.exception.PortalException;
  */
 public class SegmentsExperienceLayoutException extends PortalException {
 
-	public SegmentsExperienceLayoutException(long plid) {
-		super(
-			"Additional segments experiences can only be added to content " +
-				"page layouts that are not page templates, plid: " + plid);
+	public SegmentsExperienceLayoutException() {
+	}
+
+	public SegmentsExperienceLayoutException(String msg) {
+		super(msg);
+	}
+
+	public SegmentsExperienceLayoutException(String msg, Throwable throwable) {
+		super(msg, throwable);
+	}
+
+	public SegmentsExperienceLayoutException(Throwable throwable) {
+		super(throwable);
 	}
 
 }

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceLocalService.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceLocalService.java
@@ -502,4 +502,4 @@ public interface SegmentsExperienceLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1393386091
+// LIFERAY-SERVICE-BUILDER-HASH:443350809

--- a/modules/apps/segments/segments-service/build.gradle
+++ b/modules/apps/segments/segments-service/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:layout:layout-api")
 	compileOnly project(":apps:layout:layout-content-page-editor-api")
+	compileOnly project(":apps:layout:layout-page-template-api")
 	compileOnly project(":apps:portal-background-task:portal-background-task-api")
 	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	compileOnly project(":apps:portal-odata:portal-odata-api")

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceLocalServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceLocalServiceImpl.java
@@ -30,7 +30,7 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
-import com.liferay.segments.exception.DefaultSegmentsExperienceSegmentException;
+import com.liferay.segments.exception.DefaultSegmentsExperienceException;
 import com.liferay.segments.exception.DuplicateSegmentsExperienceKeyException;
 import com.liferay.segments.exception.LockedSegmentsExperimentException;
 import com.liferay.segments.exception.RequiredSegmentsExperienceException;
@@ -129,7 +129,8 @@ public class SegmentsExperienceLocalServiceImpl
 
 		User user = _userLocalService.getUser(userId);
 
-		_validateDefaultSegmentsEntry(segmentsEntryERC, segmentsExperienceKey);
+		_validateDefaultSegmentsExperience(
+			segmentsEntryERC, segmentsExperienceKey);
 		_validateLayout(plid, segmentsExperienceKey);
 		_validateName(nameMap);
 		_validatePriority(groupId, plid, priority);
@@ -526,7 +527,7 @@ public class SegmentsExperienceLocalServiceImpl
 			segmentsExperiencePersistence.findByPrimaryKey(
 				segmentsExperienceId);
 
-		_validateDefaultSegmentsEntry(
+		_validateDefaultSegmentsExperience(
 			segmentsEntryERC, segmentsExperience.getSegmentsExperienceKey());
 
 		if (segmentsExperience.hasSegmentsExperiment()) {
@@ -763,7 +764,7 @@ public class SegmentsExperienceLocalServiceImpl
 		segmentsExperiencePersistence.flush();
 	}
 
-	private void _validateDefaultSegmentsEntry(
+	private void _validateDefaultSegmentsExperience(
 			String segmentsEntryERC, String segmentsExperienceKey)
 		throws PortalException {
 
@@ -771,7 +772,7 @@ public class SegmentsExperienceLocalServiceImpl
 				segmentsExperienceKey) &&
 			Validator.isNotNull(segmentsEntryERC)) {
 
-			throw new DefaultSegmentsExperienceSegmentException();
+			throw new DefaultSegmentsExperienceException();
 		}
 	}
 

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceLocalServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceLocalServiceImpl.java
@@ -791,7 +791,9 @@ public class SegmentsExperienceLocalServiceImpl
 		}
 
 		if (!LayoutConstants.TYPE_CONTENT.equals(layout.getType())) {
-			throw new SegmentsExperienceLayoutException(plid);
+			throw new SegmentsExperienceLayoutException(
+				"Segments experiences cannot be added to layout " + plid +
+					" because it is not a content page");
 		}
 
 		long layoutPageTemplateEntryPlid = layout.getPlid();
@@ -805,7 +807,9 @@ public class SegmentsExperienceLocalServiceImpl
 				fetchLayoutPageTemplateEntryByPlid(layoutPageTemplateEntryPlid);
 
 		if (layoutPageTemplateEntry != null) {
-			throw new SegmentsExperienceLayoutException(plid);
+			throw new SegmentsExperienceLayoutException(
+				"Segments experiences cannot be added to layout " + plid +
+					" because it belongs to a page template");
 		}
 	}
 

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceLocalServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceLocalServiceImpl.java
@@ -819,7 +819,8 @@ public class SegmentsExperienceLocalServiceImpl
 		Locale locale = LocaleUtil.getSiteDefault();
 
 		if (nameMap.isEmpty() || Validator.isNull(nameMap.get(locale))) {
-			throw new SegmentsExperienceNameException();
+			throw new SegmentsExperienceNameException(
+				"A name in the site's default language is required");
 		}
 	}
 

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceLocalServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceLocalServiceImpl.java
@@ -5,11 +5,14 @@
 
 package com.liferay.segments.service.impl;
 
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.LockedLayoutException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
@@ -27,8 +30,11 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
+import com.liferay.segments.exception.DefaultSegmentsExperienceSegmentException;
+import com.liferay.segments.exception.DuplicateSegmentsExperienceKeyException;
 import com.liferay.segments.exception.LockedSegmentsExperimentException;
 import com.liferay.segments.exception.RequiredSegmentsExperienceException;
+import com.liferay.segments.exception.SegmentsExperienceLayoutException;
 import com.liferay.segments.exception.SegmentsExperienceNameException;
 import com.liferay.segments.exception.SegmentsExperiencePriorityException;
 import com.liferay.segments.model.SegmentsExperience;
@@ -123,8 +129,11 @@ public class SegmentsExperienceLocalServiceImpl
 
 		User user = _userLocalService.getUser(userId);
 
+		_validateDefaultSegmentsEntry(segmentsEntryERC, segmentsExperienceKey);
+		_validateLayout(plid, segmentsExperienceKey);
 		_validateName(nameMap);
 		_validatePriority(groupId, plid, priority);
+		_validateSegmentsExperienceKey(groupId, plid, segmentsExperienceKey);
 
 		long segmentsExperienceId = counterLocalService.increment();
 
@@ -517,6 +526,9 @@ public class SegmentsExperienceLocalServiceImpl
 			segmentsExperiencePersistence.findByPrimaryKey(
 				segmentsExperienceId);
 
+		_validateDefaultSegmentsEntry(
+			segmentsEntryERC, segmentsExperience.getSegmentsExperienceKey());
+
 		if (segmentsExperience.hasSegmentsExperiment()) {
 			throw new LockedSegmentsExperimentException(
 				"Segments experience " + segmentsExperienceId +
@@ -751,6 +763,52 @@ public class SegmentsExperienceLocalServiceImpl
 		segmentsExperiencePersistence.flush();
 	}
 
+	private void _validateDefaultSegmentsEntry(
+			String segmentsEntryERC, String segmentsExperienceKey)
+		throws PortalException {
+
+		if (SegmentsExperienceConstants.KEY_DEFAULT.equals(
+				segmentsExperienceKey) &&
+			Validator.isNotNull(segmentsEntryERC)) {
+
+			throw new DefaultSegmentsExperienceSegmentException();
+		}
+	}
+
+	private void _validateLayout(long plid, String segmentsExperienceKey)
+		throws PortalException {
+
+		if (SegmentsExperienceConstants.KEY_DEFAULT.equals(
+				segmentsExperienceKey)) {
+
+			return;
+		}
+
+		Layout layout = _layoutLocalService.fetchLayout(plid);
+
+		if (layout == null) {
+			return;
+		}
+
+		if (!LayoutConstants.TYPE_CONTENT.equals(layout.getType())) {
+			throw new SegmentsExperienceLayoutException(plid);
+		}
+
+		long layoutPageTemplateEntryPlid = layout.getPlid();
+
+		if (layout.getClassPK() > 0) {
+			layoutPageTemplateEntryPlid = layout.getClassPK();
+		}
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.
+				fetchLayoutPageTemplateEntryByPlid(layoutPageTemplateEntryPlid);
+
+		if (layoutPageTemplateEntry != null) {
+			throw new SegmentsExperienceLayoutException(plid);
+		}
+	}
+
 	private void _validateName(Map<Locale, String> nameMap)
 		throws PortalException {
 
@@ -774,11 +832,29 @@ public class SegmentsExperienceLocalServiceImpl
 		}
 	}
 
+	private void _validateSegmentsExperienceKey(
+			long groupId, long plid, String segmentsExperienceKey)
+		throws PortalException {
+
+		SegmentsExperience segmentsExperience =
+			segmentsExperiencePersistence.fetchByG_SEK_P(
+				groupId, segmentsExperienceKey, plid);
+
+		if (segmentsExperience != null) {
+			throw new DuplicateSegmentsExperienceKeyException(
+				segmentsExperienceKey);
+		}
+	}
+
 	@Reference
 	private Language _language;
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private LayoutPageTemplateEntryLocalService
+		_layoutPageTemplateEntryLocalService;
 
 	@Reference
 	private ResourceLocalService _resourceLocalService;

--- a/modules/apps/segments/segments-test/build.gradle
+++ b/modules/apps/segments/segments-test/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:layout:layout-api")
 	testIntegrationImplementation project(":apps:layout:layout-content-page-editor-api")
 	testIntegrationImplementation project(":apps:layout:layout-page-template-api")
+	testIntegrationImplementation project(":apps:layout:layout-page-template-test-util")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceLocalServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceLocalServiceTest.java
@@ -6,6 +6,10 @@
 package com.liferay.segments.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.test.util.DisplayPageTemplateTestUtil;
+import com.liferay.layout.page.template.test.util.LayoutPageTemplateTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
@@ -26,13 +30,17 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
 import com.liferay.segments.constants.SegmentsExperimentConstants;
+import com.liferay.segments.exception.DefaultSegmentsExperienceSegmentException;
 import com.liferay.segments.exception.DuplicateSegmentsExperienceExternalReferenceCodeException;
+import com.liferay.segments.exception.DuplicateSegmentsExperienceKeyException;
 import com.liferay.segments.exception.LockedSegmentsExperimentException;
 import com.liferay.segments.exception.RequiredSegmentsExperienceException;
+import com.liferay.segments.exception.SegmentsExperienceLayoutException;
 import com.liferay.segments.exception.SegmentsExperienceNameException;
 import com.liferay.segments.exception.SegmentsExperiencePriorityException;
 import com.liferay.segments.model.SegmentsEntry;
@@ -208,6 +216,43 @@ public class SegmentsExperienceLocalServiceTest {
 			segmentsExperiences.toString(), 3, segmentsExperiences.size());
 	}
 
+	@Test
+	public void testAddSegmentsExperienceToContentPageTemplate()
+		throws Exception {
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			LayoutPageTemplateTestUtil.addLayoutPageTemplateEntry(
+				_group.getGroupId(), LayoutPageTemplateEntryTypeConstants.BASIC,
+				WorkflowConstants.STATUS_DRAFT);
+
+		Assert.assertThrows(
+			SegmentsExperienceLayoutException.class,
+			() -> _segmentsExperienceLocalService.addSegmentsExperience(
+				null, TestPropsValues.getUserId(), _group.getGroupId(), null,
+				null, layoutPageTemplateEntry.getPlid(),
+				RandomTestUtil.randomLocaleStringMap(), true,
+				new UnicodeProperties(true),
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId())));
+	}
+
+	@Test
+	public void testAddSegmentsExperienceToDisplayPageTemplate()
+		throws Exception {
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+				_group.getGroupId());
+
+		Assert.assertThrows(
+			SegmentsExperienceLayoutException.class,
+			() -> _segmentsExperienceLocalService.addSegmentsExperience(
+				null, TestPropsValues.getUserId(), _group.getGroupId(), null,
+				null, layoutPageTemplateEntry.getPlid(),
+				RandomTestUtil.randomLocaleStringMap(), true,
+				new UnicodeProperties(true),
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId())));
+	}
+
 	@Test(
 		expected = DuplicateSegmentsExperienceExternalReferenceCodeException.class
 	)
@@ -229,6 +274,31 @@ public class SegmentsExperienceLocalServiceTest {
 			externalReferenceCode, TestPropsValues.getUserId(),
 			_group.getGroupId(), segmentsEntry.getExternalReferenceCode(), null,
 			_plid, RandomTestUtil.randomLocaleStringMap(), false,
+			new UnicodeProperties(true),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+	}
+
+	@Test(expected = DuplicateSegmentsExperienceKeyException.class)
+	public void testAddSegmentsExperienceWithExistingSegmentsExperienceKey()
+		throws Exception {
+
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId());
+
+		String segmentsExperienceKey = StringUtil.randomString();
+
+		_segmentsExperienceLocalService.addSegmentsExperience(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			segmentsEntry.getExternalReferenceCode(), null,
+			segmentsExperienceKey, _plid,
+			RandomTestUtil.randomLocaleStringMap(), 1, true,
+			new UnicodeProperties(true),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+		_segmentsExperienceLocalService.addSegmentsExperience(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			segmentsEntry.getExternalReferenceCode(), null,
+			segmentsExperienceKey, _plid,
+			RandomTestUtil.randomLocaleStringMap(), 2, true,
 			new UnicodeProperties(true),
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 	}
@@ -642,6 +712,24 @@ public class SegmentsExperienceLocalServiceTest {
 			_segmentsExperienceLocalService.fetchSegmentsExperience(
 				_group.getGroupId(), _plid,
 				segmentsExperience.getPriority() + 1));
+	}
+
+	@Test(expected = DefaultSegmentsExperienceSegmentException.class)
+	public void testUpdateDefaultSegmentsExperienceWithSegmentsEntry()
+		throws Exception {
+
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId());
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperience(
+				_plid);
+
+		_segmentsExperienceLocalService.updateSegmentsExperience(
+			TestPropsValues.getUserId(),
+			segmentsExperience.getSegmentsExperienceId(),
+			segmentsEntry.getExternalReferenceCode(), null,
+			segmentsExperience.getNameMap(), true);
 	}
 
 	@Test(expected = LockedSegmentsExperimentException.class)

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceLocalServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceLocalServiceTest.java
@@ -35,7 +35,7 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
 import com.liferay.segments.constants.SegmentsExperimentConstants;
-import com.liferay.segments.exception.DefaultSegmentsExperienceSegmentException;
+import com.liferay.segments.exception.DefaultSegmentsExperienceException;
 import com.liferay.segments.exception.DuplicateSegmentsExperienceExternalReferenceCodeException;
 import com.liferay.segments.exception.DuplicateSegmentsExperienceKeyException;
 import com.liferay.segments.exception.LockedSegmentsExperimentException;
@@ -710,7 +710,7 @@ public class SegmentsExperienceLocalServiceTest {
 				segmentsExperience.getPriority() + 1));
 	}
 
-	@Test(expected = DefaultSegmentsExperienceSegmentException.class)
+	@Test(expected = DefaultSegmentsExperienceException.class)
 	public void testUpdateDefaultSegmentsExperienceWithSegmentsEntry()
 		throws Exception {
 

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceLocalServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceLocalServiceTest.java
@@ -216,7 +216,7 @@ public class SegmentsExperienceLocalServiceTest {
 			segmentsExperiences.toString(), 3, segmentsExperiences.size());
 	}
 
-	@Test
+	@Test(expected = SegmentsExperienceLayoutException.class)
 	public void testAddSegmentsExperienceToContentPageTemplate()
 		throws Exception {
 
@@ -225,17 +225,15 @@ public class SegmentsExperienceLocalServiceTest {
 				_group.getGroupId(), LayoutPageTemplateEntryTypeConstants.BASIC,
 				WorkflowConstants.STATUS_DRAFT);
 
-		Assert.assertThrows(
-			SegmentsExperienceLayoutException.class,
-			() -> _segmentsExperienceLocalService.addSegmentsExperience(
-				null, TestPropsValues.getUserId(), _group.getGroupId(), null,
-				null, layoutPageTemplateEntry.getPlid(),
-				RandomTestUtil.randomLocaleStringMap(), true,
-				new UnicodeProperties(true),
-				ServiceContextTestUtil.getServiceContext(_group.getGroupId())));
+		_segmentsExperienceLocalService.addSegmentsExperience(
+			null, TestPropsValues.getUserId(), _group.getGroupId(), null, null,
+			layoutPageTemplateEntry.getPlid(),
+			RandomTestUtil.randomLocaleStringMap(), true,
+			new UnicodeProperties(true),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 	}
 
-	@Test
+	@Test(expected = SegmentsExperienceLayoutException.class)
 	public void testAddSegmentsExperienceToDisplayPageTemplate()
 		throws Exception {
 
@@ -243,14 +241,12 @@ public class SegmentsExperienceLocalServiceTest {
 			DisplayPageTemplateTestUtil.addDisplayPageTemplate(
 				_group.getGroupId());
 
-		Assert.assertThrows(
-			SegmentsExperienceLayoutException.class,
-			() -> _segmentsExperienceLocalService.addSegmentsExperience(
-				null, TestPropsValues.getUserId(), _group.getGroupId(), null,
-				null, layoutPageTemplateEntry.getPlid(),
-				RandomTestUtil.randomLocaleStringMap(), true,
-				new UnicodeProperties(true),
-				ServiceContextTestUtil.getServiceContext(_group.getGroupId())));
+		_segmentsExperienceLocalService.addSegmentsExperience(
+			null, TestPropsValues.getUserId(), _group.getGroupId(), null, null,
+			layoutPageTemplateEntry.getPlid(),
+			RandomTestUtil.randomLocaleStringMap(), true,
+			new UnicodeProperties(true),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
 	}
 
 	@Test(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95007

## What Is Being Fixed

The shared page utilities in headless-admin-site rejected invalid requests by throwing bare `UnsupportedOperationException`s, which reached API clients as generic errors that named no rule. In addition, several of the invariants those utilities enforce — additional experiences only on content pages, no segment on the default experience, display page template folders only under display page collections — were not enforced at the service layer at all, so non-headless consumers could violate them silently.

## How It Is Being Fixed

The bare throws are replaced with typed portal exceptions (`DefaultSegmentsExperienceException`, `DuplicateSegmentsExperienceKeyException`, `SegmentsExperienceLayoutException`, `InvalidLayoutPageTemplateCollectionTypeException`), and the same invariants are now validated in `SegmentsExperienceLocalServiceImpl` and `LayoutPageTemplateCollectionLocalServiceImpl` so every consumer is protected. Matching `ProblemMapper`s in headless-admin-site translate each exception into a typed problem response, so both the headless fail-fast path and the service path produce the same client-facing error. Service messages speak the segments domain while the mappers word the REST responses in page-experience terms. Integration tests cover the new service-layer validations.

## PR Check

**pr-check: PASS** — tested on `7364c9166472d360a1b1b1e518aec320368cecb8`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "7364c9166472d360a1b1b1e518aec320368cecb8"} -->
