### PR TITLE
LPD-99262 Prevent orphan PortletPreferences in fragment CT preview

### DIFF
--- a/modules/apps/fragment/fragment-test/build.gradle
+++ b/modules/apps/fragment/fragment-test/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:asset:asset-test-util")
 	testIntegrationImplementation project(":apps:blogs:blogs-api")
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-api")
+	testIntegrationImplementation project(":apps:change-tracking:change-tracking-spi")
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
 	testIntegrationImplementation project(":apps:configuration-admin:configuration-admin-api")
 	testIntegrationImplementation project(":apps:depot:depot-api")

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/web/internal/change/tracking/spi/display/test/FragmentEntryLinkCTDisplayRenderTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/web/internal/change/tracking/spi/display/test/FragmentEntryLinkCTDisplayRenderTest.java
@@ -1,0 +1,202 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.web.internal.change.tracking.spi.display.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.change.tracking.spi.display.CTDisplayRenderer;
+import com.liferay.change.tracking.spi.display.CTDisplayRendererRegistry;
+import com.liferay.change.tracking.spi.display.context.DisplayContext;
+import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.service.FragmentEntryLinkLocalService;
+import com.liferay.journal.constants.JournalContentPortletKeys;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.PortletPreferences;
+import com.liferay.portal.kernel.portlet.PortletIdCodec;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+@RunWith(Arquillian.class)
+public class FragmentEntryLinkCTDisplayRenderTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_company = _companyLocalService.getCompany(
+			TestPropsValues.getCompanyId());
+
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	@TestInfo("LPD-99262")
+	public void testRenderPreviewDoesNotCreateOrphanPortletPreferences()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		FragmentEntryLink fragmentEntryLink = _addPortletFragmentEntryLink(
+			draftLayout);
+
+		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
+
+		String portletId = _getPortletId(fragmentEntryLink);
+
+		List<PortletPreferences> initialPortletPreferences =
+			_portletPreferencesLocalService.getPortletPreferencesByPortletId(
+				portletId);
+
+		CTDisplayRenderer<FragmentEntryLink> ctDisplayRenderer =
+			_ctDisplayRendererRegistry.getCTDisplayRenderer(
+				_classNameLocalService.getClassNameId(FragmentEntryLink.class));
+
+		ctDisplayRenderer.renderPreview(
+			_createDisplayContext(fragmentEntryLink));
+
+		List<PortletPreferences> portletPreferences =
+			_portletPreferencesLocalService.getPortletPreferencesByPortletId(
+				portletId);
+
+		Assert.assertEquals(
+			portletPreferences.toString(), initialPortletPreferences.size(),
+			portletPreferences.size());
+	}
+
+	private FragmentEntryLink _addPortletFragmentEntryLink(Layout layout)
+		throws Exception {
+
+		JSONObject jsonObject = ContentLayoutTestUtil.addPortletToLayout(
+			layout, JournalContentPortletKeys.JOURNAL_CONTENT);
+
+		JSONObject fragmentEntryLinkJSONObject = jsonObject.getJSONObject(
+			"fragmentEntryLink");
+
+		return _fragmentEntryLinkLocalService.getFragmentEntryLink(
+			fragmentEntryLinkJSONObject.getLong("fragmentEntryLinkId"));
+	}
+
+	private DisplayContext<FragmentEntryLink> _createDisplayContext(
+			FragmentEntryLink fragmentEntryLink)
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			ContentLayoutTestUtil.getMockHttpServletRequest(
+				_company, _group, LayoutTestUtil.addTypeContentLayout(_group));
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		return new DisplayContext<FragmentEntryLink>() {
+
+			@Override
+			public String getDownloadURL(String key, long size, String title) {
+				return null;
+			}
+
+			@Override
+			public HttpServletRequest getHttpServletRequest() {
+				return mockHttpServletRequest;
+			}
+
+			@Override
+			public HttpServletResponse getHttpServletResponse() {
+				return mockHttpServletResponse;
+			}
+
+			@Override
+			public Locale getLocale() {
+				return LocaleUtil.US;
+			}
+
+			@Override
+			public FragmentEntryLink getModel() {
+				return fragmentEntryLink;
+			}
+
+			@Override
+			public void render(BaseModel<?> baseModel, Locale locale) {
+			}
+
+			@Override
+			public String renderPreview(BaseModel<?> baseModel, Locale locale) {
+				return null;
+			}
+
+		};
+	}
+
+	private String _getPortletId(FragmentEntryLink fragmentEntryLink) {
+		JSONObject editableValuesJSONObject =
+			fragmentEntryLink.getEditableValuesJSONObject();
+
+		return PortletIdCodec.encode(
+			JournalContentPortletKeys.JOURNAL_CONTENT,
+			editableValuesJSONObject.getString("instanceId"));
+	}
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	private Company _company;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject
+	private CTDisplayRendererRegistry _ctDisplayRendererRegistry;
+
+	@Inject
+	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private PortletPreferencesLocalService _portletPreferencesLocalService;
+
+}

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/change/tracking/spi/display/FragmentEntryLinkCTDisplayRender.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/change/tracking/spi/display/FragmentEntryLinkCTDisplayRender.java
@@ -12,6 +12,7 @@ import com.liferay.fragment.helper.FragmentEntryLinkHelper;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.renderer.DefaultFragmentRendererContext;
 import com.liferay.fragment.renderer.FragmentRendererController;
+import com.liferay.layout.util.LayoutServiceContextHelper;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
@@ -19,6 +20,8 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Locale;
@@ -90,15 +93,29 @@ public class FragmentEntryLinkCTDisplayRender
 
 		FragmentEntryLink fragmentEntryLink = displayContext.getModel();
 
+		Layout layout = _layoutLocalService.fetchLayout(
+			fragmentEntryLink.getPlid());
+
+		if (layout == null) {
+			return StringPool.BLANK;
+		}
+
 		DefaultFragmentRendererContext defaultFragmentRendererContext =
 			new DefaultFragmentRendererContext(fragmentEntryLink);
 
 		defaultFragmentRendererContext.setLocale(displayContext.getLocale());
 
-		return _fragmentRendererController.render(
-			defaultFragmentRendererContext,
-			displayContext.getHttpServletRequest(),
-			displayContext.getHttpServletResponse());
+		try (AutoCloseable autoCloseable =
+				_layoutServiceContextHelper.getServiceContextAutoCloseable(
+					layout)) {
+
+			ServiceContext serviceContext =
+				ServiceContextThreadLocal.getServiceContext();
+
+			return _fragmentRendererController.render(
+				defaultFragmentRendererContext, serviceContext.getRequest(),
+				displayContext.getHttpServletResponse());
+		}
 	}
 
 	@Override
@@ -144,5 +161,8 @@ public class FragmentEntryLinkCTDisplayRender
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private LayoutServiceContextHelper _layoutServiceContextHelper;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99262

## What Is Being Fixed

Previewing a Fragment Entry Link change from a publication's Review Changes screen created an orphan `PortletPreferences` record with `plid=0` that was never cleaned up. The Change Tracking preview invoked the fragment renderer with a request whose theme display did not carry the fragment entry link's layout, so any widget embedded in the fragment resolved its portlet preferences with plid zero.

## How It Is Being Fixed

`FragmentEntryLinkCTDisplayRender.renderPreview` now fetches the fragment entry link's layout and, when present, swaps the service context to that layout via `LayoutServiceContextHelper.getServiceContextAutoCloseable` for the duration of the render. The fragment renderer picks up the scoped request from `ServiceContextThreadLocal`, so any embedded widget resolves its portlet preferences against the correct layout and no orphan record is left behind. An integration test invokes the CT display renderer with an unrelated request layout and asserts that the `PortletPreferences` count does not grow.

## PR Check

**pr-check: PASS** — tested on `b7530bc9ec8222e7a16cee3a7a3907b202affb10`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b7530bc9ec8222e7a16cee3a7a3907b202affb10"} -->
