### PR TITLE
Revert "LPD-99742 Fix disappearing referenced structure field"

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
@@ -140,9 +140,41 @@ public class UpdateStructureStrutsActionTest {
 			serviceBuilderObjectDefinition2.getObjectDefinitionId());
 	}
 
+	@FeatureFlag("LPD-17564")
+	@Test
+	@TestInfo("LPD-92696")
+	public void testExecuteDoesNotDeleteObjectRelationships() throws Exception {
+		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
+		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		com.liferay.object.model.ObjectRelationship objectRelationship =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, _objectDefinition1,
+				_objectDefinition2);
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		_updateStructureStrutsAction.execute(
+			_getMockHttpServletRequest(_objectDefinition1),
+			mockHttpServletResponse);
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject(
+			mockHttpServletResponse.getContentAsString());
+
+		Assert.assertEquals(jsonObject.toString(), 0, jsonObject.length());
+
+		Assert.assertNotNull(
+			_objectFieldLocalService.fetchObjectField(
+				objectRelationship.getObjectFieldId2()));
+		Assert.assertNotNull(
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				objectRelationship.getObjectRelationshipId()));
+	}
+
 	@Test
 	@TestInfo("LPD-99742")
-	public void testExecuteDoesNotDeleteEdgeObjectRelationships()
+	public void testExecuteDoesNotDeleteReferencedStructureRelationship()
 		throws Exception {
 
 		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
@@ -172,38 +204,6 @@ public class UpdateStructureStrutsActionTest {
 
 		Assert.assertEquals(jsonObject.toString(), 0, jsonObject.length());
 
-		Assert.assertNotNull(
-			_objectRelationshipLocalService.fetchObjectRelationship(
-				objectRelationship.getObjectRelationshipId()));
-	}
-
-	@FeatureFlag("LPD-17564")
-	@Test
-	@TestInfo("LPD-92696")
-	public void testExecuteDoesNotDeleteObjectRelationships() throws Exception {
-		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
-		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition();
-
-		com.liferay.object.model.ObjectRelationship objectRelationship =
-			ObjectRelationshipTestUtil.addObjectRelationship(
-				_objectRelationshipLocalService, _objectDefinition1,
-				_objectDefinition2);
-
-		MockHttpServletResponse mockHttpServletResponse =
-			new MockHttpServletResponse();
-
-		_updateStructureStrutsAction.execute(
-			_getMockHttpServletRequest(_objectDefinition1),
-			mockHttpServletResponse);
-
-		JSONObject jsonObject = _jsonFactory.createJSONObject(
-			mockHttpServletResponse.getContentAsString());
-
-		Assert.assertEquals(jsonObject.toString(), 0, jsonObject.length());
-
-		Assert.assertNotNull(
-			_objectFieldLocalService.fetchObjectField(
-				objectRelationship.getObjectFieldId2()));
 		Assert.assertNotNull(
 			_objectRelationshipLocalService.fetchObjectRelationship(
 				objectRelationship.getObjectRelationshipId()));

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
@@ -172,43 +172,6 @@ public class UpdateStructureStrutsActionTest {
 				objectRelationship.getObjectRelationshipId()));
 	}
 
-	@Test
-	@TestInfo("LPD-99742")
-	public void testExecuteDoesNotDeleteReferencedStructureRelationship()
-		throws Exception {
-
-		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
-		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition();
-
-		com.liferay.object.model.ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.addObjectRelationship(
-				null, TestPropsValues.getUserId(),
-				_objectDefinition1.getObjectDefinitionId(),
-				_objectDefinition2.getObjectDefinitionId(), 0,
-				ObjectRelationshipConstants.DELETION_TYPE_CASCADE, true,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				StringUtil.randomId(), false,
-				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
-
-		Assert.assertTrue(objectRelationship.isEdge());
-
-		MockHttpServletResponse mockHttpServletResponse =
-			new MockHttpServletResponse();
-
-		_updateStructureStrutsAction.execute(
-			_getMockHttpServletRequest(_objectDefinition2),
-			mockHttpServletResponse);
-
-		JSONObject jsonObject = _jsonFactory.createJSONObject(
-			mockHttpServletResponse.getContentAsString());
-
-		Assert.assertEquals(jsonObject.toString(), 0, jsonObject.length());
-
-		Assert.assertNotNull(
-			_objectRelationshipLocalService.fetchObjectRelationship(
-				objectRelationship.getObjectRelationshipId()));
-	}
-
 	private HttpServletRequest _getMockHttpServletRequest(
 			com.liferay.object.model.ObjectDefinition objectDefinition)
 		throws Exception {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
@@ -125,8 +125,9 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 
 		for (com.liferay.object.model.ObjectRelationship
 				serviceBuilderObjectRelationship :
-					_objectRelationshipLocalService.getObjectRelationships(
-						objectDefinitionId, true)) {
+					_objectRelationshipLocalService.
+						getObjectRelationshipsByObjectDefinitionId2(
+							objectDefinitionId, true)) {
 
 			if (serviceBuilderObjectRelationship.isReverse()) {
 				continue;


### PR DESCRIPTION
@jkappler @janbrychtadotcom

Reverts the three commits of https://liferay.atlassian.net/browse/LPD-99742 (PR liferay-content-management#8712, forwarded as brianchandotcom#179367, merged on July 29). No new ticket — this only restores the pre-PR state so `master` goes green again while a proper fix is prepared under LPD-99742.

## Why

`6022f74e86a5c` changed the relationship cleanup in `UpdateStructureStrutsAction._deleteRelationships` from querying `objectDefinitionId2` to querying `objectDefinitionId1`:

```java
- _objectRelationshipLocalService.getObjectRelationshipsByObjectDefinitionId2(
-     objectDefinitionId, true)
+ _objectRelationshipLocalService.getObjectRelationships(
+     objectDefinitionId, true)
```

`buildObjectRelationships` builds every edge with side 1 = the referenced structure and side 2 = the structure that owns the reference field:

```ts
objectDefinitionExternalReferenceCode1: relatedContent.relatedStructureERC!,
objectDefinitionExternalReferenceCode2: parentERC,
```

`_deleteRelationships` is a delete-then-recreate step: right after it, the action re-posts the relationships the client sent in `objectRelationships`, which are exactly the edges whose side 2 is the structure being published (or one of its repeatable groups). Once the delete is keyed on side 1, it removes a set that is never recreated, so publishing a structure that contains a referenced structure or a repeatable group silently drops it.

This is user-visible data loss, not just a test problem: after publishing and reloading, the referenced structure and the repeatable group are gone from the tree.

## Evidence

The commit correlates 1:1 with the CI failures. `22f1e28` is the only build that contains it, and it failed on every routine that ran these tests; every earlier build passed.

Verified locally by A/B on the same bundle, running `referencedStructures`, `repeatableGroups`, `structureBuilder` and `uploadField`:

| | Result |
| --- | --- |
| `master` | 9 failed / 12 passed |
| With this revert | 2 failed / 19 passed |

The seven tests this revert fixes:

- `referencedStructures.spec.ts > Can reference several structures and they are persisted`
- `referencedStructures.spec.ts > Can edit Referenced Content Structure in another tab`
- `referencedStructures.spec.ts > Can not do references that cause circular dependencies`
- `repeatableGroups.spec.ts > Groups can be created, persisted and ungrouped`
- `repeatableGroups.spec.ts > Repeatable groups object definitions are deleted when updating or deleting the structure`
- `structureBuilder.spec.ts > Fields are sorted`
- `uploadField.spec.ts > Every repeat of an upload field opens the same CMS item selector`

The two still failing (`repeatableGroups.spec.ts > Check restrictions for group creation` and `structureBuilder.spec.ts > Can delete multiple fields`) fail identically on `master`, so they are unrelated to this commit. Both break on tree multi-selection (`getByText('2 Items Selected')`), and look like a separate issue worth its own ticket.

`UpdateStructureStrutsActionTest` passes on this branch (`testExecute`, `testExecuteDoesNotDeleteObjectRelationships`).

## Why all three commits

`04a8c53943fca` added `testExecuteDoesNotDeleteEdgeObjectRelationships`, which asserts the behavior introduced by `6022f74e86a5c`: it calls `execute` for `_objectDefinition2` and asserts the edge survives. Reverting only the implementation would leave that test failing, so the test commit and its rename (`0631ec6975dd9`) are reverted too. The resulting tree is byte-identical to the state before the PR.

## For the follow-up fix

The regression and LPP-64961 are mirror images of the same asymmetry, so keying the cleanup on either side alone breaks the other direction. The delete probably has to be scoped to exactly the relationships that are about to be recreated from `objectRelationships`, rather than to a broad query by one side.

Worth noting the unit test added in the PR only covered the LPP direction (republishing the referenced structure). The direction that regressed — publishing the structure that owns the reference — had no unit coverage, which is why this reached `master`. The follow-up would ideally cover both.
