### PR TITLE
LPD-99389 Fix locale payload in localizationSelectFragment test

### DIFF
--- a/modules/test/playwright/tests/layout-content-page-editor-web/form-container/localizationSelectFragment.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/form-container/localizationSelectFragment.spec.ts
@@ -45,14 +45,15 @@ test(
 		structureBuilderPage,
 	}) => {
 
-		// Create a Space with English and Italian only
+		// Create a Space with English and French only
 
 		const spaceName = getRandomString();
 
 		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
 			name: spaceName,
 			settings: {
-				availableLanguageIds: ['en-US', 'it-IT'],
+				availableLanguageIds: ['en_US', 'fr_FR'],
+				defaultLanguageId: 'en_US',
 				useCustomLanguages: true,
 			},
 			type: 'Space',
@@ -76,7 +77,7 @@ test(
 
 		await contentsPage.createContent(structureLabel, spaceName);
 
-		// Check the language picker only shows English and Italian
+		// Check the language picker only shows English and French
 
 		await localizationSelectPage.trigger.click();
 
@@ -85,7 +86,7 @@ test(
 		).toBeVisible();
 
 		await expect(
-			page.locator('.dropdown-item', {hasText: 'it-IT'})
+			page.locator('.dropdown-item', {hasText: 'fr-FR'})
 		).toBeVisible();
 
 		await expect(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99389

## What Is Being Fixed

`localizationSelectFragment.spec.ts` ("The language picker only shows the languages configured for the space") created a Space through the headless asset library API with `availableLanguageIds` in BCP-47 hyphen format (`en-US`, `it-IT`), a locale (`it-IT`) that is not in the instance's `locales.enabled`, and no `defaultLanguageId`. That payload was silently accepted until `LPD-98560` switched the Space settings write to the validating `updateGroup(groupId, String)` overload, whose `validateLanguageIds` rejects it — producing a `LocaleException` and an HTTP 500 on `POST /o/headless-asset-library/v1.0/asset-libraries`. The test payload was always malformed; the validation introduced by `LPD-98560` merely surfaced it.

## How It Is Being Fixed

Send the language ids in Liferay's underscore format using company-enabled locales (`['en_US', 'fr_FR']`) with an explicit `defaultLanguageId` (`'en_US'`), matching the payload convention used across the rest of the Playwright suite. The picker assertion is updated to the new locale. Test-only change; no product code.

## Why Are There No Tests?

This is a test-only fix to an existing Playwright test — it corrects the malformed request payload in `localizationSelectFragment.spec.ts`. There is no product code change to cover.

## PR Check

**pr-check: PASS** — tested on `9b17eea539a8560319a1ec6de1bcf9dfc8b7bbcb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

Note: Per-Module Compile and JavaScript Unit Tests matched the `.ts` path mechanically but are not applicable — `modules/test/playwright` has no `.lfrbuild-portal` (nothing to deploy) and its `package.json` `test` script is `playwright test`, which is out of pr-check scope.

<!-- pr-check {"result": "success", "sha": "9b17eea539a8560319a1ec6de1bcf9dfc8b7bbcb"} -->
