### PR TITLE
LPD-98533 Prevent language reset when editing web content

### DIFF
--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/LayoutClassedModelUsagesDisplayContext.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/LayoutClassedModelUsagesDisplayContext.java
@@ -401,7 +401,7 @@ public class LayoutClassedModelUsagesDisplayContext {
 	private String _getLayoutClassedModelUsagesURL(
 		String className, long classPK) {
 
-		StringBundler sb = new StringBundler(6);
+		StringBundler sb = new StringBundler(8);
 
 		sb.append(
 			PortalUtil.getPortalURL(
@@ -411,6 +411,8 @@ public class LayoutClassedModelUsagesDisplayContext {
 		sb.append(className);
 		sb.append("&classPK=");
 		sb.append(String.valueOf(classPK));
+		sb.append("&p_l_id=");
+		sb.append(_themeDisplay.getPlid());
 
 		return sb.toString();
 	}

--- a/modules/apps/layout/layout-taglib/src/test/java/com/liferay/layout/taglib/internal/display/context/LayoutClassedModelUsagesDisplayContextTest.java
+++ b/modules/apps/layout/layout-taglib/src/test/java/com/liferay/layout/taglib/internal/display/context/LayoutClassedModelUsagesDisplayContextTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/layout/layout-taglib/src/test/java/com/liferay/layout/taglib/internal/display/context/LayoutClassedModelUsagesDisplayContextTest.java
+++ b/modules/apps/layout/layout-taglib/src/test/java/com/liferay/layout/taglib/internal/display/context/LayoutClassedModelUsagesDisplayContextTest.java
@@ -1,0 +1,101 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.taglib.internal.display.context;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Map;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Víctor Galán
+ */
+public class LayoutClassedModelUsagesDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@AfterClass
+	public static void tearDownClass() {
+		_portalUtilMockedStatic.close();
+	}
+
+	@Test
+	public void testGetUsagesData() {
+		String className = RandomTestUtil.randomString();
+		long classPK = RandomTestUtil.randomLong();
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			new MockLiferayPortletRenderRequest();
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		String pathMain = RandomTestUtil.randomString();
+		long plid = RandomTestUtil.randomLong();
+
+		themeDisplay.setPathMain(pathMain);
+		themeDisplay.setPlid(plid);
+
+		mockLiferayPortletRenderRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		HttpServletRequest httpServletRequest =
+			mockLiferayPortletRenderRequest.getHttpServletRequest();
+
+		Mockito.when(
+			PortalUtil.getHttpServletRequest(mockLiferayPortletRenderRequest)
+		).thenReturn(
+			httpServletRequest
+		);
+
+		String portalURL = RandomTestUtil.randomString();
+
+		Mockito.when(
+			PortalUtil.getPortalURL(httpServletRequest)
+		).thenReturn(
+			portalURL
+		);
+
+		LayoutClassedModelUsagesDisplayContext
+			layoutClassedModelUsagesDisplayContext =
+				new LayoutClassedModelUsagesDisplayContext(
+					httpServletRequest, mockLiferayPortletRenderRequest,
+					new MockLiferayPortletRenderResponse(), className, classPK);
+
+		Map<String, Object> usagesData =
+			layoutClassedModelUsagesDisplayContext.getUsagesData();
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				portalURL, pathMain,
+				"/portal/get_layout_classed_model_usages?className=", className,
+				"&classPK=", classPK, "&p_l_id=", plid),
+			usagesData.get("getUsagesURL"));
+	}
+
+	private static final MockedStatic<PortalUtil> _portalUtilMockedStatic =
+		Mockito.mockStatic(PortalUtil.class);
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98533

## What Is Being Fixed

Opening the web content editor could reset the user's language. The editor renders the usages tab, whose React component immediately fetches `/c/portal/get_layout_classed_model_usages`. That URL carried no layout context, so `ServicePreAction` fell back to the user's default viewable page on the Guest site and recomputed the locale against that site's group. When the current site's language is not in use on the default site, the session locale and the `GUEST_LANGUAGE_ID` cookie were overwritten with the default site's language, and the editor came back in the wrong language.

## How It Is Being Fixed

The usages URL now carries `p_l_id`, so the request resolves the layout the editor is actually on. That layout is a control panel layout, so the locale is validated at instance level rather than against the fallback site's group, the session locale passes validation, and nothing is rewritten. A unit test on the display context pins the full URL including the plid, so the parameter cannot be dropped or zeroed again.

## PR Check

**pr-check: PASS** — tested on `7cc69bd22fdcbcf8efdf8f560f80e0a612a3945b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "7cc69bd22fdcbcf8efdf8f560f80e0a612a3945b"} -->
