### PR TITLE
LPD-99233 Route Design Library row clicks to view and reorder actions

### DIFF
--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContext.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContext.java
@@ -117,6 +117,17 @@ public class DesignLibraryResourcesDisplayContext {
 		String designLibraryResourcesURL = _getDesignLibraryResourcesURL(
 			designLibraryEntryId);
 
+		String viewFragmentCollectionURL = PortletURLBuilder.create(
+			PortalUtil.getControlPanelPortletURL(
+				_httpServletRequest, depotGroup, FragmentPortletKeys.FRAGMENT,
+				0, 0, PortletRequest.RENDER_PHASE)
+		).setBackURL(
+			designLibraryResourcesURL
+		).setParameter(
+			"fragmentCollectionExternalReferenceCode",
+			"{embedded.externalReferenceCode}"
+		).buildString();
+
 		String editFragmentCollectionURL = PortletURLBuilder.create(
 			PortalUtil.getControlPanelPortletURL(
 				_httpServletRequest, depotGroup, FragmentPortletKeys.FRAGMENT,
@@ -145,18 +156,14 @@ public class DesignLibraryResourcesDisplayContext {
 			"styleBookEntryId", "{embedded.id}"
 		).buildString();
 
-		String viewFragmentCollectionURL = PortletURLBuilder.create(
-			PortalUtil.getControlPanelPortletURL(
-				_httpServletRequest, depotGroup, FragmentPortletKeys.FRAGMENT,
-				0, 0, PortletRequest.RENDER_PHASE)
-		).setBackURL(
-			designLibraryResourcesURL
-		).setParameter(
-			"fragmentCollectionExternalReferenceCode",
-			"{embedded.externalReferenceCode}"
-		).buildString();
-
 		return ListUtil.fromArray(
+			new FDSActionDropdownItem(
+				viewFragmentCollectionURL, "view", "view",
+				LanguageUtil.get(_httpServletRequest, "view"), null, null,
+				"link",
+				HashMapBuilder.<String, Object>put(
+					"entryClassName", FragmentCollection.class.getName()
+				).build()),
 			new FDSActionDropdownItem(
 				editFragmentCollectionURL, "pencil", "edit",
 				LanguageUtil.get(_httpServletRequest, "edit"), null, null,
@@ -171,13 +178,6 @@ public class DesignLibraryResourcesDisplayContext {
 				null, "get", "link",
 				HashMapBuilder.<String, Object>put(
 					"entryClassName", StyleBookEntry.class.getName()
-				).build()),
-			new FDSActionDropdownItem(
-				viewFragmentCollectionURL, "view", "view",
-				LanguageUtil.get(_httpServletRequest, "view"), null, null,
-				"link",
-				HashMapBuilder.<String, Object>put(
-					"entryClassName", FragmentCollection.class.getName()
 				).build()),
 			new FDSActionDropdownItem(
 				"{actions.delete.href}", "trash", "delete",

--- a/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/js/props_transformer/DesignLibraryResourcesFDSPropsTransformer.tsx
+++ b/modules/apps/design-library/design-library-web/src/main/resources/META-INF/resources/js/props_transformer/DesignLibraryResourcesFDSPropsTransformer.tsx
@@ -199,6 +199,11 @@ export default function DesignLibraryResourcesFDSPropsTransformer(
 						return (
 							<LinkRenderer
 								{...rendererProps}
+								options={{
+									actionId: isFragmentCollection
+										? 'view'
+										: 'edit',
+								}}
 								stickerClassName={
 									isFragmentCollection
 										? 'design-library-fds-sticker-fragment-set'

--- a/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContextTest.java
+++ b/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContextTest.java
@@ -58,7 +58,6 @@ public class DesignLibraryResourcesDisplayContextTest {
 	@Before
 	public void setUp() {
 		_setUpDesignLibraryResourcesDisplayContext();
-		_setUpHttpServletRequest();
 	}
 
 	@After
@@ -270,6 +269,8 @@ public class DesignLibraryResourcesDisplayContextTest {
 				}
 
 			});
+
+		_setUpHttpServletRequest();
 
 		_designLibraryResourcesDisplayContext =
 			new DesignLibraryResourcesDisplayContext(

--- a/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContextTest.java
+++ b/modules/apps/design-library/design-library-web/src/test/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContextTest.java
@@ -99,13 +99,13 @@ public class DesignLibraryResourcesDisplayContextTest {
 				designLibraryEntryId);
 
 		_assertFDSActionDropdownItem(
-			FragmentCollection.class.getName(), "edit", "link",
+			FragmentCollection.class.getName(), "view", "link",
 			fdsActionDropdownItems.get(0));
 		_assertFDSActionDropdownItem(
-			StyleBookEntry.class.getName(), "edit", "link",
+			FragmentCollection.class.getName(), "edit", "link",
 			fdsActionDropdownItems.get(1));
 		_assertFDSActionDropdownItem(
-			FragmentCollection.class.getName(), "view", "link",
+			StyleBookEntry.class.getName(), "edit", "link",
 			fdsActionDropdownItems.get(2));
 		_assertFDSActionDropdownItem(
 			FragmentCollection.class.getName(), "delete", "async",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99233

## What Is Being Fixed

Clicking on a Design Library fragment set row opened the edit view, and the action dropdown listed `edit` first. The rest of the portal's FDS dropdowns lead with `view`, and for depot resources whose editor lives elsewhere the natural destination is the read-only view. The `DesignLibraryResourcesDisplayContextTest` helper also built the display context before the `HttpServletRequest` had the `THEME_DISPLAY` attribute set, so any test that reached `_themeDisplay.getLocale()` failed with a `NullPointerException`.

## How It Is Being Fixed

The `view` action moves to the top of the list returned by `getFDSActionDropdownItems`, followed by `edit` for fragment collections, `edit` for style book entries, and `delete`. The URL locals feeding those entries are reordered to match the return list, per the declare-as-used convention. The `LinkRenderer` in the FDS props transformer receives an `actionId: 'view'` option when the row is a fragment collection, so a row click routes to the view page instead of the edit page. The test's `_setUpDesignLibraryResourcesDisplayContext` helper now calls `_setUpHttpServletRequest` right before instantiating the display context, so the request attributes are in place when the constructor reads `THEME_DISPLAY`.

## PR Check

**pr-check: PASS** — tested on `5c1d8716ae7e3a9b95fc70b24559ce8510f77dd0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5c1d8716ae7e3a9b95fc70b24559ce8510f77dd0"} -->
