### PR TITLE
LPD-96528 allow Fragment* entities to be managed by Reviewers, Admin and Owners of a design Library

### DIFF
--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/instance/lifecycle/test/DepotRolesPortalInstanceLifecycleListenerTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/instance/lifecycle/test/DepotRolesPortalInstanceLifecycleListenerTest.java
@@ -149,6 +149,10 @@ public class DepotRolesPortalInstanceLifecycleListenerTest {
 					DepotRolesConstants.DESIGN_LIBRARY_OWNER)) {
 
 			_assertResourcePermissions(
+				companyId, "com.liferay.fragment",
+				ResourceConstants.SCOPE_COMPANY, String.valueOf(companyId),
+				name, List.of("MANAGE_FRAGMENT_ENTRIES"));
+			_assertResourcePermissions(
 				companyId, "com.liferay.style.book",
 				ResourceConstants.SCOPE_COMPANY, String.valueOf(companyId),
 				name, List.of("MANAGE_STYLE_BOOK_ENTRIES"));

--- a/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContext.java
+++ b/modules/apps/design-library/design-library-web/src/main/java/com/liferay/design/library/web/internal/display/context/DesignLibraryResourcesDisplayContext.java
@@ -289,7 +289,13 @@ public class DesignLibraryResourcesDisplayContext {
 		DepotEntry depotEntry = DepotEntryLocalServiceUtil.getDepotEntry(
 			designLibraryEntryId);
 
-		return _hasManageStyleBookEntriesPermission(depotEntry.getGroupId());
+		if (_hasManageFragmentEntriesPermission(depotEntry.getGroupId()) &&
+			_hasManageStyleBookEntriesPermission(depotEntry.getGroupId())) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private JSONArray _getActionItemsJSONArray(

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/search/FragmentCollectionModelSearchConfigurator.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/search/FragmentCollectionModelSearchConfigurator.java
@@ -42,6 +42,11 @@ public class FragmentCollectionModelSearchConfigurator
 		return _modelIndexWriterContributor;
 	}
 
+	@Override
+	public boolean isPermissionAware() {
+		return false;
+	}
+
 	@Activate
 	protected void activate() {
 		_modelIndexWriterContributor = new ModelIndexerWriterContributor<>(

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/security/permission/FragmentDepotRolePermissionsContributor.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/security/permission/FragmentDepotRolePermissionsContributor.java
@@ -26,15 +26,15 @@ public class FragmentDepotRolePermissionsContributor
 	public List<DepotRolePermission> getDepotRolePermissions() {
 		return List.of(
 			new DepotRolePermission(
-				DepotRolesConstants.DESIGN_LIBRARY_OWNER,
-				FragmentConstants.RESOURCE_NAME,
-				FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES),
-			new DepotRolePermission(
 				DepotRolesConstants.DESIGN_LIBRARY_ADMINISTRATOR,
 				FragmentConstants.RESOURCE_NAME,
 				FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES),
 			new DepotRolePermission(
 				DepotRolesConstants.DESIGN_LIBRARY_CONTENT_REVIEWER,
+				FragmentConstants.RESOURCE_NAME,
+				FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES),
+			new DepotRolePermission(
+				DepotRolesConstants.DESIGN_LIBRARY_OWNER,
 				FragmentConstants.RESOURCE_NAME,
 				FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES));
 	}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/security/permission/FragmentDepotRolePermissionsContributor.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/security/permission/FragmentDepotRolePermissionsContributor.java
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.security.permission;
+
+import com.liferay.depot.constants.DepotRolesConstants;
+import com.liferay.depot.role.contributor.DepotRolePermission;
+import com.liferay.depot.role.contributor.DepotRolePermissionsContributor;
+import com.liferay.fragment.constants.FragmentActionKeys;
+import com.liferay.fragment.constants.FragmentConstants;
+
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Thiago Buarque
+ */
+@Component(service = DepotRolePermissionsContributor.class)
+public class FragmentDepotRolePermissionsContributor
+	implements DepotRolePermissionsContributor {
+
+	@Override
+	public List<DepotRolePermission> getDepotRolePermissions() {
+		return List.of(
+			new DepotRolePermission(
+				DepotRolesConstants.DESIGN_LIBRARY_OWNER,
+				FragmentConstants.RESOURCE_NAME,
+				FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES),
+			new DepotRolePermission(
+				DepotRolesConstants.DESIGN_LIBRARY_ADMINISTRATOR,
+				FragmentConstants.RESOURCE_NAME,
+				FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES),
+			new DepotRolePermission(
+				DepotRolesConstants.DESIGN_LIBRARY_CONTENT_REVIEWER,
+				FragmentConstants.RESOURCE_NAME,
+				FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES));
+	}
+
+}

--- a/modules/apps/fragment/fragment-service/src/test/java/com/liferay/fragment/internal/security/permission/FragmentDepotRolePermissionsContributorTest.java
+++ b/modules/apps/fragment/fragment-service/src/test/java/com/liferay/fragment/internal/security/permission/FragmentDepotRolePermissionsContributorTest.java
@@ -1,0 +1,72 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.security.permission;
+
+import com.liferay.depot.constants.DepotRolesConstants;
+import com.liferay.depot.role.contributor.DepotRolePermission;
+import com.liferay.fragment.constants.FragmentActionKeys;
+import com.liferay.fragment.constants.FragmentConstants;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Thiago Buarque
+ */
+public class FragmentDepotRolePermissionsContributorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetDepotRolePermissions() {
+		FragmentDepotRolePermissionsContributor
+			fragmentDepotRolePermissionsContributor =
+				new FragmentDepotRolePermissionsContributor();
+
+		List<DepotRolePermission> depotRolePermissions =
+			fragmentDepotRolePermissionsContributor.getDepotRolePermissions();
+
+		Assert.assertEquals(
+			depotRolePermissions.toString(), 3, depotRolePermissions.size());
+
+		Map<String, DepotRolePermission> depotRolePermissionsMap =
+			new HashMap<>();
+
+		for (DepotRolePermission depotRolePermission : depotRolePermissions) {
+			depotRolePermissionsMap.put(
+				depotRolePermission.getRoleName(), depotRolePermission);
+		}
+
+		for (String roleName :
+				List.of(
+					DepotRolesConstants.DESIGN_LIBRARY_ADMINISTRATOR,
+					DepotRolesConstants.DESIGN_LIBRARY_CONTENT_REVIEWER,
+					DepotRolesConstants.DESIGN_LIBRARY_OWNER)) {
+
+			DepotRolePermission depotRolePermission =
+				depotRolePermissionsMap.get(roleName);
+
+			Assert.assertNotNull(roleName, depotRolePermission);
+			Assert.assertEquals(
+				FragmentConstants.RESOURCE_NAME,
+				depotRolePermission.getResourceName());
+			Assert.assertArrayEquals(
+				new String[] {FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES},
+				depotRolePermission.getActionKeys());
+		}
+	}
+
+}

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/search/test/FragmentCollectionSearchPermissionTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/search/test/FragmentCollectionSearchPermissionTest.java
@@ -1,0 +1,181 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.service.FragmentCollectionLocalService;
+import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.portal.search.searcher.Searcher;
+import com.liferay.portal.search.test.rule.SearchTestRule;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Thiago Buarque
+ */
+@RunWith(Arquillian.class)
+public class FragmentCollectionSearchPermissionTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_user = UserTestUtil.addGroupUser(_group, RoleConstants.POWER_USER);
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group, TestPropsValues.getUserId());
+
+		_fragmentCollection =
+			_fragmentCollectionLocalService.addFragmentCollection(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				_group.getGroupId(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				false, serviceContext);
+	}
+
+	@Test
+	public void testIndexerSearchLogsNoError() throws Exception {
+		_assertNoErrorLogged(() -> _indexer.search(_createSearchContext()));
+	}
+
+	@Test
+	public void testMultipleIndexerSearchLogsNoError() throws Exception {
+		_assertNoErrorLogged(
+			() -> {
+				SearchResponse searchResponse = _search(
+					FragmentCollection.class, FragmentEntry.class);
+
+				Assert.assertEquals(1, searchResponse.getTotalHits());
+			});
+	}
+
+	@Test
+	public void testSingleIndexerSearchLogsNoError() throws Exception {
+		_assertNoErrorLogged(() -> _search(FragmentCollection.class));
+	}
+
+	@Rule
+	public SearchTestRule searchTestRule = new SearchTestRule();
+
+	private void _assertNoErrorLogged(UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		UserTestUtil.setUser(_user);
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		Assert.assertFalse(
+			permissionChecker.isCompanyAdmin(TestPropsValues.getCompanyId()));
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.search.internal." +
+					"SearchPermissionCheckerImpl",
+				LoggerTestUtil.ERROR)) {
+
+			unsafeRunnable.run();
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertTrue(logEntries.toString(), logEntries.isEmpty());
+		}
+	}
+
+	private SearchContext _createSearchContext() throws Exception {
+		SearchContext searchContext = new SearchContext();
+
+		searchContext.setCompanyId(TestPropsValues.getCompanyId());
+		searchContext.setGroupIds(new long[] {_group.getGroupId()});
+		searchContext.setKeywords(_fragmentCollection.getName());
+		searchContext.setUserId(_user.getUserId());
+
+		return searchContext;
+	}
+
+	private SearchResponse _search(Class<?>... clazzes) throws Exception {
+		return _searcher.search(
+			_searchRequestBuilderFactory.builder(
+			).companyId(
+				TestPropsValues.getCompanyId()
+			).entryClassNames(
+				TransformUtil.transformToArray(
+					ListUtil.fromArray(clazzes), Class::getName, String.class)
+			).groupIds(
+				_group.getGroupId()
+			).modelIndexerClasses(
+				clazzes
+			).queryString(
+				_fragmentCollection.getName()
+			).withSearchContext(
+				searchContext -> searchContext.setUserId(_user.getUserId())
+			).build());
+	}
+
+	private FragmentCollection _fragmentCollection;
+
+	@Inject
+	private FragmentCollectionLocalService _fragmentCollectionLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject(
+		filter = "indexer.class.name=com.liferay.fragment.model.FragmentCollection"
+	)
+	private Indexer<FragmentCollection> _indexer;
+
+	@Inject
+	private Searcher _searcher;
+
+	@Inject
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+}

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/security/permission/StyleBookDepotRolePermissionsContributor.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/security/permission/StyleBookDepotRolePermissionsContributor.java
@@ -26,15 +26,15 @@ public class StyleBookDepotRolePermissionsContributor
 	public List<DepotRolePermission> getDepotRolePermissions() {
 		return List.of(
 			new DepotRolePermission(
-				DepotRolesConstants.DESIGN_LIBRARY_OWNER,
-				StyleBookConstants.RESOURCE_NAME,
-				StyleBookActionKeys.MANAGE_STYLE_BOOK_ENTRIES),
-			new DepotRolePermission(
 				DepotRolesConstants.DESIGN_LIBRARY_ADMINISTRATOR,
 				StyleBookConstants.RESOURCE_NAME,
 				StyleBookActionKeys.MANAGE_STYLE_BOOK_ENTRIES),
 			new DepotRolePermission(
 				DepotRolesConstants.DESIGN_LIBRARY_CONTENT_REVIEWER,
+				StyleBookConstants.RESOURCE_NAME,
+				StyleBookActionKeys.MANAGE_STYLE_BOOK_ENTRIES),
+			new DepotRolePermission(
+				DepotRolesConstants.DESIGN_LIBRARY_OWNER,
 				StyleBookConstants.RESOURCE_NAME,
 				StyleBookActionKeys.MANAGE_STYLE_BOOK_ENTRIES));
 	}


### PR DESCRIPTION
### Fragment permissions for Design Library roles

We recently added `DepotRolePermissionsContributor`, the SPI that lets each app declare which resource permissions every Design Library role receives. `StyleBookDepotRolePermissionsContributor` was the first implementation: it grants `MANAGE_STYLE_BOOK_ENTRIES` on `com.liferay.style.book` to Design Library Owner, Administrator, and Content Reviewer, so those three roles can edit style books while Design Library Member cannot.

Fragments had no equivalent contributor, so the same three roles could not manage fragments in a Design Library. This adds `FragmentDepotRolePermissionsContributor`, mirroring the style book one: the same three roles, `com.liferay.fragment` as the resource, and `MANAGE_FRAGMENT_ENTRIES` as the action key. Design Library Member is deliberately excluded.

Coverage is a unit test on the contributor plus an assertion in `DepotRolesPortalInstanceLifecycleListenerTest`, which is what proves the component is discovered at instance startup and that its permissions actually reach `ResourcePermissionLocalService`. The fragment assertion was folded into the loop that already covers style books, since the role set is identical.

### Fragment collection searches no longer log a permission error

Granting the Content Reviewer role access to the fragments listing surfaced a pre-existing defect. Any search over `FragmentCollection` by a user who is not a company admin logged:

```
ERROR [SearchPermissionCheckerImpl] com.liferay.fragment.model.FragmentCollection#VIEW
NoSuchResourceActionException: com.liferay.fragment.model.FragmentCollection#VIEW
	at ResourceActionLocalServiceImpl.getResourceAction(...:366)
	at ResourcePermissionLocalServiceImpl.hasResourcePermission(...:1156)
	at SearchPermissionCheckerImpl._getPermissionFilter(...:497)
```

The search layer resolves the `VIEW` resource action whenever an indexer reports itself as permission aware, but fragment collections have no model resource at all — `resource-actions/default.xml` declares only `com.liferay.fragment`, supporting `MANAGE_FRAGMENT_ENTRIES` and `PERMISSIONS`, with no `VIEW`. Company admins never reach that code because the permission filter short circuits on `isCompanyAdmin`, which is why the error stayed hidden until Design Library roles gained access to the listing.

`FragmentCollectionModelSearchConfigurator` now returns `false` from `isPermissionAware()`. It reported `true` only because both inputs to that decision default to true: `ModelSearchConfigurator.isPermissionAware()`, and `IndexerPermissionPostFilterImpl`, which returns `true` whenever a `ModelResourcePermission` is registered for the model. Returning `false` stops the search layer from building a filter it has no data for.

**Runtime behavior is unchanged.** `getPermissionBooleanFilter` already caught the exception, logged it, and returned the filter unmodified, so fragment collection results were never permission filtered to begin with. This removes the log noise and makes the existing behavior explicit.

`FragmentEntry` needs no equivalent change — no `ModelResourcePermission` is registered for it, so its indexer is not permission aware in the first place. This was verified by applying the change there, writing a test, then reverting the change and confirming the test still passed.

`FragmentCollectionSearchPermissionTest` covers three search shapes as a non-admin user — a multi-class `Searcher` request, a single-class one, and `Indexer.search` directly — asserting that `SearchPermissionCheckerImpl` logs no error. All three were confirmed to fail before the fix and pass after it.

If the Fragments team decides fragment collections *should* be permission filtered, this is the commit to revert as part of doing that properly: it would need model resources for the class, a `VIEW` action, `addResources` on create, and an upgrade process to backfill existing rows.

### Test results

**pr-check: PASS** — tested on `93d82b6fff1cd1ab27f0810f4e0329885582f2dd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |


