### PR TITLE
LPD-97443 Fix NPE staging a widget page converted to a content page

### DIFF
--- a/modules/apps/layout/layout-page-template-service/bnd.bnd
+++ b/modules/apps/layout/layout-page-template-service/bnd.bnd
@@ -5,6 +5,6 @@ Import-Package:\
 	com.liferay.layout.page.template.util.comparator,\
 	\
 	*
-Liferay-Require-SchemaVersion: 6.1.0
+Liferay-Require-SchemaVersion: 6.2.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/registry/LayoutPageTemplateServiceUpgradeStepRegistrator.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/registry/LayoutPageTemplateServiceUpgradeStepRegistrator.java
@@ -266,6 +266,13 @@ public class LayoutPageTemplateServiceUpgradeStepRegistrator
 			LayoutPageTemplateStructureRelElementVariationAudienceEntryRelTable.
 				create(),
 			LayoutPageTemplateStructureRelElementVariationTable.create());
+
+		registry.register(
+			"6.1.0", "6.2.0",
+			new com.liferay.layout.page.template.internal.upgrade.v6_2_0.
+				LayoutPageTemplateStructureRelUpgradeProcess(
+					_layoutLocalService, _segmentsExperienceLocalService,
+					_userLocalService));
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/registry/LayoutPageTemplateServiceUpgradeStepRegistrator.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/registry/LayoutPageTemplateServiceUpgradeStepRegistrator.java
@@ -19,6 +19,7 @@ import com.liferay.layout.page.template.internal.upgrade.v3_4_1.FragmentEntryLin
 import com.liferay.layout.page.template.internal.upgrade.v5_3_0.LayoutPageTemplateCollectionUpgradeProcess;
 import com.liferay.layout.page.template.internal.upgrade.v6_1_0.util.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelTable;
 import com.liferay.layout.page.template.internal.upgrade.v6_1_0.util.LayoutPageTemplateStructureRelElementVariationTable;
+import com.liferay.portal.kernel.lock.LockManager;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutPrototypeLocalService;
@@ -271,8 +272,8 @@ public class LayoutPageTemplateServiceUpgradeStepRegistrator
 			"6.1.0", "6.2.0",
 			new com.liferay.layout.page.template.internal.upgrade.v6_2_0.
 				LayoutPageTemplateStructureRelUpgradeProcess(
-					_layoutLocalService, _segmentsExperienceLocalService,
-					_userLocalService));
+					_layoutLocalService, _lockManager,
+					_segmentsExperienceLocalService, _userLocalService));
 	}
 
 	@Reference
@@ -289,6 +290,9 @@ public class LayoutPageTemplateServiceUpgradeStepRegistrator
 
 	@Reference
 	private LayoutPrototypeLocalService _layoutPrototypeLocalService;
+
+	@Reference
+	private LockManager _lockManager;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v6_2_0/LayoutPageTemplateStructureRelUpgradeProcess.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v6_2_0/LayoutPageTemplateStructureRelUpgradeProcess.java
@@ -1,0 +1,207 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.internal.upgrade.v6_2_0;
+
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.segments.constants.SegmentsExperienceConstants;
+import com.liferay.segments.model.SegmentsExperience;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Balázs Sáfrány-Kovalik
+ */
+public class LayoutPageTemplateStructureRelUpgradeProcess
+	extends UpgradeProcess {
+
+	public LayoutPageTemplateStructureRelUpgradeProcess(
+		LayoutLocalService layoutLocalService,
+		SegmentsExperienceLocalService segmentsExperienceLocalService,
+		UserLocalService userLocalService) {
+
+		_layoutLocalService = layoutLocalService;
+		_segmentsExperienceLocalService = segmentsExperienceLocalService;
+		_userLocalService = userLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select distinct LayoutPageTemplateStructureRel.",
+					"ctCollectionId, LayoutPageTemplateStructureRel.",
+					"lPageTemplateStructureRelId, ",
+					"LayoutPageTemplateStructureRel.",
+					"layoutPageTemplateStructureId, ",
+					"LayoutPageTemplateStructure.companyId, ",
+					"LayoutPageTemplateStructure.plid, ",
+					"LayoutPageTemplateStructure.userId from ",
+					"LayoutPageTemplateStructure inner join ",
+					"LayoutPageTemplateStructureRel on ",
+					"LayoutPageTemplateStructureRel.",
+					"layoutPageTemplateStructureId = ",
+					"LayoutPageTemplateStructure.",
+					"layoutPageTemplateStructureId where ",
+					"LayoutPageTemplateStructureRel.segmentsExperienceId = 0"));
+
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				long ctCollectionId = resultSet.getLong("ctCollectionId");
+
+				try (SafeCloseable safeCloseable =
+						CTCollectionThreadLocal.
+							setCTCollectionIdWithSafeCloseable(
+								ctCollectionId)) {
+
+					_repairLayoutPageTemplateStructureRel(
+						resultSet.getLong("companyId"), ctCollectionId,
+						resultSet.getLong("layoutPageTemplateStructureId"),
+						resultSet.getLong("lPageTemplateStructureRelId"),
+						resultSet.getLong("plid"), resultSet.getLong("userId"));
+				}
+			}
+		}
+	}
+
+	private void _deleteLayoutPageTemplateStructureRel(
+			long ctCollectionId, long layoutPageTemplateStructureRelId)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"delete from LayoutPageTemplateStructureRel where ",
+					"ctCollectionId = ? and lPageTemplateStructureRelId = ",
+					"?"))) {
+
+			preparedStatement.setLong(1, ctCollectionId);
+			preparedStatement.setLong(2, layoutPageTemplateStructureRelId);
+
+			preparedStatement.executeUpdate();
+		}
+	}
+
+	private long _getDefaultSegmentsExperienceId(
+			long companyId, long plid, long userId)
+		throws Exception {
+
+		long defaultSegmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				plid);
+
+		if (defaultSegmentsExperienceId !=
+				SegmentsExperienceConstants.ID_DEFAULT) {
+
+			return defaultSegmentsExperienceId;
+		}
+
+		User user = _userLocalService.fetchUser(userId);
+
+		if (user == null) {
+			userId = _userLocalService.getGuestUserId(companyId);
+		}
+
+		SegmentsExperience defaultSegmentsExperience =
+			_segmentsExperienceLocalService.addDefaultSegmentsExperience(
+				null, userId, plid, new ServiceContext());
+
+		return defaultSegmentsExperience.getSegmentsExperienceId();
+	}
+
+	private boolean _hasDefaultSegmentsExperienceLayoutPageTemplateStructureRel(
+			long ctCollectionId, long defaultSegmentsExperienceId,
+			long layoutPageTemplateStructureId,
+			long layoutPageTemplateStructureRelId)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select lPageTemplateStructureRelId from ",
+					"LayoutPageTemplateStructureRel where ctCollectionId in ",
+					"(0, ?) and lPageTemplateStructureRelId != ? and ",
+					"layoutPageTemplateStructureId = ? and ",
+					"segmentsExperienceId = ?"))) {
+
+			preparedStatement.setLong(1, ctCollectionId);
+			preparedStatement.setLong(2, layoutPageTemplateStructureRelId);
+			preparedStatement.setLong(3, layoutPageTemplateStructureId);
+			preparedStatement.setLong(4, defaultSegmentsExperienceId);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				return resultSet.next();
+			}
+		}
+	}
+
+	private void _repairLayoutPageTemplateStructureRel(
+			long companyId, long ctCollectionId,
+			long layoutPageTemplateStructureId,
+			long layoutPageTemplateStructureRelId, long plid, long userId)
+		throws Exception {
+
+		Layout layout = _layoutLocalService.fetchLayout(plid);
+
+		if (layout == null) {
+			_deleteLayoutPageTemplateStructureRel(
+				ctCollectionId, layoutPageTemplateStructureRelId);
+
+			return;
+		}
+
+		long defaultSegmentsExperienceId = _getDefaultSegmentsExperienceId(
+			companyId, plid, userId);
+
+		if (_hasDefaultSegmentsExperienceLayoutPageTemplateStructureRel(
+				ctCollectionId, defaultSegmentsExperienceId,
+				layoutPageTemplateStructureId,
+				layoutPageTemplateStructureRelId)) {
+
+			_deleteLayoutPageTemplateStructureRel(
+				ctCollectionId, layoutPageTemplateStructureRelId);
+		}
+		else {
+			_updateLayoutPageTemplateStructureRel(
+				ctCollectionId, defaultSegmentsExperienceId,
+				layoutPageTemplateStructureRelId);
+		}
+	}
+
+	private void _updateLayoutPageTemplateStructureRel(
+			long ctCollectionId, long defaultSegmentsExperienceId,
+			long layoutPageTemplateStructureRelId)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"update LayoutPageTemplateStructureRel set ",
+					"segmentsExperienceId = ? where ctCollectionId = ? and ",
+					"lPageTemplateStructureRelId = ? and segmentsExperienceId ",
+					"= 0"))) {
+
+			preparedStatement.setLong(1, defaultSegmentsExperienceId);
+			preparedStatement.setLong(2, ctCollectionId);
+			preparedStatement.setLong(3, layoutPageTemplateStructureRelId);
+
+			preparedStatement.executeUpdate();
+		}
+	}
+
+	private final LayoutLocalService _layoutLocalService;
+	private final SegmentsExperienceLocalService
+		_segmentsExperienceLocalService;
+	private final UserLocalService _userLocalService;
+
+}

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v6_2_0/LayoutPageTemplateStructureRelUpgradeProcess.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v6_2_0/LayoutPageTemplateStructureRelUpgradeProcess.java
@@ -8,6 +8,7 @@ package com.liferay.layout.page.template.internal.upgrade.v6_2_0;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+import com.liferay.portal.kernel.lock.LockManager;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -28,17 +29,20 @@ public class LayoutPageTemplateStructureRelUpgradeProcess
 	extends UpgradeProcess {
 
 	public LayoutPageTemplateStructureRelUpgradeProcess(
-		LayoutLocalService layoutLocalService,
+		LayoutLocalService layoutLocalService, LockManager lockManager,
 		SegmentsExperienceLocalService segmentsExperienceLocalService,
 		UserLocalService userLocalService) {
 
 		_layoutLocalService = layoutLocalService;
+		_lockManager = lockManager;
 		_segmentsExperienceLocalService = segmentsExperienceLocalService;
 		_userLocalService = userLocalService;
 	}
 
 	@Override
 	protected void doUpgrade() throws Exception {
+		_unlockLayouts();
+
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				StringBundler.concat(
 					"select distinct LayoutPageTemplateStructureRel.",
@@ -179,6 +183,21 @@ public class LayoutPageTemplateStructureRelUpgradeProcess
 		}
 	}
 
+	private void _unlockLayouts() throws Exception {
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select key_ from Lock_ where className = ?")) {
+
+			preparedStatement.setString(1, Layout.class.getName());
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					_lockManager.unlock(
+						Layout.class.getName(), resultSet.getString("key_"));
+				}
+			}
+		}
+	}
+
 	private void _updateLayoutPageTemplateStructureRel(
 			long ctCollectionId, long defaultSegmentsExperienceId,
 			long layoutPageTemplateStructureRelId)
@@ -200,6 +219,7 @@ public class LayoutPageTemplateStructureRelUpgradeProcess
 	}
 
 	private final LayoutLocalService _layoutLocalService;
+	private final LockManager _lockManager;
 	private final SegmentsExperienceLocalService
 		_segmentsExperienceLocalService;
 	private final UserLocalService _userLocalService;

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureRelLocalServiceImpl.java
@@ -5,8 +5,10 @@
 
 package com.liferay.layout.page.template.service.impl;
 
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRel;
 import com.liferay.layout.page.template.service.base.LayoutPageTemplateStructureRelLocalServiceBaseImpl;
+import com.liferay.layout.page.template.service.persistence.LayoutPageTemplateStructurePersistence;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.SystemEventConstants;
@@ -15,6 +17,8 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.segments.constants.SegmentsExperienceConstants;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
 
 import java.util.Date;
 import java.util.List;
@@ -40,6 +44,9 @@ public class LayoutPageTemplateStructureRelLocalServiceImpl
 		throws PortalException {
 
 		User user = _userLocalService.getUser(userId);
+
+		segmentsExperienceId = _getSegmentsExperienceId(
+			layoutPageTemplateStructureId, segmentsExperienceId);
 
 		long layoutPageTemplateStructureRelId = counterLocalService.increment();
 
@@ -170,6 +177,29 @@ public class LayoutPageTemplateStructureRelLocalServiceImpl
 		return layoutPageTemplateStructureRelPersistence.update(
 			layoutPageTemplateStructureRel);
 	}
+
+	private long _getSegmentsExperienceId(
+			long layoutPageTemplateStructureId, long segmentsExperienceId)
+		throws PortalException {
+
+		if (segmentsExperienceId != SegmentsExperienceConstants.ID_DEFAULT) {
+			return segmentsExperienceId;
+		}
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_layoutPageTemplateStructurePersistence.findByPrimaryKey(
+				layoutPageTemplateStructureId);
+
+		return _segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+			layoutPageTemplateStructure.getPlid());
+	}
+
+	@Reference
+	private LayoutPageTemplateStructurePersistence
+		_layoutPageTemplateStructurePersistence;
+
+	@Reference
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/layout/layout-page-template-test/build.gradle
+++ b/modules/apps/layout/layout-page-template-test/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:asset:asset-link-api")
 	testIntegrationImplementation project(":apps:asset:asset-list-api")
 	testIntegrationImplementation project(":apps:audiences:audiences-api")
+	testIntegrationImplementation project(":apps:change-tracking:change-tracking-api")
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
 	testIntegrationImplementation project(":apps:depot:depot-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/exportimport/test/LayoutPageTemplateStructureRelExportImportTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/exportimport/test/LayoutPageTemplateStructureRelExportImportTest.java
@@ -14,6 +14,9 @@ import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.exportimport.test.util.lar.BaseExportImportTestCase;
 import com.liferay.journal.model.JournalArticle;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureServiceUtil;
 import com.liferay.layout.provider.LayoutStructureProvider;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
@@ -47,6 +50,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.segments.constants.SegmentsExperienceConstants;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
 
 import org.junit.After;
@@ -380,6 +384,45 @@ public class LayoutPageTemplateStructureRelExportImportTest
 			guestGroup.getExternalReferenceCode());
 	}
 
+	@Test
+	@TestInfo("LPD-97443")
+	public void testImportedLayoutPageTemplateStructureRelHasDefaultSegmentsExperience()
+		throws Exception {
+
+		exportImportLayouts(
+			new long[] {layout.getLayoutId()}, getImportParameterMap());
+
+		importedLayout = _layoutLocalService.getLayoutByExternalReferenceCode(
+			layout.getExternalReferenceCode(), importedGroup.getGroupId());
+
+		long defaultSegmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				importedLayout.getPlid());
+
+		Assert.assertNotEquals(
+			SegmentsExperienceConstants.ID_DEFAULT,
+			defaultSegmentsExperienceId);
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_layoutPageTemplateStructureLocalService.
+				fetchLayoutPageTemplateStructure(
+					importedGroup.getGroupId(), importedLayout.getPlid());
+
+		Assert.assertNull(
+			_layoutPageTemplateStructureRelLocalService.
+				fetchLayoutPageTemplateStructureRel(
+					layoutPageTemplateStructure.
+						getLayoutPageTemplateStructureId(),
+					SegmentsExperienceConstants.ID_DEFAULT));
+
+		Assert.assertNotNull(
+			_layoutPageTemplateStructureRelLocalService.
+				fetchLayoutPageTemplateStructureRel(
+					layoutPageTemplateStructure.
+						getLayoutPageTemplateStructureId(),
+					defaultSegmentsExperienceId));
+	}
+
 	private AssetListEntry _addAssetListEntry(Group group) throws Exception {
 		return _assetListEntryLocalService.addAssetListEntry(
 			null, TestPropsValues.getUserId(), group.getGroupId(),
@@ -659,6 +702,14 @@ public class LayoutPageTemplateStructureRelExportImportTest
 
 	@Inject
 	private LayoutLocalService _layoutLocalService;
+
+	@Inject
+	private LayoutPageTemplateStructureLocalService
+		_layoutPageTemplateStructureLocalService;
+
+	@Inject
+	private LayoutPageTemplateStructureRelLocalService
+		_layoutPageTemplateStructureRelLocalService;
 
 	@Inject
 	private LayoutStructureProvider _layoutStructureProvider;

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v6_2_0/test/LayoutPageTemplateStructureRelUpgradeProcessTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v6_2_0/test/LayoutPageTemplateStructureRelUpgradeProcessTest.java
@@ -1,0 +1,390 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.internal.upgrade.v6_2_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.change.tracking.service.CTCollectionLocalService;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRel;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelLocalService;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+import com.liferay.segments.constants.SegmentsExperienceConstants;
+import com.liferay.segments.model.SegmentsExperience;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
+import com.liferay.segments.test.util.SegmentsTestUtil;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Balázs Sáfrány-Kovalik
+ */
+@RunWith(Arquillian.class)
+public class LayoutPageTemplateStructureRelUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	@TestInfo("LPD-97443")
+	public void testUpgradeDeletesRedundantOrphanedLayoutPageTemplateStructureRel()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_fetchLayoutPageTemplateStructure(draftLayout);
+
+		long defaultSegmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				draftLayout.getPlid());
+
+		SegmentsExperience segmentsExperience =
+			SegmentsTestUtil.addSegmentsExperience(
+				_group.getGroupId(), draftLayout.getPlid());
+
+		_layoutPageTemplateStructureRelLocalService.
+			addLayoutPageTemplateStructureRel(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				layoutPageTemplateStructure.getLayoutPageTemplateStructureId(),
+				segmentsExperience.getSegmentsExperienceId(), StringPool.BLANK,
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId()));
+
+		_orphanLayoutPageTemplateStructureRel(
+			layoutPageTemplateStructure,
+			segmentsExperience.getSegmentsExperienceId());
+
+		Assert.assertNotNull(
+			_fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure,
+				SegmentsExperienceConstants.ID_DEFAULT));
+
+		_runUpgrade();
+
+		Assert.assertNull(
+			_fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure,
+				SegmentsExperienceConstants.ID_DEFAULT));
+
+		Assert.assertNotNull(
+			_fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure, defaultSegmentsExperienceId));
+	}
+
+	@Test
+	@TestInfo("LPD-97443")
+	public void testUpgradeReassignsOrphanedLayoutPageTemplateStructureRelCreatedInPublication()
+		throws Exception {
+
+		CTCollection ctCollection = _addCTCollection();
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure = null;
+
+		long defaultSegmentsExperienceId =
+			SegmentsExperienceConstants.ID_DEFAULT;
+		String data = null;
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollection.getCtCollectionId())) {
+
+			Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+			Layout draftLayout = layout.fetchDraftLayout();
+
+			layoutPageTemplateStructure = _fetchLayoutPageTemplateStructure(
+				draftLayout);
+
+			defaultSegmentsExperienceId =
+				_segmentsExperienceLocalService.
+					fetchDefaultSegmentsExperienceId(draftLayout.getPlid());
+
+			LayoutPageTemplateStructureRel layoutPageTemplateStructureRel =
+				_fetchLayoutPageTemplateStructureRel(
+					layoutPageTemplateStructure, defaultSegmentsExperienceId);
+
+			data = layoutPageTemplateStructureRel.getData();
+
+			_orphanLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure, defaultSegmentsExperienceId);
+
+			Assert.assertNotNull(
+				_fetchLayoutPageTemplateStructureRel(
+					layoutPageTemplateStructure,
+					SegmentsExperienceConstants.ID_DEFAULT));
+		}
+
+		_runUpgrade();
+
+		Assert.assertNull(
+			_fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure,
+				SegmentsExperienceConstants.ID_DEFAULT));
+		Assert.assertNull(
+			_fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure, defaultSegmentsExperienceId));
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollection.getCtCollectionId())) {
+
+			Assert.assertNull(
+				_fetchLayoutPageTemplateStructureRel(
+					layoutPageTemplateStructure,
+					SegmentsExperienceConstants.ID_DEFAULT));
+
+			LayoutPageTemplateStructureRel layoutPageTemplateStructureRel =
+				_fetchLayoutPageTemplateStructureRel(
+					layoutPageTemplateStructure, defaultSegmentsExperienceId);
+
+			Assert.assertEquals(data, layoutPageTemplateStructureRel.getData());
+		}
+
+		_ctCollectionLocalService.deleteCTCollection(ctCollection);
+	}
+
+	@Test
+	@TestInfo("LPD-97443")
+	public void testUpgradeReassignsOrphanedLayoutPageTemplateStructureRelModifiedInPublication()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_fetchLayoutPageTemplateStructure(draftLayout);
+
+		long defaultSegmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				draftLayout.getPlid());
+
+		LayoutPageTemplateStructureRel defaultLayoutPageTemplateStructureRel =
+			_fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure, defaultSegmentsExperienceId);
+
+		String data = defaultLayoutPageTemplateStructureRel.getData();
+
+		CTCollection ctCollection = _addCTCollection();
+
+		String publicationData = RandomTestUtil.randomString();
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollection.getCtCollectionId())) {
+
+			LayoutPageTemplateStructureRel layoutPageTemplateStructureRel =
+				_fetchLayoutPageTemplateStructureRel(
+					layoutPageTemplateStructure, defaultSegmentsExperienceId);
+
+			layoutPageTemplateStructureRel.setSegmentsExperienceId(
+				SegmentsExperienceConstants.ID_DEFAULT);
+			layoutPageTemplateStructureRel.setData(publicationData);
+
+			_layoutPageTemplateStructureRelLocalService.
+				updateLayoutPageTemplateStructureRel(
+					layoutPageTemplateStructureRel);
+
+			Assert.assertNotNull(
+				_fetchLayoutPageTemplateStructureRel(
+					layoutPageTemplateStructure,
+					SegmentsExperienceConstants.ID_DEFAULT));
+		}
+
+		_runUpgrade();
+
+		LayoutPageTemplateStructureRel layoutPageTemplateStructureRel =
+			_fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure, defaultSegmentsExperienceId);
+
+		Assert.assertEquals(data, layoutPageTemplateStructureRel.getData());
+
+		Assert.assertNull(
+			_fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure,
+				SegmentsExperienceConstants.ID_DEFAULT));
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollection.getCtCollectionId())) {
+
+			Assert.assertNull(
+				_fetchLayoutPageTemplateStructureRel(
+					layoutPageTemplateStructure,
+					SegmentsExperienceConstants.ID_DEFAULT));
+
+			layoutPageTemplateStructureRel =
+				_fetchLayoutPageTemplateStructureRel(
+					layoutPageTemplateStructure, defaultSegmentsExperienceId);
+
+			Assert.assertEquals(
+				publicationData, layoutPageTemplateStructureRel.getData());
+		}
+
+		_ctCollectionLocalService.deleteCTCollection(ctCollection);
+	}
+
+	@Test
+	@TestInfo("LPD-97443")
+	public void testUpgradeReassignsOrphanedLayoutPageTemplateStructureRelToDefaultExperience()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_fetchLayoutPageTemplateStructure(draftLayout);
+
+		long defaultSegmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				draftLayout.getPlid());
+
+		LayoutPageTemplateStructureRel defaultLayoutPageTemplateStructureRel =
+			_fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure, defaultSegmentsExperienceId);
+
+		String data = defaultLayoutPageTemplateStructureRel.getData();
+
+		_orphanLayoutPageTemplateStructureRel(
+			layoutPageTemplateStructure, defaultSegmentsExperienceId);
+
+		Assert.assertNull(
+			_fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure, defaultSegmentsExperienceId));
+
+		_runUpgrade();
+
+		Assert.assertNull(
+			_fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure,
+				SegmentsExperienceConstants.ID_DEFAULT));
+
+		LayoutPageTemplateStructureRel layoutPageTemplateStructureRel =
+			_fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure, defaultSegmentsExperienceId);
+
+		Assert.assertEquals(data, layoutPageTemplateStructureRel.getData());
+	}
+
+	private CTCollection _addCTCollection() throws Exception {
+		return _ctCollectionLocalService.addCTCollection(
+			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			0, RandomTestUtil.randomString(), RandomTestUtil.randomString());
+	}
+
+	private LayoutPageTemplateStructure _fetchLayoutPageTemplateStructure(
+		Layout layout) {
+
+		return _layoutPageTemplateStructureLocalService.
+			fetchLayoutPageTemplateStructure(
+				layout.getGroupId(), layout.getPlid());
+	}
+
+	private LayoutPageTemplateStructureRel _fetchLayoutPageTemplateStructureRel(
+		LayoutPageTemplateStructure layoutPageTemplateStructure,
+		long segmentsExperienceId) {
+
+		return _layoutPageTemplateStructureRelLocalService.
+			fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure.getLayoutPageTemplateStructureId(),
+				segmentsExperienceId);
+	}
+
+	private void _orphanLayoutPageTemplateStructureRel(
+		LayoutPageTemplateStructure layoutPageTemplateStructure,
+		long segmentsExperienceId) {
+
+		LayoutPageTemplateStructureRel layoutPageTemplateStructureRel =
+			_fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure, segmentsExperienceId);
+
+		layoutPageTemplateStructureRel.setSegmentsExperienceId(
+			SegmentsExperienceConstants.ID_DEFAULT);
+
+		_layoutPageTemplateStructureRelLocalService.
+			updateLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructureRel);
+	}
+
+	private void _runUpgrade() throws Exception {
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator, _CLASS_NAME);
+
+		upgradeProcess.upgrade();
+
+		_entityCache.clearCache();
+
+		_multiVMPool.clear();
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.layout.page.template.internal.upgrade.v6_2_0." +
+			"LayoutPageTemplateStructureRelUpgradeProcess";
+
+	@Inject
+	private CTCollectionLocalService _ctCollectionLocalService;
+
+	@Inject
+	private EntityCache _entityCache;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private LayoutPageTemplateStructureLocalService
+		_layoutPageTemplateStructureLocalService;
+
+	@Inject
+	private LayoutPageTemplateStructureRelLocalService
+		_layoutPageTemplateStructureRelLocalService;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	@Inject
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.layout.page.template.internal.upgrade.registry.LayoutPageTemplateServiceUpgradeStepRegistrator))"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v6_2_0/test/LayoutPageTemplateStructureRelUpgradeProcessTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/upgrade/v6_2_0/test/LayoutPageTemplateStructureRelUpgradeProcessTest.java
@@ -18,17 +18,23 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.lock.LockManager;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
@@ -51,8 +57,10 @@ public class LayoutPageTemplateStructureRelUpgradeProcessTest {
 
 	@ClassRule
 	@Rule
-	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
-		new LiferayIntegrationTestRule();
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@Before
 	public void setUp() throws Exception {
@@ -304,6 +312,83 @@ public class LayoutPageTemplateStructureRelUpgradeProcessTest {
 		Assert.assertEquals(data, layoutPageTemplateStructureRel.getData());
 	}
 
+	@Test
+	@TestInfo("LPD-97443")
+	public void testUpgradeUnlocksLayoutsAndRepairsOrphanedLayoutPageTemplateStructureRel()
+		throws Exception {
+
+		Layout layout1 = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout draftLayout1 = layout1.fetchDraftLayout();
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_fetchLayoutPageTemplateStructure(draftLayout1);
+
+		long defaultSegmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				draftLayout1.getPlid());
+
+		LayoutPageTemplateStructureRel layoutPageTemplateStructureRel =
+			_fetchLayoutPageTemplateStructureRel(
+				layoutPageTemplateStructure, defaultSegmentsExperienceId);
+
+		String data = layoutPageTemplateStructureRel.getData();
+
+		_orphanLayoutPageTemplateStructureRel(
+			layoutPageTemplateStructure, defaultSegmentsExperienceId);
+
+		_segmentsExperienceLocalService.deleteSegmentsExperience(
+			_segmentsExperienceLocalService.getSegmentsExperience(
+				defaultSegmentsExperienceId));
+
+		Layout layout2 = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout draftLayout2 = layout2.fetchDraftLayout();
+
+		_user = UserTestUtil.addUser();
+
+		_lockManager.lock(
+			_user.getUserId(), Layout.class.getName(), draftLayout1.getPlid(),
+			null, false, Time.HOUR);
+		_lockManager.lock(
+			_user.getUserId(), Layout.class.getName(), draftLayout2.getPlid(),
+			null, false, Time.HOUR);
+
+		try {
+			_runUpgrade();
+
+			Assert.assertNull(
+				_lockManager.fetchLock(
+					Layout.class.getName(), draftLayout1.getPlid()));
+			Assert.assertNull(
+				_lockManager.fetchLock(
+					Layout.class.getName(), draftLayout2.getPlid()));
+
+			Assert.assertNull(
+				_fetchLayoutPageTemplateStructureRel(
+					layoutPageTemplateStructure,
+					SegmentsExperienceConstants.ID_DEFAULT));
+
+			defaultSegmentsExperienceId =
+				_segmentsExperienceLocalService.
+					fetchDefaultSegmentsExperienceId(draftLayout1.getPlid());
+
+			Assert.assertNotEquals(
+				SegmentsExperienceConstants.ID_DEFAULT,
+				defaultSegmentsExperienceId);
+
+			layoutPageTemplateStructureRel =
+				_fetchLayoutPageTemplateStructureRel(
+					layoutPageTemplateStructure, defaultSegmentsExperienceId);
+
+			Assert.assertEquals(data, layoutPageTemplateStructureRel.getData());
+		}
+		finally {
+			_lockManager.unlock(Layout.class.getName(), draftLayout1.getPlid());
+			_lockManager.unlock(Layout.class.getName(), draftLayout2.getPlid());
+		}
+	}
+
 	private CTCollection _addCTCollection() throws Exception {
 		return _ctCollectionLocalService.addCTCollection(
 			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
@@ -377,6 +462,9 @@ public class LayoutPageTemplateStructureRelUpgradeProcessTest {
 		_layoutPageTemplateStructureRelLocalService;
 
 	@Inject
+	private LockManager _lockManager;
+
+	@Inject
 	private MultiVMPool _multiVMPool;
 
 	@Inject
@@ -386,5 +474,8 @@ public class LayoutPageTemplateStructureRelUpgradeProcessTest {
 		filter = "(&(component.name=com.liferay.layout.page.template.internal.upgrade.registry.LayoutPageTemplateServiceUpgradeStepRegistrator))"
 	)
 	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@DeleteAfterTestRun
+	private User _user;
 
 }

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateStructureRelLocalServiceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateStructureRelLocalServiceTest.java
@@ -1,0 +1,113 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRel;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelLocalService;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.segments.constants.SegmentsExperienceConstants;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Balázs Sáfrány-Kovalik
+ */
+@RunWith(Arquillian.class)
+public class LayoutPageTemplateStructureRelLocalServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	@TestInfo("LPD-97443")
+	public void testAddLayoutPageTemplateStructureRelReassignsDefaultSegmentsExperienceId()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_layoutPageTemplateStructureLocalService.
+				fetchLayoutPageTemplateStructure(
+					draftLayout.getGroupId(), draftLayout.getPlid());
+
+		long defaultSegmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				draftLayout.getPlid());
+
+		Assert.assertNotEquals(
+			SegmentsExperienceConstants.ID_DEFAULT,
+			defaultSegmentsExperienceId);
+
+		_layoutPageTemplateStructureRelLocalService.
+			deleteLayoutPageTemplateStructureRel(
+				_layoutPageTemplateStructureRelLocalService.
+					fetchLayoutPageTemplateStructureRel(
+						layoutPageTemplateStructure.
+							getLayoutPageTemplateStructureId(),
+						defaultSegmentsExperienceId));
+
+		LayoutPageTemplateStructureRel layoutPageTemplateStructureRel =
+			_layoutPageTemplateStructureRelLocalService.
+				addLayoutPageTemplateStructureRel(
+					TestPropsValues.getUserId(), _group.getGroupId(),
+					layoutPageTemplateStructure.
+						getLayoutPageTemplateStructureId(),
+					SegmentsExperienceConstants.ID_DEFAULT, StringPool.BLANK,
+					ServiceContextTestUtil.getServiceContext(
+						_group.getGroupId(), TestPropsValues.getUserId()));
+
+		Assert.assertEquals(
+			defaultSegmentsExperienceId,
+			layoutPageTemplateStructureRel.getSegmentsExperienceId());
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private LayoutPageTemplateStructureLocalService
+		_layoutPageTemplateStructureLocalService;
+
+	@Inject
+	private LayoutPageTemplateStructureRelLocalService
+		_layoutPageTemplateStructureRelLocalService;
+
+	@Inject
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
+
+}

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
@@ -433,13 +433,30 @@ public class LayoutLocalServiceWrapper
 					targetLayout.getGroupId(), targetLayout.getPlid());
 
 		if (targetLayoutPageTemplateStructure == null) {
+			long targetDefaultSegmentsExperienceId =
+				_segmentsExperienceLocalService.
+					fetchDefaultSegmentsExperienceId(targetLayout.getPlid());
+
+			if (targetDefaultSegmentsExperienceId ==
+					SegmentsExperienceConstants.ID_DEFAULT) {
+
+				SegmentsExperience defaultSegmentsExperience =
+					_segmentsExperienceLocalService.
+						addDefaultSegmentsExperience(
+							targetLayout.getExternalReferenceCode() +
+								LayoutConstants.
+									EXTERNAL_REFERENCE_CODE_SUFFIX_DEFAULT,
+							user.getUserId(), targetLayout.getPlid(),
+							ServiceContextThreadLocal.getServiceContext());
+
+				targetDefaultSegmentsExperienceId =
+					defaultSegmentsExperience.getSegmentsExperienceId();
+			}
+
 			_layoutPageTemplateStructureLocalService.
 				addLayoutPageTemplateStructure(
 					user.getUserId(), targetLayout.getGroupId(),
-					targetLayout.getPlid(),
-					_segmentsExperienceLocalService.
-						fetchDefaultSegmentsExperienceId(
-							targetLayout.getPlid()),
+					targetLayout.getPlid(), targetDefaultSegmentsExperienceId,
 					null, ServiceContextThreadLocal.getServiceContext());
 		}
 

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceCopyLayoutContentTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceCopyLayoutContentTest.java
@@ -35,6 +35,7 @@ import com.liferay.layout.model.LayoutClassedModelUsage;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRel;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElementVariation;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryService;
@@ -815,6 +816,47 @@ public class LayoutLocalServiceCopyLayoutContentTest {
 		Assert.assertEquals(
 			draftFragmentEntryLink2.getEditableValues(),
 			updatedFragmentEntryLink2.getEditableValues());
+	}
+
+	@Test
+	@TestInfo("LPD-97443")
+	public void testCopyLayoutContentToWidgetPageCreatesValidSegmentsExperience()
+		throws Exception {
+
+		Layout sourceLayout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout targetLayout = LayoutTestUtil.addTypePortletLayout(
+			_group.getGroupId(), StringPool.BLANK);
+
+		Assert.assertNull(
+			_layoutPageTemplateStructureLocalService.
+				fetchLayoutPageTemplateStructure(
+					targetLayout.getGroupId(), targetLayout.getPlid()));
+
+		_layoutLocalService.copyLayoutContent(sourceLayout, targetLayout);
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_layoutPageTemplateStructureLocalService.
+				fetchLayoutPageTemplateStructure(
+					targetLayout.getGroupId(), targetLayout.getPlid());
+
+		List<LayoutPageTemplateStructureRel> layoutPageTemplateStructureRels =
+			_layoutPageTemplateStructureRelLocalService.
+				getLayoutPageTemplateStructureRels(
+					layoutPageTemplateStructure.
+						getLayoutPageTemplateStructureId());
+
+		Assert.assertEquals(
+			layoutPageTemplateStructureRels.toString(), 1,
+			layoutPageTemplateStructureRels.size());
+
+		LayoutPageTemplateStructureRel layoutPageTemplateStructureRel =
+			layoutPageTemplateStructureRels.get(0);
+
+		Assert.assertEquals(
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				targetLayout.getPlid()),
+			layoutPageTemplateStructureRel.getSegmentsExperienceId());
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97443

## What Is Being Fixed

Publishing a widget page that was converted to a content page fails with a `ClassedModel.getModelClassName()` NPE during staging. The conversion creates a `LayoutPageTemplateStructureRel` with `segmentsExperienceId = 0` (the deprecated `ID_DEFAULT` sentinel) before the layout's default `SegmentsExperience` exists, so no experience backs the rel and the publish path dereferences a null model. Master does not throw the NPE but carries the same latent data corruption.

## How It Is Being Fixed

The conversion path (`LayoutLocalServiceWrapper._copyLayoutPageTemplateStructure`) now materializes the default experience before creating the structure, keeping the invariant where it belongs — with the `Layout` entity, as `LayoutModelListener` already does on creation. `LayoutPageTemplateStructureRelLocalServiceImpl` additionally resolves a requested `0` onto the existing default experience (fetch-only, no creation).

Existing data is repaired by a 6.2.0 upgrade process that re-points each orphaned `0`-rel onto its layout's default experience, materializing one when missing. The repair is publication-aware: every statement is scoped by `ctCollectionId`, each row is processed in its own change tracking collection context (same pattern as `CPConfigurationUpgradeProcess`), and the redundancy check is relId-precise so a publication's modified copy of the production default rel is re-pointed rather than deleted. Because `addDefaultSegmentsExperience` refuses locked layouts and layout locks are page editor session state with no meaning during an upgrade, the upgrade releases all layout locks up front instead of skipping rows that would then stay broken forever.

This supersedes #18733, addressing all 3 review comments there: `ctCollectionId` handling in the upgrade SQL, the `LockedLayoutException` concern, and moving the default experience creation out of the rel service chokepoint into the conversion path.

## PR Check

**pr-check: PASS** — tested on `b75dc1351eb20a31aaa207c93bedb0b3bb1afa5b`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

`ModulesStructureTest` reports 2 pre-existing master-level findings (unused `testImplementation` dependencies in the root `modules/build.gradle` and a scanner NPE), both unrelated to this diff.

<!-- pr-check {"result": "success", "sha": "b75dc1351eb20a31aaa207c93bedb0b3bb1afa5b"} -->
