### PR TITLE
LPD-100256 Restore the trigger guard in clickAndExpectToBeHidden

### DIFF
--- a/modules/test/playwright/utils/clickAndExpectToBeHidden.ts
+++ b/modules/test/playwright/utils/clickAndExpectToBeHidden.ts
@@ -15,7 +15,7 @@ export async function clickAndExpectToBeHidden({
 	trigger: Locator;
 }) {
 	await expect(async () => {
-		if (await target.isVisible()) {
+		if (await trigger.isVisible()) {
 			await trigger.click({timeout});
 		}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100256

## What Is Being Fixed

Four Playwright tests in the page-management routine started failing in the 2026-07-30 build, all the same way: after the item selector modal selection, `.page-editor__item-selector__content-input` is still an empty readonly input when asserted.

- `layout-content-page-editor-web/fragments/contentDisplayFragment.spec.ts:154`
- `layout-content-page-editor-web/fragments/contentDisplayFragment.spec.ts:250`
- `layout-content-page-editor-web/fragments/fragmentConfiguration.spec.ts:645`
- `layout-content-page-editor-web/main/mapping.spec.ts:569`

Commit 8d4e1aa9065fd (LPD-99989 LPD-99994) changed the guard in `clickAndExpectToBeHidden` from `trigger.isVisible()` to `target.isVisible()`. When the target is not visible before the interaction, the trigger is never clicked, `expect(target).toBeHidden()` then passes for the wrong reason, and the helper returns without ever performing the interaction. That assumption holds when dismissing an alert, but not for callers whose target only appears as a result of the click.

## How It Is Being Fixed

The guard goes back to `trigger.isVisible()`, which is also the helper's documented contract: it clicks the trigger and retries until the target becomes hidden. The `click({timeout})` bound introduced by the same commit is kept, because that bound is the part that actually fixed the hang LPD-99989 and LPD-99994 reported, where a bare `click()` has no action timeout in this configuration and can consume the whole 90s test budget.

Verified locally against a bundle at ce5402ecf5. With this fix the four tests pass. With master's code three of the four fail with the CI signature, while mapping.spec.ts:569 does not reproduce locally. To confirm the original flake fix survives, styleBookAdmin.spec.ts and styleBookManagementToolbar.spec.ts ran with --repeat-each=3, and 27 of 27 passed.

## Why Are There No Tests?

The change is itself a fix to Playwright test infrastructure, so the coverage is the existing suites it repairs rather than a new test. Verification was running them, as described above.

## PR Check

**pr-check: PASS** — tested on `aa2c74206b795`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "aa2c74206b7951c864f6c2263d2380ec55a2964c"} -->
