### PR TITLE
LPD-99346 Include ancestor site vocabularies in the vocabulary picker

### DIFF
--- a/modules/apps/asset/asset-categories-item-selector-web/src/main/java/com/liferay/asset/categories/item/selector/web/internal/display/context/SelectAssetVocabularyDisplayContext.java
+++ b/modules/apps/asset/asset-categories-item-selector-web/src/main/java/com/liferay/asset/categories/item/selector/web/internal/display/context/SelectAssetVocabularyDisplayContext.java
@@ -9,10 +9,7 @@ import com.liferay.asset.categories.item.selector.web.internal.constants.AssetCa
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.model.AssetVocabularyConstants;
 import com.liferay.asset.kernel.service.AssetVocabularyServiceUtil;
-import com.liferay.depot.constants.DepotConstants;
-import com.liferay.depot.model.DepotEntry;
-import com.liferay.depot.service.DepotEntryServiceUtil;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.depot.util.SiteConnectedGroupGroupProviderUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -20,7 +17,6 @@ import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -34,7 +30,6 @@ import jakarta.portlet.PortletURL;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -113,22 +108,10 @@ public class SelectAssetVocabularyDisplayContext {
 	private List<AssetVocabulary> _getAssetVocabularies()
 		throws PortalException {
 
-		List<Long> groupIds = new ArrayList<>();
-
-		groupIds.add(_themeDisplay.getCompanyGroupId());
-		groupIds.add(_themeDisplay.getScopeGroupId());
-
-		List<DepotEntry> depotEntries =
-			DepotEntryServiceUtil.getCurrentAndGroupConnectedDepotEntries(
-				_themeDisplay.getScopeGroupId(), DepotConstants.TYPE_ANY,
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
-
-		for (DepotEntry depotEntry : depotEntries) {
-			groupIds.add(depotEntry.getGroupId());
-		}
-
 		return AssetVocabularyServiceUtil.getGroupVocabularies(
-			ArrayUtil.toLongArray(groupIds),
+			SiteConnectedGroupGroupProviderUtil.
+				getCurrentAndAncestorSiteAndDepotGroupIds(
+					_themeDisplay.getScopeGroupId()),
 			new int[] {AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC});
 	}
 

--- a/modules/apps/asset/asset-categories-item-selector-web/src/test/java/com/liferay/asset/categories/item/selector/web/internal/display/context/SelectAssetVocabularyDisplayContextTest.java
+++ b/modules/apps/asset/asset-categories-item-selector-web/src/test/java/com/liferay/asset/categories/item/selector/web/internal/display/context/SelectAssetVocabularyDisplayContextTest.java
@@ -1,0 +1,143 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.categories.item.selector.web.internal.display.context;
+
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.model.AssetVocabularyConstants;
+import com.liferay.asset.kernel.service.AssetVocabularyServiceUtil;
+import com.liferay.depot.util.SiteConnectedGroupGroupProviderUtil;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public class SelectAssetVocabularyDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_setUpSiteConnectedGroupGroupProviderUtil();
+
+		Mockito.when(
+			_themeDisplay.getScopeGroupId()
+		).thenReturn(
+			_GROUP_ID
+		);
+	}
+
+	@After
+	public void tearDown() {
+		_assetVocabularyServiceUtilMockedStatic.close();
+		_frameworkUtilMockedStatic.close();
+		_siteConnectedGroupGroupProviderUtilMockedStatic.close();
+	}
+
+	@Test
+	@TestInfo("LPD-99346")
+	public void testGetAssetVocabularies() throws Exception {
+		long[] groupIds = {
+			_GROUP_ID, RandomTestUtil.randomLong(), RandomTestUtil.randomLong(),
+			RandomTestUtil.randomLong()
+		};
+
+		_siteConnectedGroupGroupProviderUtilMockedStatic.when(
+			() ->
+				SiteConnectedGroupGroupProviderUtil.
+					getCurrentAndAncestorSiteAndDepotGroupIds(_GROUP_ID)
+		).thenReturn(
+			groupIds
+		);
+
+		List<AssetVocabulary> assetVocabularies = Arrays.asList(
+			Mockito.mock(AssetVocabulary.class),
+			Mockito.mock(AssetVocabulary.class),
+			Mockito.mock(AssetVocabulary.class),
+			Mockito.mock(AssetVocabulary.class));
+
+		_assetVocabularyServiceUtilMockedStatic.when(
+			() -> AssetVocabularyServiceUtil.getGroupVocabularies(
+				Mockito.eq(groupIds),
+				Mockito.eq(
+					new int[] {
+						AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC
+					}))
+		).thenReturn(
+			assetVocabularies
+		);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _themeDisplay);
+
+		SelectAssetVocabularyDisplayContext
+			selectAssetVocabularyDisplayContext =
+				new SelectAssetVocabularyDisplayContext(
+					mockHttpServletRequest, null);
+
+		Assert.assertEquals(
+			assetVocabularies,
+			ReflectionTestUtil.invoke(
+				selectAssetVocabularyDisplayContext, "_getAssetVocabularies",
+				new Class<?>[0]));
+	}
+
+	private void _setUpSiteConnectedGroupGroupProviderUtil() {
+		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+		_frameworkUtilMockedStatic.when(
+			() -> FrameworkUtil.getBundle(
+				SiteConnectedGroupGroupProviderUtil.class)
+		).thenReturn(
+			bundleContext.getBundle()
+		);
+
+		_siteConnectedGroupGroupProviderUtilMockedStatic = Mockito.mockStatic(
+			SiteConnectedGroupGroupProviderUtil.class);
+	}
+
+	private static final long _GROUP_ID = RandomTestUtil.randomLong();
+
+	private static final MockedStatic<AssetVocabularyServiceUtil>
+		_assetVocabularyServiceUtilMockedStatic = Mockito.mockStatic(
+			AssetVocabularyServiceUtil.class);
+	private static final MockedStatic<FrameworkUtil>
+		_frameworkUtilMockedStatic = Mockito.mockStatic(FrameworkUtil.class);
+
+	private MockedStatic<SiteConnectedGroupGroupProviderUtil>
+		_siteConnectedGroupGroupProviderUtilMockedStatic;
+	private final ThemeDisplay _themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99346

## What Is Being Fixed

The vocabulary picker opened from the Collection Filter Fragment's Category configuration did not list vocabularies owned by ancestor sites in the site hierarchy. Every other asset picker in the portal already respected that hierarchy, so a child site could not filter by a vocabulary its parent site owned even though the same vocabulary was usable elsewhere.

## How It Is Being Fixed

The vocabulary lookup in `SelectAssetVocabularyDisplayContext` now delegates to `SiteConnectedGroupGroupProviderUtil.getCurrentAndAncestorSiteAndDepotGroupIds`, the helper the rest of the asset framework uses. That call returns the company group, the current site, its ancestors, and connected asset libraries in one shot, replacing the manual collection that only reached the current site and connected libraries. A companion unit test asserts that the display context passes the provider's result through to `AssetVocabularyServiceUtil.getGroupVocabularies`.

## Ownership

`asset-categories-item-selector-web` currently has no explicit entry in `.github/CODEOWNERS`. It falls through to `modules/apps/asset/`, which itself has no team assigned, leaving the module effectively unowned.

Its only public entry point, `AssetCategoryTreeNodeItemSelectorCriterion` (exposed by `asset-categories-item-selector-api`), has a single consumer in the repository: `ContentPageEditorDisplayContext` in `layout-content-page-editor-web`, owned by `@liferay-page-management`. That is why this review is being requested in the page-management fork.

## PR Check

**pr-check: PASS** — tested on `48aaf88f9f61a0e4bb8272c2b1cbd8ea5f5d4443`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "48aaf88f9f61a0e4bb8272c2b1cbd8ea5f5d4443"} -->
