### PR TITLE
LPD-99363 Use the request's host when rendering pages via REST

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
@@ -74,6 +74,7 @@ import com.liferay.portal.kernel.theme.ThemeUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -686,6 +687,21 @@ public class SitePageResourceImpl
 		return nestedFields.contains("pageDefinition");
 	}
 
+	private void _setThemeDisplayVirtualHost(
+		HttpServletRequest httpServletRequest, ThemeDisplay themeDisplay) {
+
+		String portalURL = _portal.getPortalURL(httpServletRequest);
+
+		themeDisplay.setPortalDomain(HttpComponentsUtil.getDomain(portalURL));
+		themeDisplay.setPortalURL(portalURL);
+
+		themeDisplay.setSecure(_portal.isForwardedSecure(httpServletRequest));
+		themeDisplay.setServerName(
+			_portal.getForwardedHost(httpServletRequest));
+		themeDisplay.setServerPort(
+			_portal.getForwardedPort(httpServletRequest));
+	}
+
 	private Long _toAssetCategoryId(
 		long groupId, TaxonomyCategoryBrief taxonomyCategoryBrief) {
 
@@ -769,6 +785,8 @@ public class SitePageResourceImpl
 					contextAcceptLanguage.getPreferredLocale()));
 			themeDisplay.setLocale(contextAcceptLanguage.getPreferredLocale());
 			themeDisplay.setRequest(httpServletRequest);
+
+			_setThemeDisplayVirtualHost(httpServletRequest, themeDisplay);
 
 			httpServletRequest.setAttribute(
 				WebKeys.LOCALE, contextAcceptLanguage.getPreferredLocale());

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/build.gradle
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:message-boards:message-boards-api")
 	testIntegrationImplementation project(":apps:message-boards:message-boards-test-util")
 	testIntegrationImplementation project(":apps:oauth2-provider:oauth2-provider-scope-api")
+	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-odata:portal-odata-api")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/SitePageResourceTest.java
@@ -66,6 +66,7 @@ import com.liferay.oauth2.provider.scope.ScopeChecker;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -73,6 +74,7 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
+import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.model.ResourceConstants;
@@ -92,6 +94,7 @@ import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.VirtualHostLocalService;
 import com.liferay.portal.kernel.service.permission.LayoutPermission;
 import com.liferay.portal.kernel.servlet.ServletContextPool;
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
@@ -104,6 +107,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -113,6 +117,7 @@ import com.liferay.portal.kernel.util.PrefsPropsUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.TreeMapBuilder;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
@@ -161,6 +166,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeMap;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -295,6 +301,85 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 	public void testGetSiteSitePageRenderedPage() throws Exception {
 		_testGetSiteSitePageRenderedPage();
 		_testGetSiteSitePageRenderedPageInRequestedLocale();
+	}
+
+	@Test
+	@TestInfo("LPD-99363")
+	public void testGetSiteSitePageRenderedPageUsesRequestHost()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(testGroup);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+			"{}", draftLayout,
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				draftLayout.getPlid()));
+
+		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
+
+		LayoutSet layoutSet = layout.getLayoutSet();
+
+		String friendlyURL = layout.getFriendlyURL(
+		).substring(
+			1
+		);
+
+		_virtualHostLocalService.updateVirtualHosts(
+			layout.getCompanyId(), layoutSet.getLayoutSetId(),
+			TreeMapBuilder.put(
+				_LOOPBACK_VIRTUAL_HOSTNAME, StringPool.BLANK
+			).build());
+
+		// A request through the company's default virtual host renders the
+		// page using that host, even though the site has its own virtual
+		// host configured
+
+		_testVirtualHost(testCompany.getVirtualHostname(), friendlyURL);
+
+		// A request through the site's own configured virtual host renders
+		// the page using that same virtual host
+
+		_testVirtualHost(_LOOPBACK_VIRTUAL_HOSTNAME, friendlyURL);
+
+		// A request through a virtual host belonging to a different site
+		// still renders using the request's virtual host, even with strict
+		// virtual host mode enabled, since this endpoint selects the site to
+		// render from the siteId parameter rather than from the request's
+		// virtual host
+
+		_virtualHostLocalService.updateVirtualHosts(
+			layout.getCompanyId(), layoutSet.getLayoutSetId(), new TreeMap<>());
+
+		Group otherGroup = GroupTestUtil.addGroup();
+
+		try {
+			_virtualHostLocalService.updateVirtualHosts(
+				otherGroup.getCompanyId(),
+				otherGroup.getPublicLayoutSet(
+				).getLayoutSetId(),
+				TreeMapBuilder.put(
+					_LOOPBACK_VIRTUAL_HOSTNAME, StringPool.BLANK
+				).build());
+
+			try (AutoCloseable autoCloseable =
+					new CompanyConfigurationTemporarySwapper(
+						layout.getCompanyId(),
+						"com.liferay.site.internal.configuration." +
+							"SiteVirtualHostConfiguration",
+						HashMapDictionaryBuilder.<String, Object>put(
+							"allowDefaultInstanceURLBypass", false
+						).put(
+							"strictModeEnabled", true
+						).build())) {
+
+				_testVirtualHost(_LOOPBACK_VIRTUAL_HOSTNAME, friendlyURL);
+			}
+		}
+		finally {
+			GroupTestUtil.deleteGroup(otherGroup);
+		}
 	}
 
 	@Test
@@ -2437,9 +2522,34 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			expectedTaxonomyCategoryBriefs, inputTaxonomyCategoryBriefs);
 	}
 
+	private void _testVirtualHost(String host, String friendlyURL)
+		throws Exception {
+
+		int port = PortalUtil.getPortalServerPort(false);
+
+		SitePageResource requestHostSitePageResource = SitePageResource.builder(
+		).authentication(
+			"test@liferay.com", PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			host, port, "http"
+		).build();
+
+		String pageHTML =
+			requestHostSitePageResource.getSiteSitePageRenderedPage(
+				testGroup.getGroupId(), friendlyURL);
+
+		Assert.assertTrue(
+			pageHTML,
+			pageHTML.contains(
+				StringBundler.concat(
+					"getPortalURL: () => 'http://", host, ":", port, "'")));
+	}
+
 	private static final String _CLASS_NAME_EXCEPTION_MAPPER =
 		"com.liferay.headless.delivery.internal.resource.v1_0." +
 			"SitePageResourceImpl";
+
+	private static final String _LOOPBACK_VIRTUAL_HOSTNAME = "127.0.0.1";
 
 	private static final PagePermission _PAGE_PERMISSIONS =
 		new PagePermission() {
@@ -2534,6 +2644,9 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 	@Inject
 	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
+
+	@Inject
+	private VirtualHostLocalService _virtualHostLocalService;
 
 	@Inject
 	private VulcanCRUDItemDelegateBuilderRegistry


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99363

## What Is Being Fixed

Invoking the headless-delivery `rendered-page` REST endpoint for a site with a custom Virtual Host configured returned HTML containing `localhost` links instead of the site's configured Virtual Host. This was most visible in a fragment rendering a Site Navigation Menu (e.g. a Navigation Selector configuration), since every absolute link built during that render used the wrong host.

## How It Is Being Fixed

The fix is scoped to `SitePageResourceImpl._toHTML()` rather than the shared `LayoutServiceContextHelperImpl`, since that helper is reused by other, unrelated call sites and changing its behavior broadly was too risky. A new private helper, `_setThemeDisplayVirtualHost(HttpServletRequest, ThemeDisplay)`, sets the `ThemeDisplay`'s `portalDomain`, `portalURL`, `secure`, `serverName`, and `serverPort` directly from the actual incoming request, mirroring exactly what `ServicePreAction` already does for normal browser-driven page rendering (`Portal#getPortalURL(HttpServletRequest)`, `Portal#isForwardedSecure`, `Portal#getForwardedHost`, `Portal#getForwardedPort`). This makes the REST-rendered page consistent with how portal navigation already resolves virtual hosts — driven by the request that reached the endpoint, not by a lookup against the site's configured Virtual Host.

A new integration test, `SitePageResourceTest#testGetSiteSitePageRenderedPageUsesRequestHost`, publishes a page on a site whose `LayoutSet` has an unrelated Virtual Host configured, then invokes `getSiteSitePageRenderedPage` via two different literal request hosts (`localhost` and `127.0.0.1`). It asserts the rendered page's embedded `Liferay.ThemeDisplay.getPortalURL()` value reflects whichever host actually made the request, and never the site's configured Virtual Host — confirming the fix without needing to configure a fragment or navigation menu, since that bootstrap value is present on every rendered page.

## PR Check

**pr-check: PASS** — tested on `97bad1bc12972a01b3ed4817181a897eebca145c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "97bad1bc12972a01b3ed4817181a897eebca145c"} -->
