### PR TITLE
LPD-99764 Expect IllegalArgumentException for an invalid parent folder

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateFolderResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/DisplayPageTemplateFolderResourceTest.java
@@ -701,7 +701,9 @@ public class DisplayPageTemplateFolderResourceTest
 		throws Exception {
 
 		_assertProblemException(
-			"BAD_REQUEST", null,
+			"BAD_REQUEST",
+			"The parent display page template folder type does not match the " +
+				"display page type",
 			() -> _testPutSiteDisplayPageTemplateFolder(
 				randomDisplayPageTemplateFolder(),
 				RandomTestUtil.randomString()));
@@ -748,8 +750,7 @@ public class DisplayPageTemplateFolderResourceTest
 
 			Problem problem = problemException.getProblem();
 
-			Assert.assertEquals(
-				"UnsupportedOperationException", problem.getType());
+			Assert.assertEquals("IllegalArgumentException", problem.getType());
 		}
 
 		try (SafeCloseable safeCloseable =


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99764

## What Is Being Fixed

`DisplayPageTemplateFolderResourceTest.testPutSiteDisplayPageTemplateFolder` has failed on the `[master] ci:test:page-management` routine since build 335 (2026-07-25):

```
java.lang.AssertionError: expected:<null> but was:<The parent display page template folder type does not match the display page type>
	at ...DisplayPageTemplateFolderResourceTest._assertProblemException(DisplayPageTemplateFolderResourceTest.java:472)
	at ...DisplayPageTemplateFolderResourceTest._testPutSiteDisplayPageTemplateFolderWithParentDisplayPageTemplateFolder(DisplayPageTemplateFolderResourceTest.java:703)
	at ...DisplayPageTemplateFolderResourceTest.testPutSiteDisplayPageTemplateFolder(DisplayPageTemplateFolderResourceTest.java:295)
```

LPD-95007 replaced the bare `UnsupportedOperationException` thrown by `DisplayPageTemplateFolderUtil.getParentLayoutPageTemplateCollectionId` with a message carrying exception, settled as `IllegalArgumentException` in 2bbc3182e30d4. The resulting `Problem` now exposes the validation message as its title and `IllegalArgumentException` as its type, where before it exposed a null title and `UnsupportedOperationException`. LPD-95007 updated `LayoutPageTemplateCollectionLocalServiceTest` and `SegmentsExperienceLocalServiceTest` for the new exceptions but missed this test, which still encoded the old bare exception shape.

## How It Is Being Fixed

The test is outdated rather than the product being wrong, so both stale assertions in `_testPutSiteDisplayPageTemplateFolderWithParentDisplayPageTemplateFolder` move to the documented contract. The first now expects the validation message as the `Problem` title instead of null, and the second expects the `Problem` type `IllegalArgumentException` instead of `UnsupportedOperationException`. The second assertion was latent behind the first, so it would have failed on the next line once the first was fixed. The full class passes locally, 22 tests with the 3 preexisting `@Ignore`s.

## PR Check

**pr-check: PASS** — tested on `c48f81b9259fb0726ee5856ad0e1bb56354e2510`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "c48f81b9259fb0726ee5856ad0e1bb56354e2510"} -->
