### PR TITLE
LPD-99298 Fix flaky simulation menu segment preview test

### DIFF
--- a/modules/test/playwright/tests/layout-admin-web/main/simulationMenu.spec.ts
+++ b/modules/test/playwright/tests/layout-admin-web/main/simulationMenu.spec.ts
@@ -14,6 +14,7 @@ import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
 import {pageViewModePagesTest} from '../../../fixtures/pageViewModePagesTest';
+import {clickAndExpectToBeHidden} from '../../../utils/clickAndExpectToBeHidden';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../../utils/getRandomString';
 import {waitForAlert} from '../../../utils/waitForAlert';
@@ -257,11 +258,19 @@ test.describe('Page content', () => {
 			);
 
 			await clickAndExpectToBeVisible({
-				autoClick: true,
 				target: selectCollectionIframe.getByRole('button', {
 					name: assetListEntryName,
 				}),
+				timeout: 2000,
 				trigger: configurationIFrame.getByLabel('Select Collection'),
+			});
+
+			await clickAndExpectToBeHidden({
+				target: configurationIFrame.locator('.modal-dialog'),
+				timeout: 2000,
+				trigger: selectCollectionIframe.getByRole('button', {
+					name: assetListEntryName,
+				}),
 			});
 
 			await expect(
@@ -280,7 +289,7 @@ test.describe('Page content', () => {
 
 			await expect(
 				page.getByText('Showing content for the segment "Anyone".')
-			).toBeVisible({timeout: 5000});
+			).toBeVisible();
 
 			const simulationPreviewIframe = page.frameLocator(
 				'iframe[title="Simulation Preview"]'
@@ -312,7 +321,7 @@ test.describe('Page content', () => {
 					page.getByText(
 						`Showing content for the segment "${segmentsEntryName}".`
 					)
-				).toBeVisible({timeout: 5000});
+				).toBeVisible();
 
 				await expect(
 					simulationPreviewIframe.getByRole('link', {
@@ -356,7 +365,7 @@ test.describe('Page content', () => {
 
 			await expect(
 				page.getByText('Showing content for the segment "Anyone".')
-			).toBeVisible({timeout: 5000});
+			).toBeVisible();
 
 			await expect(
 				page.getByText(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99298

## What Is Being Fixed

The Playwright test layout-admin-web/main/simulationMenu.spec.ts > Page content > Preview content in a widget page by segment is flaky under load (first boot, CI). Two timing races cause it: the segment banner assertion used a fixed 5s timeout, too tight for the SimulationPreview component to become ready, and the Asset Publisher collection selection treated "button clicked" as success rather than "collection selected", so under load the following value assertion failed.

## How It Is Being Fixed

The banner assertions now use a bare toBeVisible() that auto-retries for the specific element and defers to the suite's central expect timeout instead of a per-test magic value. The Asset Publisher collection selection follows the existing AssetPublisherPage.selectCollectionProvider pattern: open the selector, then click the entry and wait for the modal to close (the real post-condition that the selection applied) before asserting the value. Validated with 30 consecutive passes locally.

## PR Check

**pr-check: PASS** — tested on `5e9474211a858f86d9104464f922a8a681f7c964`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "5e9474211a858f86d9104464f922a8a681f7c964"} -->
