### PR TITLE
LPD-99386 Provide a non-null locale on the layout reindex mock request

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutServiceContextHelperImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutServiceContextHelperImpl.java
@@ -296,6 +296,23 @@ public class LayoutServiceContextHelperImpl
 						return Collections.emptyEnumeration();
 					}
 
+					public Locale getLocale() {
+						ThemeDisplay themeDisplay =
+							(ThemeDisplay)_attributes.get(
+								WebKeys.THEME_DISPLAY);
+
+						if (themeDisplay == null) {
+							return LocaleUtil.getDefault();
+						}
+
+						return themeDisplay.getLocale();
+					}
+
+					public Enumeration<Locale> getLocales() {
+						return Collections.enumeration(
+							Collections.singletonList(getLocale()));
+					}
+
 					public String getMethod() {
 						return HttpMethods.GET;
 					}

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/util/test/LayoutServiceContextHelperTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/util/test/LayoutServiceContextHelperTest.java
@@ -1,0 +1,99 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.util.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.layout.util.LayoutServiceContextHelper;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Georgel Pop
+ */
+@RunWith(Arquillian.class)
+public class LayoutServiceContextHelperTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId());
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	@TestInfo("LPD-99386")
+	public void testGetServiceContextAutoCloseable() throws Exception {
+		try (AutoCloseable autoCloseable =
+				_layoutServiceContextHelper.getServiceContextAutoCloseable(
+					_layout)) {
+
+			ServiceContext serviceContext =
+				ServiceContextThreadLocal.getServiceContext();
+
+			HttpServletRequest httpServletRequest = serviceContext.getRequest();
+
+			Assert.assertNotNull(httpServletRequest.getLocale());
+
+			List<Locale> locales = Collections.list(
+				httpServletRequest.getLocales());
+
+			Assert.assertFalse(locales.isEmpty());
+		}
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Layout _layout;
+
+	@Inject
+	private LayoutServiceContextHelper _layoutServiceContextHelper;
+
+	private ServiceContext _serviceContext;
+
+}

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/util/test/LayoutServiceContextHelperTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/util/test/LayoutServiceContextHelperTest.java
@@ -8,10 +8,12 @@ package com.liferay.layout.util.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.layout.util.LayoutServiceContextHelper;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.servlet.HttpMethods;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -26,6 +28,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -66,7 +69,7 @@ public class LayoutServiceContextHelperTest {
 	}
 
 	@Test
-	@TestInfo("LPD-99386")
+	@TestInfo({"LPD-79722", "LPD-99386"})
 	public void testGetServiceContextAutoCloseable() throws Exception {
 		try (AutoCloseable autoCloseable =
 				_layoutServiceContextHelper.getServiceContextAutoCloseable(
@@ -83,6 +86,21 @@ public class LayoutServiceContextHelperTest {
 				httpServletRequest.getLocales());
 
 			Assert.assertFalse(locales.isEmpty());
+
+			Assert.assertEquals(
+				HttpMethods.GET, httpServletRequest.getMethod());
+			Assert.assertEquals(
+				StringPool.SLASH, httpServletRequest.getRequestURI());
+			Assert.assertEquals("http", httpServletRequest.getScheme());
+			Assert.assertNotNull(httpServletRequest.getContextPath());
+			Assert.assertNotNull(httpServletRequest.getServletContext());
+			Assert.assertNotNull(httpServletRequest.getSession());
+			Assert.assertEquals(0, httpServletRequest.getCookies().length);
+
+			Map<String, String[]> parameterMap =
+				httpServletRequest.getParameterMap();
+
+			Assert.assertTrue(parameterMap.isEmpty());
 		}
 	}
 

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/util/test/LayoutServiceContextHelperTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/util/test/LayoutServiceContextHelperTest.java
@@ -16,23 +16,21 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.servlet.HttpMethods;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
-import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -51,34 +49,27 @@ public class LayoutServiceContextHelperTest {
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
 
-	@Before
-	public void setUp() throws Exception {
-		_group = GroupTestUtil.addGroup();
-
-		_layout = LayoutTestUtil.addTypeContentLayout(_group);
-
-		_serviceContext = ServiceContextTestUtil.getServiceContext(
-			_group.getGroupId());
-
-		ServiceContextThreadLocal.pushServiceContext(_serviceContext);
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		ServiceContextThreadLocal.popServiceContext();
-	}
-
 	@Test
 	@TestInfo({"LPD-79722", "LPD-99386"})
 	public void testGetServiceContextAutoCloseable() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(group);
+
 		try (AutoCloseable autoCloseable =
 				_layoutServiceContextHelper.getServiceContextAutoCloseable(
-					_layout)) {
+					layout)) {
 
 			ServiceContext serviceContext =
 				ServiceContextThreadLocal.getServiceContext();
 
 			HttpServletRequest httpServletRequest = serviceContext.getRequest();
+
+			Assert.assertNotNull(httpServletRequest.getContextPath());
+
+			Cookie[] cookies = httpServletRequest.getCookies();
+
+			Assert.assertEquals(Arrays.toString(cookies), 0, cookies.length);
 
 			Assert.assertNotNull(httpServletRequest.getLocale());
 
@@ -89,29 +80,21 @@ public class LayoutServiceContextHelperTest {
 
 			Assert.assertEquals(
 				HttpMethods.GET, httpServletRequest.getMethod());
-			Assert.assertEquals(
-				StringPool.SLASH, httpServletRequest.getRequestURI());
-			Assert.assertEquals("http", httpServletRequest.getScheme());
-			Assert.assertNotNull(httpServletRequest.getContextPath());
-			Assert.assertNotNull(httpServletRequest.getServletContext());
-			Assert.assertNotNull(httpServletRequest.getSession());
-			Assert.assertEquals(0, httpServletRequest.getCookies().length);
 
 			Map<String, String[]> parameterMap =
 				httpServletRequest.getParameterMap();
 
 			Assert.assertTrue(parameterMap.isEmpty());
+
+			Assert.assertEquals(
+				StringPool.SLASH, httpServletRequest.getRequestURI());
+			Assert.assertEquals("http", httpServletRequest.getScheme());
+			Assert.assertNotNull(httpServletRequest.getServletContext());
+			Assert.assertNotNull(httpServletRequest.getSession());
 		}
 	}
 
-	@DeleteAfterTestRun
-	private Group _group;
-
-	private Layout _layout;
-
 	@Inject
 	private LayoutServiceContextHelper _layoutServiceContextHelper;
-
-	private ServiceContext _serviceContext;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99386

## What Is Being Fixed

During a full reindex, a NullPointerException is logged when a published content page holds a portlet that uses the Portlet 3.0 taglib together with `<portlet:defineObjects />`. Reindexing renders each content page to index its text, and that render runs under a mock HttpServletRequest built by LayoutServiceContextHelperImpl. The mock is a delegate proxy backed by a dummy instance, so every method the delegate does not declare returns null for object return types, and neither getLocale nor getLocales was declared. PortletRequestImpl.getLocales forwards straight to the underlying request with no null guard, and DefineObjectsTag3 calls Collections.list on the result, which throws. Only Portlet 3.0 reaches it, because the 1.0 and 2.0 taglibs map defineObjects to DefineObjectsTag, which never reads locales. The reindex itself completes and no indexed data is affected, so the only symptom is the logged error.

## How It Is Being Fixed

The mock request now implements both locale methods, which is where the servlet contract says the fix belongs, since ServletRequest.getLocale and getLocales must never return null. getLocale returns the theme display's locale, falling back to the portal default for the window before the theme display is set on the request. getLocales returns a single-element enumeration of that locale, matching what a real container returns for a request that carries no Accept-Language header. A single locale is also the right answer for the reindex specifically: LayoutModelDocumentContributor already loops over the site's available locales and LayoutContentProviderImpl sets the theme display locale on each pass, so reading the theme display keeps the mock reporting whichever locale is currently being indexed rather than a fixed list.

An integration test covers the two locale methods along with the rest of the mock request contract.

## PR Check

**pr-check: PASS** — tested on `5bb3f75d211ca850816d907877cf7ef01ca2693e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5bb3f75d211ca850816d907877cf7ef01ca2693e"} -->
