### PR TITLE
LPD-99564 Add Fragment Set no longer edits an existing global set

### DIFF
--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
@@ -294,6 +294,31 @@ public class FragmentDisplayContext {
 		return _contributedEntriesSearchContainer;
 	}
 
+	public long getEditFragmentCollectionId() {
+		long fragmentCollectionId = ParamUtil.getLong(
+			_httpServletRequest, "fragmentCollectionId");
+
+		if (fragmentCollectionId == 0) {
+			String externalReferenceCode = ParamUtil.getString(
+				_httpServletRequest, "fragmentCollectionExternalReferenceCode");
+
+			if (Validator.isNotNull(externalReferenceCode)) {
+				FragmentCollection fragmentCollection =
+					FragmentCollectionLocalServiceUtil.
+						fetchFragmentCollectionByExternalReferenceCode(
+							externalReferenceCode,
+							_themeDisplay.getScopeGroupId());
+
+				if (fragmentCollection != null) {
+					fragmentCollectionId =
+						fragmentCollection.getFragmentCollectionId();
+				}
+			}
+		}
+
+		return fragmentCollectionId;
+	}
+
 	public FragmentCollection getFragmentCollection() {
 		if (_fragmentCollection != null) {
 			return _fragmentCollection;
@@ -342,26 +367,7 @@ public class FragmentDisplayContext {
 			return _fragmentCollectionId;
 		}
 
-		long fragmentCollectionId = ParamUtil.getLong(
-			_httpServletRequest, "fragmentCollectionId");
-
-		if (fragmentCollectionId == 0) {
-			String externalReferenceCode = ParamUtil.getString(
-				_httpServletRequest, "fragmentCollectionExternalReferenceCode");
-
-			if (Validator.isNotNull(externalReferenceCode)) {
-				FragmentCollection fragmentCollection =
-					FragmentCollectionLocalServiceUtil.
-						fetchFragmentCollectionByExternalReferenceCode(
-							externalReferenceCode,
-							_themeDisplay.getScopeGroupId());
-
-				if (fragmentCollection != null) {
-					fragmentCollectionId =
-						fragmentCollection.getFragmentCollectionId();
-				}
-			}
-		}
+		long fragmentCollectionId = getEditFragmentCollectionId();
 
 		if (fragmentCollectionId == 0) {
 			fragmentCollectionId = _getDefaultFragmentCollectionId();

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/edit_fragment_collection.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/edit_fragment_collection.jsp
@@ -8,7 +8,7 @@
 <%@ include file="/init.jsp" %>
 
 <%
-long fragmentCollectionId = fragmentDisplayContext.getFragmentCollectionId();
+long fragmentCollectionId = fragmentDisplayContext.getEditFragmentCollectionId();
 
 FragmentCollection fragmentCollection = FragmentCollectionLocalServiceUtil.fetchFragmentCollection(fragmentCollectionId);
 

--- a/modules/test/playwright/pages/fragment-web/FragmentsPage.ts
+++ b/modules/test/playwright/pages/fragment-web/FragmentsPage.ts
@@ -122,7 +122,7 @@ export class FragmentsPage {
 		}
 		else if (setExists) {
 			await this.page
-				.getByLabel('Fragment Sets')
+				.getByLabel('Fragment Set', {exact: true})
 				.selectOption({label: setName});
 		}
 		else {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99564

## What Is Being Fixed

When the current scope (site) has no fragment sets of its own but a global fragment set exists, "Add Fragment Set" did not create a new set — it silently renamed/edited the existing global set. The add form derived its collection id from `getFragmentCollectionId()`, which falls back to `_getDefaultFragmentCollectionId()`; with no collection in the current scope, that fallback returned the first global collection's id, so the add form opened in edit mode and Save updated the global set.

## How It Is Being Fixed

Extracted `getEditFragmentCollectionId()` on `FragmentDisplayContext`, which resolves only the explicitly targeted collection id (request parameter, then external reference code) and returns 0 when nothing is targeted, with no default fallback. `getFragmentCollectionId()` still applies the default fallback, so the collections view keeps its auto-selection behavior. The add/edit JSP uses `getEditFragmentCollectionId()`, so opening "Add Fragment Set" with no id yields 0 and creates a new set. The copy-to-set Playwright helper's locator was updated to the renamed "Fragment Set" dropdown label from LPD-97638.

## Why Are There No Tests?

The behavior is covered by the existing Playwright test `fragmentsAdmin.spec.ts` "Can add, delete, copy and rename a fragment via UI", which fails when a global fragment set is present (reproducing the bug) and passes with this fix; the copy-to-set tests (233/280) and `FragmentDisplayContextTest` exercise the affected paths.

## PR Check

**pr-check: PASS** — tested on `7bb9552bb59d6fe912dfe76c8072b75b534928f6`

| Validation | Result |
| --- | --- |
| Transaction Usage | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "7bb9552bb59d6fe912dfe76c8072b75b534928f6"} -->
