### PR TITLE
LPD-99386 Provide a non-null locale on the layout reindex mock request

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutServiceContextHelperImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutServiceContextHelperImpl.java
@@ -296,6 +296,23 @@ public class LayoutServiceContextHelperImpl
 						return Collections.emptyEnumeration();
 					}
 
+					public Locale getLocale() {
+						ThemeDisplay themeDisplay =
+							(ThemeDisplay)_attributes.get(
+								WebKeys.THEME_DISPLAY);
+
+						if (themeDisplay == null) {
+							return LocaleUtil.getDefault();
+						}
+
+						return themeDisplay.getLocale();
+					}
+
+					public Enumeration<Locale> getLocales() {
+						return Collections.enumeration(
+							Collections.singletonList(getLocale()));
+					}
+
 					public String getMethod() {
 						return HttpMethods.GET;
 					}

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/util/test/LayoutServiceContextHelperTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/util/test/LayoutServiceContextHelperTest.java
@@ -1,0 +1,99 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.util.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.layout.util.LayoutServiceContextHelper;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Georgel Pop
+ */
+@RunWith(Arquillian.class)
+public class LayoutServiceContextHelperTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId());
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	@TestInfo("LPD-99386")
+	public void testGetServiceContextAutoCloseable() throws Exception {
+		try (AutoCloseable autoCloseable =
+				_layoutServiceContextHelper.getServiceContextAutoCloseable(
+					_layout)) {
+
+			ServiceContext serviceContext =
+				ServiceContextThreadLocal.getServiceContext();
+
+			HttpServletRequest httpServletRequest = serviceContext.getRequest();
+
+			Assert.assertNotNull(httpServletRequest.getLocale());
+
+			List<Locale> locales = Collections.list(
+				httpServletRequest.getLocales());
+
+			Assert.assertFalse(locales.isEmpty());
+		}
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Layout _layout;
+
+	@Inject
+	private LayoutServiceContextHelper _layoutServiceContextHelper;
+
+	private ServiceContext _serviceContext;
+
+}

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/util/test/LayoutServiceContextHelperTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/util/test/LayoutServiceContextHelperTest.java
@@ -8,10 +8,12 @@ package com.liferay.layout.util.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.layout.util.LayoutServiceContextHelper;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.servlet.HttpMethods;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -26,6 +28,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -66,7 +69,7 @@ public class LayoutServiceContextHelperTest {
 	}
 
 	@Test
-	@TestInfo("LPD-99386")
+	@TestInfo({"LPD-79722", "LPD-99386"})
 	public void testGetServiceContextAutoCloseable() throws Exception {
 		try (AutoCloseable autoCloseable =
 				_layoutServiceContextHelper.getServiceContextAutoCloseable(
@@ -83,6 +86,21 @@ public class LayoutServiceContextHelperTest {
 				httpServletRequest.getLocales());
 
 			Assert.assertFalse(locales.isEmpty());
+
+			Assert.assertEquals(
+				HttpMethods.GET, httpServletRequest.getMethod());
+			Assert.assertEquals(
+				StringPool.SLASH, httpServletRequest.getRequestURI());
+			Assert.assertEquals("http", httpServletRequest.getScheme());
+			Assert.assertNotNull(httpServletRequest.getContextPath());
+			Assert.assertNotNull(httpServletRequest.getServletContext());
+			Assert.assertNotNull(httpServletRequest.getSession());
+			Assert.assertEquals(0, httpServletRequest.getCookies().length);
+
+			Map<String, String[]> parameterMap =
+				httpServletRequest.getParameterMap();
+
+			Assert.assertTrue(parameterMap.isEmpty());
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99386

## What Is Being Fixed

During a full reindex, a NullPointerException is logged when a custom portlet uses the Portlet 3.0 taglib with <portlet:defineObjects />. The reindex renders each published content page's portlets under a mock HttpServletRequest built by LayoutServiceContextHelperImpl. That mock did not implement getLocale() or getLocales(), so the calls fell through to a dummy proxy that returns null, and DefineObjectsTag3.doStartTag() then threw on Collections.list(portletRequest.getLocales()). Per the Servlet spec, getLocale() and getLocales() must never return null, so the fix belongs in the mock request.

## How It Is Being Fixed

Implement getLocale() and getLocales() on the mock request delegate. getLocale() returns the request's WebKeys.LOCALE (the theme display locale the helper already stores) and falls back to LocaleUtil.getDefault(), so it is never null; getLocales() wraps it in a single-element enumeration. A new integration test pins the whole mock request contract, so this bug and the related null-getScheme regression (LPD-79722) are guarded going forward.

## PR Check

**pr-check: PASS** — tested on `bcdde1292f02ed9dd4dba06535010f7f68c2d549`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "bcdde1292f02ed9dd4dba06535010f7f68c2d549"} -->
