### PR TITLE
LPD-99545 Match the wordsmithed entries per feed label in RSS test

### DIFF
--- a/modules/test/playwright/tests/rss-web/main/rssPublisherWidget.spec.ts
+++ b/modules/test/playwright/tests/rss-web/main/rssPublisherWidget.spec.ts
@@ -74,7 +74,7 @@ test(
 		// Assert number of entries per feed allows integer numbers greater than 10
 
 		await configurationIFrame
-			.getByLabel('# of Entries Per Feed', {exact: true})
+			.getByLabel('# of Entries per Feed', {exact: true})
 			.fill('11');
 
 		await widgetPagePage.save('RSS Publisher');
@@ -84,7 +84,7 @@ test(
 			.click();
 
 		await expect(
-			configurationIFrame.getByLabel('# of Entries Per Feed', {
+			configurationIFrame.getByLabel('# of Entries per Feed', {
 				exact: true,
 			})
 		).toHaveValue('11');


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99545

## What Is Being Fixed

The Playwright test `rss-web/main/rssPublisherWidget.spec.ts > The user can configure display settings on rss publisher widget` has failed on the page-management routine since the 2026-07-24 build with a 90s timeout on `locator.fill`, waiting for `getByLabel('# of Entries Per Feed', {exact: true})` inside the RSS Publisher configuration iframe.

The test matched the field label exactly. Commit `61db31d1321d7` ("LPD-96038 Wordsmith") changed the `num-of-entries-per-feed` language key from `# of Entries Per Feed` to `# of Entries per Feed` (lowercasing the preposition), so the exact-match locator no longer resolved and the fill timed out.

## How It Is Being Fixed

The two `getByLabel('# of Entries Per Feed', {exact: true})` references in the test are updated to `# of Entries per Feed`, matching the wordsmithed label the portal now renders. The product label change is intentional, so the assertion was stale rather than the code being wrong.

## Why Are There No Tests?

This change fixes an existing Playwright test to track an intentional UI label change. The updated test is itself the coverage; no new test is warranted.

## PR Check

**pr-check: PASS** — tested on `31411f654645d3656c0cd4c95871bc764adaed16`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "31411f654645d3656c0cd4c95871bc764adaed16"} -->
