### PR TITLE
LPD-99757 Allow mapping date and time fields to date editables

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-impl/src/main/java/com/liferay/fragment/entry/processor/internal/helper/FragmentEntryProcessorHelperImpl.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-impl/src/main/java/com/liferay/fragment/entry/processor/internal/helper/FragmentEntryProcessorHelperImpl.java
@@ -74,6 +74,8 @@ import java.net.URISyntaxException;
 import java.text.DateFormat;
 import java.text.ParseException;
 
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.time.chrono.IsoChronology;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.FormatStyle;
@@ -623,6 +625,27 @@ public class FragmentEntryProcessorHelperImpl
 
 			return labeledFieldValue.getLabel(
 				fragmentEntryProcessorContext.getLocale());
+		}
+		else if (value instanceof LocalDateTime) {
+			HttpServletRequest httpServletRequest =
+				fragmentEntryProcessorContext.getHttpServletRequest();
+
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)httpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			LocalDateTime localDateTime = (LocalDateTime)value;
+
+			TimeZone timeZone = themeDisplay.getTimeZone();
+
+			ZonedDateTime zonedDateTime = localDateTime.atZone(
+				timeZone.toZoneId());
+
+			return _getDateValue(
+				editableValueJSONObject, Date.from(zonedDateTime.toInstant()),
+				_getShortTimeStylePattern(
+					fragmentEntryProcessorContext.getLocale()),
+				fragmentEntryProcessorContext.getLocale(), timeZone);
 		}
 		else if (value instanceof String) {
 			infoField = infoFieldValue.getInfoField();

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/MappingSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/MappingSelector.js
@@ -77,7 +77,7 @@ function filterFields(
 	return fields.reduce((acc, fieldSet) => {
 		const newFields = fieldSet.fields.filter((field) => {
 			if (fieldType === EDITABLE_TYPES['date-time']) {
-				return field.type === 'date';
+				return field.type === 'date' || field.type === 'date-time';
 			}
 			else if (fieldType === EDITABLE_TYPES.link && filterLinkTypes) {
 				return (

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/mapping.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/mapping.spec.ts
@@ -20,6 +20,7 @@ import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
 import {pageManagementSiteTest} from '../../../fixtures/pageManagementSiteTest';
 import {clickAndExpectToBeHidden} from '../../../utils/clickAndExpectToBeHidden';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
+import {getRandomInt} from '../../../utils/getRandomInt';
 import getRandomString from '../../../utils/getRandomString';
 import addApprovedStructuredContent from '../../../utils/structured-content/addApprovedStructuredContent';
 import getBasicWebContentStructureId from '../../../utils/structured-content/getBasicWebContentStructureId';
@@ -953,5 +954,155 @@ test(
 				.getByLabel('Field', {exact: true})
 				.locator('option:checked')
 		).toHaveText('Fruit Size');
+	}
+);
+
+test(
+	'Allows mapping a date and time field to a date editable',
+	{
+		tag: '@LPD-99757',
+	},
+	async ({apiHelpers, page, pageEditorPage, site}) => {
+
+		// Create an object definition with a date and time field
+
+		const objectDefinitionAPIClient =
+			await apiHelpers.buildRestClient(ObjectDefinitionAPI);
+
+		const objectDefinitionName = 'Event' + getRandomInt();
+
+		const {body: objectDefinition} =
+			await objectDefinitionAPIClient.postObjectDefinition({
+				active: true,
+				label: {
+					en_US: objectDefinitionName,
+				},
+				name: objectDefinitionName,
+				objectFields: [
+					{
+						DBType: 'String',
+						businessType: 'Text',
+						indexed: true,
+						indexedAsKeyword: false,
+						label: {
+							en_US: 'Name',
+						},
+						localized: false,
+						name: 'name',
+						required: false,
+					},
+					{
+						DBType: 'DateTime',
+						businessType: 'DateTime',
+						indexed: true,
+						indexedAsKeyword: false,
+						label: {
+							en_US: 'Date And Time',
+						},
+						localized: false,
+						name: 'dateAndTime',
+						objectFieldSettings: [
+							{
+								name: 'timeStorage',
+								value: 'useInputAsEntered' as unknown as object,
+							},
+						],
+						required: false,
+					},
+				],
+				pluralLabel: {
+					en_US: objectDefinitionName,
+				},
+				scope: 'company',
+				status: {
+					code: 0,
+				},
+				titleObjectFieldName: 'name',
+			});
+
+		apiHelpers.data.push({
+			id: objectDefinition.id,
+			type: 'objectDefinition',
+		});
+
+		// Add an object entry with a date and time value
+
+		const objectEntryName = getRandomString();
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{
+				dateAndTime: '2026-07-28T14:30:00.000Z',
+				name: objectEntryName,
+			},
+			'c/' + objectDefinition.name.toLowerCase() + 's'
+		);
+
+		// Create content page with a date fragment and go to edit mode
+
+		const dateId = getRandomString();
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				getFragmentDefinition({
+					id: dateId,
+					key: 'BASIC_COMPONENT-date',
+				}),
+			]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		// Map the date editable to the date and time field
+
+		await pageEditorPage.selectEditable(dateId, 'element-date');
+
+		await pageEditorPage.setMappingConfiguration({
+			mapping: {
+				entity: objectDefinitionName,
+				entry: objectEntryName,
+				field: 'Date And Time',
+			},
+		});
+
+		// Check the value is rendered with the default format
+
+		const editable = pageEditorPage.getEditable({
+			editableId: 'element-date',
+			fragmentId: dateId,
+		});
+
+		await expect(editable).toContainText('7/28/26');
+
+		await expect(editable).toContainText('2:30 PM');
+
+		// Check the value honors a custom format
+
+		await pageEditorPage.changeEditableConfiguration({
+			editableId: 'element-date',
+			fieldLabel: 'Date Format',
+			fragmentId: dateId,
+			tab: 'Mapping',
+			value: 'custom',
+		});
+
+		await pageEditorPage.changeEditableConfiguration({
+			editableId: 'element-date',
+			fieldLabel: 'Custom Format',
+			fragmentId: dateId,
+			tab: 'Mapping',
+			value: 'yyyy-MM-dd HH:mm',
+		});
+
+		await expect(editable).toHaveText('2026-07-28 14:30');
+
+		// Publish and check the published page
+
+		await pageEditorPage.publishPage();
+
+		await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`);
+
+		await expect(page.getByText('2026-07-28 14:30')).toBeVisible();
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99757

## What Is Being Fixed

The date fragment's editable could only be mapped to info fields of type date, so a CMS/object field such as Display Date never appeared in the Field dropdown. The restriction dates to LPS-161508, which predates the date and time info field type entirely, so it was staleness rather than a deliberate exclusion.

Lifting the restriction alone was not enough. Fields of that type reach the fragment as a LocalDateTime, which matched none of the branches in FragmentEntryProcessorHelperImpl#getFieldValue and fell through to toString, so the value rendered as the raw ISO timestamp 2026-07-28T14:30 and ignored the editable's configured date format.

## How It Is Being Fixed

The field filter in MappingSelector now accepts both date and date-time info fields for a date editable, and getFieldValue gains a LocalDateTime branch that routes the value through the same _getDateValue path the java.util.Date branch already uses, so the editable's date format configuration applies. The conversion uses the theme display time zone for both the instant and the formatting, which preserves the wall clock: the object layer has already applied the field's time storage setting, so converting through any other zone would shift the value a second time.

## PR Check

**pr-check: PASS** — tested on `47d13ce8662b86d7aacc6b0d8fbf2fb95d75085e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "47d13ce8662b86d7aacc6b0d8fbf2fb95d75085e"} -->
