### PR TITLE
LPD-99227 Keep the Audience Builder values when a save fails

### DIFF
--- a/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/display/context/EditAudiencesEntryDisplayContext.java
+++ b/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/display/context/EditAudiencesEntryDisplayContext.java
@@ -58,6 +58,11 @@ public class EditAudiencesEntryDisplayContext {
 
 	public JSONObject getAudiencesEntryJSONObject() {
 		try {
+			if (_hasSubmittedValues()) {
+				return JSONFactoryUtil.createJSONObject(
+					ParamUtil.getString(_httpServletRequest, "json"));
+			}
+
 			AudiencesEntry audiencesEntry = _getAudiencesEntry();
 
 			if (audiencesEntry != null) {
@@ -152,6 +157,8 @@ public class EditAudiencesEntryDisplayContext {
 		).put(
 			"backURLTitle", getBackURLTitle()
 		).put(
+			"expandGeneralSettings", _hasSubmittedValues()
+		).put(
 			"externalReferenceCode", _getExternalReferenceCode()
 		).put(
 			"name", _getName()
@@ -183,12 +190,19 @@ public class EditAudiencesEntryDisplayContext {
 			return _title;
 		}
 
-		AudiencesEntry audiencesEntry = _getAudiencesEntry();
-
-		if (audiencesEntry != null) {
-			_title = audiencesEntry.getName();
+		if (_hasSubmittedValues()) {
+			_title = ParamUtil.getString(_httpServletRequest, "name");
 		}
-		else {
+
+		if (Validator.isNull(_title)) {
+			AudiencesEntry audiencesEntry = _getAudiencesEntry();
+
+			if (audiencesEntry != null) {
+				_title = audiencesEntry.getName();
+			}
+		}
+
+		if (Validator.isNull(_title)) {
 			_title = LanguageUtil.get(_httpServletRequest, "new-audience");
 		}
 
@@ -213,6 +227,11 @@ public class EditAudiencesEntryDisplayContext {
 	}
 
 	private String _getExternalReferenceCode() {
+		if (_hasSubmittedValues()) {
+			return ParamUtil.getString(
+				_httpServletRequest, "externalReferenceCode");
+		}
+
 		try {
 			AudiencesEntry audiencesEntry = _getAudiencesEntry();
 
@@ -230,6 +249,10 @@ public class EditAudiencesEntryDisplayContext {
 	}
 
 	private String _getName() {
+		if (_hasSubmittedValues()) {
+			return ParamUtil.getString(_httpServletRequest, "name");
+		}
+
 		try {
 			AudiencesEntry audiencesEntry = _getAudiencesEntry();
 
@@ -244,6 +267,10 @@ public class EditAudiencesEntryDisplayContext {
 		}
 
 		return StringPool.BLANK;
+	}
+
+	private boolean _hasSubmittedValues() {
+		return ParamUtil.getBoolean(_httpServletRequest, "redisplay");
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/portlet/action/UpdateAudiencesEntryMVCActionCommand.java
+++ b/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/portlet/action/UpdateAudiencesEntryMVCActionCommand.java
@@ -108,7 +108,22 @@ public class UpdateAudiencesEntryMVCActionCommand extends BaseMVCActionCommand {
 					actionRequest, exception.getClass(), exception);
 
 				actionResponse.setRenderParameter(
+					"audiencesEntryId", String.valueOf(audiencesEntryId));
+				actionResponse.setRenderParameter(
+					"externalReferenceCode", externalReferenceCode);
+				actionResponse.setRenderParameter("json", json);
+				actionResponse.setRenderParameter(
 					"mvcRenderCommandName", "/audiences/edit_audiences_entry");
+				actionResponse.setRenderParameter("name", name);
+				actionResponse.setRenderParameter(
+					"redisplay", Boolean.TRUE.toString());
+
+				String redirect = ParamUtil.getString(
+					actionRequest, "redirect");
+
+				if (Validator.isNotNull(redirect)) {
+					actionResponse.setRenderParameter("redirect", redirect);
+				}
 			}
 			else {
 				throw exception;

--- a/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/portlet/action/UpdateAudiencesEntryMVCActionCommand.java
+++ b/modules/apps/audiences/audiences-web/src/main/java/com/liferay/audiences/web/internal/portlet/action/UpdateAudiencesEntryMVCActionCommand.java
@@ -107,6 +107,8 @@ public class UpdateAudiencesEntryMVCActionCommand extends BaseMVCActionCommand {
 				SessionErrors.add(
 					actionRequest, exception.getClass(), exception);
 
+				hideDefaultErrorMessage(actionRequest);
+
 				actionResponse.setRenderParameter(
 					"audiencesEntryId", String.valueOf(audiencesEntryId));
 				actionResponse.setRenderParameter(

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/AudienceBuilder.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/AudienceBuilder.tsx
@@ -36,6 +36,7 @@ interface IProps {
 	audiencesCriteriaTypes?: AudiencesCriteriaType[];
 	backURL?: string;
 	backURLTitle?: string;
+	expandGeneralSettings?: boolean;
 	externalReferenceCode?: string;
 	name?: string;
 	namespace?: string;
@@ -46,6 +47,7 @@ export default function AudienceBuilder({
 	audiencesCriteriaTypes = [],
 	backURL,
 	backURLTitle,
+	expandGeneralSettings = false,
 	externalReferenceCode,
 	name,
 	namespace = '',
@@ -118,6 +120,7 @@ export default function AudienceBuilder({
 								</ClayForm.Group>
 
 								<GeneralSettings
+									defaultExpanded={expandGeneralSettings}
 									externalReferenceCode={
 										state.externalReferenceCode
 									}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/GeneralSettings.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/GeneralSettings.tsx
@@ -6,7 +6,7 @@
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayPanel from '@clayui/panel';
-import React from 'react';
+import React, {useState} from 'react';
 
 interface IProps {
 	defaultExpanded?: boolean;
@@ -21,17 +21,20 @@ export default function GeneralSettings({
 	namespace,
 	onExternalReferenceCodeChange,
 }: IProps) {
+	const [expanded, setExpanded] = useState(defaultExpanded);
+
 	return (
 		<ClayPanel
 			className="audience-builder-general-settings border mt-4 rounded"
 			collapsable
 			collapseHeaderClassNames="align-items-center d-flex justify-content-between px-4 py-3"
-			defaultExpanded={defaultExpanded}
 			displayTitle={
 				<span className="font-weight-bold text-6">
 					{Liferay.Language.get('general-settings')}
 				</span>
 			}
+			expanded={expanded}
+			onExpandedChange={setExpanded}
 			showCollapseIcon
 		>
 			<ClayPanel.Body>
@@ -63,6 +66,7 @@ export default function GeneralSettings({
 						onChange={(event) =>
 							onExternalReferenceCodeChange(event.target.value)
 						}
+						onInvalid={() => setExpanded(true)}
 						required
 						type="text"
 						value={externalReferenceCode}

--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/GeneralSettings.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/components/GeneralSettings.tsx
@@ -9,12 +9,14 @@ import ClayPanel from '@clayui/panel';
 import React from 'react';
 
 interface IProps {
+	defaultExpanded?: boolean;
 	externalReferenceCode: string;
 	namespace: string;
 	onExternalReferenceCodeChange: (externalReferenceCode: string) => void;
 }
 
 export default function GeneralSettings({
+	defaultExpanded = false,
 	externalReferenceCode,
 	namespace,
 	onExternalReferenceCodeChange,
@@ -24,6 +26,7 @@ export default function GeneralSettings({
 			className="audience-builder-general-settings border mt-4 rounded"
 			collapsable
 			collapseHeaderClassNames="align-items-center d-flex justify-content-between px-4 py-3"
+			defaultExpanded={defaultExpanded}
 			displayTitle={
 				<span className="font-weight-bold text-6">
 					{Liferay.Language.get('general-settings')}

--- a/modules/apps/audiences/audiences-web/src/test/java/com/liferay/audiences/web/internal/display/context/EditAudiencesEntryDisplayContextTest.java
+++ b/modules/apps/audiences/audiences-web/src/test/java/com/liferay/audiences/web/internal/display/context/EditAudiencesEntryDisplayContextTest.java
@@ -1,0 +1,171 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.audiences.web.internal.display.context;
+
+import com.liferay.audiences.criteria.AudiencesCriteriaProvider;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.portlet.RenderResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+/**
+ * @author Georgel Pop
+ */
+public class EditAudiencesEntryDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		LanguageUtil languageUtil = new LanguageUtil();
+
+		Mockito.when(
+			_language.get(
+				Mockito.any(HttpServletRequest.class), Mockito.anyString())
+		).thenAnswer(
+			(Answer<String>)invocationOnMock -> invocationOnMock.getArgument(
+				1, String.class)
+		);
+
+		languageUtil.setLanguage(_language);
+	}
+
+	@Test
+	@TestInfo("LPD-99227")
+	public void testGetData() throws Exception {
+		_testGetDataRestoresSubmittedValues();
+		_testGetDataIgnoresStrayValues();
+	}
+
+	private EditAudiencesEntryDisplayContext _createDisplayContext(
+		HttpServletRequest httpServletRequest) {
+
+		return new EditAudiencesEntryDisplayContext(
+			_audiencesCriteriaProvider, httpServletRequest,
+			Mockito.mock(RenderResponse.class));
+	}
+
+	private HttpServletRequest _mockHttpServletRequest() {
+		HttpServletRequest httpServletRequest = Mockito.mock(
+			HttpServletRequest.class);
+
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			themeDisplay.getLocale()
+		).thenReturn(
+			LocaleUtil.US
+		);
+
+		Mockito.when(
+			httpServletRequest.getAttribute(WebKeys.THEME_DISPLAY)
+		).thenReturn(
+			themeDisplay
+		);
+
+		Mockito.when(
+			httpServletRequest.getParameter("redirect")
+		).thenReturn(
+			"/redirect"
+		);
+
+		Mockito.when(
+			_audiencesCriteriaProvider.getAudiencesCriteriaTypes(
+				Mockito.anyLong(), Mockito.any())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		return httpServletRequest;
+	}
+
+	private void _testGetDataIgnoresStrayValues() throws Exception {
+		HttpServletRequest httpServletRequest = _mockHttpServletRequest();
+
+		Mockito.when(
+			httpServletRequest.getParameter("name")
+		).thenReturn(
+			"My audience"
+		);
+
+		EditAudiencesEntryDisplayContext editAudiencesEntryDisplayContext =
+			_createDisplayContext(httpServletRequest);
+
+		Map<String, Object> data = editAudiencesEntryDisplayContext.getData();
+
+		Assert.assertEquals(Boolean.FALSE, data.get("expandGeneralSettings"));
+		Assert.assertEquals("", data.get("name"));
+
+		Assert.assertEquals(
+			"new-audience", editAudiencesEntryDisplayContext.getTitle());
+	}
+
+	private void _testGetDataRestoresSubmittedValues() throws Exception {
+		HttpServletRequest httpServletRequest = _mockHttpServletRequest();
+
+		Mockito.when(
+			httpServletRequest.getParameter("json")
+		).thenReturn(
+			"{\"conjunction\":\"AND\"}"
+		);
+
+		Mockito.when(
+			httpServletRequest.getParameter("name")
+		).thenReturn(
+			"My audience"
+		);
+
+		Mockito.when(
+			httpServletRequest.getParameter("redisplay")
+		).thenReturn(
+			"true"
+		);
+
+		EditAudiencesEntryDisplayContext editAudiencesEntryDisplayContext =
+			_createDisplayContext(httpServletRequest);
+
+		Map<String, Object> data = editAudiencesEntryDisplayContext.getData();
+
+		Assert.assertEquals(Boolean.TRUE, data.get("expandGeneralSettings"));
+		Assert.assertEquals("My audience", data.get("name"));
+
+		JSONObject rulesGroupJSONObject = (JSONObject)data.get("rulesGroup");
+
+		Assert.assertEquals(
+			"AND", rulesGroupJSONObject.getString("conjunction"));
+
+		Assert.assertEquals(
+			"My audience", editAudiencesEntryDisplayContext.getTitle());
+	}
+
+	private final AudiencesCriteriaProvider _audiencesCriteriaProvider =
+		Mockito.mock(AudiencesCriteriaProvider.class);
+	private final Language _language = Mockito.mock(Language.class);
+
+}

--- a/modules/test/playwright/pages/audiences-web/AudiencesPage.ts
+++ b/modules/test/playwright/pages/audiences-web/AudiencesPage.ts
@@ -12,6 +12,8 @@ import {waitForAlert} from '../../utils/waitForAlert';
 
 export class AudiencesPage {
 	readonly apiHelpers: DataApiHelpers;
+	readonly externalReferenceCodeInput: Locator;
+	readonly generalSettingsButton: Locator;
 	readonly nameInput: Locator;
 	readonly newAudienceButton: Locator;
 	readonly page: Page;
@@ -21,6 +23,12 @@ export class AudiencesPage {
 
 	constructor(page: Page, apiHelpers: DataApiHelpers) {
 		this.apiHelpers = apiHelpers;
+		this.externalReferenceCodeInput = page.getByRole('textbox', {
+			name: 'ERC',
+		});
+		this.generalSettingsButton = page.getByRole('button', {
+			name: 'General Settings',
+		});
 		this.nameInput = page.getByPlaceholder('New Audience');
 		this.newAudienceButton = page.getByLabel('New', {exact: true});
 		this.page = page;
@@ -57,12 +65,14 @@ export class AudiencesPage {
 
 	async createAudience({
 		attributeName,
+		externalReferenceCode,
 		name,
 		operator,
 		value,
 		valueType = 'text',
 	}: {
 		attributeName: string;
+		externalReferenceCode?: string;
 		name: string;
 		operator?: string;
 		value: string;
@@ -107,6 +117,10 @@ export class AudiencesPage {
 			await this.valueInput.fill(value);
 		}
 
+		if (externalReferenceCode) {
+			await this.fillExternalReferenceCode(externalReferenceCode);
+		}
+
 		await this.saveButton.click();
 
 		await waitForAlert(this.page);
@@ -145,6 +159,12 @@ export class AudiencesPage {
 		});
 
 		await waitForAlert(this.page);
+	}
+
+	async fillExternalReferenceCode(externalReferenceCode: string) {
+		await this.generalSettingsButton.click();
+
+		await this.externalReferenceCodeInput.fill(externalReferenceCode);
 	}
 
 	async goto() {

--- a/modules/test/playwright/tests/audiences-web/main/audiences.spec.ts
+++ b/modules/test/playwright/tests/audiences-web/main/audiences.spec.ts
@@ -375,6 +375,106 @@ test(
 );
 
 test(
+	'Keeps the values and avoids a duplicate when a save fails',
+	{
+		tag: '@LPD-99227',
+	},
+	async ({audiencesPage, page}) => {
+		const externalReferenceCode = 'ERC-' + getRandomString();
+
+		// Create the audience that already owns the external reference code
+
+		await audiencesPage.goto();
+
+		await audiencesPage.createAudience({
+			attributeName: 'Browser Name',
+			externalReferenceCode,
+			name: 'Audience ' + getRandomString(),
+			value: 'Chrome',
+		});
+
+		// Create the audience to edit
+
+		const audienceName = 'Audience ' + getRandomString();
+
+		await audiencesPage.createAudience({
+			attributeName: 'Browser Name',
+			name: audienceName,
+			value: 'Chrome',
+		});
+
+		// Edit it
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: page.getByRole('menuitem', {name: 'Edit'}),
+			trigger: page
+				.locator('tr')
+				.filter({hasText: audienceName})
+				.locator('button.dropdown-toggle'),
+		});
+
+		// An empty external reference code expands the general settings on save
+
+		await audiencesPage.generalSettingsButton.click();
+
+		await audiencesPage.externalReferenceCodeInput.fill('');
+
+		await audiencesPage.generalSettingsButton.click();
+
+		await audiencesPage.saveButton.click();
+
+		await expect(audiencesPage.externalReferenceCodeInput).toBeVisible();
+
+		// Reuse the external reference code already in use
+
+		await audiencesPage.externalReferenceCodeInput.fill(
+			externalReferenceCode
+		);
+
+		await audiencesPage.saveButton.click();
+
+		await waitForAlert(
+			page,
+			'Please enter a unique external reference code.',
+			{autoClose: false, type: 'danger'}
+		);
+
+		// Only the specific error shows, not the generic failure message
+
+		await expect(
+			page.locator('#ToastAlertContainer .alert-danger')
+		).toHaveCount(1);
+
+		// The values survive and the general settings stay expanded
+
+		await expect(audiencesPage.nameInput).toHaveValue(audienceName);
+		await expect(
+			page.locator('.audience-builder-rule').getByText('Browser Name')
+		).toBeVisible();
+		await expect(audiencesPage.valueInput).toHaveValue('Chrome');
+		await expect(audiencesPage.externalReferenceCodeInput).toBeVisible();
+		await expect(audiencesPage.externalReferenceCodeInput).toHaveValue(
+			externalReferenceCode
+		);
+
+		// Fixing the code updates the audience instead of duplicating it
+
+		await audiencesPage.externalReferenceCodeInput.fill(
+			'ERC-' + getRandomString()
+		);
+
+		await audiencesPage.saveButton.click();
+
+		await waitForAlert(page);
+
+		await expect(
+			page.locator('tr').filter({hasText: audienceName})
+		).toHaveCount(1);
+	}
+);
+
+test(
 	'Groups, navigates, keeps the conjunction independent, caps nesting, and unwraps',
 	{
 		tag: '@LPD-98159',


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99227

## What Is Being Fixed

When saving an audience failed, the Audience Builder discarded the user's input: a new audience came back blank and an existing one reverted to its saved state, so every condition had to be rebuilt. A failed edit could also create a duplicate audience on the corrected resubmit. An invalid external reference code was hard to recover from because the field is required and hidden in a collapsed panel, so Save silently did nothing, and a generic "Your request failed to complete." message showed alongside the specific validation error.

## How It Is Being Fixed

On a failed save the update action now forwards the submitted values (name, conditions, external reference code) plus a redisplay marker, and the display context prefers them over the persisted entity only on that redisplay. It also forwards the audiencesEntryId so a failed edit updates the original audience instead of creating a duplicate, and preserves the redirect. The General Settings section expands when the external reference code is invalid, both on the server redisplay and client-side when the required field is empty on Save, so the offending field is visible instead of failing silently. Finally, hideDefaultErrorMessage suppresses Liferay's generic error toast so only the specific validation error shows.

## PR Check

**pr-check: PASS** — tested on `6d102bb1817d2e7c2ab6d68aa93582e082d98c72`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "6d102bb1817d2e7c2ab6d68aa93582e082d98c72"} -->
