### PR TITLE
LPD-99541 Link the language selector to crawlable localized URLs

### DIFF
--- a/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/UpdateLanguageActionTest.java
+++ b/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/UpdateLanguageActionTest.java
@@ -726,7 +726,8 @@ public class UpdateLanguageActionTest {
 		throws Exception {
 
 		_testGetRedirectWithLayoutFriendlyURL(
-			"/tags/tagname", sourceLocale, _targetLocale, false);
+			"/tags/" + RandomTestUtil.randomString(), sourceLocale,
+			_targetLocale, false);
 	}
 
 	private void _updateLayoutFriendlyURL(String suffix) throws Exception {

--- a/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/UpdateLanguageActionTest.java
+++ b/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/UpdateLanguageActionTest.java
@@ -135,7 +135,7 @@ public class UpdateLanguageActionTest {
 	}
 
 	@Test
-	@TestInfo("LPD-86415")
+	@TestInfo({"LPD-86415", "LPD-99541"})
 	public void testGetRedirect() throws Exception {
 		_testGetRedirectWithControlPanelURL(false);
 		_testGetRedirectWithControlPanelURL(true);
@@ -143,6 +143,9 @@ public class UpdateLanguageActionTest {
 		_testGetRedirectWithFriendlyURL(true);
 		_testGetRedirectWithGroupFriendlyURLWithPortletURLMapping();
 		_testGetRedirectWithLayoutFriendlyURLWithPortletURLMapping();
+		_testGetRedirectWithoutLayoutFriendlyURLWithPortletURLMapping(
+			_sourceLocale);
+		_testGetRedirectWithoutLayoutFriendlyURLWithPortletURLMapping(null);
 		_testGetRedirectWithPortletFriendlyURL(_sourceLocale);
 		_testGetRedirectWithPortletFriendlyURL(null);
 		_testGetRedirectWithPortletURLMapping(_sourceLocale);
@@ -680,6 +683,25 @@ public class UpdateLanguageActionTest {
 				PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
 				_group.getFriendlyURL(), _layout.getFriendlyURL(_targetLocale),
 				"?queryString"),
+			false);
+	}
+
+	private void _testGetRedirectWithoutLayoutFriendlyURLWithPortletURLMapping(
+			Locale sourceLocale)
+		throws Exception {
+
+		String mappingPart = "/tags/" + RandomTestUtil.randomString();
+
+		_testGetRedirect(
+			sourceLocale,
+			StringBundler.concat(
+				PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
+				_group.getFriendlyURL(), mappingPart),
+			_targetLocale,
+			StringBundler.concat(
+				PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
+				_group.getFriendlyURL(), _layout.getFriendlyURL(_targetLocale),
+				mappingPart),
 			false);
 	}
 

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplAlternateURLTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplAlternateURLTest.java
@@ -57,6 +57,7 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PrefsPropsUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.TreeMapBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -427,6 +428,50 @@ public class PortalImplAlternateURLTest {
 			"test.com",
 			Arrays.asList(LocaleUtil.US, LocaleUtil.SPAIN, LocaleUtil.GERMANY),
 			LocaleUtil.SPAIN, LocaleUtil.US, "/en");
+	}
+
+	@Test
+	@TestInfo("LPD-99541")
+	public void testChangeLanguageURLs() throws Exception {
+		TestPropsUtil.set(PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE, "1");
+
+		_group = GroupTestUtil.updateDisplaySettings(
+			_group.getGroupId(), Arrays.asList(LocaleUtil.SPAIN, LocaleUtil.US),
+			LocaleUtil.US);
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(
+			_group.getGroupId(), RandomTestUtil.randomString(), false);
+
+		String canonicalURL = _generateURL(
+			"localhost", StringPool.BLANK, _group.getFriendlyURL(),
+			layout.getFriendlyURL());
+
+		ThemeDisplay themeDisplay = _getThemeDisplay(_group, canonicalURL);
+
+		Map<Locale, String> alternateURLs = _portal.getAlternateURLs(
+			canonicalURL, themeDisplay, layout,
+			SetUtil.fromArray(LocaleUtil.SPAIN, LocaleUtil.US));
+
+		String spanishURL = _generateURL(
+			"localhost", "/es", _group.getFriendlyURL(),
+			layout.getFriendlyURL());
+
+		Assert.assertEquals(canonicalURL, alternateURLs.get(LocaleUtil.US));
+		Assert.assertEquals(spanishURL, alternateURLs.get(LocaleUtil.SPAIN));
+
+		Map<Locale, String> changeLanguageURLs = _portal.getChangeLanguageURLs(
+			canonicalURL, themeDisplay, layout,
+			SetUtil.fromArray(LocaleUtil.SPAIN, LocaleUtil.US));
+
+		String englishChangeLanguageURL = _generateURL(
+			"localhost", "/en", _group.getFriendlyURL(),
+			layout.getFriendlyURL());
+
+		Assert.assertEquals(
+			englishChangeLanguageURL, changeLanguageURLs.get(LocaleUtil.US));
+
+		Assert.assertEquals(
+			spanishURL, changeLanguageURLs.get(LocaleUtil.SPAIN));
 	}
 
 	@Test

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplAlternateURLTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplAlternateURLTest.java
@@ -308,6 +308,33 @@ public class PortalImplAlternateURLTest {
 	}
 
 	@Test
+	@TestInfo("LPD-99541")
+	public void testAlternateURLsWithoutLayoutFriendlyURL() throws Exception {
+		TestPropsUtil.set(PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE, "1");
+
+		_group = GroupTestUtil.updateDisplaySettings(
+			_group.getGroupId(), Arrays.asList(LocaleUtil.SPAIN, LocaleUtil.US),
+			LocaleUtil.US);
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(
+			_group.getGroupId(), RandomTestUtil.randomString(), false);
+
+		String canonicalURL = _generateURL(
+			"localhost", StringPool.BLANK, _group.getFriendlyURL(),
+			StringPool.SLASH);
+
+		Map<Locale, String> alternateURLs = _portal.getAlternateURLs(
+			canonicalURL, _getThemeDisplay(_group, canonicalURL), layout,
+			SetUtil.fromArray(LocaleUtil.SPAIN, LocaleUtil.US));
+
+		String alternateURL = _generateURL(
+			"localhost", "/es", _group.getFriendlyURL(), StringPool.SLASH);
+
+		Assert.assertEquals(canonicalURL, alternateURLs.get(LocaleUtil.US));
+		Assert.assertEquals(alternateURL, alternateURLs.get(LocaleUtil.SPAIN));
+	}
+
+	@Test
 	public void testAlternateURLWithAssetDisplayPageEntry() throws Exception {
 		Collection<Locale> availableLocales = Arrays.asList(
 			LocaleUtil.US, LocaleUtil.SPAIN, LocaleUtil.GERMANY);

--- a/modules/apps/site-navigation/site-navigation-language-web/src/main/resources/com/liferay/site/navigation/language/web/portlet/display/template/dependencies/portlet_display_template_icon_menu.ftl
+++ b/modules/apps/site-navigation/site-navigation-language-web/src/main/resources/com/liferay/site/navigation/language/web/portlet/display/template/dependencies/portlet_display_template_icon_menu.ftl
@@ -35,6 +35,7 @@
 						iconCssClass="inline-item inline-item-before"
 						markupView="lexicon"
 						message=displayName
+						method="get"
 						url=entry.getURL()
 					/>
 				</#if>

--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/LanguageTag.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/LanguageTag.java
@@ -5,7 +5,9 @@
 
 package com.liferay.site.navigation.taglib.servlet.taglib;
 
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -14,6 +16,7 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolverRegistryUtil;
 import com.liferay.portal.kernel.portletdisplaytemplate.PortletDisplayTemplateManagerUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
 import com.liferay.portal.kernel.servlet.taglib.ui.LanguageEntry;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -200,6 +203,24 @@ public class LanguageTag extends IncludeTag {
 		return SKIP_BODY;
 	}
 
+	private String _addMappingPart(String url, String mappingPart) {
+		if (Validator.isNull(mappingPart)) {
+			return url;
+		}
+
+		String queryString = StringPool.BLANK;
+
+		int index = url.indexOf(CharPool.QUESTION);
+
+		if (index != -1) {
+			queryString = url.substring(index);
+
+			url = url.substring(0, index);
+		}
+
+		return url + mappingPart + queryString;
+	}
+
 	private Map<Locale, String> _getChangeLanguageURLs(
 		Layout layout, Collection<Locale> locales, ThemeDisplay themeDisplay) {
 
@@ -215,6 +236,13 @@ public class LanguageTag extends IncludeTag {
 		}
 
 		try {
+			String mappingPart = _getMappingPart(
+				currentCompleteURL, layout, themeDisplay);
+
+			if (mappingPart == null) {
+				return Collections.emptyMap();
+			}
+
 			Map<Locale, String> portalChangeLanguageURLs =
 				PortalUtil.getChangeLanguageURLs(
 					PortalUtil.getCanonicalURL(
@@ -252,7 +280,8 @@ public class LanguageTag extends IncludeTag {
 					}
 				}
 
-				changeLanguageURLs.put(locale, changeLanguageURL);
+				changeLanguageURLs.put(
+					locale, _addMappingPart(changeLanguageURL, mappingPart));
 			}
 
 			return changeLanguageURLs;
@@ -423,6 +452,52 @@ public class LanguageTag extends IncludeTag {
 				WebKeys.THEME_DISPLAY);
 
 		return LanguageUtil.getAvailableLocales(themeDisplay.getSiteGroupId());
+	}
+
+	private String _getMappingPart(
+		String url, Layout layout, ThemeDisplay themeDisplay) {
+
+		String path = url;
+
+		int index = path.indexOf(CharPool.QUESTION);
+
+		if (index != -1) {
+			path = path.substring(0, index);
+		}
+
+		String layoutFriendlyURL = themeDisplay.getLayoutFriendlyURL(layout);
+
+		for (index = path.lastIndexOf(layoutFriendlyURL); index != -1;
+			 index = path.lastIndexOf(layoutFriendlyURL, index - 1)) {
+
+			String mappingPart =
+				PortletLocalServiceUtil.getPortletFriendlyURLMappingPart(
+					path.substring(index + layoutFriendlyURL.length()));
+
+			if (Validator.isNotNull(mappingPart)) {
+				return mappingPart;
+			}
+		}
+
+		Group group = layout.getGroup();
+
+		String groupFriendlyURL = group.getFriendlyURL();
+
+		index = path.indexOf(groupFriendlyURL);
+
+		if (index != -1) {
+			return PortletLocalServiceUtil.getPortletFriendlyURLMappingPart(
+				path.substring(index + groupFriendlyURL.length()));
+		}
+
+		if (Validator.isNotNull(
+				PortletLocalServiceUtil.getPortletFriendlyURLMappingPart(
+					path))) {
+
+			return null;
+		}
+
+		return StringPool.BLANK;
 	}
 
 	private String _getNamespacedName() {

--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/LanguageTag.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/LanguageTag.java
@@ -5,9 +5,13 @@
 
 package com.liferay.site.navigation.taglib.servlet.taglib;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.FriendlyURLResolverRegistryUtil;
 import com.liferay.portal.kernel.portletdisplaytemplate.PortletDisplayTemplateManagerUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.servlet.taglib.ui.LanguageEntry;
@@ -19,6 +23,8 @@ import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.site.navigation.taglib.internal.servlet.ServletContextUtil;
@@ -36,11 +42,14 @@ import jakarta.servlet.jsp.PageContext;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -191,6 +200,76 @@ public class LanguageTag extends IncludeTag {
 		return SKIP_BODY;
 	}
 
+	private Map<Locale, String> _getChangeLanguageURLs(
+		Layout layout, Collection<Locale> locales, ThemeDisplay themeDisplay) {
+
+		if (layout == null) {
+			return Collections.emptyMap();
+		}
+
+		String currentCompleteURL = PortalUtil.getCurrentCompleteURL(
+			getRequest());
+
+		if (_hasRedirectParameter(currentCompleteURL)) {
+			return Collections.emptyMap();
+		}
+
+		try {
+			Map<Locale, String> portalChangeLanguageURLs =
+				PortalUtil.getChangeLanguageURLs(
+					PortalUtil.getCanonicalURL(
+						currentCompleteURL, themeDisplay, layout,
+						!_hasFriendlyURLResolverSeparator(currentCompleteURL),
+						true),
+					themeDisplay, layout, new HashSet<>(locales));
+
+			String portalURL = themeDisplay.getPortalURL();
+
+			NavigableMap<String, String> virtualHostnames =
+				PortalUtil.getVirtualHostnames(themeDisplay.getLayoutSet());
+
+			Map<Locale, String> changeLanguageURLs = new HashMap<>();
+
+			for (Map.Entry<Locale, String> entry :
+					portalChangeLanguageURLs.entrySet()) {
+
+				Locale locale = entry.getKey();
+				String changeLanguageURL = entry.getValue();
+
+				if (changeLanguageURL.startsWith(portalURL)) {
+					changeLanguageURL = changeLanguageURL.substring(
+						portalURL.length());
+				}
+				else {
+					String virtualHostnameLanguageId = virtualHostnames.get(
+						HttpComponentsUtil.getDomain(changeLanguageURL));
+
+					if (!Objects.equals(
+							virtualHostnameLanguageId,
+							LocaleUtil.toLanguageId(locale))) {
+
+						continue;
+					}
+				}
+
+				changeLanguageURLs.put(locale, changeLanguageURL);
+			}
+
+			return changeLanguageURLs;
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					StringBundler.concat(
+						"Unable to build the language selector localized URLs ",
+						"for \"", currentCompleteURL, "\""),
+					exception);
+			}
+
+			return Collections.emptyMap();
+		}
+	}
+
 	private long _getDisplayStyleGroupId() {
 		HttpServletRequest httpServletRequest = getRequest();
 
@@ -273,28 +352,51 @@ public class LanguageTag extends IncludeTag {
 			}
 		}
 
-		Locale currentLocale = null;
+		HttpServletRequest httpServletRequest = getRequest();
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		Locale currentLocale = themeDisplay.getLocale();
 
 		if (Validator.isNotNull(_languageId)) {
 			currentLocale = LocaleUtil.fromLanguageId(_languageId);
 		}
-		else {
-			HttpServletRequest httpServletRequest = getRequest();
 
-			ThemeDisplay themeDisplay =
-				(ThemeDisplay)httpServletRequest.getAttribute(
-					WebKeys.THEME_DISPLAY);
+		boolean useChangeLanguageURLs = false;
 
-			currentLocale = themeDisplay.getLocale();
+		if (Validator.isNull(_formAction) && !themeDisplay.isSignedIn()) {
+			int localePrependFriendlyURLStyle = PrefsPropsUtil.getInteger(
+				themeDisplay.getCompanyId(),
+				PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE);
+
+			if (localePrependFriendlyURLStyle != 0) {
+				useChangeLanguageURLs = true;
+			}
 		}
+
+		Map<Locale, String> changeLanguageURLs = null;
 
 		for (Locale locale : locales) {
 			boolean disabled = false;
 			String url = null;
 
 			if (!LocaleUtil.equals(locale, currentLocale)) {
-				url = HttpComponentsUtil.setParameter(
-					formAction, parameterName, LocaleUtil.toLanguageId(locale));
+				if (useChangeLanguageURLs && (changeLanguageURLs == null)) {
+					changeLanguageURLs = _getChangeLanguageURLs(
+						themeDisplay.getLayout(), locales, themeDisplay);
+				}
+
+				if (changeLanguageURLs != null) {
+					url = changeLanguageURLs.get(locale);
+				}
+
+				if (Validator.isNull(url)) {
+					url = HttpComponentsUtil.setParameter(
+						formAction, parameterName,
+						LocaleUtil.toLanguageId(locale));
+				}
 			}
 			else if (!displayCurrentLocale) {
 				disabled = true;
@@ -349,7 +451,34 @@ public class LanguageTag extends IncludeTag {
 		return name;
 	}
 
+	private boolean _hasFriendlyURLResolverSeparator(String url) {
+		for (String urlSeparator :
+				FriendlyURLResolverRegistryUtil.getURLSeparators()) {
+
+			if (url.contains(urlSeparator)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private boolean _hasRedirectParameter(String url) {
+		for (String parameterName :
+				HttpComponentsUtil.getParameterNames(
+					HttpComponentsUtil.getQueryString(url))) {
+
+			if (parameterName.endsWith("redirect")) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	private static final String _PAGE = "/language/page.jsp";
+
+	private static final Log _log = LogFactoryUtil.getLog(LanguageTag.class);
 
 	private String _ddmTemplateGroupKey;
 	private String _ddmTemplateKey;

--- a/modules/apps/site-navigation/site-navigation-test/build.gradle
+++ b/modules/apps/site-navigation/site-navigation-test/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:knowledge-base:knowledge-base-test-util")
 	testIntegrationImplementation project(":apps:layout:layout-api")
 	testIntegrationImplementation project(":apps:layout:layout-page-template-api")
+	testIntegrationImplementation project(":apps:layout:layout-page-template-test-util")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
 	testIntegrationImplementation project(":apps:object:object-api")
 	testIntegrationImplementation project(":apps:object:object-rest-test-util")

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/taglib/servlet/taglib/test/LanguageTagTest.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/taglib/servlet/taglib/test/LanguageTagTest.java
@@ -1,0 +1,617 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.navigation.taglib.servlet.taglib.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.test.util.DisplayPageTemplateTestUtil;
+import com.liferay.layout.test.util.LayoutFriendlyURLRandomizerBumper;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.model.LayoutTypePortlet;
+import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
+import com.liferay.portal.kernel.servlet.taglib.ui.LanguageEntry;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.TreeMapBuilder;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.site.navigation.taglib.servlet.taglib.LanguageTag;
+
+import jakarta.portlet.PortletPreferences;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockPageContext;
+import org.springframework.mock.web.MockServletContext;
+
+/**
+ * @author Georgel Pop
+ */
+@RunWith(Arquillian.class)
+public class LanguageTagTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		_group = GroupTestUtil.updateDisplaySettings(
+			group.getGroupId(), Arrays.asList(LocaleUtil.FRANCE, LocaleUtil.US),
+			LocaleUtil.US);
+	}
+
+	@Test
+	@TestInfo("LPD-99541")
+	public void testGetLanguageEntries() throws Exception {
+		Layout layout = _addLayout();
+
+		_testGetLanguageEntriesWhenSignedIn(layout);
+		_testGetLanguageEntriesWithAnotherLocaleFriendlyURL(layout);
+		_testGetLanguageEntriesWithDefaultPageMappingPart(layout);
+
+		_testGetLanguageEntriesWithDisplayPage();
+
+		_testGetLanguageEntriesWithFormAction(layout);
+		_testGetLanguageEntriesWithLocalePrependFriendlyURLStyle(layout, 2);
+		_testGetLanguageEntriesWithLocalePrependFriendlyURLStyle(layout, 3);
+		_testGetLanguageEntriesWithLocalizedVirtualHostname(layout);
+		_testGetLanguageEntriesWithMappingPart(layout);
+
+		_testGetLanguageEntriesWithoutLayout();
+
+		_testGetLanguageEntriesWithoutLocalePrependFriendlyURLStyle(layout);
+		_testGetLanguageEntriesWithRedirectParameter(layout);
+		_testGetLanguageEntriesWithVirtualHostname(layout);
+	}
+
+	private Layout _addLayout() throws Exception {
+		return LayoutTestUtil.addTypePortletLayout(
+			_group.getGroupId(), false,
+			HashMapBuilder.put(
+				LocaleUtil.FRANCE, RandomTestUtil.randomString()
+			).put(
+				LocaleUtil.US, RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.FRANCE,
+				StringPool.SLASH + RandomTestUtil.randomString()
+			).put(
+				LocaleUtil.US, StringPool.SLASH + RandomTestUtil.randomString()
+			).build());
+	}
+
+	private void _assertLocalizedURL(
+		String url, Layout layout, Locale locale, String suffix) {
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				StringPool.SLASH, locale.getLanguage(),
+				PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
+				_group.getFriendlyURL(), layout.getFriendlyURL(locale), suffix),
+			url);
+	}
+
+	private List<LanguageEntry> _getLanguageEntries(ThemeDisplay themeDisplay) {
+		return _getLanguageEntries(themeDisplay, null);
+	}
+
+	private List<LanguageEntry> _getLanguageEntries(
+		ThemeDisplay themeDisplay, String formAction) {
+
+		return _getLanguageEntries(themeDisplay, formAction, StringPool.BLANK);
+	}
+
+	private List<LanguageEntry> _getLanguageEntries(
+		ThemeDisplay themeDisplay, String formAction, String currentURLSuffix) {
+
+		Layout layout = themeDisplay.getLayout();
+
+		String currentCompleteURL = null;
+
+		if (layout != null) {
+			currentCompleteURL = StringBundler.concat(
+				themeDisplay.getPortalURL(),
+				PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
+				_group.getFriendlyURL(),
+				layout.getFriendlyURL(themeDisplay.getLocale()),
+				currentURLSuffix);
+		}
+
+		return _getLanguageEntriesForURL(
+			themeDisplay, formAction, currentCompleteURL);
+	}
+
+	private List<LanguageEntry> _getLanguageEntriesForURL(
+		ThemeDisplay themeDisplay, String formAction,
+		String currentCompleteURL) {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		Layout layout = themeDisplay.getLayout();
+
+		if (layout != null) {
+			mockHttpServletRequest.setAttribute(
+				WebKeys.CURRENT_COMPLETE_URL, currentCompleteURL);
+			mockHttpServletRequest.setAttribute(WebKeys.LAYOUT, layout);
+		}
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		themeDisplay.setRequest(mockHttpServletRequest);
+
+		LanguageTag languageTag = new LanguageTag();
+
+		languageTag.setPageContext(
+			new MockPageContext(
+				new MockServletContext(), mockHttpServletRequest));
+
+		if (formAction != null) {
+			languageTag.setFormAction(formAction);
+		}
+
+		return ReflectionTestUtil.invoke(
+			languageTag, "_getLanguageEntries",
+			new Class<?>[] {
+				Collection.class, boolean.class, String.class, String.class
+			},
+			Arrays.asList(LocaleUtil.FRANCE, LocaleUtil.US), true,
+			(formAction == null) ? _UPDATE_LANGUAGE_PATH : formAction,
+			"languageId");
+	}
+
+	private String _getLocalePrependFriendlyURLStyle() throws Exception {
+		PortletPreferences portletPreferences = PrefsPropsUtil.getPreferences(
+			_group.getCompanyId());
+
+		return portletPreferences.getValue(
+			PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE,
+			String.valueOf(PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE));
+	}
+
+	private String _getRandomFriendlyURL() {
+		return _friendlyURLNormalizer.normalize(
+			RandomTestUtil.randomString(
+				LayoutFriendlyURLRandomizerBumper.INSTANCE));
+	}
+
+	private ThemeDisplay _getThemeDisplay(Layout layout, Locale locale)
+		throws Exception {
+
+		Company company = CompanyLocalServiceUtil.getCompany(
+			_group.getCompanyId());
+
+		return _getThemeDisplay(
+			layout, locale, company.getPortalURL(_group.getGroupId()));
+	}
+
+	private ThemeDisplay _getThemeDisplay(
+			Layout layout, Locale locale, String portalURL)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		Company company = CompanyLocalServiceUtil.getCompany(
+			_group.getCompanyId());
+
+		LayoutSet layoutSet = layout.getLayoutSet();
+
+		themeDisplay.setCompany(company);
+		themeDisplay.setLanguageId(LocaleUtil.toLanguageId(locale));
+		themeDisplay.setLayout(layout);
+		themeDisplay.setLayoutSet(layoutSet);
+		themeDisplay.setLayoutTypePortlet(
+			(LayoutTypePortlet)layout.getLayoutType());
+		themeDisplay.setLocale(locale);
+		themeDisplay.setLookAndFeel(
+			layoutSet.getTheme(), layoutSet.getColorScheme());
+		themeDisplay.setPlid(layout.getPlid());
+		themeDisplay.setPortalDomain(HttpComponentsUtil.getDomain(portalURL));
+		themeDisplay.setPortalURL(portalURL);
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+		themeDisplay.setServerPort(PortalUtil.getPortalServerPort(false));
+		themeDisplay.setSiteGroupId(_group.getGroupId());
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		return themeDisplay;
+	}
+
+	private String _getURL(List<LanguageEntry> languageEntries, Locale locale) {
+		for (LanguageEntry languageEntry : languageEntries) {
+			if (LocaleUtil.equals(languageEntry.getLocale(), locale)) {
+				return languageEntry.getURL();
+			}
+		}
+
+		return null;
+	}
+
+	private void _setLocalePrependFriendlyURLStyle(
+			String localePrependFriendlyURLStyle)
+		throws Exception {
+
+		PortletPreferences portletPreferences = PrefsPropsUtil.getPreferences(
+			_group.getCompanyId());
+
+		portletPreferences.setValue(
+			PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE,
+			localePrependFriendlyURLStyle);
+
+		portletPreferences.store();
+	}
+
+	private void _testGetLanguageEntriesWhenSignedIn(Layout layout)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = _getThemeDisplay(layout, LocaleUtil.US);
+
+		themeDisplay.setSignedIn(true);
+
+		Assert.assertEquals(
+			_UPDATE_LANGUAGE_PATH + "?languageId=fr_FR",
+			_getURL(_getLanguageEntries(themeDisplay), LocaleUtil.FRANCE));
+	}
+
+	private void _testGetLanguageEntriesWithAnotherLocaleFriendlyURL(
+			Layout layout)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = _getThemeDisplay(layout, LocaleUtil.US);
+
+		_assertLocalizedURL(
+			_getURL(
+				_getLanguageEntriesForURL(
+					themeDisplay, null,
+					StringBundler.concat(
+						themeDisplay.getPortalURL(),
+						PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
+						_group.getFriendlyURL(),
+						layout.getFriendlyURL(LocaleUtil.FRANCE))),
+				LocaleUtil.FRANCE),
+			layout, LocaleUtil.FRANCE, StringPool.BLANK);
+
+		_assertLocalizedURL(
+			_getURL(
+				_getLanguageEntriesForURL(
+					themeDisplay, null,
+					StringBundler.concat(
+						themeDisplay.getPortalURL(),
+						PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
+						_group.getFriendlyURL(),
+						layout.getFriendlyURL(LocaleUtil.FRANCE),
+						_FRIENDLY_URL_MAPPING_PART)),
+				LocaleUtil.FRANCE),
+			layout, LocaleUtil.FRANCE, _FRIENDLY_URL_MAPPING_PART);
+	}
+
+	private void _testGetLanguageEntriesWithDefaultPageMappingPart(
+			Layout layout)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = _getThemeDisplay(layout, LocaleUtil.US);
+
+		_assertLocalizedURL(
+			_getURL(
+				_getLanguageEntriesForURL(
+					themeDisplay, null,
+					StringBundler.concat(
+						themeDisplay.getPortalURL(),
+						PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
+						_group.getFriendlyURL(), _FRIENDLY_URL_MAPPING_PART)),
+				LocaleUtil.FRANCE),
+			layout, LocaleUtil.FRANCE, _FRIENDLY_URL_MAPPING_PART);
+	}
+
+	private void _testGetLanguageEntriesWithDisplayPage() throws Exception {
+		Map<Locale, String> friendlyURLMap = HashMapBuilder.put(
+			LocaleUtil.FRANCE, _getRandomFriendlyURL()
+		).put(
+			LocaleUtil.US, _getRandomFriendlyURL()
+		).build();
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			RandomTestUtil.randomString(), _group.getGroupId(), 0,
+			PortalUtil.getClassNameId(JournalArticle.class), null, true,
+			HashMapBuilder.put(
+				LocaleUtil.FRANCE, RandomTestUtil.randomString()
+			).put(
+				LocaleUtil.US, RandomTestUtil.randomString()
+			).build(),
+			null, friendlyURLMap,
+			HashMapBuilder.put(
+				LocaleUtil.FRANCE, RandomTestUtil.randomString()
+			).put(
+				LocaleUtil.US, RandomTestUtil.randomString()
+			).build(),
+			null, LocaleUtil.US, null, null, false, true,
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId()));
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			DisplayPageTemplateTestUtil.addDisplayPageTemplate(
+				_group.getGroupId(),
+				PortalUtil.getClassNameId(JournalArticle.class),
+				journalArticle.getDDMStructureKey(), true,
+				WorkflowConstants.STATUS_APPROVED);
+
+		ThemeDisplay themeDisplay = _getThemeDisplay(
+			LayoutLocalServiceUtil.getLayout(layoutPageTemplateEntry.getPlid()),
+			LocaleUtil.US);
+
+		String frenchURL = _getURL(
+			_getLanguageEntriesForURL(
+				themeDisplay, null,
+				StringBundler.concat(
+					themeDisplay.getPortalURL(),
+					PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
+					_group.getFriendlyURL(),
+					FriendlyURLResolverConstants.URL_SEPARATOR_JOURNAL_ARTICLE,
+					friendlyURLMap.get(LocaleUtil.US))),
+			LocaleUtil.FRANCE);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"/fr", PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
+				_group.getFriendlyURL(),
+				FriendlyURLResolverConstants.URL_SEPARATOR_JOURNAL_ARTICLE,
+				friendlyURLMap.get(LocaleUtil.FRANCE)),
+			frenchURL);
+	}
+
+	private void _testGetLanguageEntriesWithFormAction(Layout layout)
+		throws Exception {
+
+		Assert.assertEquals(
+			_FORM_ACTION + "?languageId=fr_FR",
+			_getURL(
+				_getLanguageEntries(
+					_getThemeDisplay(layout, LocaleUtil.US), _FORM_ACTION),
+				LocaleUtil.FRANCE));
+	}
+
+	private void _testGetLanguageEntriesWithLocalePrependFriendlyURLStyle(
+			Layout layout, int localePrependFriendlyURLStyle)
+		throws Exception {
+
+		String localePrependFriendlyURLStyleValue =
+			_getLocalePrependFriendlyURLStyle();
+
+		try {
+			_setLocalePrependFriendlyURLStyle(
+				String.valueOf(localePrependFriendlyURLStyle));
+
+			_assertLocalizedURL(
+				_getURL(
+					_getLanguageEntries(
+						_getThemeDisplay(layout, LocaleUtil.US)),
+					LocaleUtil.FRANCE),
+				layout, LocaleUtil.FRANCE, StringPool.BLANK);
+
+			_assertLocalizedURL(
+				_getURL(
+					_getLanguageEntries(
+						_getThemeDisplay(layout, LocaleUtil.FRANCE)),
+					LocaleUtil.US),
+				layout, LocaleUtil.US, StringPool.BLANK);
+		}
+		finally {
+			_setLocalePrependFriendlyURLStyle(
+				localePrependFriendlyURLStyleValue);
+		}
+	}
+
+	private void _testGetLanguageEntriesWithLocalizedVirtualHostname(
+			Layout layout)
+		throws Exception {
+
+		LayoutSet layoutSet = layout.getLayoutSet();
+
+		layoutSet.setVirtualHostnames(
+			TreeMapBuilder.put(
+				_VIRTUAL_HOSTNAME, StringPool.BLANK
+			).put(
+				_VIRTUAL_HOSTNAME_FRENCH,
+				LocaleUtil.toLanguageId(LocaleUtil.FRANCE)
+			).build());
+
+		try {
+			Assert.assertEquals(
+				StringBundler.concat(
+					"http://", _VIRTUAL_HOSTNAME_FRENCH, StringPool.COLON,
+					PortalUtil.getPortalServerPort(false), "/fr",
+					layout.getFriendlyURL(LocaleUtil.FRANCE)),
+				_getURL(
+					_getLanguageEntries(
+						_getThemeDisplay(layout, LocaleUtil.US)),
+					LocaleUtil.FRANCE));
+		}
+		finally {
+			layoutSet.setVirtualHostnames(new TreeMap<>());
+		}
+	}
+
+	private void _testGetLanguageEntriesWithMappingPart(Layout layout)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = _getThemeDisplay(layout, LocaleUtil.US);
+
+		_assertLocalizedURL(
+			_getURL(
+				_getLanguageEntries(
+					themeDisplay, null, _FRIENDLY_URL_MAPPING_PART),
+				LocaleUtil.FRANCE),
+			layout, LocaleUtil.FRANCE, _FRIENDLY_URL_MAPPING_PART);
+
+		_assertLocalizedURL(
+			_getURL(
+				_getLanguageEntries(
+					themeDisplay, null,
+					_FRIENDLY_URL_MAPPING_PART + "?foo=bar"),
+				LocaleUtil.FRANCE),
+			layout, LocaleUtil.FRANCE, _FRIENDLY_URL_MAPPING_PART + "?foo=bar");
+
+		_assertLocalizedURL(
+			_getURL(
+				_getLanguageEntries(themeDisplay, null, "/tags/new%20york"),
+				LocaleUtil.FRANCE),
+			layout, LocaleUtil.FRANCE, "/tags/new%20york");
+
+		_assertLocalizedURL(
+			_getURL(
+				_getLanguageEntries(themeDisplay, null, "/tags"),
+				LocaleUtil.FRANCE),
+			layout, LocaleUtil.FRANCE, "/tags");
+
+		_assertLocalizedURL(
+			_getURL(
+				_getLanguageEntries(themeDisplay, null, "/-/blogs/blog-1"),
+				LocaleUtil.FRANCE),
+			layout, LocaleUtil.FRANCE, "/-/blogs/blog-1");
+	}
+
+	private void _testGetLanguageEntriesWithoutLayout() throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			CompanyLocalServiceUtil.getCompany(_group.getCompanyId()));
+		themeDisplay.setLocale(LocaleUtil.US);
+
+		Assert.assertEquals(
+			_UPDATE_LANGUAGE_PATH + "?languageId=fr_FR",
+			_getURL(_getLanguageEntries(themeDisplay), LocaleUtil.FRANCE));
+	}
+
+	private void _testGetLanguageEntriesWithoutLocalePrependFriendlyURLStyle(
+			Layout layout)
+		throws Exception {
+
+		String localePrependFriendlyURLStyleValue =
+			_getLocalePrependFriendlyURLStyle();
+
+		try {
+			_setLocalePrependFriendlyURLStyle("0");
+
+			Assert.assertEquals(
+				_UPDATE_LANGUAGE_PATH + "?languageId=fr_FR",
+				_getURL(
+					_getLanguageEntries(
+						_getThemeDisplay(layout, LocaleUtil.US)),
+					LocaleUtil.FRANCE));
+			Assert.assertEquals(
+				_UPDATE_LANGUAGE_PATH + "?languageId=en_US",
+				_getURL(
+					_getLanguageEntries(
+						_getThemeDisplay(layout, LocaleUtil.FRANCE)),
+					LocaleUtil.US));
+		}
+		finally {
+			_setLocalePrependFriendlyURLStyle(
+				localePrependFriendlyURLStyleValue);
+		}
+	}
+
+	private void _testGetLanguageEntriesWithRedirectParameter(Layout layout)
+		throws Exception {
+
+		Assert.assertEquals(
+			_UPDATE_LANGUAGE_PATH + "?languageId=fr_FR",
+			_getURL(
+				_getLanguageEntries(
+					_getThemeDisplay(layout, LocaleUtil.US), null,
+					"?redirect=" + RandomTestUtil.randomString()),
+				LocaleUtil.FRANCE));
+	}
+
+	private void _testGetLanguageEntriesWithVirtualHostname(Layout layout)
+		throws Exception {
+
+		LayoutSet layoutSet = layout.getLayoutSet();
+
+		layoutSet.setVirtualHostnames(
+			TreeMapBuilder.put(
+				_VIRTUAL_HOSTNAME, StringPool.BLANK
+			).build());
+
+		try {
+			Company company = CompanyLocalServiceUtil.getCompany(
+				_group.getCompanyId());
+
+			Assert.assertEquals(
+				_UPDATE_LANGUAGE_PATH + "?languageId=fr_FR",
+				_getURL(
+					_getLanguageEntries(
+						_getThemeDisplay(
+							layout, LocaleUtil.US, company.getPortalURL(0))),
+					LocaleUtil.FRANCE));
+		}
+		finally {
+			layoutSet.setVirtualHostnames(new TreeMap<>());
+		}
+	}
+
+	private static final String _FORM_ACTION = "/custom/view";
+
+	private static final String _FRIENDLY_URL_MAPPING_PART = "/tags/mytag";
+
+	private static final String _UPDATE_LANGUAGE_PATH =
+		"/c/portal/update_language";
+
+	private static final String _VIRTUAL_HOSTNAME = "mysite.com";
+
+	private static final String _VIRTUAL_HOSTNAME_FRENCH = "fr.mysite.com";
+
+	@Inject
+	private FriendlyURLNormalizer _friendlyURLNormalizer;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 131.0.1
+Bundle-Version: 131.1.0
 CPE-Name: ${cpe.name}
 Export-Package:\
 	com.liferay.portal.bean,\

--- a/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
+++ b/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
@@ -15,7 +15,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.VirtualLayoutConstants;
-import com.liferay.portal.kernel.portlet.FriendlyURLMapper;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolverRegistryUtil;
 import com.liferay.portal.kernel.portlet.LayoutFriendlyURLSeparatorComposite;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
@@ -39,7 +38,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
-import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
@@ -208,34 +206,24 @@ public class UpdateLanguageAction implements Action {
 		}
 
 		if (currentLayoutFriendlyURLIndex != -1) {
-			int fromIndex =
-				currentLayoutFriendlyURLIndex +
-					currentLayoutFriendlyURL.length();
+			mappingPart =
+				PortletLocalServiceUtil.getPortletFriendlyURLMappingPart(
+					layoutURL.substring(
+						currentLayoutFriendlyURLIndex +
+							currentLayoutFriendlyURL.length()));
+		}
+		else {
+			Group group = layout.getGroup();
 
-			List<FriendlyURLMapper> friendlyURLMappers =
-				PortletLocalServiceUtil.getFriendlyURLMappers();
+			String groupFriendlyURL = group.getFriendlyURL();
 
-			for (FriendlyURLMapper friendlyURLMapper : friendlyURLMappers) {
-				if (friendlyURLMapper.isCheckMappingWithPrefix()) {
-					continue;
-				}
+			int groupFriendlyURLIndex = layoutURL.indexOf(groupFriendlyURL);
 
-				String mappingPath =
-					StringPool.SLASH + friendlyURLMapper.getMapping();
-
-				int mappingIndex = layoutURL.indexOf(mappingPath, fromIndex);
-
-				if (mappingIndex == -1) {
-					continue;
-				}
-
-				int mappingEndIndex = mappingIndex + mappingPath.length();
-
-				if ((mappingEndIndex == layoutURL.length()) ||
-					(layoutURL.charAt(mappingEndIndex) == CharPool.SLASH)) {
-
-					mappingPart = layoutURL.substring(mappingIndex);
-				}
+			if (groupFriendlyURLIndex != -1) {
+				mappingPart =
+					PortletLocalServiceUtil.getPortletFriendlyURLMappingPart(
+						layoutURL.substring(
+							groupFriendlyURLIndex + groupFriendlyURL.length()));
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -898,6 +898,30 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 	@Override
 	@Transactional(enabled = false)
+	public String getPortletFriendlyURLMappingPart(String url) {
+		if (Validator.isNull(url)) {
+			return StringPool.BLANK;
+		}
+
+		PortletFriendlyURLMapperMatch portletFriendlyURLMapperMatch =
+			getPortletFriendlyURLMapperMatch(url);
+
+		if (portletFriendlyURLMapperMatch == null) {
+			return StringPool.BLANK;
+		}
+
+		FriendlyURLMapper friendlyURLMapper =
+			portletFriendlyURLMapperMatch.getFriendlyURLMapper();
+
+		if (friendlyURLMapper.isCheckMappingWithPrefix()) {
+			return StringPool.BLANK;
+		}
+
+		return url.substring(portletFriendlyURLMapperMatch.getPosition());
+	}
+
+	@Override
+	@Transactional(enabled = false)
 	public List<Portlet> getPortlets() {
 		return ListUtil.fromMapValues(_portletsMap);
 	}

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -7509,6 +7509,10 @@ public class PortalImpl implements Portal {
 				alternateURL = canonicalURLPrefix.concat(alternateURLSuffix);
 			}
 
+			if (Validator.isNull(alternateURLSuffix)) {
+				alternateURLSuffix = canonicalURLSuffix;
+			}
+
 			String i18NPath = _buildI18NPath(
 				languageId, locale, themeDisplay.getSiteGroup());
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1213,258 +1213,8 @@ public class PortalImpl implements Portal {
 			Set<Locale> availableLocales)
 		throws PortalException {
 
-		Map<Locale, String> alternateURLs = new HashMap<>();
-
-		String defaultVirtualHostname = _getDefaultVirtualHostname(
-			themeDisplay.getCompany());
-		String portalDomain = themeDisplay.getPortalDomain();
-
-		NavigableMap<String, String> virtualHostnames = getVirtualHostnames(
-			themeDisplay.getLayoutSet());
-
-		String virtualHostname = _getVirtualHostname(themeDisplay);
-
-		if ((!Validator.isBlank(portalDomain) &&
-			 !StringUtil.equalsIgnoreCase(
-				 portalDomain, defaultVirtualHostname) &&
-			 StringUtil.equalsIgnoreCase(
-				 virtualHostname, defaultVirtualHostname)) ||
-			virtualHostnames.containsKey(portalDomain)) {
-
-			virtualHostname = portalDomain;
-		}
-
-		if (Validator.isNull(virtualHostname)) {
-			for (Locale locale : availableLocales) {
-				String i18nPath = _buildI18NPath(
-					locale, themeDisplay.getSiteGroup());
-
-				alternateURLs.put(
-					locale,
-					canonicalURL.replaceFirst(
-						_PUBLIC_GROUP_SERVLET_MAPPING,
-						i18nPath.concat(_PUBLIC_GROUP_SERVLET_MAPPING)));
-			}
-
-			return _getAlternateURLsMap(
-				alternateURLs, portalDomain, virtualHostnames);
-		}
-
-		// www.liferay.com:8080/ctx/page to www.liferay.com:8080/ctx/es/page
-
-		int pos = canonicalURL.indexOf(virtualHostname);
-
-		if (pos < 0) {
-			pos = canonicalURL.indexOf(portalDomain);
-			virtualHostname = portalDomain;
-		}
-
-		if (pos > 0) {
-			pos = canonicalURL.indexOf(
-				CharPool.SLASH, pos + virtualHostname.length());
-
-			if (Validator.isNotNull(_pathContext)) {
-				pos = canonicalURL.indexOf(
-					CharPool.SLASH, pos + _pathContext.length());
-			}
-		}
-
-		Locale siteDefaultLocale = getSiteDefaultLocale(layout.getGroupId());
-
-		int localePrependFriendlyURLStyle = PrefsPropsUtil.getInteger(
-			themeDisplay.getCompanyId(),
-			PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE);
-
-		if ((pos <= 0) || (pos >= canonicalURL.length())) {
-			for (Locale locale : availableLocales) {
-				if ((localePrependFriendlyURLStyle == 0) ||
-					((localePrependFriendlyURLStyle != 2) &&
-					 siteDefaultLocale.equals(locale))) {
-
-					alternateURLs.put(locale, canonicalURL);
-				}
-				else {
-					alternateURLs.put(
-						locale,
-						StringBundler.concat(
-							canonicalURL,
-							_buildI18NPath(locale, themeDisplay.getSiteGroup()),
-							StringPool.SLASH));
-				}
-			}
-
-			return _getAlternateURLsMap(
-				alternateURLs, virtualHostname, virtualHostnames);
-		}
-
-		boolean replaceFriendlyURL = true;
-
-		String currentURL = canonicalURL.substring(pos);
-
-		String siteDefaultLocaleI18nPath = _buildI18NPath(
-			siteDefaultLocale, layout.getGroup());
-
-		if (currentURL.startsWith(
-				siteDefaultLocaleI18nPath + StringPool.SLASH)) {
-
-			currentURL = currentURL.substring(
-				siteDefaultLocaleI18nPath.length());
-		}
-
-		int[] groupFriendlyURLIndex = getGroupFriendlyURLIndex(currentURL);
-
-		if (groupFriendlyURLIndex != null) {
-			int y = groupFriendlyURLIndex[1];
-
-			currentURL = currentURL.substring(y);
-
-			if (currentURL.equals(StringPool.SLASH)) {
-				replaceFriendlyURL = false;
-			}
-		}
-
-		List<LayoutFriendlyURL> layoutFriendlyURLs = null;
-
-		String groupFriendlyURLPrefix = null;
-
-		if (replaceFriendlyURL) {
-			layoutFriendlyURLs =
-				LayoutFriendlyURLLocalServiceUtil.getLayoutFriendlyURLs(
-					layout.getPlid());
-
-			if (layout instanceof VirtualLayout) {
-				VirtualLayout virtualLayout = (VirtualLayout)layout;
-
-				layout = virtualLayout.getSourceLayout();
-
-				Group group = layout.getGroup();
-
-				groupFriendlyURLPrefix =
-					VirtualLayoutConstants.CANONICAL_URL_SEPARATOR.concat(
-						group.getFriendlyURL());
-			}
-		}
-
-		String canonicalURLPrefix = canonicalURL.substring(0, pos);
-
-		String canonicalURLSuffix = canonicalURL.substring(pos);
-
-		if (canonicalURLSuffix.startsWith(
-				siteDefaultLocaleI18nPath + StringPool.SLASH)) {
-
-			canonicalURLSuffix = canonicalURLSuffix.substring(
-				siteDefaultLocaleI18nPath.length());
-		}
-
-		String groupFriendlyURL = StringPool.BLANK;
-
-		if (!currentURL.equals(canonicalURLSuffix) &&
-			(groupFriendlyURLIndex != null)) {
-
-			groupFriendlyURL = canonicalURLSuffix.substring(
-				0, groupFriendlyURLIndex[1]);
-		}
-
-		for (Locale locale : availableLocales) {
-			String alternateURL = canonicalURL;
-			String alternateURLSuffix = null;
-			String languageId = LocaleUtil.toLanguageId(locale);
-
-			if (replaceFriendlyURL) {
-				String[] urlSeparators =
-					FriendlyURLResolverRegistryUtil.getURLSeparators();
-
-				for (String urlSeparator : urlSeparators) {
-					if (!currentURL.startsWith(urlSeparator)) {
-						continue;
-					}
-
-					FriendlyURLResolver friendlyURLResolver =
-						FriendlyURLResolverRegistryUtil.getFriendlyURLResolver(
-							themeDisplay.getCompanyId(), urlSeparator);
-
-					HttpServletRequest httpServletRequest =
-						themeDisplay.getRequest();
-
-					try {
-						LayoutFriendlyURLComposite layoutFriendlyURLComposite =
-							friendlyURLResolver.getLayoutFriendlyURLComposite(
-								themeDisplay.getCompanyId(),
-								themeDisplay.getScopeGroupId(), false,
-								currentURL,
-								httpServletRequest.getParameterMap(),
-								HashMapBuilder.<String, Object>put(
-									"request", httpServletRequest
-								).put(
-									WebKeys.LOCALE, locale
-								).build());
-
-						if (layoutFriendlyURLComposite != null) {
-							alternateURLSuffix =
-								groupFriendlyURL +
-									layoutFriendlyURLComposite.getFriendlyURL();
-						}
-
-						break;
-					}
-					catch (PortalException portalException) {
-						if (_log.isDebugEnabled()) {
-							_log.debug(portalException);
-						}
-					}
-				}
-
-				if (Validator.isNull(alternateURLSuffix)) {
-					alternateURLSuffix = canonicalURLSuffix;
-
-					String friendlyURL = null;
-
-					for (LayoutFriendlyURL layoutFriendlyURL :
-							layoutFriendlyURLs) {
-
-						if (!languageId.equals(
-								layoutFriendlyURL.getLanguageId())) {
-
-							continue;
-						}
-
-						friendlyURL = layoutFriendlyURL.getFriendlyURL();
-
-						if (groupFriendlyURLPrefix != null) {
-							friendlyURL = groupFriendlyURLPrefix.concat(
-								friendlyURL);
-						}
-
-						break;
-					}
-
-					if (friendlyURL != null) {
-						alternateURLSuffix = StringUtil.replaceFirst(
-							alternateURLSuffix, layout.getFriendlyURL(),
-							friendlyURL);
-					}
-				}
-
-				alternateURL = canonicalURLPrefix.concat(alternateURLSuffix);
-			}
-
-			String i18NPath = _buildI18NPath(
-				languageId, locale, themeDisplay.getSiteGroup());
-
-			if (!alternateURLSuffix.startsWith(i18NPath + StringPool.SLASH) &&
-				((localePrependFriendlyURLStyle == 2) ||
-				 ((localePrependFriendlyURLStyle != 0) &&
-				  !siteDefaultLocale.equals(locale)))) {
-
-				alternateURL =
-					canonicalURLPrefix + i18NPath + alternateURLSuffix;
-			}
-
-			alternateURLs.put(locale, alternateURL);
-		}
-
-		return _getAlternateURLsMap(
-			alternateURLs, virtualHostname, virtualHostnames);
+		return _getAlternateURLs(
+			canonicalURL, themeDisplay, layout, availableLocales, false);
 	}
 
 	@Override
@@ -1760,6 +1510,16 @@ public class PortalImpl implements Portal {
 		_cdnHostHttpsMap.put(companyId, cdnHostHttps);
 
 		return cdnHostHttps;
+	}
+
+	@Override
+	public Map<Locale, String> getChangeLanguageURLs(
+			String canonicalURL, ThemeDisplay themeDisplay, Layout layout,
+			Set<Locale> availableLocales)
+		throws PortalException {
+
+		return _getAlternateURLs(
+			canonicalURL, themeDisplay, layout, availableLocales, true);
 	}
 
 	@Override
@@ -7506,6 +7266,267 @@ public class PortalImpl implements Portal {
 		}
 
 		return i18nErrorPath.concat(redirect);
+	}
+
+	private Map<Locale, String> _getAlternateURLs(
+			String canonicalURL, ThemeDisplay themeDisplay, Layout layout,
+			Set<Locale> availableLocales, boolean includeDefaultLocaleI18nPath)
+		throws PortalException {
+
+		Map<Locale, String> alternateURLs = new HashMap<>();
+
+		String defaultVirtualHostname = _getDefaultVirtualHostname(
+			themeDisplay.getCompany());
+		String portalDomain = themeDisplay.getPortalDomain();
+
+		NavigableMap<String, String> virtualHostnames = getVirtualHostnames(
+			themeDisplay.getLayoutSet());
+
+		String virtualHostname = _getVirtualHostname(themeDisplay);
+
+		if ((!Validator.isBlank(portalDomain) &&
+			 !StringUtil.equalsIgnoreCase(
+				 portalDomain, defaultVirtualHostname) &&
+			 StringUtil.equalsIgnoreCase(
+				 virtualHostname, defaultVirtualHostname)) ||
+			virtualHostnames.containsKey(portalDomain)) {
+
+			virtualHostname = portalDomain;
+		}
+
+		if (Validator.isNull(virtualHostname)) {
+			for (Locale locale : availableLocales) {
+				String i18nPath = _buildI18NPath(
+					locale, themeDisplay.getSiteGroup());
+
+				alternateURLs.put(
+					locale,
+					canonicalURL.replaceFirst(
+						_PUBLIC_GROUP_SERVLET_MAPPING,
+						i18nPath.concat(_PUBLIC_GROUP_SERVLET_MAPPING)));
+			}
+
+			return _getAlternateURLsMap(
+				alternateURLs, portalDomain, virtualHostnames);
+		}
+
+		// www.liferay.com:8080/ctx/page to www.liferay.com:8080/ctx/es/page
+
+		int pos = canonicalURL.indexOf(virtualHostname);
+
+		if (pos < 0) {
+			pos = canonicalURL.indexOf(portalDomain);
+			virtualHostname = portalDomain;
+		}
+
+		if (pos > 0) {
+			pos = canonicalURL.indexOf(
+				CharPool.SLASH, pos + virtualHostname.length());
+
+			if (Validator.isNotNull(_pathContext)) {
+				pos = canonicalURL.indexOf(
+					CharPool.SLASH, pos + _pathContext.length());
+			}
+		}
+
+		Locale siteDefaultLocale = getSiteDefaultLocale(layout.getGroupId());
+
+		int localePrependFriendlyURLStyle = PrefsPropsUtil.getInteger(
+			themeDisplay.getCompanyId(),
+			PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE);
+
+		if ((pos <= 0) || (pos >= canonicalURL.length())) {
+			for (Locale locale : availableLocales) {
+				if ((localePrependFriendlyURLStyle == 0) ||
+					((localePrependFriendlyURLStyle != 2) &&
+					 !includeDefaultLocaleI18nPath &&
+					 siteDefaultLocale.equals(locale))) {
+
+					alternateURLs.put(locale, canonicalURL);
+				}
+				else {
+					alternateURLs.put(
+						locale,
+						StringBundler.concat(
+							canonicalURL,
+							_buildI18NPath(locale, themeDisplay.getSiteGroup()),
+							StringPool.SLASH));
+				}
+			}
+
+			return _getAlternateURLsMap(
+				alternateURLs, virtualHostname, virtualHostnames);
+		}
+
+		boolean replaceFriendlyURL = true;
+
+		String currentURL = canonicalURL.substring(pos);
+
+		String siteDefaultLocaleI18nPath = _buildI18NPath(
+			siteDefaultLocale, layout.getGroup());
+
+		if (currentURL.startsWith(
+				siteDefaultLocaleI18nPath + StringPool.SLASH)) {
+
+			currentURL = currentURL.substring(
+				siteDefaultLocaleI18nPath.length());
+		}
+
+		int[] groupFriendlyURLIndex = getGroupFriendlyURLIndex(currentURL);
+
+		if (groupFriendlyURLIndex != null) {
+			int y = groupFriendlyURLIndex[1];
+
+			currentURL = currentURL.substring(y);
+
+			if (currentURL.equals(StringPool.SLASH)) {
+				replaceFriendlyURL = false;
+			}
+		}
+
+		List<LayoutFriendlyURL> layoutFriendlyURLs = null;
+
+		String groupFriendlyURLPrefix = null;
+
+		if (replaceFriendlyURL) {
+			layoutFriendlyURLs =
+				LayoutFriendlyURLLocalServiceUtil.getLayoutFriendlyURLs(
+					layout.getPlid());
+
+			if (layout instanceof VirtualLayout) {
+				VirtualLayout virtualLayout = (VirtualLayout)layout;
+
+				layout = virtualLayout.getSourceLayout();
+
+				Group group = layout.getGroup();
+
+				groupFriendlyURLPrefix =
+					VirtualLayoutConstants.CANONICAL_URL_SEPARATOR.concat(
+						group.getFriendlyURL());
+			}
+		}
+
+		String canonicalURLPrefix = canonicalURL.substring(0, pos);
+
+		String canonicalURLSuffix = canonicalURL.substring(pos);
+
+		if (canonicalURLSuffix.startsWith(
+				siteDefaultLocaleI18nPath + StringPool.SLASH)) {
+
+			canonicalURLSuffix = canonicalURLSuffix.substring(
+				siteDefaultLocaleI18nPath.length());
+		}
+
+		String groupFriendlyURL = StringPool.BLANK;
+
+		if (!currentURL.equals(canonicalURLSuffix) &&
+			(groupFriendlyURLIndex != null)) {
+
+			groupFriendlyURL = canonicalURLSuffix.substring(
+				0, groupFriendlyURLIndex[1]);
+		}
+
+		for (Locale locale : availableLocales) {
+			String alternateURL = canonicalURL;
+			String alternateURLSuffix = null;
+			String languageId = LocaleUtil.toLanguageId(locale);
+
+			if (replaceFriendlyURL) {
+				String[] urlSeparators =
+					FriendlyURLResolverRegistryUtil.getURLSeparators();
+
+				for (String urlSeparator : urlSeparators) {
+					if (!currentURL.startsWith(urlSeparator)) {
+						continue;
+					}
+
+					FriendlyURLResolver friendlyURLResolver =
+						FriendlyURLResolverRegistryUtil.getFriendlyURLResolver(
+							themeDisplay.getCompanyId(), urlSeparator);
+
+					HttpServletRequest httpServletRequest =
+						themeDisplay.getRequest();
+
+					try {
+						LayoutFriendlyURLComposite layoutFriendlyURLComposite =
+							friendlyURLResolver.getLayoutFriendlyURLComposite(
+								themeDisplay.getCompanyId(),
+								themeDisplay.getScopeGroupId(), false,
+								currentURL,
+								httpServletRequest.getParameterMap(),
+								HashMapBuilder.<String, Object>put(
+									"request", httpServletRequest
+								).put(
+									WebKeys.LOCALE, locale
+								).build());
+
+						if (layoutFriendlyURLComposite != null) {
+							alternateURLSuffix =
+								groupFriendlyURL +
+									layoutFriendlyURLComposite.getFriendlyURL();
+						}
+
+						break;
+					}
+					catch (PortalException portalException) {
+						if (_log.isDebugEnabled()) {
+							_log.debug(portalException);
+						}
+					}
+				}
+
+				if (Validator.isNull(alternateURLSuffix)) {
+					alternateURLSuffix = canonicalURLSuffix;
+
+					String friendlyURL = null;
+
+					for (LayoutFriendlyURL layoutFriendlyURL :
+							layoutFriendlyURLs) {
+
+						if (!languageId.equals(
+								layoutFriendlyURL.getLanguageId())) {
+
+							continue;
+						}
+
+						friendlyURL = layoutFriendlyURL.getFriendlyURL();
+
+						if (groupFriendlyURLPrefix != null) {
+							friendlyURL = groupFriendlyURLPrefix.concat(
+								friendlyURL);
+						}
+
+						break;
+					}
+
+					if (friendlyURL != null) {
+						alternateURLSuffix = StringUtil.replaceFirst(
+							alternateURLSuffix, layout.getFriendlyURL(),
+							friendlyURL);
+					}
+				}
+
+				alternateURL = canonicalURLPrefix.concat(alternateURLSuffix);
+			}
+
+			String i18NPath = _buildI18NPath(
+				languageId, locale, themeDisplay.getSiteGroup());
+
+			if (!alternateURLSuffix.startsWith(i18NPath + StringPool.SLASH) &&
+				((localePrependFriendlyURLStyle == 2) ||
+				 ((localePrependFriendlyURLStyle != 0) &&
+				  (includeDefaultLocaleI18nPath ||
+				   !siteDefaultLocale.equals(locale))))) {
+
+				alternateURL =
+					canonicalURLPrefix + i18NPath + alternateURLSuffix;
+			}
+
+			alternateURLs.put(locale, alternateURL);
+		}
+
+		return _getAlternateURLsMap(
+			alternateURLs, virtualHostname, virtualHostnames);
 	}
 
 	private Map<Locale, String> _getAlternateURLsMap(

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 79.1.0
+version 79.2.0

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 189.0.0
+Bundle-Version: 189.1.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/service/PortletLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/PortletLocalService.java
@@ -316,6 +316,9 @@ public interface PortletLocalService
 		String url);
 
 	@Transactional(enabled = false)
+	public String getPortletFriendlyURLMappingPart(String url);
+
+	@Transactional(enabled = false)
 	public List<Portlet> getPortlets();
 
 	/**
@@ -398,4 +401,4 @@ public interface PortletLocalService
 	public void visitPortlets(long companyId, Consumer<Portlet> consumer);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:705430672
+// LIFERAY-SERVICE-BUILDER-HASH:1610591780

--- a/portal-kernel/src/com/liferay/portal/kernel/service/PortletLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/PortletLocalServiceUtil.java
@@ -375,6 +375,10 @@ public class PortletLocalServiceUtil {
 		return getService().getPortletFriendlyURLMapperMatch(url);
 	}
 
+	public static String getPortletFriendlyURLMappingPart(String url) {
+		return getService().getPortletFriendlyURLMappingPart(url);
+	}
+
 	public static List<Portlet> getPortlets() {
 		return getService().getPortlets();
 	}
@@ -498,4 +502,4 @@ public class PortletLocalServiceUtil {
 	private static volatile PortletLocalService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:823056039
+// LIFERAY-SERVICE-BUILDER-HASH:-2093949445

--- a/portal-kernel/src/com/liferay/portal/kernel/service/PortletLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/PortletLocalServiceWrapper.java
@@ -447,6 +447,11 @@ public class PortletLocalServiceWrapper
 	}
 
 	@Override
+	public String getPortletFriendlyURLMappingPart(String url) {
+		return _portletLocalService.getPortletFriendlyURLMappingPart(url);
+	}
+
+	@Override
 	public java.util.List<com.liferay.portal.kernel.model.Portlet>
 		getPortlets() {
 
@@ -607,4 +612,4 @@ public class PortletLocalServiceWrapper
 	private PortletLocalService _portletLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:751490583
+// LIFERAY-SERVICE-BUILDER-HASH:-665980387

--- a/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 54.1.0
+version 54.2.0

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java
@@ -382,6 +382,11 @@ public interface Portal {
 	 */
 	public String getCDNHostHttps(long companyId);
 
+	public Map<Locale, String> getChangeLanguageURLs(
+			String canonicalURL, ThemeDisplay themeDisplay, Layout layout,
+			Set<Locale> availableLocales)
+		throws PortalException;
+
 	/**
 	 * Returns the fully qualified name of the class from its ID.
 	 *

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java
@@ -483,6 +483,15 @@ public class PortalUtil {
 		return _portal.getCDNHostHttps(companyId);
 	}
 
+	public static Map<Locale, String> getChangeLanguageURLs(
+			String canonicalURL, ThemeDisplay themeDisplay, Layout layout,
+			Set<Locale> availableLocales)
+		throws PortalException {
+
+		return _portal.getChangeLanguageURLs(
+			canonicalURL, themeDisplay, layout, availableLocales);
+	}
+
 	/**
 	 * Returns the fully qualified name of the class from its ID.
 	 *

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 100.0.0
+version 100.1.0

--- a/portal-test/src/com/liferay/portal/test/rule/LanguageIdsTestRule.java
+++ b/portal-test/src/com/liferay/portal/test/rule/LanguageIdsTestRule.java
@@ -12,8 +12,12 @@ import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
+
+import jakarta.portlet.PortletPreferences;
 
 import org.junit.runner.Description;
 
@@ -35,9 +39,16 @@ public class LanguageIdsTestRule extends ClassTestRule<Void> {
 			return;
 		}
 
-		_setCompanyLocales(
-			_originalAvailableLanguageIds, _originalDefaultLanguageId,
-			_originalLocalesEnabled);
+		try {
+			_setCompanyLocales(
+				_originalAvailableLanguageIds, _originalDefaultLanguageId,
+				_originalLocalesEnabled);
+		}
+		finally {
+			if (_originalAvailableLanguageIds == null) {
+				_unsetCompanyLocales();
+			}
+		}
 	}
 
 	@Override
@@ -48,8 +59,12 @@ public class LanguageIdsTestRule extends ClassTestRule<Void> {
 			return null;
 		}
 
-		_originalAvailableLanguageIds = StringUtil.merge(
-			LocaleUtil.toLanguageIds(LanguageUtil.getAvailableLocales()));
+		PortletPreferences portletPreferences = PrefsPropsUtil.getPreferences(
+			PortalUtil.getDefaultCompanyId());
+
+		_originalAvailableLanguageIds = portletPreferences.getValue(
+			PropsKeys.LOCALES, null);
+
 		_originalDefaultLanguageId = LocaleUtil.toLanguageId(
 			LocaleUtil.getDefault());
 		_originalLocalesEnabled = PropsValues.LOCALES_ENABLED;
@@ -70,11 +85,28 @@ public class LanguageIdsTestRule extends ClassTestRule<Void> {
 
 		LanguageUtil.init();
 
+		if (availableLanguageIds == null) {
+			availableLanguageIds = StringUtil.merge(localesEnabled);
+		}
+
 		CompanyTestUtil.resetCompanyLocales(
 			PortalUtil.getDefaultCompanyId(), availableLanguageIds,
 			defaultLanguageId);
 
 		PropsValues.LOCALES_ENABLED = localesEnabled;
+	}
+
+	private void _unsetCompanyLocales() throws Exception {
+		long companyId = PortalUtil.getDefaultCompanyId();
+
+		PortletPreferences portletPreferences = PrefsPropsUtil.getPreferences(
+			companyId);
+
+		portletPreferences.reset(PropsKeys.LOCALES);
+
+		portletPreferences.store();
+
+		LanguageUtil.resetAvailableLocales(companyId);
 	}
 
 	private String _originalAvailableLanguageIds;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99541

## What Is Being Fixed

The Language Selector rendered each language as a `/c/portal/update_language` redirect rather than the final localized URL. Crawlers following those links never reached the localized pages directly, which produces redundant indexing and misses the crawlable localized URLs the localization URL strategy (LPD-98224) calls for.

## How It Is Being Fixed

Adds `getChangeLanguageURLs` to `Portal`/`PortalUtil`, implemented in `PortalImpl`, returning one URL per locale with the i18n path kept for every locale including the default one. It is its own method rather than a flag on `getAlternateURLs` because the two answer different questions: an SEO alternate leaves the default locale unprefixed, so its entry is the canonical URL itself, while a change-language URL must carry the default locale's path too, or that entry is the URL the visitor is already reading and choosing the language does nothing. Both maps come out of the same private builder, so the choice does not reach the kernel's public signature.

For anonymous visitors and crawlers, `LanguageTag` and its `icon_menu.ftl` template now link each language entry to that URL instead of the `update_language` action, so following a link returns `200` with the localized content instead of a `302`. When a distinct localized URL cannot be produced, the entry falls back to the existing `update_language` URL.

The selector also keeps a friendly URL mapping part that is not checked with a prefix, so a filtered view keeps its filter when the language changes. The case that matters is an Asset Publisher filtered by a tag (`/page/tags/mytag`, LPD-32573), whose mapper reports `isCheckMappingWithPrefix()` as `false`. Without this, the canonical URL rebuild drops that segment and the localized URL loses the filter, which is state the `update_language` path preserves.

That lookup previously existed only inline in `UpdateLanguageAction`, out of reach of the taglib, so it moved to `PortletLocalServiceImpl.getPortletFriendlyURLMappingPart` and both callers now share it. `buildService` generated it onto `PortletLocalServiceUtil`, so no new kernel API was needed.

One behavior difference is worth calling out, since the shared lookup is not a transcription of the loop it replaces: it delegates to the cached `getPortletFriendlyURLMapperMatch` and returns blank when the matched mapper checks its mapping with a prefix. That is what the selector needs, because it reads the untruncated complete URL and `getCanonicalURL` already splits the separator part off and re-appends it, so returning `/tags/` for a URL like `/page/-/blogs/tags/` would append it a second time. It is not a fix for a defect on master: `UpdateLanguageAction` truncates the URL at the friendly URL separator before its loop runs and carries that tail separately, so the loop never sees such a URL.

Three smaller fixes ride along, each in its own commit. A locale with no `LayoutFriendlyURL` for the layout left the alternate URL's suffix unset, so it now falls back to the canonical URL's suffix before the locale prefix is applied. `UpdateLanguageAction` keeps the mapping part through the shared lookup, and falls back to the group friendly URL when the URL carries no layout friendly URL, which the old loop could not handle. `LanguageTag` logs the URL it could not rebuild, so a fallback is diagnosable rather than silent.

## Testing

`LanguageTagTest` covers the selector's URLs for `locale.prepend.friendly.url.style` 2 and 3 and for the unset case, the signed-in and explicit form action fallbacks, the layout-less case, a redirect parameter, a virtual hostname and a localized virtual hostname, another locale's friendly URL, a display page, and the mapping part both on its own and on a default page. `PortalImplAlternateURLTest` adds `testChangeLanguageURLs`, asserting both maps side by side so the default locale's difference is explicit, plus the alternate URLs for a layout with no friendly URL for the locale. `UpdateLanguageActionTest` covers the redirect side, including the mapping part, a query string, a virtual host, and the no-layout and invalid-redirect fallbacks.

Verified manually on a local bundle, always as a logged-out guest since the clean URL path is guest only. That pass predates the `getChangeLanguageURLs` rename and the shared lookup, but `LanguageTagTest` now asserts most of it directly, including both mapping part shapes the table lists, `/tags/mytag` and `/-/blogs/blog-1`, as well as each style, the signed-in case and both kinds of virtual hostname. The three rows it cannot assert, because they are not URL shapes, are the translated web content switching per locale, the guest language cookie persisting across visits, and impersonation.

| Case | Result |
| --- | --- |
| Guest, style 3 | Localized URLs, no `update_language` |
| Guest, style 0 | Falls back to `update_language` |
| Signed in | Keeps `update_language` (intended, see below) |
| Content page mapping part (`/-/blogs/blog-1`) | Preserved |
| Query string and portlet state | Preserved |
| Translated web content | Content switches per locale |
| Localized layout friendly URL | Uses the localized URL per locale (`/ca/page1-ca-`) |
| Guest language cookie | Persists across leaving and returning |
| Asset Publisher tag filter (LPD-32573) | Filter kept (`/de/page3/tags/mytag`), also with a query string |
| Impersonation (LPD-88958) | Unaffected, still `update_language`, profile language persists |
| Localized virtual hosts (LPD-90275) | Matches both the `hreflang` alternates and the old `update_language` destination |

Two notes on scope. The `hreflang` alternates in the page head still come from `getAlternateURLs` and behave exactly as before this change, so where they already pointed at an unfiltered or current-host URL they still do. On a site with localized virtual hosts, a language that has no virtual host of its own keeps the current host rather than falling back to the default one; that is pre-existing behavior shared with the `update_language` flow and with the `hreflang` alternates, so it is not changed here.

## Review Notes

**`_hasFriendlyURLResolverSeparator` should use `startsWith` rather than `contains`.** It should not. The cited precedent at `PortalImpl:1155` tests an already-isolated `friendlyURL` fragment that begins with the separator. The input here is `currentCompleteURL`, a full URL starting with `http`, so `startsWith` would be false for every separator and would pin `forceLayoutFriendlyURL` to `true` on every call.

## Known Limitation

This change renders the final localized friendly URL (for example `/de/home`) directly in the Language Selector for anonymous visitors and search engine crawlers. That satisfies the SEO objective of LPD-98224 for the audience that matters to it: no `update_language` redirector, a `200` response instead of a `302`, and no duplicate-content indexing. AC 1 and AC 2 are met for bots and anonymous users.

Signed-in users still receive the existing `/c/portal/update_language` link. This is intentional, not a defect. For a signed-in user, `update_language` persists the chosen language to their user profile (`UpdateLanguageAction` calls `UserServiceUtil.updateLanguageId`), whereas plain navigation to `/de/home` only changes the language on prefixed pages and would not persist the preference. Serving the clean URL to signed-in users without adding persistence would silently break "my language choice sticks."

Full coverage for signed-in users is feasible (LPD-98224 Gap A): render the clean URL for everyone and fire a persist-only `navigator.sendBeacon(update_language)` on click so the profile still updates, with no change to `UpdateLanguageAction`. It was left out of this slice because it is a three-module change across three owners: a new `persistURL` public API on the `portal-kernel` `LanguageEntry` (which needs a baseline bump), populating it in the `site-navigation-taglib` `LanguageTag`, and a new client-side handler plus a `data-persist-url` attribute across the five display templates in `site-navigation-language-web`.
