### PR TITLE
LPD-100295 Run audiences-web.main in the page-management routines

### DIFF
--- a/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementManager.tsx
+++ b/modules/apps/audiences/audiences-web/src/main/resources/META-INF/resources/js/keyboard_movement/KeyboardMovementManager.tsx
@@ -71,6 +71,10 @@ export default function KeyboardMovementManager({
 			)
 		: -1;
 
+	const initialIndex = getInitialIndex(targets, sourceIndex);
+
+	const targetIndex = currentIndex === -1 ? initialIndex : currentIndex;
+
 	useEffect(() => {
 		if (target.nodeId !== null) {
 			return;
@@ -92,7 +96,7 @@ export default function KeyboardMovementManager({
 			return;
 		}
 
-		setTarget(toMovementTarget(getInitialTarget(targets, sourceIndex)));
+		setTarget(toMovementTarget(targets[initialIndex]));
 
 		setText(
 			Liferay.Language.get(
@@ -102,17 +106,17 @@ export default function KeyboardMovementManager({
 	}, [
 		disableMovement,
 		dispatch,
+		initialIndex,
 		setTarget,
 		setText,
 		source,
-		sourceIndex,
 		target,
 		targets,
 	]);
 
 	useEffect(() => {
 		const confirmPlacement = () => {
-			const moveTarget = targets[currentIndex];
+			const moveTarget = targets[targetIndex];
 
 			if (!moveTarget) {
 				return;
@@ -201,10 +205,10 @@ export default function KeyboardMovementManager({
 			event.stopPropagation();
 
 			if (event.code === ARROW_DOWN_KEY_CODE) {
-				moveTo(currentIndex + 1);
+				moveTo(targetIndex + 1);
 			}
 			else if (event.code === ARROW_UP_KEY_CODE) {
-				moveTo(currentIndex - 1);
+				moveTo(targetIndex - 1);
 			}
 			else if (event.code === END_KEY_CODE) {
 				moveTo(targets.length - 1);
@@ -245,15 +249,12 @@ function getPositionLabel(position: DropZone): string {
 	return Liferay.Language.get('bottom');
 }
 
-function getInitialTarget(
-	targets: MoveTarget[],
-	sourceIndex: number
-): MoveTarget {
+function getInitialIndex(targets: MoveTarget[], sourceIndex: number): number {
 	if (sourceIndex !== -1) {
-		return targets[sourceIndex + 1] ?? targets[sourceIndex];
+		return Math.min(sourceIndex + 1, targets.length - 1);
 	}
 
-	return targets[targets.length - 1];
+	return targets.length - 1;
 }
 
 function toMovementTarget(moveTarget: MoveTarget): MovementTarget {

--- a/test.properties
+++ b/test.properties
@@ -4952,6 +4952,7 @@
         **/headless/headless-admin-site/**/WidgetPageWidgetInstanceResourceTest.java
 
     page.management.playwright.projects=\
+        audiences-web.main,\
         fragment-web.main,\
         iframe-web.main,\
         layout-admin-web.main,\


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100295

## What Is Being Fixed

The Audience Builder had Playwright coverage that no page-management routine ran, so its keyboard and CRUD flows were only exercised by the analytics-cloud-upstream routine.

Running the project locally before adding it exposed a second problem, a race in the Audience Builder keyboard movement. Pressing Enter on a sidebar attribute paints the dragging state one render before the initial move target is computed in an effect, and because the keydown listener closes over the render that installed it, a confirming Enter arriving in that gap reached a handler with no target to act on. It hit a guard that returned early, which skipped the dispatch so no condition was added, skipped the announcement so nothing reached a screen reader, and skipped disableMovement so the movement stayed switched on, swallowing every later key. The result was a drag that looked armed but whose confirming keystroke had already been spent. A keyboard user pressing Enter twice quickly hits the same dead end, and the keyboard grouping test tagged @LPD-98159 lost the race deterministically on its third condition.

## How It Is Being Fixed

The first commit adds audiences-web.main to page.management.playwright.projects, which is enough to run it in both page-management and page-management-playwright since that single list feeds the playwright.projects.includes entry of each.

The second commit removes the state the handler could not act on rather than narrowing the window in which it is observable. The position a movement acts on is now derived during render, falling back to the initial position when the user has not navigated anywhere yet, so the too-early closure and the corrected one resolve to the same entry and it no longer matters which receives the keystroke. That knowledge already existed but was trapped inside the effect and immediately converted into state, forcing every consumer to wait for a round trip through a value the component could compute from its props all along. The effect still sets the context target, since that is what paints the drop indicator, but it reads through the same derived position. Deriving an index rather than a target also fixes a quieter instance of the same race on the arrow keys, where an early press stepped from -1 and jumped to the topmost position, and leaves one source of truth so the highlight and the confirmation cannot disagree.

## Why Are There No Tests?

The defect lives in the gap between a React render and its passive effects. jsdom flushes both inside the same act, so a Jest test of the same three-condition sequence passes against the broken code as readily as against the fixed one. That was verified, not assumed: the test was written, confirmed to pass before the fix, and deleted rather than left behind as a guard that guards nothing. The existing @LPD-98159 Playwright test is the real reproducer, failing 3 of 3 before and passing 3 of 3 after, and the first commit is what puts it in a routine that runs it.

## PR Check

**pr-check: PASS** — tested on `28c7d6ddf0aee27e8a28d8695adb0040720fdc4b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| PQL Validation | PASS |
| JavaScript Unit Tests | PASS |

Note: `git fetch origin master` could not run at the time pr-check executed, so the branch was verified against local `master` at `ce5402ecf57dd` rather than the live remote tip. The fetch succeeded afterwards and `page-management/master` is at that same commit, so the branch is current.

<!-- pr-check {"result": "success", "sha": "28c7d6ddf0aee27e8a28d8695adb0040720fdc4b"} -->
