### PR TITLE
LPD-99753 Default the control panel plid when the site has none

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v1_1_0/PortletPreferencesUpgradeProcess.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v1_1_0/PortletPreferencesUpgradeProcess.java
@@ -108,7 +108,9 @@ public class PortletPreferencesUpgradeProcess extends UpgradeProcess {
 			preparedStatement.setString(1, namespace);
 			preparedStatement.setLong(2, groupId);
 			preparedStatement.setLong(
-				3, _companyControlPanelPlids.get(companyId));
+				3,
+				_companyControlPanelPlids.getOrDefault(
+					companyId, LayoutConstants.DEFAULT_PLID));
 
 			ResultSet resultSet = preparedStatement.executeQuery();
 
@@ -161,9 +163,11 @@ public class PortletPreferencesUpgradeProcess extends UpgradeProcess {
 					List<Long> layoutPortletPreferencesIds = new ArrayList<>();
 
 					long companyControlPanelPlid =
-						_companyControlPanelPlids.get(companyId);
-					long groupControlPanelPlid = _groupControlPanelPlids.get(
-						groupId);
+						_companyControlPanelPlids.getOrDefault(
+							companyId, LayoutConstants.DEFAULT_PLID);
+					long groupControlPanelPlid =
+						_groupControlPanelPlids.getOrDefault(
+							groupId, LayoutConstants.DEFAULT_PLID);
 					long layoutPlid = classPK;
 
 					for (Map.Entry<Long, Long> entry :

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v1_1_0/test/PortletPreferencesUpgradeProcessTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v1_1_0/test/PortletPreferencesUpgradeProcessTest.java
@@ -292,6 +292,38 @@ public class PortletPreferencesUpgradeProcessTest {
 			layout.getPlid(), groupControlPanelPortletPreferences.getPlid());
 	}
 
+	@Test
+	public void testUpgradeWithGroupWithoutControlPanelLayout()
+		throws Exception {
+
+		Layout layout1 = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout controlPanelLayout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		_layoutLocalService.updateType(
+			controlPanelLayout.getPlid(), LayoutConstants.TYPE_CONTROL_PANEL);
+
+		_clonePortletPreferences(
+			controlPanelLayout.getPlid(),
+			_getPortletPreferences(
+				layout1, _addPortletFragmentEntryLink(layout1)));
+
+		Group group2 = GroupTestUtil.addGroup();
+
+		Layout layout2 = LayoutTestUtil.addTypeContentLayout(group2);
+
+		PortletPreferences portletPreferences2 = _getPortletPreferences(
+			layout2, _addPortletFragmentEntryLink(layout2));
+
+		_assertUpgrade();
+
+		portletPreferences2 =
+			_portletPreferencesLocalService.fetchPortletPreferences(
+				portletPreferences2.getPortletPreferencesId());
+
+		Assert.assertEquals(layout2.getPlid(), portletPreferences2.getPlid());
+	}
+
 	private void _addFragmentEntryLink(Layout layout) throws Exception {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99753

## What Is Being Fixed

`PortletPreferencesUpgradeProcess` iterates over every `FragmentEntryLink` row in the database and looks up the control panel plid for each row's company and group. Both lookups assign the result of `Map.get` to a primitive `long`, so a missing entry unboxes `null` and throws a `NullPointerException`. `_groupControlPanelPlids` only contains sites that have a group scoped control panel layout, so any other site with a widget fragment entry link hits this. The surrounding `catch` swallows the exception into `_log.error`, so the upgrade does not fail outright; it silently leaves those portlet preferences unmigrated and logs one error per affected row.

The defect is latent and predates the regression. Commit `4d0719bb3df41` ("LPD-97613 Remove FF") removed `feature.flag.LPD-66359` from `portal.properties` and the `Liferay-Site-Initializer-Feature-Flag` header from both Digital Sales Room site initializers, moving Digital Sales Room to GA. Those initializers now run on every portal instance and create sites that have Document Library widget fragment entry links but no control panel layout, so the null unboxing is reached everywhere. That change is correct and intentional; only the upgrade process needed fixing.

This surfaced as `PortletPreferencesUpgradeProcessTest` failing on the `[master] ci:test:page-management` routine, where all four existing methods fail at once because each asserts the upgrade class logged nothing. Last pass `b4d38dda9d78e`, first fail `dadf51d421ea7`.

## How It Is Being Fixed

All three lookups now use `getOrDefault` with `LayoutConstants.DEFAULT_PLID` as the sentinel. Zero cannot collide with a real plid, because every value in those maps originates from a `Layout` row selected by the process itself, so a site with no control panel layout falls through to "no preferences to migrate" rather than throwing. The third lookup, in `_getPortletPreferencesMap`, carried the same hazard on a `setLong` binding and is fixed alongside the two that produced the reported failure.

The added test builds the condition explicitly, with a second site that has a widget fragment entry link and no control panel layout. This matters because the four existing tests only detected the defect while Digital Sales Room data happened to be present; a control run with that data removed and the fix reverted showed those four passing while the new test still failed.

## PR Check

**pr-check: PASS** — tested on `e7e41b36eef59`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "e7e41b36eef5987f8366dbb38f8a9103db1a0d52"} -->
