### PR TITLE
LPD-99774 Expect the page specification validation messages

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
@@ -1796,7 +1796,8 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 			});
 
 		_assertProblemException(
-			"BAD_REQUEST", null,
+			"BAD_REQUEST",
+			"The page specification is invalid or has not been approved",
 			() -> _postSitePageTemplate(
 				pageTemplate, testGroup.getExternalReferenceCode()));
 
@@ -1816,7 +1817,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 			});
 
 		_assertProblemException(
-			"BAD_REQUEST", null,
+			"BAD_REQUEST", "Exactly one page specification is required",
 			() -> _postSitePageTemplate(
 				pageTemplate, testGroup.getExternalReferenceCode()));
 
@@ -1826,7 +1827,8 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 			() -> new PageSpecification[] {widgetPageSpecification});
 
 		_assertProblemException(
-			"BAD_REQUEST", null,
+			"BAD_REQUEST",
+			"The page specification is invalid or has not been approved",
 			() -> _postSitePageTemplate(
 				pageTemplate, testGroup.getExternalReferenceCode()));
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99774

## What Is Being Fixed

`PageTemplateResourceTest.testPostSitePageTemplate` has failed on the `[master] ci:test:page-management` routine since build 335 (2026-07-25):

```
java.lang.AssertionError: expected:<null> but was:<The page specification is invalid or has not been approved>
	at ...PageTemplateResourceTest._assertProblemException(PageTemplateResourceTest.java:784)
	at ...PageTemplateResourceTest._testPostSitePageTemplateWidgetPageTemplateWithPageSpecifications(PageTemplateResourceTest.java:1798)
	at ...PageTemplateResourceTest._testPostSitePageTemplateWithPageSpecifications(PageTemplateResourceTest.java:1877)
	at ...PageTemplateResourceTest.testPostSitePageTemplate(PageTemplateResourceTest.java:398)
```

LPD-95007 replaced the four bare `UnsupportedOperationException` throws in `PageSpecificationUtil` with message carrying `IllegalArgumentException` throws, so the resulting `Problem` now exposes the validation message as its title where before it exposed a null title. Three assertions in `_testPostSitePageTemplateWidgetPageTemplateWithPageSpecifications` still expected null.

This is the same regression already fixed for `DisplayPageTemplateFolderResourceTest` under LPD-99763.

## How It Is Being Fixed

The test is outdated rather than the product being wrong, so each assertion moves to the message the validation now returns. The widget page template handed a content page specification and the draft widget page specification both land on `The page specification is invalid or has not been approved`, one failing the type guard and the other the approved status check. Supplying the same specification twice trips the arity guard instead, so it expects `Exactly one page specification is required`. Only the first assertion failed today because it aborted the method before the other two ran, which is why all three move together. The full class passes locally, 24 tests with the 1 preexisting `@Ignore`.

## PR Check

**pr-check: PASS** — tested on `6deafa88531f2fe96d00e75af8c670c03c0e5eb1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "6deafa88531f2fe96d00e75af8c670c03c0e5eb1"} -->
