### PR TITLE
LPD-98882 Propagate fragment entry changes to Design Library sites

### DIFF
--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalService.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLocalService.java
@@ -513,4 +513,4 @@ public interface FragmentEntryLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-895421038
+// LIFERAY-SERVICE-BUILDER-HASH:-1873906920

--- a/modules/apps/fragment/fragment-service/build.gradle
+++ b/modules/apps/fragment/fragment-service/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 	compileOnly project(":apps:asset:asset-info-display-api")
 	compileOnly project(":apps:asset:asset-list-api")
 	compileOnly project(":apps:change-tracking:change-tracking-spi")
+	compileOnly project(":apps:depot:depot-api")
 	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compileOnly project(":apps:export-import:export-import-api")

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
@@ -985,10 +985,6 @@ public class FragmentEntryLocalServiceImpl
 
 		Group group = _groupLocalService.getGroup(fragmentEntry.getGroupId());
 
-		if (group.isDepot()) {
-			return;
-		}
-
 		ActionableDynamicQuery actionableDynamicQuery =
 			_fragmentEntryLinkLocalService.getActionableDynamicQuery();
 

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
@@ -5,6 +5,10 @@
 
 package com.liferay.fragment.service.impl;
 
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.model.DepotEntryGroupRel;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.fragment.configuration.FragmentServiceConfiguration;
@@ -21,6 +25,7 @@ import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.fragment.service.base.FragmentEntryLocalServiceBaseImpl;
 import com.liferay.fragment.service.persistence.FragmentCollectionPersistence;
 import com.liferay.fragment.validator.FragmentEntryValidator;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
@@ -895,6 +900,14 @@ public class FragmentEntryLocalServiceImpl
 		}
 	}
 
+	private DepotEntry _fetchGroupDepotEntry(Group group) {
+		if (!group.isDepot()) {
+			return null;
+		}
+
+		return _depotEntryLocalService.fetchGroupDepotEntry(group.getGroupId());
+	}
+
 	private Map<String, FileEntry> _getFileEntries(
 		long fragmentCollectionId, FragmentEntry fragmentEntry) {
 
@@ -991,6 +1004,20 @@ public class FragmentEntryLocalServiceImpl
 		actionableDynamicQuery.setAddCriteriaMethod(
 			dynamicQuery -> {
 				Conjunction conjunction = RestrictionsFactoryUtil.conjunction();
+
+				DepotEntry depotEntry = _fetchGroupDepotEntry(group);
+
+				if (depotEntry != null) {
+					List<Long> groupIds = TransformUtil.transform(
+						_depotEntryGroupRelLocalService.getDepotEntryGroupRels(
+							depotEntry),
+						DepotEntryGroupRel::getToGroupId);
+
+					groupIds.add(group.getGroupId());
+
+					conjunction.add(
+						RestrictionsFactoryUtil.in("groupId", groupIds));
+				}
 
 				conjunction.add(
 					RestrictionsFactoryUtil.eq(
@@ -1126,6 +1153,12 @@ public class FragmentEntryLocalServiceImpl
 
 	@Reference
 	private CustomSQL _customSQL;
+
+	@Reference
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/ViewGroupFragmentEntryUsagesMVCRenderCommandTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/ViewGroupFragmentEntryUsagesMVCRenderCommandTest.java
@@ -74,10 +74,25 @@ public class ViewGroupFragmentEntryUsagesMVCRenderCommandTest {
 		FragmentEntry fragmentEntry = FragmentEntryTestUtil.addFragmentEntry(
 			fragmentCollection.getFragmentCollectionId());
 
+		_addFragmentEntryLink(fragmentEntry, _group.getGroupId());
+
+		Assert.assertEquals(
+			2,
+			(long)ReflectionTestUtil.invoke(
+				_getGroupFragmentEntryLinkDisplayContext(
+					fragmentEntry.getFragmentEntryId()),
+				"getFragmentGroupUsageCount", new Class<?>[] {Group.class},
+				_group));
+	}
+
+	private void _addFragmentEntryLink(
+			FragmentEntry fragmentEntry, long groupId)
+		throws Exception {
+
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
 			_layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
-				null, TestPropsValues.getUserId(), _group.getGroupId(), 0, null,
-				0, null, RandomTestUtil.randomString(),
+				null, TestPropsValues.getUserId(), groupId, 0, null, 0, null,
+				RandomTestUtil.randomString(),
 				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE, 0, true, 0,
 				0, 0, WorkflowConstants.STATUS_APPROVED, new ServiceContext());
 
@@ -99,29 +114,25 @@ public class ViewGroupFragmentEntryUsagesMVCRenderCommandTest {
 				draftLayout.getPlid()));
 
 		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
+	}
+
+	private Object _getGroupFragmentEntryLinkDisplayContext(
+			long fragmentEntryId)
+		throws Exception {
 
 		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
 			new MockLiferayPortletRenderRequest();
 
 		mockLiferayPortletRenderRequest.setParameter(
-			"fragmentEntryId",
-			String.valueOf(fragmentEntry.getFragmentEntryId()));
+			"fragmentEntryId", String.valueOf(fragmentEntryId));
 
 		_mvcRenderCommand.render(
 			mockLiferayPortletRenderRequest,
 			new MockLiferayPortletRenderResponse());
 
-		Object groupFragmentEntryLinkDisplayContext =
-			mockLiferayPortletRenderRequest.getAttribute(
-				"com.liferay.fragment.web.internal.display.context." +
-					"GroupFragmentEntryLinkDisplayContext");
-
-		Assert.assertEquals(
-			2,
-			(long)ReflectionTestUtil.invoke(
-				groupFragmentEntryLinkDisplayContext,
-				"getFragmentGroupUsageCount", new Class<?>[] {Group.class},
-				_group));
+		return mockLiferayPortletRenderRequest.getAttribute(
+			"com.liferay.fragment.web.internal.display.context." +
+				"GroupFragmentEntryLinkDisplayContext");
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/ViewGroupFragmentEntryUsagesMVCRenderCommandTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/ViewGroupFragmentEntryUsagesMVCRenderCommandTest.java
@@ -6,6 +6,10 @@
 package com.liferay.fragment.internal.portlet.action.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.test.util.FragmentEntryTestUtil;
@@ -29,13 +33,19 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ScopeUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
+
+import java.util.Collections;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -83,6 +93,44 @@ public class ViewGroupFragmentEntryUsagesMVCRenderCommandTest {
 					fragmentEntry.getFragmentEntryId()),
 				"getFragmentGroupUsageCount", new Class<?>[] {Group.class},
 				_group));
+	}
+
+	@Test
+	@TestInfo("LPD-98882")
+	public void testGetGroupFragmentEntryUsages() throws Exception {
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			Collections.emptyMap(), DepotConstants.TYPE_DESIGN_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
+
+		FragmentCollection fragmentCollection =
+			FragmentTestUtil.addFragmentCollection(depotEntry.getGroupId());
+
+		FragmentEntry fragmentEntry = FragmentEntryTestUtil.addFragmentEntry(
+			fragmentCollection.getFragmentCollectionId());
+
+		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+			depotEntry.getDepotEntryId(), _group.getGroupId());
+
+		_addFragmentEntryLink(fragmentEntry, _group.getGroupId());
+
+		Group notConnectedGroup = GroupTestUtil.addGroup();
+
+		_addFragmentEntryLink(fragmentEntry, notConnectedGroup.getGroupId());
+
+		Map<Group, Integer> groupFragmentEntryUsages =
+			ReflectionTestUtil.invoke(
+				_getGroupFragmentEntryLinkDisplayContext(
+					fragmentEntry.getFragmentEntryId()),
+				"_getGroupFragmentEntryUsages", new Class<?>[0]);
+
+		Assert.assertEquals(
+			Integer.valueOf(2), groupFragmentEntryUsages.get(_group));
+		Assert.assertFalse(
+			groupFragmentEntryUsages.toString(),
+			groupFragmentEntryUsages.containsKey(notConnectedGroup));
 	}
 
 	private void _addFragmentEntryLink(
@@ -134,6 +182,12 @@ public class ViewGroupFragmentEntryUsagesMVCRenderCommandTest {
 			"com.liferay.fragment.web.internal.display.context." +
 				"GroupFragmentEntryLinkDisplayContext");
 	}
+
+	@Inject
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
@@ -8,6 +8,7 @@ package com.liferay.fragment.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.configuration.FragmentServiceConfiguration;
 import com.liferay.fragment.constants.FragmentConstants;
@@ -240,6 +241,15 @@ public class FragmentEntryLocalServiceTest {
 		_testUpdateFragmentEntryWithHtmlWithAmpersand();
 		_testUpdateFragmentEntryWithPreviewFileEntryId();
 		_testUpdateFragmentEntryWithPropagateChanges();
+	}
+
+	private DepotEntry _addDesignLibraryDepotEntry() throws Exception {
+		return _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			Collections.emptyMap(), DepotConstants.TYPE_DESIGN_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
 	}
 
 	private FragmentEntry _addFragmentEntry(long groupId) throws Exception {
@@ -1308,18 +1318,27 @@ public class FragmentEntryLocalServiceTest {
 		FragmentEntryLink companyGroupFragmentEntryLink = _addFragmentEntryLink(
 			companyGroupFragmentEntry, draftLayout, segmentsExperienceId);
 
-		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
-			HashMapBuilder.put(
-				LocaleUtil.getDefault(), RandomTestUtil.randomString()
-			).build(),
-			Collections.emptyMap(), DepotConstants.TYPE_DESIGN_LIBRARY,
-			ServiceContextTestUtil.getServiceContext());
+		DepotEntry connectedDepotEntry = _addDesignLibraryDepotEntry();
 
-		FragmentEntry depotFragmentEntry = _addFragmentEntry(
-			depotEntry.getGroupId());
+		_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+			connectedDepotEntry.getDepotEntryId(), _group.getGroupId());
 
-		FragmentEntryLink depotFragmentEntryLink = _addFragmentEntryLink(
-			depotFragmentEntry, draftLayout, segmentsExperienceId);
+		FragmentEntry connectedDepotFragmentEntry = _addFragmentEntry(
+			connectedDepotEntry.getGroupId());
+
+		FragmentEntryLink connectedDepotFragmentEntryLink =
+			_addFragmentEntryLink(
+				connectedDepotFragmentEntry, draftLayout, segmentsExperienceId);
+
+		DepotEntry disconnectedDepotEntry = _addDesignLibraryDepotEntry();
+
+		FragmentEntry disconnectedDepotFragmentEntry = _addFragmentEntry(
+			disconnectedDepotEntry.getGroupId());
+
+		FragmentEntryLink disconnectedDepotFragmentEntryLink =
+			_addFragmentEntryLink(
+				disconnectedDepotFragmentEntry, draftLayout,
+				segmentsExperienceId);
 
 		FragmentEntry siteFragmentEntry = _addFragmentEntry(
 			_group.getGroupId());
@@ -1329,20 +1348,22 @@ public class FragmentEntryLocalServiceTest {
 
 		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
 
-		String originalHTML = depotFragmentEntry.getHtml();
+		String originalHTML = disconnectedDepotFragmentEntry.getHtml();
 
 		String updatedHTML = RandomTestUtil.randomString();
 
 		_updateFragmentEntriesWithPropagateChanges(
-			updatedHTML, companyGroupFragmentEntry, depotFragmentEntry,
-			siteFragmentEntry);
+			updatedHTML, companyGroupFragmentEntry, connectedDepotFragmentEntry,
+			disconnectedDepotFragmentEntry, siteFragmentEntry);
 
 		_assertFragmentEntryLinksHTML(
 			updatedHTML, companyGroupFragmentEntryLink.getFragmentEntryLinkId(),
+			connectedDepotFragmentEntryLink.getFragmentEntryLinkId(),
 			siteFragmentEntryLink.getFragmentEntryLinkId());
 
 		_assertFragmentEntryLinksHTML(
-			originalHTML, depotFragmentEntryLink.getFragmentEntryLinkId());
+			originalHTML,
+			disconnectedDepotFragmentEntryLink.getFragmentEntryLinkId());
 	}
 
 	private void _updateFragmentEntriesWithPropagateChanges(
@@ -1376,6 +1397,9 @@ public class FragmentEntryLocalServiceTest {
 			}
 		}
 	}
+
+	@Inject
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
 
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
@@ -230,7 +230,7 @@ public class FragmentEntryLocalServiceTest {
 	}
 
 	@Test
-	@TestInfo("LPD-98538")
+	@TestInfo("LPD-98882")
 	public void testUpdateFragmentEntry() throws Exception {
 		_testUpdateFragmentEntryFragmentCollectionId();
 		_testUpdateFragmentEntryName();

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
@@ -288,14 +288,16 @@ public class FragmentEntryLocalServiceTest {
 			fragmentEntry.getType(), copyFragmentEntry.getType());
 	}
 
-	private void _assertFragmentEntryLinkHTML(
-		long fragmentEntryLinkId, String html) {
+	private void _assertFragmentEntryLinksHTML(
+		String expectedHtml, long... fragmentEntryLinkIds) {
 
-		FragmentEntryLink fragmentEntryLink =
-			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
-				fragmentEntryLinkId);
+		for (long fragmentEntryLinkId : fragmentEntryLinkIds) {
+			FragmentEntryLink fragmentEntryLink =
+				_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+					fragmentEntryLinkId);
 
-		Assert.assertEquals(html, fragmentEntryLink.getHtml());
+			Assert.assertEquals(expectedHtml, fragmentEntryLink.getHtml());
+		}
 	}
 
 	private String _read(String fileName) throws Exception {
@@ -1297,6 +1299,15 @@ public class FragmentEntryLocalServiceTest {
 			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
 				draftLayout.getPlid());
 
+		Group companyGroup = GroupLocalServiceUtil.getCompanyGroup(
+			TestPropsValues.getCompanyId());
+
+		FragmentEntry companyGroupFragmentEntry = _addFragmentEntry(
+			companyGroup.getGroupId());
+
+		FragmentEntryLink companyGroupFragmentEntryLink = _addFragmentEntryLink(
+			companyGroupFragmentEntry, draftLayout, segmentsExperienceId);
+
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()
@@ -1323,12 +1334,15 @@ public class FragmentEntryLocalServiceTest {
 		String updatedHTML = RandomTestUtil.randomString();
 
 		_updateFragmentEntriesWithPropagateChanges(
-			updatedHTML, depotFragmentEntry, siteFragmentEntry);
+			updatedHTML, companyGroupFragmentEntry, depotFragmentEntry,
+			siteFragmentEntry);
 
-		_assertFragmentEntryLinkHTML(
-			depotFragmentEntryLink.getFragmentEntryLinkId(), originalHTML);
-		_assertFragmentEntryLinkHTML(
-			siteFragmentEntryLink.getFragmentEntryLinkId(), updatedHTML);
+		_assertFragmentEntryLinksHTML(
+			updatedHTML, companyGroupFragmentEntryLink.getFragmentEntryLinkId(),
+			siteFragmentEntryLink.getFragmentEntryLinkId());
+
+		_assertFragmentEntryLinksHTML(
+			originalHTML, depotFragmentEntryLink.getFragmentEntryLinkId());
 	}
 
 	private void _updateFragmentEntriesWithPropagateChanges(

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/web/internal/display/context/test/GroupFragmentEntryLinkDisplayContextTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/web/internal/display/context/test/GroupFragmentEntryLinkDisplayContextTest.java
@@ -1,9 +1,9 @@
 /**
- * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.fragment.internal.portlet.action.test;
+package com.liferay.fragment.web.internal.display.context.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.constants.DepotConstants;
@@ -58,7 +58,7 @@ import org.junit.runner.RunWith;
  * @author Eudaldo Alonso
  */
 @RunWith(Arquillian.class)
-public class ViewGroupFragmentEntryUsagesMVCRenderCommandTest {
+public class GroupFragmentEntryLinkDisplayContextTest {
 
 	@ClassRule
 	@Rule

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/GroupFragmentEntryLinkDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/GroupFragmentEntryLinkDisplayContext.java
@@ -177,6 +177,21 @@ public class GroupFragmentEntryLinkDisplayContext {
 		return _searchContainer;
 	}
 
+	private Predicate _getFragmentEntryScopePredicate(Group group) {
+		return Predicate.withParentheses(
+			FragmentEntryLinkTable.INSTANCE.fragmentEntryScopeERC.eq(
+				group.getExternalReferenceCode()
+			).or(
+				Predicate.withParentheses(
+					FragmentEntryLinkTable.INSTANCE.fragmentEntryScopeERC.
+						isNull(
+						).and(
+							FragmentEntryLinkTable.INSTANCE.groupId.eq(
+								group.getGroupId())
+						))
+			));
+	}
+
 	private Map<Group, Integer> _getGroupFragmentEntryUsages()
 		throws PortalException {
 
@@ -204,18 +219,7 @@ public class GroupFragmentEntryLinkDisplayContext {
 			FragmentEntryLinkTable.INSTANCE.fragmentEntryERC.eq(
 				fragmentEntry.getExternalReferenceCode()
 			).and(
-				Predicate.withParentheses(
-					FragmentEntryLinkTable.INSTANCE.fragmentEntryScopeERC.eq(
-						group.getExternalReferenceCode()
-					).or(
-						Predicate.withParentheses(
-							FragmentEntryLinkTable.INSTANCE.
-								fragmentEntryScopeERC.isNull(
-								).and(
-									FragmentEntryLinkTable.INSTANCE.groupId.eq(
-										fragmentEntry.getGroupId())
-								))
-					))
+				_getFragmentEntryScopePredicate(group)
 			).and(
 				FragmentEntryLinkTable.INSTANCE.deleted.eq(false)
 			)

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/GroupFragmentEntryLinkDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/GroupFragmentEntryLinkDisplayContext.java
@@ -5,6 +5,9 @@
 
 package com.liferay.fragment.web.internal.display.context;
 
+import com.liferay.depot.model.DepotEntryGroupRel;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.constants.FragmentActionKeys;
 import com.liferay.fragment.constants.FragmentPortletKeys;
 import com.liferay.fragment.model.FragmentEntry;
@@ -12,6 +15,7 @@ import com.liferay.fragment.model.FragmentEntryLinkTable;
 import com.liferay.fragment.service.FragmentEntryLinkLocalServiceUtil;
 import com.liferay.fragment.service.FragmentEntryLocalServiceUtil;
 import com.liferay.fragment.web.internal.security.permission.resource.FragmentPermission;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.expression.Predicate;
@@ -23,6 +27,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.SearchOrderByUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -44,8 +49,12 @@ import java.util.Objects;
 public class GroupFragmentEntryLinkDisplayContext {
 
 	public GroupFragmentEntryLinkDisplayContext(
+		DepotEntryGroupRelLocalService depotEntryGroupRelLocalService,
+		DepotEntryLocalService depotEntryLocalService,
 		RenderRequest renderRequest, RenderResponse renderResponse) {
 
+		_depotEntryGroupRelLocalService = depotEntryGroupRelLocalService;
+		_depotEntryLocalService = depotEntryLocalService;
 		_renderRequest = renderRequest;
 		_renderResponse = renderResponse;
 	}
@@ -177,18 +186,43 @@ public class GroupFragmentEntryLinkDisplayContext {
 		return _searchContainer;
 	}
 
-	private Predicate _getFragmentEntryScopePredicate(Group group) {
+	private Predicate _getFragmentEntryScopePredicate(Group group)
+		throws PortalException {
+
+		Predicate emptyScopePredicate = Predicate.withParentheses(
+			FragmentEntryLinkTable.INSTANCE.fragmentEntryScopeERC.isNull(
+			).and(
+				FragmentEntryLinkTable.INSTANCE.groupId.eq(group.getGroupId())
+			));
+
+		if (!group.isDepot()) {
+			return Predicate.withParentheses(
+				FragmentEntryLinkTable.INSTANCE.fragmentEntryScopeERC.eq(
+					group.getExternalReferenceCode()
+				).or(
+					emptyScopePredicate
+				));
+		}
+
+		Long[] connectedSiteGroupIds = TransformUtil.transformToArray(
+			_depotEntryGroupRelLocalService.getDepotEntryGroupRels(
+				_depotEntryLocalService.getGroupDepotEntry(group.getGroupId())),
+			DepotEntryGroupRel::getToGroupId, Long.class);
+
+		if (ArrayUtil.isEmpty(connectedSiteGroupIds)) {
+			return emptyScopePredicate;
+		}
+
 		return Predicate.withParentheses(
-			FragmentEntryLinkTable.INSTANCE.fragmentEntryScopeERC.eq(
-				group.getExternalReferenceCode()
+			Predicate.withParentheses(
+				FragmentEntryLinkTable.INSTANCE.fragmentEntryScopeERC.eq(
+					group.getExternalReferenceCode()
+				).and(
+					FragmentEntryLinkTable.INSTANCE.groupId.in(
+						connectedSiteGroupIds)
+				)
 			).or(
-				Predicate.withParentheses(
-					FragmentEntryLinkTable.INSTANCE.fragmentEntryScopeERC.
-						isNull(
-						).and(
-							FragmentEntryLinkTable.INSTANCE.groupId.eq(
-								group.getGroupId())
-						))
+				emptyScopePredicate
 			));
 	}
 
@@ -243,6 +277,9 @@ public class GroupFragmentEntryLinkDisplayContext {
 		return _groupFragmentEntryUsages;
 	}
 
+	private final DepotEntryGroupRelLocalService
+		_depotEntryGroupRelLocalService;
+	private final DepotEntryLocalService _depotEntryLocalService;
 	private Long _fragmentCollectionId;
 	private FragmentEntry _fragmentEntry;
 	private Long _fragmentEntryId;

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/GroupFragmentEntryLinkDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/GroupFragmentEntryLinkDisplayContext.java
@@ -12,8 +12,8 @@ import com.liferay.fragment.constants.FragmentActionKeys;
 import com.liferay.fragment.constants.FragmentPortletKeys;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.model.FragmentEntryLinkTable;
-import com.liferay.fragment.service.FragmentEntryLinkLocalServiceUtil;
-import com.liferay.fragment.service.FragmentEntryLocalServiceUtil;
+import com.liferay.fragment.service.FragmentEntryLinkLocalService;
+import com.liferay.fragment.service.FragmentEntryLocalService;
 import com.liferay.fragment.web.internal.security.permission.resource.FragmentPermission;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
@@ -25,7 +25,7 @@ import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.SearchOrderByUtil;
-import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -51,10 +51,16 @@ public class GroupFragmentEntryLinkDisplayContext {
 	public GroupFragmentEntryLinkDisplayContext(
 		DepotEntryGroupRelLocalService depotEntryGroupRelLocalService,
 		DepotEntryLocalService depotEntryLocalService,
-		RenderRequest renderRequest, RenderResponse renderResponse) {
+		FragmentEntryLinkLocalService fragmentEntryLinkLocalService,
+		FragmentEntryLocalService fragmentEntryLocalService,
+		GroupLocalService groupLocalService, RenderRequest renderRequest,
+		RenderResponse renderResponse) {
 
 		_depotEntryGroupRelLocalService = depotEntryGroupRelLocalService;
 		_depotEntryLocalService = depotEntryLocalService;
+		_fragmentEntryLinkLocalService = fragmentEntryLinkLocalService;
+		_fragmentEntryLocalService = fragmentEntryLocalService;
+		_groupLocalService = groupLocalService;
 		_renderRequest = renderRequest;
 		_renderResponse = renderResponse;
 	}
@@ -76,7 +82,7 @@ public class GroupFragmentEntryLinkDisplayContext {
 		}
 
 		try {
-			_fragmentEntry = FragmentEntryLocalServiceUtil.getFragmentEntry(
+			_fragmentEntry = _fragmentEntryLocalService.getFragmentEntry(
 				getFragmentEntryId());
 		}
 		catch (PortalException portalException) {
@@ -235,8 +241,7 @@ public class GroupFragmentEntryLinkDisplayContext {
 
 		FragmentEntry fragmentEntry = getFragmentEntry();
 
-		Group group = GroupLocalServiceUtil.getGroup(
-			fragmentEntry.getGroupId());
+		Group group = _groupLocalService.getGroup(fragmentEntry.getGroupId());
 
 		Map<Group, Integer> groupFragmentEntryUsages = new HashMap<>();
 
@@ -261,7 +266,7 @@ public class GroupFragmentEntryLinkDisplayContext {
 			FragmentEntryLinkTable.INSTANCE.groupId
 		);
 
-		List<Object[]> results = FragmentEntryLinkLocalServiceUtil.dslQuery(
+		List<Object[]> results = _fragmentEntryLinkLocalService.dslQuery(
 			dslQuery);
 
 		for (Object[] result : results) {
@@ -269,7 +274,7 @@ public class GroupFragmentEntryLinkDisplayContext {
 			Number count = (Number)result[1];
 
 			groupFragmentEntryUsages.put(
-				GroupLocalServiceUtil.getGroup(groupId), count.intValue());
+				_groupLocalService.getGroup(groupId), count.intValue());
 		}
 
 		_groupFragmentEntryUsages = groupFragmentEntryUsages;
@@ -283,7 +288,10 @@ public class GroupFragmentEntryLinkDisplayContext {
 	private Long _fragmentCollectionId;
 	private FragmentEntry _fragmentEntry;
 	private Long _fragmentEntryId;
+	private final FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
+	private final FragmentEntryLocalService _fragmentEntryLocalService;
 	private Map<Group, Integer> _groupFragmentEntryUsages;
+	private final GroupLocalService _groupLocalService;
 	private String _orderByCol;
 	private String _orderByType;
 	private String _redirect;

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/ViewGroupFragmentEntryUsagesMVCRenderCommand.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/ViewGroupFragmentEntryUsagesMVCRenderCommand.java
@@ -8,8 +8,11 @@ package com.liferay.fragment.web.internal.portlet.action;
 import com.liferay.depot.service.DepotEntryGroupRelLocalService;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.constants.FragmentPortletKeys;
+import com.liferay.fragment.service.FragmentEntryLinkLocalService;
+import com.liferay.fragment.service.FragmentEntryLocalService;
 import com.liferay.fragment.web.internal.display.context.GroupFragmentEntryLinkDisplayContext;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.service.GroupLocalService;
 
 import jakarta.portlet.RenderRequest;
 import jakarta.portlet.RenderResponse;
@@ -38,7 +41,8 @@ public class ViewGroupFragmentEntryUsagesMVCRenderCommand
 			GroupFragmentEntryLinkDisplayContext.class.getName(),
 			new GroupFragmentEntryLinkDisplayContext(
 				_depotEntryGroupRelLocalService, _depotEntryLocalService,
-				renderRequest, renderResponse));
+				_fragmentEntryLinkLocalService, _fragmentEntryLocalService,
+				_groupLocalService, renderRequest, renderResponse));
 
 		return "/view_group_fragment_entry_usages.jsp";
 	}
@@ -48,5 +52,14 @@ public class ViewGroupFragmentEntryUsagesMVCRenderCommand
 
 	@Reference
 	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Reference
+	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
+
+	@Reference
+	private FragmentEntryLocalService _fragmentEntryLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/ViewGroupFragmentEntryUsagesMVCRenderCommand.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/ViewGroupFragmentEntryUsagesMVCRenderCommand.java
@@ -5,6 +5,8 @@
 
 package com.liferay.fragment.web.internal.portlet.action;
 
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.constants.FragmentPortletKeys;
 import com.liferay.fragment.web.internal.display.context.GroupFragmentEntryLinkDisplayContext;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
@@ -13,6 +15,7 @@ import jakarta.portlet.RenderRequest;
 import jakarta.portlet.RenderResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Jürgen Kappler
@@ -34,9 +37,16 @@ public class ViewGroupFragmentEntryUsagesMVCRenderCommand
 		renderRequest.setAttribute(
 			GroupFragmentEntryLinkDisplayContext.class.getName(),
 			new GroupFragmentEntryLinkDisplayContext(
+				_depotEntryGroupRelLocalService, _depotEntryLocalService,
 				renderRequest, renderResponse));
 
 		return "/view_group_fragment_entry_usages.jsp";
 	}
+
+	@Reference
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
 
 }

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProvider.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProvider.java
@@ -20,6 +20,7 @@ import com.liferay.item.selector.criteria.FileEntryItemSelectorReturnType;
 import com.liferay.item.selector.criteria.UUIDItemSelectorReturnType;
 import com.liferay.item.selector.criteria.upload.criterion.UploadItemSelectorCriterion;
 import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
@@ -132,8 +133,12 @@ public class BasicFragmentEntryActionDropdownItemsProvider {
 						() ->
 							hasManageFragmentEntriesPermission &&
 							!_fragmentEntry.isReadOnly() &&
-							(_fragmentEntry.getGroupId() ==
-								_themeDisplay.getCompanyGroupId()),
+							((_fragmentEntry.getGroupId() ==
+								_themeDisplay.getCompanyGroupId()) ||
+							 (FeatureFlagManagerUtil.isEnabled(
+								 _fragmentEntry.getCompanyId(), "LPD-57283") &&
+							  DesignLibraryUtil.isDesignLibraryScope(
+								  _themeDisplay.getScopeGroup()))),
 						_getViewGroupFragmentEntryUsagesActionUnsafeConsumer()
 					).add(
 						() ->

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProvider.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProvider.java
@@ -133,21 +133,10 @@ public class BasicFragmentEntryActionDropdownItemsProvider {
 						() ->
 							hasManageFragmentEntriesPermission &&
 							!_fragmentEntry.isReadOnly() &&
-							((_fragmentEntry.getGroupId() ==
-								_themeDisplay.getCompanyGroupId()) ||
-							 (FeatureFlagManagerUtil.isEnabled(
-								 _fragmentEntry.getCompanyId(), "LPD-57283") &&
-							  DesignLibraryUtil.isDesignLibraryScope(
-								  _themeDisplay.getScopeGroup()))),
-						_getViewGroupFragmentEntryUsagesActionUnsafeConsumer()
-					).add(
-						() ->
-							hasManageFragmentEntriesPermission &&
-							!_fragmentEntry.isReadOnly() &&
-							(_fragmentEntry.getGroupId() !=
-								_themeDisplay.getCompanyGroupId()) &&
-							!DesignLibraryUtil.isDesignLibraryScope(
-								_themeDisplay.getScopeGroup()),
+							(FeatureFlagManagerUtil.isEnabled(
+								_fragmentEntry.getCompanyId(), "LPD-57283") ||
+							 !DesignLibraryUtil.isDesignLibraryScope(
+								 _themeDisplay.getScopeGroup())),
 						_getViewFragmentEntryUsagesActionUnsafeConsumer()
 					).build());
 				dropdownGroupItem.setSeparator(true);
@@ -500,34 +489,36 @@ public class BasicFragmentEntryActionDropdownItemsProvider {
 	private UnsafeConsumer<DropdownItem, Exception>
 		_getViewFragmentEntryUsagesActionUnsafeConsumer() {
 
+		boolean viewSiteUsages = _isViewSiteUsages();
+
 		return dropdownItem -> {
 			dropdownItem.setDisabled(_fragmentEntry.getUsageCount() == 0);
 			dropdownItem.setHref(
 				_renderResponse.createRenderURL(), "mvcRenderCommandName",
-				"/fragment/view_fragment_entry_usages", "redirect",
-				_themeDisplay.getURLCurrent(), "fragmentCollectionId",
+				viewSiteUsages ? "/fragment/view_group_fragment_entry_usages" :
+					"/fragment/view_fragment_entry_usages",
+				"redirect", _themeDisplay.getURLCurrent(),
+				"fragmentCollectionId",
 				_fragmentEntry.getFragmentCollectionId(), "fragmentEntryId",
 				_fragmentEntry.getFragmentEntryId());
 			dropdownItem.setIcon("list-ul");
 			dropdownItem.setLabel(
-				LanguageUtil.get(_httpServletRequest, "view-usages"));
+				LanguageUtil.get(
+					_httpServletRequest,
+					viewSiteUsages ? "view-site-usages" : "view-usages"));
 		};
 	}
 
-	private UnsafeConsumer<DropdownItem, Exception>
-		_getViewGroupFragmentEntryUsagesActionUnsafeConsumer() {
+	private boolean _isViewSiteUsages() {
+		if ((_fragmentEntry.getGroupId() ==
+				_themeDisplay.getCompanyGroupId()) ||
+			DesignLibraryUtil.isDesignLibraryScope(
+				_themeDisplay.getScopeGroup())) {
 
-		return dropdownItem -> {
-			dropdownItem.setDisabled(_fragmentEntry.getUsageCount() == 0);
-			dropdownItem.setHref(
-				_renderResponse.createRenderURL(), "mvcRenderCommandName",
-				"/fragment/view_group_fragment_entry_usages", "redirect",
-				_themeDisplay.getURLCurrent(), "fragmentCollectionId",
-				_fragmentEntry.getFragmentCollectionId(), "fragmentEntryId",
-				_fragmentEntry.getFragmentEntryId());
-			dropdownItem.setLabel(
-				LanguageUtil.get(_httpServletRequest, "view-site-usages"));
-		};
+			return true;
+		}
+
+		return false;
 	}
 
 	private final FragmentEntry _fragmentEntry;

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProviderTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProviderTest.java
@@ -7,6 +7,7 @@ package com.liferay.fragment.web.internal.servlet.taglib.util;
 
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.web.internal.util.DesignLibraryUtil;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -113,7 +114,7 @@ public class BasicFragmentEntryActionDropdownItemsProviderTest
 	}
 
 	@Test
-	@TestInfo("LPD-98538")
+	@TestInfo({"LPD-98538", "LPD-98882"})
 	public void testGetActionDropdownItemsForSiteScopedFragmentEntry()
 		throws Exception {
 
@@ -132,7 +133,10 @@ public class BasicFragmentEntryActionDropdownItemsProviderTest
 					_fragmentEntry, renderRequest, renderResponse);
 
 		try (MockedStatic<DesignLibraryUtil> designLibraryUtilMockedStatic =
-				Mockito.mockStatic(DesignLibraryUtil.class)) {
+				Mockito.mockStatic(DesignLibraryUtil.class);
+			MockedStatic<FeatureFlagManagerUtil>
+				featureFlagManagerUtilMockedStatic = Mockito.mockStatic(
+					FeatureFlagManagerUtil.class)) {
 
 			designLibraryUtilMockedStatic.when(
 				() -> DesignLibraryUtil.isDesignLibraryScope(
@@ -159,6 +163,19 @@ public class BasicFragmentEntryActionDropdownItemsProviderTest
 					getActionDropdownItems(),
 				"edit", "change-thumbnail", "rename", "mark-as-cacheable",
 				"export", "make-a-copy", "move", "delete");
+
+			featureFlagManagerUtilMockedStatic.when(
+				() -> FeatureFlagManagerUtil.isEnabled(
+					Mockito.anyLong(), Mockito.eq("LPD-57283"))
+			).thenReturn(
+				true
+			);
+
+			assertDropdownItemsInCorrectOrder(
+				basicFragmentEntryActionDropdownItemsProvider.
+					getActionDropdownItems(),
+				"edit", "change-thumbnail", "rename", "mark-as-cacheable",
+				"view-site-usages", "export", "make-a-copy", "move", "delete");
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98882

## What Is Being Fixed

LPD-98538 restricted fragment entry propagation and hid the "view usages" UI for Design Library fragments. Now that Design Libraries need to participate fully, both restrictions need to be lifted so a Design Library depot's fragment entries can be maintained and reviewed like any other fragment entry.

## How It Is Being Fixed

The view-usages entry in the fragment action dropdown is enabled for Design Library scope, gated by the `LPD-57283` feature flag so the UI stays hidden until the feature is turned on. The propagation restriction on depot-hosted fragment entries is removed, and `_propagateChanges` now iterates over the connected sites of the Design Library depot so an update reaches every fragment entry link inside them. The `GroupFragmentEntryLinkDisplayContext` lists usages across every connected site of the Design Library depot using the entry's scope external reference code, and the display-context queries move off `*LocalServiceUtil` onto `@Reference`-injected services.

## PR Check

**pr-check: PASS** — tested on `d9fcd289c6dca43ee14ea470c82b229349251340`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "d9fcd289c6dca43ee14ea470c82b229349251340"} -->
