### PR TITLE
LPD-98055 Keep page path in canonical URL for non-ASCII friendly URLs

### DIFF
--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
@@ -17,9 +17,11 @@ import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.model.impl.VirtualLayout;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolverRegistryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.LayoutFriendlyURLLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.VirtualHostLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
@@ -180,6 +182,14 @@ public class PortalImplCanonicalURLTest {
 			HashMapBuilder.put(
 				LocaleUtil.US, "/test-page"
 			).build());
+		_layout6 = LayoutTestUtil.addTypePortletLayout(
+			_group.getGroupId(), false,
+			HashMapBuilder.put(
+				LocaleUtil.US, "Pöge"
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.US, "/pöge"
+			).build());
 
 		String groupKey = PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME;
 
@@ -239,6 +249,31 @@ public class PortalImplCanonicalURLTest {
 	}
 
 	@Test
+	@TestInfo("LPD-98055")
+	public void testCanonicalURLLayoutFriendlyURLWithNonasciiCharacter()
+		throws Exception {
+
+		Assert.assertEquals("/p%C3%B6ge", _layout6.getFriendlyURL());
+
+		_testCanonicalURL(
+			"localhost", "localhost", _group, _layout6, null, null, "/en",
+			"/p%C3%B6ge", false, false);
+		_testCanonicalURL(
+			"localhost", "localhost", _group, _addLegacyLayout("/legacy-pöge"),
+			null, null, "/en", "/legacy-p%C3%B6ge", false, false);
+	}
+
+	@Test
+	@TestInfo("LPD-98055")
+	public void testCanonicalURLLegacyLayoutFriendlyURLWithMixedCase()
+		throws Exception {
+
+		_testCanonicalURL(
+			"localhost", "localhost", _group, _addLegacyLayout("/LegacyHome1"),
+			null, null, "/en", "/LegacyHome1", false, false);
+	}
+
+	@Test
 	public void testCanonicalURLPartialCollisionWIthPublicGroupServletMapping()
 		throws Exception {
 
@@ -265,6 +300,21 @@ public class PortalImplCanonicalURLTest {
 					completeURL, "_ga",
 					"2.237928582.786466685.1515402734-1365236376"),
 				themeDisplay, _layout4, false, false));
+	}
+
+	@Test
+	@TestInfo("LPD-98055")
+	public void testCanonicalURLVirtualLayout() throws Exception {
+		_targetGroup = GroupTestUtil.addGroup();
+
+		Layout virtualLayout = new VirtualLayout(_layout6, _targetGroup);
+
+		_testCanonicalURL(
+			"localhost", "localhost", _targetGroup, virtualLayout, null, null,
+			"/en", StringPool.BLANK, false, false);
+		_testCanonicalURL(
+			"localhost", "localhost", _targetGroup, virtualLayout, null, null,
+			"/en", virtualLayout.getFriendlyURL(), true, false);
 	}
 
 	@Test
@@ -630,6 +680,21 @@ public class PortalImplCanonicalURLTest {
 			"/home2", false, false);
 	}
 
+	private Layout _addLegacyLayout(String friendlyURL) throws Exception {
+		Layout layout = LayoutTestUtil.addTypePortletLayout(
+			_group.getGroupId());
+
+		_layoutFriendlyURLLocalService.updateLayoutFriendlyURL(
+			TestPropsValues.getUserId(), layout.getCompanyId(),
+			layout.getGroupId(), layout.getPlid(), layout.isPrivateLayout(),
+			friendlyURL, LocaleUtil.toLanguageId(LocaleUtil.US),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		layout.setFriendlyURL(friendlyURL);
+
+		return _layoutLocalService.updateLayout(layout);
+	}
+
 	private ThemeDisplay _createThemeDisplay(
 			String portalDomain, Group group, int serverPort, boolean secure)
 		throws Exception {
@@ -811,11 +876,18 @@ public class PortalImplCanonicalURLTest {
 	private Layout _layout3;
 	private Layout _layout4;
 	private Layout _layout5;
+	private Layout _layout6;
+
+	@Inject
+	private LayoutFriendlyURLLocalService _layoutFriendlyURLLocalService;
 
 	@Inject
 	private LayoutLocalService _layoutLocalService;
 
 	@Inject
 	private Portal _portal;
+
+	@DeleteAfterTestRun
+	private Group _targetGroup;
 
 }

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1570,9 +1570,8 @@ public class PortalImpl implements Portal {
 			(!(layout instanceof VirtualLayout) &&
 			 (!layout.isFirstParent() || Validator.isNotNull(parametersURL)) &&
 			 _requiresLayoutFriendlyURL(
-				 layoutGroup.getFriendlyURL(),
-				 themeDisplay.getLayoutFriendlyURL(layout),
-				 groupFriendlyURL)) ||
+				 groupFriendlyURL, themeDisplay.getLayoutFriendlyURL(layout),
+				 layoutGroup.getFriendlyURL())) ||
 			groupFriendlyURL.endsWith(
 				StringPool.SLASH + layout.getLayoutId())) {
 
@@ -8183,8 +8182,8 @@ public class PortalImpl implements Portal {
 	}
 
 	private boolean _requiresLayoutFriendlyURL(
-		String siteGroupFriendlyURL, String layoutFriendlyURL,
-		String groupFriendlyURL) {
+		String groupFriendlyURL, String layoutFriendlyURL,
+		String siteGroupFriendlyURL) {
 
 		groupFriendlyURL = FriendlyURLNormalizerUtil.normalizeWithEncoding(
 			groupFriendlyURL);

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1576,6 +1576,16 @@ public class PortalImpl implements Portal {
 			groupFriendlyURL.endsWith(
 				StringPool.SLASH + layout.getLayoutId())) {
 
+			if (!(layout instanceof VirtualLayout)) {
+				String decodedDefaultLayoutFriendlyURL =
+					HttpComponentsUtil.decodePath(defaultLayoutFriendlyURL);
+
+				if (Validator.isNotNull(decodedDefaultLayoutFriendlyURL)) {
+					defaultLayoutFriendlyURL = HttpComponentsUtil.encodePath(
+						decodedDefaultLayoutFriendlyURL);
+				}
+			}
+
 			canonicalLayoutFriendlyURL = defaultLayoutFriendlyURL;
 		}
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1567,11 +1567,12 @@ public class PortalImpl implements Portal {
 		Group layoutGroup = layout.getGroup();
 
 		if (forceLayoutFriendlyURL ||
-			((!layout.isFirstParent() || Validator.isNotNull(parametersURL)) &&
+			(!(layout instanceof VirtualLayout) &&
+			 (!layout.isFirstParent() || Validator.isNotNull(parametersURL)) &&
 			 _requiresLayoutFriendlyURL(
 				 layoutGroup.getFriendlyURL(),
 				 themeDisplay.getLayoutFriendlyURL(layout),
-				 StringUtil.toLowerCase(groupFriendlyURL))) ||
+				 groupFriendlyURL)) ||
 			groupFriendlyURL.endsWith(
 				StringPool.SLASH + layout.getLayoutId())) {
 
@@ -8178,20 +8179,23 @@ public class PortalImpl implements Portal {
 		groupFriendlyURL = FriendlyURLNormalizerUtil.normalizeWithEncoding(
 			groupFriendlyURL);
 
+		layoutFriendlyURL = FriendlyURLNormalizerUtil.normalizeWithEncoding(
+			layoutFriendlyURL);
+
 		if (groupFriendlyURL.contains(
 				_PUBLIC_GROUP_SERVLET_MAPPING + StringPool.SLASH)) {
 
 			if (groupFriendlyURL.contains(
 					StringBundler.concat(
-						_PUBLIC_GROUP_SERVLET_MAPPING, siteGroupFriendlyURL,
-						StringUtil.toLowerCase(layoutFriendlyURL)))) {
+						_PUBLIC_GROUP_SERVLET_MAPPING,
+						FriendlyURLNormalizerUtil.normalizeWithEncoding(
+							siteGroupFriendlyURL),
+						layoutFriendlyURL))) {
 
 				return true;
 			}
 		}
-		else if (groupFriendlyURL.contains(
-					StringUtil.toLowerCase(layoutFriendlyURL))) {
-
+		else if (groupFriendlyURL.contains(layoutFriendlyURL)) {
 			return true;
 		}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98055

Sent to Page Management first per the Core Infra review of https://github.com/liferay-core-infra/liferay-portal/pull/10146: the logic lives in `PortalImpl`, but the behavior belongs to Pages/SEO.

## What Is Being Fixed

When a page's friendly URL contains a non-ASCII character (for example `/pöge`), the canonical and hreflang alternate link tags in the page head drop the page path and point at the site root. `PortalImpl._requiresLayoutFriendlyURL` compares the request URL, normalized by `FriendlyURLNormalizerUtil.normalizeWithEncoding` into uppercase percent-hex escapes (`/p%C3%B6ge`), against the stored layout friendly URL, which was only lowercased (`/p%c3%b6ge`), so the `contains` check never matched and the page path was dropped. The asymmetry dates to LPD-64244, which added the request-side normalization.

## How It Is Being Fixed

Both sides of the comparison are now normalized with the same `normalizeWithEncoding` call, which also covers friendly URLs stored before the current normalization rules (raw non-ASCII or mixed case values written through `LayoutFriendlyURLLocalService`, which does not normalize). This supersedes https://github.com/liferay-core-infra/liferay-portal/pull/10085, which was closed because normalizing the canonical output with `normalizeWithEncoding` corrupted virtual layout URLs by rewriting the `/~/` separator into `/-/`. Two design changes address that review:

Virtual layouts are excluded from the comparison with an explicit `instanceof VirtualLayout` gate. On master the comparison could never match a virtual layout anyway (the needle keeps `~` while the normalized request side maps it to `-`), so the gate keeps virtual layout canonical URLs byte-identical to master.

The canonical page path is re-encoded through `HttpComponentsUtil.decodePath` and `encodePath` instead of `normalizeWithEncoding`, in its own commit since it is the one behavior change beyond the bug fix. That round trip is an identity for every canonically stored friendly URL and only changes legacy raw values, which now render in percent-encoded form (`/pöge` becomes `/p%C3%B6ge`) while keeping their case and content — a legacy `/Home1` stays `/Home1` instead of being lowercased into a URL that 404s on case-sensitive databases.

The hreflang alternate links flow through the same path: `OpenGraphTopHeadDynamicInclude` computes the canonical URL first and passes it to `getAlternateURL`, so they inherit the corrected page path. One deliberate side effect: `siteGroupFriendlyURL` in the `/web` branch is now normalized too, so a site group friendly URL stored in non-canonical form (possible through plain `updateGroup(Group)` model updates) also keeps the page path, erring toward retaining it.

Three integration tests, all asserting through the existing `_testCanonicalURL` helper, cover the scenario matrix: non-ASCII stored canonically plus the same value stored raw through `LayoutFriendlyURLLocalService` (legacy rows), mixed-case legacy (pins LPS-153646, which shipped without a test — this case fails if the output is normalized with `normalizeWithEncoding` as in the previous PR), and virtual layouts with and without `forceLayoutFriendlyURL` (fails if the gate is omitted or the `/~` separator is rewritten). The full `PortalImplCanonicalURLTest` and `PortalImplAlternateURLTest` suites pass against a deployed bundle, preserving the scenarios from LPS-106526, LPS-119160, LPS-135694, LPS-135807, LPS-153646, and LPD-64244, and the virtual layout behavior was additionally verified by hand against the user group repro from the previous review, on master and on this branch.

## PR Check

**pr-check: PASS** — tested on `81358f675081ba5b0d7adfa1dcb3a60da11e54a5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "81358f675081ba5b0d7adfa1dcb3a60da11e54a5"} -->
