### PR TITLE
LPD-99530 Provision the Design Library roles in the depot test fixtures

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/ChangeStyleBookEntryMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/ChangeStyleBookEntryMVCActionCommandTest.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.FeatureFlagTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -91,6 +92,9 @@ public class ChangeStyleBookEntryMVCActionCommandTest {
 	}
 
 	private Group _addConnectedDepotGroup() throws Exception {
+		FeatureFlagTestUtil.invokeFeatureFlagListeners(
+			TestPropsValues.getCompanyId(), true, "LPD-57283");
+
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			RandomTestUtil.randomLocaleStringMap(),
 			RandomTestUtil.randomLocaleStringMap(),

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/importer/test/MasterLayoutsImporterTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/importer/test/MasterLayoutsImporterTest.java
@@ -60,6 +60,7 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.FeatureFlagTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -640,6 +641,9 @@ public class MasterLayoutsImporterTest {
 	}
 
 	private DepotEntry _addConnectedDesignLibraryDepotEntry() throws Exception {
+		FeatureFlagTestUtil.invokeFeatureFlagListeners(
+			TestPropsValues.getCompanyId(), true, "LPD-57283");
+
 		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
 			HashMapBuilder.put(
 				LocaleUtil.getDefault(), RandomTestUtil.randomString()


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99530

## What Is Being Fixed

`MasterLayoutsImporterTest.testImportMasterLayoutDropZoneAllowedFragments` and `ChangeStyleBookEntryMVCActionCommandTest.testChangeStyleBookEntry` have failed on the page-management routine since the 2026-07-23 build with `NoSuchRoleException: No Role exists with the key {companyId=..., name=design library owner}`.

Since LPD-98812, `addDepotEntry` resolves the owner role from the depot subtype, and LPD-99354 gated the Design Library variant behind the LPD-57283 feature flag. Both tests enable LPD-57283 through the method-level `@FeatureFlag` annotation, so the lookup asks for the Design Library Owner role. That role is only created by `DepotRolesPortalInstanceLifecycleListener` at portal instance registration and by `DesignLibraryFeatureFlagListener` when the flag is toggled at runtime. `FeatureFlagTestRule` triggers neither, because it only flips a `PropsUtil` value and installs a `MockFeatureFlagManager`, so the roles were never provisioned and the role lookup threw.

This is why LPD-99354 cleared five of the seven failures in this wave but not these two: the five create Design Library depots with the flag off and take the Asset Library Owner fallback, whereas these two enable the flag and request a role that does not exist.

## How It Is Being Fixed

Each test's private depot fixture now calls `FeatureFlagTestUtil.invokeFeatureFlagListeners` before `addDepotEntry`, which fires `DesignLibraryFeatureFlagListener` and provisions the Design Library roles the same way a runtime toggle does. This is the pattern `FragmentSetResourceTest` already uses for the same reason. Both fixtures are reached only from the flag-annotated test methods, so no other test in either class changes behavior.

No production code change is needed: the roles are provisioned correctly outside tests, both at boot and on a runtime flag toggle. The gap is specific to `FeatureFlagTestRule` not notifying feature flag listeners.

## PR Check

**pr-check: PASS** — tested on `c13736266058a3d0b5e71ec9b35df558182475be`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |
| Transaction Usage | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c13736266058a3d0b5e71ec9b35df558182475be"} -->
