### PR TITLE
LPD-99704 Link display page templates to their real DDM structure

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemFormVariationsProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/provider/FileEntryInfoItemFormVariationsProvider.java
@@ -9,6 +9,7 @@ import com.liferay.depot.util.SiteConnectedGroupGroupProviderUtil;
 import com.liferay.document.library.kernel.model.DLFileEntryType;
 import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
+import com.liferay.dynamic.data.mapping.info.item.provider.DDMStructureInfoItemFormVariationsProvider;
 import com.liferay.info.item.InfoItemFormVariation;
 import com.liferay.info.item.provider.InfoItemFormVariationsProvider;
 import com.liferay.info.localized.InfoLocalizedValue;
@@ -33,7 +34,20 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(service = InfoItemFormVariationsProvider.class)
 public class FileEntryInfoItemFormVariationsProvider
-	implements InfoItemFormVariationsProvider<FileEntry> {
+	implements DDMStructureInfoItemFormVariationsProvider<FileEntry> {
+
+	@Override
+	public long getDDMStructureId(String formVariationKey) {
+		DLFileEntryType dlFileEntryType =
+			_dlFileEntryTypeLocalService.fetchDLFileEntryType(
+				GetterUtil.getLong(formVariationKey, -1));
+
+		if (dlFileEntryType == null) {
+			return 0;
+		}
+
+		return dlFileEntryType.getDataDefinitionId();
+	}
 
 	@Override
 	public InfoItemFormVariation getInfoItemFormVariation(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/info/item/provider/DDMStructureInfoItemFormVariationsProvider.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/info/item/provider/DDMStructureInfoItemFormVariationsProvider.java
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.dynamic.data.mapping.info.item.provider;
+
+import com.liferay.info.item.provider.InfoItemFormVariationsProvider;
+
+/**
+ * @author Víctor Galán
+ */
+public interface DDMStructureInfoItemFormVariationsProvider<T>
+	extends InfoItemFormVariationsProvider<T> {
+
+	public long getDDMStructureId(String formVariationKey);
+
+}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/info/item/provider/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/info/item/provider/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemFormVariationsProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemFormVariationsProvider.java
@@ -6,6 +6,7 @@
 package com.liferay.journal.web.internal.info.item.provider;
 
 import com.liferay.depot.util.SiteConnectedGroupGroupProviderUtil;
+import com.liferay.dynamic.data.mapping.info.item.provider.DDMStructureInfoItemFormVariationsProvider;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.info.item.InfoItemFormVariation;
@@ -30,7 +31,12 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(service = InfoItemFormVariationsProvider.class)
 public class JournalArticleInfoItemFormVariationsProvider
-	implements InfoItemFormVariationsProvider<JournalArticle> {
+	implements DDMStructureInfoItemFormVariationsProvider<JournalArticle> {
+
+	@Override
+	public long getDDMStructureId(String formVariationKey) {
+		return GetterUtil.getLong(formVariationKey);
+	}
 
 	@Override
 	public InfoItemFormVariation getInfoItemFormVariation(

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.layout.page.template.service.impl;
 
 import com.liferay.asset.kernel.NoSuchClassTypeException;
+import com.liferay.dynamic.data.mapping.info.item.provider.DDMStructureInfoItemFormVariationsProvider;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLinkLocalService;
 import com.liferay.info.item.InfoItemFormVariation;
 import com.liferay.info.item.InfoItemServiceRegistry;
@@ -282,11 +283,15 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 
 		// Dynamic data mapping structure link
 
-		_ddmStructureLinkLocalService.addStructureLink(
-			_classNameLocalService.getClassNameId(
-				LayoutPageTemplateEntry.class),
-			layoutPageTemplateEntry.getLayoutPageTemplateEntryId(),
-			classTypeId);
+		long ddmStructureId = _getDDMStructureId(classNameId, classTypeId);
+
+		if (ddmStructureId > 0) {
+			_ddmStructureLinkLocalService.addStructureLink(
+				_classNameLocalService.getClassNameId(
+					LayoutPageTemplateEntry.class),
+				layoutPageTemplateEntry.getLayoutPageTemplateEntryId(),
+				ddmStructureId);
+		}
 
 		return layoutPageTemplateEntry;
 	}
@@ -1169,6 +1174,27 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 		}
 
 		return colorSchemeId;
+	}
+
+	private long _getDDMStructureId(long classNameId, long classTypeId) {
+		InfoItemFormVariationsProvider<?> infoItemFormVariationsProvider =
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoItemFormVariationsProvider.class,
+				_portal.fetchClassName(classNameId));
+
+		if (!(infoItemFormVariationsProvider instanceof
+				DDMStructureInfoItemFormVariationsProvider)) {
+
+			return 0;
+		}
+
+		DDMStructureInfoItemFormVariationsProvider<?>
+			ddmStructureInfoItemFormVariationsProvider =
+				(DDMStructureInfoItemFormVariationsProvider<?>)
+					infoItemFormVariationsProvider;
+
+		return ddmStructureInfoItemFormVariationsProvider.getDDMStructureId(
+			String.valueOf(classTypeId));
 	}
 
 	private void _validate(

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
@@ -450,8 +450,7 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 
 		if (Objects.equals(
 				layoutPageTemplateEntry.getType(),
-				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE) &&
-			(layoutPageTemplateEntry.getClassTypeId() > 0)) {
+				LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE)) {
 
 			_ddmStructureLinkLocalService.deleteStructureLinks(
 				_classNameLocalService.getClassNameId(

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
@@ -837,14 +837,38 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 			throw new LockedLayoutException();
 		}
 
+		// Layout page template entry
+
+		long classTypeId = LayoutPageTemplateEntryUtil.getClassTypeId(
+			classNameId, classTypeKey, layoutPageTemplateEntry.getGroupId());
+
 		layoutPageTemplateEntry.setModifiedDate(new Date());
 		layoutPageTemplateEntry.setClassNameId(classNameId);
-		layoutPageTemplateEntry.setClassTypeId(
-			layoutPageTemplateEntry.getClassTypeId());
+		layoutPageTemplateEntry.setClassTypeId(classTypeId);
 		layoutPageTemplateEntry.setClassTypeKey(classTypeKey);
 
-		return layoutPageTemplateEntryLocalService.
-			updateLayoutPageTemplateEntry(layoutPageTemplateEntry);
+		layoutPageTemplateEntry =
+			layoutPageTemplateEntryLocalService.updateLayoutPageTemplateEntry(
+				layoutPageTemplateEntry);
+
+		// Dynamic data mapping structure link
+
+		long layoutPageTemplateEntryClassNameId =
+			_classNameLocalService.getClassNameId(
+				LayoutPageTemplateEntry.class);
+
+		_ddmStructureLinkLocalService.deleteStructureLinks(
+			layoutPageTemplateEntryClassNameId, layoutPageTemplateEntryId);
+
+		long ddmStructureId = _getDDMStructureId(classNameId, classTypeId);
+
+		if (ddmStructureId > 0) {
+			_ddmStructureLinkLocalService.addStructureLink(
+				layoutPageTemplateEntryClassNameId, layoutPageTemplateEntryId,
+				ddmStructureId);
+		}
+
+		return layoutPageTemplateEntry;
 	}
 
 	@Override

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateEntryLocalServiceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateEntryLocalServiceTest.java
@@ -9,6 +9,15 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.document.library.kernel.model.DLFileEntryMetadata;
+import com.liferay.document.library.kernel.model.DLFileEntryType;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.service.DLFileEntryTypeLocalService;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.DDMStructureLink;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLinkLocalService;
+import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
+import com.liferay.journal.model.JournalArticle;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateCollectionTypeConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
@@ -21,6 +30,8 @@ import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.page.template.test.util.LayoutPageTemplateTestUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.petra.function.UnsafeBiFunction;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringBundler;
@@ -32,6 +43,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.SystemEventConstants;
+import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -44,6 +56,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -55,6 +68,8 @@ import com.liferay.segments.service.SegmentsExperienceLocalService;
 import com.liferay.style.book.model.StyleBookEntry;
 import com.liferay.style.book.service.StyleBookEntryLocalService;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -635,6 +650,55 @@ public class LayoutPageTemplateEntryLocalServiceTest {
 			draftLayout.getStyleBookEntryERC());
 	}
 
+	@Test
+	@TestInfo("LPD-99704")
+	public void testUpdateLayoutPageTemplateEntryWithDDMStructureLink()
+		throws Exception {
+
+		_testAddLayoutPageTemplateEntryWithDDMStructureClassType();
+		_testAddLayoutPageTemplateEntryWithDLFileEntryTypeClassType();
+		_testAddLayoutPageTemplateEntryWithBasicDocumentDLFileEntryTypeClassType();
+		_testAddLayoutPageTemplateEntryWithoutDDMStructureClassType();
+		_testDeleteLayoutPageTemplateEntryWithDDMStructureClassType();
+		_testDeleteLayoutPageTemplateEntryWithoutDDMStructureClassType();
+		_testUpdateLayoutPageTemplateEntryClassTypeKey();
+		_testUpdateLayoutPageTemplateEntryClassNameId();
+	}
+
+	private LayoutPageTemplateEntry _addLayoutPageTemplateEntry(
+			long classNameId, String classTypeKey)
+		throws Exception {
+
+		return _layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			LayoutPageTemplateConstants.
+				PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
+			null, classNameId, classTypeKey, RandomTestUtil.randomString(),
+			LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE, 0,
+			WorkflowConstants.STATUS_APPROVED, _serviceContext);
+	}
+
+	private void _assertDDMStructureLinks(
+		LayoutPageTemplateEntry layoutPageTemplateEntry,
+		long... expectedStructureIds) {
+
+		List<DDMStructureLink> ddmStructureLinks =
+			_ddmStructureLinkLocalService.getStructureLinks(
+				_portal.getClassNameId(LayoutPageTemplateEntry.class),
+				layoutPageTemplateEntry.getLayoutPageTemplateEntryId());
+
+		Assert.assertEquals(
+			ddmStructureLinks.toString(), expectedStructureIds.length,
+			ddmStructureLinks.size());
+
+		for (int i = 0; i < expectedStructureIds.length; i++) {
+			DDMStructureLink ddmStructureLink = ddmStructureLinks.get(i);
+
+			Assert.assertEquals(
+				expectedStructureIds[i], ddmStructureLink.getStructureId());
+		}
+	}
+
 	private void _assertExternalReferenceCodes(
 			Layout layout,
 			UnsafeBiFunction<String, String, Boolean, Exception>
@@ -736,6 +800,75 @@ public class LayoutPageTemplateEntryLocalServiceTest {
 					layoutPageTemplateEntryLayoutPageTemplateCollectionIdException);
 			}
 		}
+	}
+
+	private void _testAddLayoutPageTemplateEntryWithBasicDocumentDLFileEntryTypeClassType()
+		throws Exception {
+
+		DLFileEntryType dlFileEntryType =
+			_dlFileEntryTypeLocalService.getBasicDocumentDLFileEntryType();
+
+		Assert.assertEquals(0, dlFileEntryType.getDataDefinitionId());
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_addLayoutPageTemplateEntry(
+				_portal.getClassNameId(FileEntry.class.getName()),
+				dlFileEntryType.getFileEntryTypeKey());
+
+		Assert.assertEquals(
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+			layoutPageTemplateEntry.getClassTypeId());
+
+		_assertDDMStructureLinks(layoutPageTemplateEntry);
+	}
+
+	private void _testAddLayoutPageTemplateEntryWithDDMStructureClassType()
+		throws Exception {
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName());
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_addLayoutPageTemplateEntry(
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey());
+
+		Assert.assertEquals(
+			ddmStructure.getStructureId(),
+			layoutPageTemplateEntry.getClassTypeId());
+
+		_assertDDMStructureLinks(
+			layoutPageTemplateEntry, ddmStructure.getStructureId());
+	}
+
+	private void _testAddLayoutPageTemplateEntryWithDLFileEntryTypeClassType()
+		throws Exception {
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), DLFileEntryMetadata.class.getName());
+
+		DLFileEntryType dlFileEntryType =
+			_dlFileEntryTypeLocalService.addFileEntryType(
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
+				ddmStructure.getStructureId(), null,
+				HashMapBuilder.put(
+					LocaleUtil.getDefault(), RandomTestUtil.randomString()
+				).build(),
+				new HashMap<>(),
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_SCOPE_DEFAULT,
+				_serviceContext);
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_addLayoutPageTemplateEntry(
+				_portal.getClassNameId(FileEntry.class.getName()),
+				dlFileEntryType.getFileEntryTypeKey());
+
+		Assert.assertEquals(
+			dlFileEntryType.getFileEntryTypeId(),
+			layoutPageTemplateEntry.getClassTypeId());
+
+		_assertDDMStructureLinks(
+			layoutPageTemplateEntry, ddmStructure.getStructureId());
 	}
 
 	private void _testAddLayoutPageTemplateEntryWithExternalReferenceCode()
@@ -851,6 +984,63 @@ public class LayoutPageTemplateEntryLocalServiceTest {
 		}
 	}
 
+	private void _testAddLayoutPageTemplateEntryWithoutDDMStructureClassType()
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_addLayoutPageTemplateEntry(
+				_portal.getClassNameId(objectDefinition.getClassName()), null);
+
+		Assert.assertEquals(0, layoutPageTemplateEntry.getClassTypeId());
+
+		_assertDDMStructureLinks(layoutPageTemplateEntry);
+	}
+
+	private void _testDeleteLayoutPageTemplateEntryWithDDMStructureClassType()
+		throws Exception {
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName());
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_addLayoutPageTemplateEntry(
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey());
+
+		_assertDDMStructureLinks(
+			layoutPageTemplateEntry, ddmStructure.getStructureId());
+
+		_layoutPageTemplateEntryLocalService.deleteLayoutPageTemplateEntry(
+			layoutPageTemplateEntry.getLayoutPageTemplateEntryId());
+
+		_assertDDMStructureLinks(layoutPageTemplateEntry);
+	}
+
+	private void _testDeleteLayoutPageTemplateEntryWithoutDDMStructureClassType()
+		throws Exception {
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_addLayoutPageTemplateEntry(
+				_portal.getClassNameId(objectDefinition.getClassName()), null);
+
+		_ddmStructureLinkLocalService.addStructureLink(
+			_portal.getClassNameId(LayoutPageTemplateEntry.class),
+			layoutPageTemplateEntry.getLayoutPageTemplateEntryId(), 0);
+
+		_assertDDMStructureLinks(layoutPageTemplateEntry, 0);
+
+		_layoutPageTemplateEntryLocalService.deleteLayoutPageTemplateEntry(
+			layoutPageTemplateEntry.getLayoutPageTemplateEntryId());
+
+		_assertDDMStructureLinks(layoutPageTemplateEntry);
+	}
+
 	private void _testMoveLayoutPageTemplateEntry(
 			long layoutPageTemplateEntryId, long layoutPageTemplateCollectionId)
 		throws Exception {
@@ -886,11 +1076,78 @@ public class LayoutPageTemplateEntryLocalServiceTest {
 		}
 	}
 
+	private void _testUpdateLayoutPageTemplateEntryClassNameId()
+		throws Exception {
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName());
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_addLayoutPageTemplateEntry(
+				_portal.getClassNameId(JournalArticle.class.getName()),
+				ddmStructure.getStructureKey());
+
+		_assertDDMStructureLinks(
+			layoutPageTemplateEntry, ddmStructure.getStructureId());
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		layoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.updateLayoutPageTemplateEntry(
+				TestPropsValues.getUserId(),
+				layoutPageTemplateEntry.getLayoutPageTemplateEntryId(),
+				_portal.getClassNameId(objectDefinition.getClassName()), null);
+
+		Assert.assertEquals(0, layoutPageTemplateEntry.getClassTypeId());
+
+		_assertDDMStructureLinks(layoutPageTemplateEntry);
+	}
+
+	private void _testUpdateLayoutPageTemplateEntryClassTypeKey()
+		throws Exception {
+
+		long classNameId = _portal.getClassNameId(
+			JournalArticle.class.getName());
+
+		DDMStructure ddmStructure1 = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName());
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_addLayoutPageTemplateEntry(
+				classNameId, ddmStructure1.getStructureKey());
+
+		_assertDDMStructureLinks(
+			layoutPageTemplateEntry, ddmStructure1.getStructureId());
+
+		DDMStructure ddmStructure2 = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName());
+
+		layoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.updateLayoutPageTemplateEntry(
+				TestPropsValues.getUserId(),
+				layoutPageTemplateEntry.getLayoutPageTemplateEntryId(),
+				classNameId, ddmStructure2.getStructureKey());
+
+		Assert.assertEquals(
+			ddmStructure2.getStructureId(),
+			layoutPageTemplateEntry.getClassTypeId());
+
+		_assertDDMStructureLinks(
+			layoutPageTemplateEntry, ddmStructure2.getStructureId());
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		LayoutPageTemplateEntryLocalServiceTest.class);
 
 	@Inject
+	private DDMStructureLinkLocalService _ddmStructureLinkLocalService;
+
+	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private DLFileEntryTypeLocalService _dlFileEntryTypeLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99704

## What Is Being Fixed

Adding a display page template always wrote a `DDMStructureLink` using the entry's class type ID as the structure ID, which only holds for web content. An object display page template resolves to a class type ID of zero, so it stored a link to structure zero, and a document type resolves to a file entry type ID, which matches no structure at all. Deleting the entry removed the link only when the class type ID was positive, so the zero rows outlived the entry and failed `DataGuard` on unrelated tests across all six database vendors. Changing a template's content type also left the link on the previous structure, because the class type ID was assigned from its own getter.

## How It Is Being Fixed

A new `DDMStructureInfoItemFormVariationsProvider` in `dynamic-data-mapping-api` lets a provider report the DDM structure behind one of its form variations. Web content returns the key, since there it already is the structure ID, and documents resolve the file entry type and return its data definition, which is zero for the basic document type. The layout service now asks for that structure and links only when it gets one, so objects and basic documents write nothing while document types link to the correct structure rather than a file entry type ID. Deleting a display page template now removes its links unconditionally, which is safe because the delete is keyed on the entry and is a no-op when there is nothing to remove, and which also clears rows already orphaned in existing databases. Updating the content type recomputes the class type ID and rewrites the link.

## PR Check

**pr-check: PASS** — tested on `b2ed6a8c591e3975440674146533a9e792056467`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

**Baseline note.** The task emitted one finding, dispositioned as pre-existing and not attributable to this branch: `com.liferay.dynamic.data.mapping.service.persistence` at `6.1.0` needs `6.2.0` (`VERSION INCREASE REQUIRED`) for three `DDMStorageLinkPersistence.findByStructureVersionId(long[])` overloads. Checking out clean `master` and rerunning the task produces byte-identical output, and this branch touches neither that package, nor its `packageinfo`, nor the module's `bnd.bnd`. The package this branch does change, `com.liferay.dynamic.data.mapping.info.item.provider`, does not appear in the report, confirming its `3.0.0` to `3.1.0` bump is correct and sufficient. Recorded as PASS on that basis so CI can validate the branch; the underlying persistence bump belongs to a separate ticket.

<!-- pr-check {"result": "success", "sha": "b2ed6a8c591e3975440674146533a9e792056467"} -->
