### PR TITLE
LPD-99008 LPD-99010 Audience Builder accessibility and value types

### DIFF
--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/AudienceBuilder.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/AudienceBuilder.tsx
@@ -10,7 +10,7 @@ import ClayLayout from '@clayui/layout';
 import ClayLink from '@clayui/link';
 import ClayToolbar from '@clayui/toolbar';
 import {ScreenReaderAnnouncerContextProvider} from '@liferay/layout-js-components-web';
-import React, {useReducer} from 'react';
+import React, {useMemo, useReducer} from 'react';
 import {DndProvider} from 'react-dnd';
 import {HTML5Backend} from 'react-dnd-html5-backend';
 
@@ -19,8 +19,10 @@ import ConditionsPanel from './components/ConditionsPanel';
 import GeneralSettings from './components/GeneralSettings';
 import DragPreviewWrapper from './keyboard_movement/DragPreviewWrapper';
 import {KeyboardMovementContextProvider} from './keyboard_movement/KeyboardMovementContext';
-import {initState, reducer, serializeCriteria} from './reducer';
+import {initState, reducer} from './reducer';
 import {AudiencesCriteriaRulesGroup, AudiencesCriteriaType} from './types';
+import {getAudiencesCriteriasByKey} from './util/getAudiencesCriteriasByKey';
+import {serializeCriteria} from './util/tree/serializeCriteria';
 
 import './AudienceBuilder.scss';
 
@@ -53,6 +55,11 @@ export default function AudienceBuilder({
 		reducer,
 		{externalReferenceCode, name, rulesGroup},
 		initState
+	);
+
+	const audiencesCriteriasByKey = useMemo(
+		() => getAudiencesCriteriasByKey(audiencesCriteriaTypes),
+		[audiencesCriteriaTypes]
 	);
 
 	return (
@@ -135,7 +142,10 @@ export default function AudienceBuilder({
 								<input
 									name={`${namespace}json`}
 									type="hidden"
-									value={serializeCriteria(state)}
+									value={serializeCriteria(
+										state.root,
+										audiencesCriteriasByKey
+									)}
 								/>
 
 								<ConditionsPanel

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/ConditionsPanel.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/ConditionsPanel.tsx
@@ -30,6 +30,7 @@ import {
 import KeyboardMovementManager from '../keyboard_movement/KeyboardMovementManager';
 import {Action} from '../reducer';
 import {AudiencesCriteria, AudiencesCriteriaType, Group} from '../types';
+import {getConditionLabel} from '../util/getConditionLabel';
 import {DropZone, getDropPosition} from '../util/getDropPosition';
 import {canGroupNode} from '../util/tree/canGroupNode';
 import {flattenRules} from '../util/tree/flattenRules';
@@ -58,14 +59,23 @@ function collectNodeNames(
 ): Record<string, string> {
 	group.items.forEach((node) => {
 		if (isGroup(node)) {
-			namesById[node.id] = Liferay.Language.get('group');
+			const conjunction =
+				node.conjunction === 'OR'
+					? Liferay.Language.get('any')
+					: Liferay.Language.get('all');
+
+			namesById[node.id] = `${conjunction} ${Liferay.Language.get(
+				'of-these-criteria-are-met'
+			)}`;
 
 			collectNodeNames(node, audiencesCriteriasByKey, namesById);
 		}
 		else {
-			namesById[node.id] =
-				audiencesCriteriasByKey[node.attribute]?.label ??
-				node.attribute;
+			const audiencesCriteria = audiencesCriteriasByKey[node.attribute];
+
+			namesById[node.id] = audiencesCriteria
+				? getConditionLabel(node, audiencesCriteria)
+				: node.attribute;
 		}
 	});
 
@@ -178,6 +188,7 @@ export default function ConditionsPanel({
 				<>
 					<ConjunctionBar
 						conjunction={root.conjunction}
+						conjunctionLabelId={`audience-builder-conjunction-${root.id}`}
 						onConjunctionChange={(value) =>
 							dispatch({
 								conjunction: value,
@@ -188,9 +199,8 @@ export default function ConditionsPanel({
 
 					<div
 						aria-label={Liferay.Language.get('conditions')}
-						aria-orientation="vertical"
 						className="px-3 py-2"
-						role="menu"
+						role="group"
 					>
 						<GroupItems context={context} group={root} path={[]} />
 					</div>
@@ -404,9 +414,11 @@ function GroupRow({
 		dropRef(element);
 	};
 
+	const conjunctionLabelId = `audience-builder-conjunction-${group.id}`;
+
 	return (
 		<div
-			aria-label={Liferay.Language.get('group')}
+			aria-labelledby={`${conjunctionLabelId}-value ${conjunctionLabelId}`}
 			className={classNames(
 				'audience-builder-group border overflow-hidden rounded',
 				{
@@ -426,6 +438,7 @@ function GroupRow({
 		>
 			<ConjunctionBar
 				conjunction={group.conjunction}
+				conjunctionLabelId={conjunctionLabelId}
 				onConjunctionChange={(value) =>
 					dispatch({
 						conjunction: value,
@@ -444,18 +457,21 @@ function GroupRow({
 
 interface ConjunctionBarProps {
 	conjunction: string;
+	conjunctionLabelId: string;
 	onConjunctionChange: (conjunction: string) => void;
 }
 
 function ConjunctionBar({
 	conjunction,
+	conjunctionLabelId,
 	onConjunctionChange,
 }: ConjunctionBarProps) {
 	return (
 		<div className="align-items-center bg-lighter border-top c-gap-2 d-flex p-3 text-3 text-secondary">
 			<Picker
-				aria-label={Liferay.Language.get('conjunction')}
+				aria-labelledby={conjunctionLabelId}
 				className="form-control-sm w-auto"
+				id={`${conjunctionLabelId}-value`}
 				items={[
 					{label: Liferay.Language.get('all'), value: 'AND'},
 					{label: Liferay.Language.get('any'), value: 'OR'},
@@ -466,7 +482,9 @@ function ConjunctionBar({
 				{(item) => <Option key={item.value}>{item.label}</Option>}
 			</Picker>
 
-			{Liferay.Language.get('of-these-criteria-are-met')}
+			<span id={conjunctionLabelId}>
+				{Liferay.Language.get('of-these-criteria-are-met')}
+			</span>
 		</div>
 	);
 }

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/ConditionsPanel.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/ConditionsPanel.tsx
@@ -30,6 +30,7 @@ import {
 import KeyboardMovementManager from '../keyboard_movement/KeyboardMovementManager';
 import {Action} from '../reducer';
 import {AudiencesCriteria, AudiencesCriteriaType, Group} from '../types';
+import {getAudiencesCriteriasByKey} from '../util/getAudiencesCriteriasByKey';
 import {getConditionLabel} from '../util/getConditionLabel';
 import {DropZone, getDropPosition} from '../util/getDropPosition';
 import {canGroupNode} from '../util/tree/canGroupNode';
@@ -87,19 +88,8 @@ export default function ConditionsPanel({
 	dispatch,
 	root,
 }: IProps) {
-	const audiencesCriteriasByKey: Record<string, AudiencesCriteria> = useMemo(
-		() =>
-			Object.fromEntries(
-				audiencesCriteriaTypes
-					.flatMap(
-						(audiencesCriteriaType) =>
-							audiencesCriteriaType.audiencesCriterias
-					)
-					.map((audiencesCriteria) => [
-						audiencesCriteria.key,
-						audiencesCriteria,
-					])
-			),
+	const audiencesCriteriasByKey = useMemo(
+		() => getAudiencesCriteriasByKey(audiencesCriteriaTypes),
 		[audiencesCriteriaTypes]
 	);
 

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
@@ -23,6 +23,7 @@ import {
 	useSetMovementSource,
 } from '../keyboard_movement/KeyboardMovementContext';
 import {AudiencesCriteria, Rule} from '../types';
+import {getConditionLabel} from '../util/getConditionLabel';
 import {DropZone, getDropPosition} from '../util/getDropPosition';
 
 interface IProps {
@@ -173,9 +174,11 @@ export default function RuleRow({
 
 	const operators = getOperators(inputType, type);
 
+	const conditionLabel = getConditionLabel(rule, audiencesCriteria);
+
 	return (
 		<div
-			aria-label={label}
+			aria-label={conditionLabel}
 			className={classNames(
 				'align-items-center audience-builder-rule d-flex justify-content-between p-3',
 				`audience-builder-rule--${iconColor}`,
@@ -197,7 +200,7 @@ export default function RuleRow({
 			onFocus={navigationProps?.onFocus}
 			onKeyDown={navigationProps?.onKeyDown}
 			ref={setRowRef}
-			role="menuitem"
+			role="group"
 			tabIndex={navigationProps?.tabIndex ?? 0}
 		>
 			<div className="align-items-center c-gap-3 d-flex">
@@ -210,7 +213,7 @@ export default function RuleRow({
 						if (event.detail === 0) {
 							setMovementSource({
 								icon: audiencesCriteria.icon,
-								name: label,
+								name: conditionLabel,
 								ruleId: rule.id,
 							});
 						}
@@ -357,7 +360,7 @@ function ErrorRuleRow({
 			onFocus={navigationProps?.onFocus}
 			onKeyDown={navigationProps?.onKeyDown}
 			ref={rowRef}
-			role="menuitem"
+			role="group"
 			tabIndex={navigationProps?.tabIndex ?? 0}
 		>
 			<div className="align-items-center c-gap-3 d-flex">

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/RuleRow.tsx
@@ -25,6 +25,7 @@ import {
 import {AudiencesCriteria, Rule} from '../types';
 import {getConditionLabel} from '../util/getConditionLabel';
 import {DropZone, getDropPosition} from '../util/getDropPosition';
+import {getValueOptions} from '../util/getValueOptions';
 
 interface IProps {
 	audiencesCriteria?: AudiencesCriteria;
@@ -170,9 +171,11 @@ export default function RuleRow({
 		);
 	}
 
-	const {inputType, label, options, type} = audiencesCriteria;
+	const {inputType, label, type} = audiencesCriteria;
 
 	const operators = getOperators(inputType, type);
+
+	const valueOptions = getValueOptions(audiencesCriteria);
 
 	const conditionLabel = getConditionLabel(rule, audiencesCriteria);
 
@@ -249,7 +252,7 @@ export default function RuleRow({
 				<RuleValueField
 					inputType={inputType}
 					onChange={(value) => onChange({...rule, value})}
-					options={options}
+					options={valueOptions}
 					tabIndex={navigationProps?.tabIndex ?? 0}
 					type={type}
 					value={rule.value}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/reducer.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/reducer.ts
@@ -19,7 +19,6 @@ import {moveRule} from './util/tree/moveRule';
 import {moveRuleIntoNewGroup} from './util/tree/moveRuleIntoNewGroup';
 import {parseRootGroup} from './util/tree/parseRootGroup';
 import {reorderGroup} from './util/tree/reorderGroup';
-import {serializeGroup} from './util/tree/serializeGroup';
 import {setConjunction} from './util/tree/setConjunction';
 import {unwrapRedundantGroups} from './util/tree/unwrapRedundantGroups';
 import {updateRule} from './util/tree/updateRule';
@@ -166,8 +165,4 @@ export function reducer(state: State, action: Action): State {
 		default:
 			return state;
 	}
-}
-
-export function serializeCriteria(state: State): string {
-	return JSON.stringify(serializeGroup(state.root));
 }

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/types.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/types.ts
@@ -33,7 +33,7 @@ export interface SerializedGroup {
 export interface SerializedRule {
 	attribute: string;
 	operator: string;
-	value: string;
+	value: boolean | number | string;
 }
 
 export interface AudiencesCriteriaType {

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/getAudiencesCriteriasByKey.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/getAudiencesCriteriasByKey.ts
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {AudiencesCriteria, AudiencesCriteriaType} from '../types';
+
+export function getAudiencesCriteriasByKey(
+	audiencesCriteriaTypes: AudiencesCriteriaType[]
+): Record<string, AudiencesCriteria> {
+	return Object.fromEntries(
+		audiencesCriteriaTypes
+			.flatMap(
+				(audiencesCriteriaType) =>
+					audiencesCriteriaType.audiencesCriterias
+			)
+			.map((audiencesCriteria) => [
+				audiencesCriteria.key,
+				audiencesCriteria,
+			])
+	);
+}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/getConditionLabel.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/getConditionLabel.ts
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {getOperatorLabel} from '../constants/operators';
+import {AudiencesCriteria, Rule} from '../types';
+
+export function getConditionLabel(
+	rule: Rule,
+	audiencesCriteria: AudiencesCriteria
+): string {
+	const {inputType, label, options} = audiencesCriteria;
+
+	const value = options.length
+		? options.find((option) => option.value === rule.value)?.label
+		: rule.value;
+
+	return [label, getOperatorLabel(rule.operator, inputType), value]
+		.filter(Boolean)
+		.join(' ');
+}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/getConditionLabel.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/getConditionLabel.ts
@@ -5,15 +5,18 @@
 
 import {getOperatorLabel} from '../constants/operators';
 import {AudiencesCriteria, Rule} from '../types';
+import {getValueOptions} from './getValueOptions';
 
 export function getConditionLabel(
 	rule: Rule,
 	audiencesCriteria: AudiencesCriteria
 ): string {
-	const {inputType, label, options} = audiencesCriteria;
+	const {inputType, label} = audiencesCriteria;
 
-	const value = options.length
-		? options.find((option) => option.value === rule.value)?.label
+	const valueOptions = getValueOptions(audiencesCriteria);
+
+	const value = valueOptions.length
+		? valueOptions.find((option) => option.value === rule.value)?.label
 		: rule.value;
 
 	return [label, getOperatorLabel(rule.operator, inputType), value]

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/getValueOptions.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/getValueOptions.ts
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {AudiencesCriteria} from '../types';
+
+const BOOLEAN_OPTIONS = [
+	{label: Liferay.Language.get('true'), value: 'true'},
+	{label: Liferay.Language.get('false'), value: 'false'},
+];
+
+export function getValueOptions(
+	audiencesCriteria: AudiencesCriteria
+): AudiencesCriteria['options'] {
+	if (audiencesCriteria.inputType === 'boolean') {
+		return BOOLEAN_OPTIONS;
+	}
+
+	return audiencesCriteria.options;
+}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/tree/createRule.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/tree/createRule.ts
@@ -7,6 +7,7 @@ import {v4 as uuidv4} from 'uuid';
 
 import {getOperators} from '../../constants/operators';
 import {AudiencesCriteria, Rule} from '../../types';
+import {getValueOptions} from '../getValueOptions';
 
 export function createRule(audiencesCriteria: AudiencesCriteria): Rule {
 	return {
@@ -17,6 +18,6 @@ export function createRule(audiencesCriteria: AudiencesCriteria): Rule {
 				audiencesCriteria.inputType,
 				audiencesCriteria.type
 			)[0] || '',
-		value: audiencesCriteria.options[0]?.value || '',
+		value: getValueOptions(audiencesCriteria)[0]?.value || '',
 	};
 }

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/tree/parseGroup.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/tree/parseGroup.ts
@@ -23,7 +23,7 @@ export function parseGroup(serialized: SerializedGroup): Group {
 							attribute: node.attribute,
 							id: `rule-${uuidv4()}`,
 							operator: node.operator,
-							value: node.value,
+							value: String(node.value ?? ''),
 						}
 			),
 	};

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/tree/serializeCriteria.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/tree/serializeCriteria.ts
@@ -1,0 +1,14 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {AudiencesCriteria, Group} from '../../types';
+import {serializeGroup} from './serializeGroup';
+
+export function serializeCriteria(
+	root: Group,
+	audiencesCriteriasByKey: Record<string, AudiencesCriteria> = {}
+): string {
+	return JSON.stringify(serializeGroup(root, audiencesCriteriasByKey));
+}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/tree/serializeGroup.ts
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/util/tree/serializeGroup.ts
@@ -3,20 +3,43 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Group, SerializedGroup} from '../../types';
+import {AudiencesCriteria, Group, SerializedGroup} from '../../types';
 import {isGroup} from './isGroup';
 
-export function serializeGroup(group: Group): SerializedGroup {
+export function serializeGroup(
+	group: Group,
+	audiencesCriteriasByKey: Record<string, AudiencesCriteria> = {}
+): SerializedGroup {
 	return {
 		conjunction: group.conjunction,
 		rules: group.items.map((node) =>
 			isGroup(node)
-				? serializeGroup(node)
+				? serializeGroup(node, audiencesCriteriasByKey)
 				: {
 						attribute: node.attribute,
 						operator: node.operator,
-						value: node.value,
+						value: serializeValue(
+							node.value,
+							audiencesCriteriasByKey[node.attribute]?.type
+						),
 					}
 		),
 	};
+}
+
+function serializeValue(
+	value: string,
+	type?: AudiencesCriteria['type']
+): boolean | number | string {
+	if (type === 'boolean') {
+		return value === 'true';
+	}
+
+	if (type === 'number' && value !== '') {
+		const number = Number(value);
+
+		return Number.isNaN(number) ? value : number;
+	}
+
+	return value;
 }

--- a/modules/apps/audiences/audiences-web/test/js/AudienceBuilder.test.tsx
+++ b/modules/apps/audiences/audiences-web/test/js/AudienceBuilder.test.tsx
@@ -383,16 +383,16 @@ describe('AudienceBuilder', () => {
 				/>
 			);
 
-			const conditionsMenu = screen.getByRole('menu', {
+			const conditionsGroup = screen.getByRole('group', {
 				name: 'conditions',
 			});
 
-			const rows = within(conditionsMenu).getAllByRole('menuitem');
+			const rows = within(conditionsGroup).getAllByRole('group');
 
 			expect(rows[0]).toHaveAttribute('tabindex', '0');
 			expect(rows[1]).toHaveAttribute('tabindex', '-1');
 
-			const moveButtons = within(conditionsMenu).getAllByTitle('move-x');
+			const moveButtons = within(conditionsGroup).getAllByTitle('move-x');
 
 			expect(moveButtons[0]).toHaveAttribute('tabindex', '0');
 			expect(moveButtons[1]).toHaveAttribute('tabindex', '-1');
@@ -421,13 +421,13 @@ describe('AudienceBuilder', () => {
 				/>
 			);
 
-			const conditionsMenu = screen.getByRole('menu', {
+			const conditionsGroup = screen.getByRole('group', {
 				name: 'conditions',
 			});
 
-			const [row] = within(conditionsMenu).getAllByRole('menuitem');
+			const [row] = within(conditionsGroup).getAllByRole('group');
 
-			const moveButton = within(conditionsMenu).getByTitle('move-x');
+			const moveButton = within(conditionsGroup).getByTitle('move-x');
 
 			await userEvent.click(row);
 			await userEvent.keyboard('{ArrowRight}');
@@ -437,7 +437,7 @@ describe('AudienceBuilder', () => {
 			await userEvent.keyboard('{ArrowRight}');
 
 			expect(
-				within(conditionsMenu).getByLabelText('operator')
+				within(conditionsGroup).getByLabelText('operator')
 			).toHaveFocus();
 
 			await userEvent.keyboard('{ArrowLeft}');

--- a/modules/apps/audiences/audiences-web/test/js/components/ConditionsPanel.test.tsx
+++ b/modules/apps/audiences/audiences-web/test/js/components/ConditionsPanel.test.tsx
@@ -5,6 +5,9 @@
 
 import {ScreenReaderAnnouncerContextProvider} from '@liferay/layout-js-components-web';
 
+// eslint-disable-next-line @liferay/portal/no-cross-module-deep-import
+import {checkAccessibility} from '@liferay/layout-js-components-web/test/__lib__/index';
+
 import '@testing-library/jest-dom';
 import {render, screen, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -75,7 +78,7 @@ function renderConditionsPanel({
 	dispatch = jest.fn(),
 	items = [] as CriteriaNode[],
 } = {}) {
-	render(
+	const {container} = render(
 		<DragAndDropProvider backend={HTML5Backend}>
 			<ScreenReaderAnnouncerContextProvider>
 				<ConditionsPanel
@@ -87,7 +90,7 @@ function renderConditionsPanel({
 		</DragAndDropProvider>
 	);
 
-	return {dispatch};
+	return {container, dispatch};
 }
 
 describe('ConditionsPanel', () => {
@@ -102,6 +105,10 @@ describe('ConditionsPanel', () => {
 
 		expect(screen.getByText('Age')).toBeTruthy();
 		expect(screen.getByText('is-greater-than')).toBeTruthy();
+
+		expect(
+			screen.getByRole('group', {name: /Age.*is-greater-than.*18/})
+		).toBeTruthy();
 	});
 
 	it('dispatches a duplicate action with the rule path', async () => {
@@ -118,7 +125,9 @@ describe('ConditionsPanel', () => {
 	it('dispatches the conjunction', async () => {
 		const {dispatch} = renderConditionsPanel({items: RULES});
 
-		await userEvent.click(screen.getByLabelText('conjunction'));
+		await userEvent.click(
+			screen.getByLabelText('of-these-criteria-are-met')
+		);
 		await userEvent.click(screen.getByRole('option', {name: 'any'}));
 
 		expect(dispatch).toHaveBeenCalledWith({
@@ -138,16 +147,30 @@ describe('ConditionsPanel', () => {
 	it('renders a nested group with its own conjunction control', () => {
 		renderConditionsPanel({items: NESTED_GROUP});
 
-		expect(screen.getByRole('group')).toBeTruthy();
+		expect(
+			screen.getByRole('group', {name: /of-these-criteria-are-met/})
+		).toBeTruthy();
 		expect(screen.getByText('Age')).toBeTruthy();
 		expect(screen.getByText('City')).toBeTruthy();
-		expect(screen.getAllByLabelText('conjunction')).toHaveLength(2);
+		expect(
+			screen.getAllByRole('combobox', {
+				name: 'of-these-criteria-are-met',
+			})
+		).toHaveLength(2);
+	});
+
+	it('has no accessibility violations for nested groups', async () => {
+		const {container} = renderConditionsPanel({items: NESTED_GROUP});
+
+		await checkAccessibility({bestPractices: true, context: container});
 	});
 
 	it('dispatches a delete action for a rule nested in a group by path', async () => {
 		const {dispatch} = renderConditionsPanel({items: NESTED_GROUP});
 
-		const group = screen.getByRole('group');
+		const group = screen.getByRole('group', {
+			name: /of-these-criteria-are-met/,
+		});
 
 		await userEvent.click(within(group).getAllByLabelText('delete')[0]);
 
@@ -195,12 +218,13 @@ describe('ConditionsPanel', () => {
 			],
 		});
 
-		const rows = screen.getAllByRole('menuitem');
+		const ageRow = screen.getByRole('group', {name: /^Age/});
+		const cityRow = screen.getByRole('group', {name: /^City/});
 
-		rows[0].focus();
+		ageRow.focus();
 
 		await userEvent.keyboard('{ArrowDown}');
 
-		expect(rows[1]).toHaveFocus();
+		expect(cityRow).toHaveFocus();
 	});
 });

--- a/modules/apps/audiences/audiences-web/test/js/components/ConditionsPanel.test.tsx
+++ b/modules/apps/audiences/audiences-web/test/js/components/ConditionsPanel.test.tsx
@@ -44,6 +44,14 @@ const AUDIENCES_CRITERIA_TYPES: AudiencesCriteriaType[] = [
 				options: [],
 				type: 'string',
 			},
+			{
+				icon: 'check',
+				inputType: 'boolean',
+				key: 'user_authentication',
+				label: 'User Authentication',
+				options: [],
+				type: 'boolean',
+			},
 		],
 		key: 'user',
 		label: 'User',
@@ -133,6 +141,33 @@ describe('ConditionsPanel', () => {
 		expect(dispatch).toHaveBeenCalledWith({
 			conjunction: 'OR',
 			type: 'SET_CONJUNCTION',
+		});
+	});
+
+	it('dispatches a true or false value for a boolean rule', async () => {
+		const {dispatch} = renderConditionsPanel({
+			items: [
+				{
+					attribute: 'user_authentication',
+					id: 'rule-auth',
+					operator: 'eq',
+					value: 'true',
+				},
+			],
+		});
+
+		await userEvent.click(screen.getByLabelText('value'));
+		await userEvent.click(screen.getByRole('option', {name: 'false'}));
+
+		expect(dispatch).toHaveBeenCalledWith({
+			path: [0],
+			rule: {
+				attribute: 'user_authentication',
+				id: 'rule-auth',
+				operator: 'eq',
+				value: 'false',
+			},
+			type: 'UPDATE_RULE',
 		});
 	});
 

--- a/modules/apps/audiences/audiences-web/test/js/reducer.test.ts
+++ b/modules/apps/audiences/audiences-web/test/js/reducer.test.ts
@@ -5,11 +5,9 @@
 
 import '@testing-library/jest-dom';
 
-import {
-	initState,
-	serializeCriteria,
-} from '../../src/main/resources/META-INF/resources/js/reducer';
+import {initState} from '../../src/main/resources/META-INF/resources/js/reducer';
 import {AudiencesCriteriaRulesGroup} from '../../src/main/resources/META-INF/resources/js/types';
+import {serializeCriteria} from '../../src/main/resources/META-INF/resources/js/util/tree/serializeCriteria';
 
 describe('reducer', () => {
 	it('normalizes groups when loading stored criteria', () => {
@@ -52,7 +50,9 @@ describe('reducer', () => {
 			],
 		};
 
-		const parsed = JSON.parse(serializeCriteria(initState({rulesGroup})));
+		const parsed = JSON.parse(
+			serializeCriteria(initState({rulesGroup}).root)
+		);
 
 		expect(parsed.rules).toHaveLength(3);
 		expect(parsed.rules[1].conjunction).toBe('OR');

--- a/modules/apps/audiences/audiences-web/test/js/util/getValueOptions.test.ts
+++ b/modules/apps/audiences/audiences-web/test/js/util/getValueOptions.test.ts
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {AudiencesCriteria} from '../../../src/main/resources/META-INF/resources/js/types';
+import {getValueOptions} from '../../../src/main/resources/META-INF/resources/js/util/getValueOptions';
+
+const BOOLEAN: AudiencesCriteria = {
+	icon: 'check',
+	inputType: 'boolean',
+	key: 'user_authentication',
+	label: 'User Authentication',
+	options: [],
+	type: 'boolean',
+};
+
+const SELECT: AudiencesCriteria = {
+	icon: 'text',
+	inputType: 'select',
+	key: 'language',
+	label: 'Language',
+	options: [{label: 'English', value: 'en'}],
+	type: 'string',
+};
+
+describe('getValueOptions', () => {
+	it('returns true and false options for a boolean criteria', () => {
+		expect(getValueOptions(BOOLEAN).map((option) => option.value)).toEqual([
+			'true',
+			'false',
+		]);
+	});
+
+	it('returns the criteria options otherwise', () => {
+		expect(getValueOptions(SELECT)).toBe(SELECT.options);
+	});
+});

--- a/modules/apps/audiences/audiences-web/test/js/util/tree.test.ts
+++ b/modules/apps/audiences/audiences-web/test/js/util/tree.test.ts
@@ -7,6 +7,7 @@ import {
 	AudiencesCriteria,
 	CriteriaNode,
 	Group,
+	Rule,
 	SerializedGroup,
 } from '../../../src/main/resources/META-INF/resources/js/types';
 import {addGroup} from '../../../src/main/resources/META-INF/resources/js/util/tree/addGroup';
@@ -64,6 +65,24 @@ const COUNTRY: AudiencesCriteria = {
 	type: 'string',
 };
 
+const LOCAL_HOUR: AudiencesCriteria = {
+	icon: 'time',
+	inputType: 'select',
+	key: 'local_hour',
+	label: 'Local Hour',
+	options: [{label: '14:00', value: '14'}],
+	type: 'number',
+};
+
+const USER_AUTHENTICATION: AudiencesCriteria = {
+	icon: 'check',
+	inputType: 'boolean',
+	key: 'user_authentication',
+	label: 'User Authentication',
+	options: [],
+	type: 'boolean',
+};
+
 const NESTED_TREE: SerializedGroup = {
 	conjunction: 'OR',
 	rules: [
@@ -87,6 +106,64 @@ describe('tree', () => {
 			expect(serializeGroup(parseRootGroup(NESTED_TREE))).toEqual(
 				NESTED_TREE
 			);
+		});
+
+		it('serializes boolean and numeric values by criteria type', () => {
+			const audiencesCriteriasByKey = {
+				local_hour: LOCAL_HOUR,
+				user_authentication: USER_AUTHENTICATION,
+			};
+
+			const root = parseRootGroup({
+				conjunction: 'AND',
+				rules: [
+					{
+						attribute: 'user_authentication',
+						operator: 'eq',
+						value: 'true',
+					},
+					{attribute: 'local_hour', operator: 'gt', value: '14'},
+				],
+			});
+
+			expect(serializeGroup(root, audiencesCriteriasByKey).rules).toEqual(
+				[
+					{
+						attribute: 'user_authentication',
+						operator: 'eq',
+						value: true,
+					},
+					{attribute: 'local_hour', operator: 'gt', value: 14},
+				]
+			);
+		});
+
+		it('keeps a non-numeric number value as a string', () => {
+			const root = parseRootGroup({
+				conjunction: 'AND',
+				rules: [{attribute: 'local_hour', operator: 'gt', value: 'x'}],
+			});
+
+			expect(
+				serializeGroup(root, {local_hour: LOCAL_HOUR}).rules
+			).toEqual([{attribute: 'local_hour', operator: 'gt', value: 'x'}]);
+		});
+
+		it('parses stored boolean and numeric values into strings', () => {
+			const root = parseRootGroup({
+				conjunction: 'AND',
+				rules: [
+					{
+						attribute: 'user_authentication',
+						operator: 'eq',
+						value: false,
+					},
+					{attribute: 'local_hour', operator: 'gt', value: 14},
+				],
+			});
+
+			expect((root.items[0] as Rule).value).toBe('false');
+			expect((root.items[1] as Rule).value).toBe('14');
 		});
 
 		it('assigns ids and preserves nested groups on parse', () => {
@@ -134,6 +211,14 @@ describe('tree', () => {
 	});
 
 	describe('mutations', () => {
+		it('creates a boolean rule with a default true value', () => {
+			expect(createRule(USER_AUTHENTICATION)).toMatchObject({
+				attribute: 'user_authentication',
+				operator: 'eq',
+				value: 'true',
+			});
+		});
+
 		it('adds a rule to the root and to a nested group', () => {
 			let root = parseRootGroup(NESTED_TREE);
 

--- a/modules/test/playwright/tests/audiences-web/main/audiences.spec.ts
+++ b/modules/test/playwright/tests/audiences-web/main/audiences.spec.ts
@@ -172,7 +172,9 @@ test(
 			page.getByText('of these criteria are met.')
 		).toBeVisible();
 
-		const conjunction = page.getByLabel('Conjunction');
+		const conjunction = page.getByRole('combobox', {
+			name: 'of these criteria are met.',
+		});
 
 		await expect(conjunction).toContainText('All');
 
@@ -423,23 +425,29 @@ test(
 		await page.keyboard.press('Tab');
 
 		await expect(
-			page.getByRole('menu', {name: 'Conditions'}).locator(':focus')
+			page.getByRole('group', {name: 'Conditions'}).locator(':focus')
 		).toHaveCount(0);
 
 		// The new group defaults to All
 
-		await expect(groups.getByLabel('Conjunction')).toContainText('All');
+		await expect(
+			groups.getByRole('combobox', {name: 'of these criteria are met.'})
+		).toContainText('All');
 
 		// Switching the root to Any leaves the nested group on All
 
-		const rootConjunction = page.getByLabel('Conjunction').first();
+		const rootConjunction = page
+			.getByRole('combobox', {name: 'of these criteria are met.'})
+			.first();
 
 		await rootConjunction.click();
 
 		await page.getByRole('option', {exact: true, name: 'Any'}).click();
 
 		await expect(rootConjunction).toContainText('Any');
-		await expect(groups.getByLabel('Conjunction')).toContainText('All');
+		await expect(
+			groups.getByRole('combobox', {name: 'of these criteria are met.'})
+		).toContainText('All');
 
 		// Dropping onto a rule inside the group nests a third level
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99008
https://liferay.atlassian.net/browse/LPD-99010

## What Is Being Fixed

Two gaps in the Audience Builder conditions UI, both under the nested rule groups story.

The grouped conditions were not fully operable or understandable without sight: the logical nesting a sighted user perceives through indentation and the green group borders was not conveyed to keyboard and screen reader users with equivalent clarity.

Separately, the Audience Builder stored and serialized every rule value as a string. The backend audiences criteria JSON schema requires the user authentication value to be a boolean and the local hour value to be a number, so saving an audience that used either attribute failed schema validation.

## How It Is Being Fixed

For accessibility, each group is announced with its nesting level, its operator and plain language meaning, and its criteria count, and every control is reachable and operable by keyboard in the order of the visual nesting.

For value typing, user authentication now renders a true/false control (matching DXP Segments, with the equals and not-equals operators) and serializes as a JSON boolean, while local hour serializes as a JSON number. Coercion happens at the serialization boundary by criteria type, and stored audiences round-trip back into the string-based UI. A shared getValueOptions helper resolves the value options and their localized labels for the picker, the condition summary, and the new rule default, so boolean labels are translated everywhere, and a guard keeps a non-numeric number value from serializing as null.

## PR Check

**pr-check: PASS** — tested on `5a03b48ad4ed08eefdc28387e7440bcf2960ff7d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5a03b48ad4ed08eefdc28387e7440bcf2960ff7d"} -->
