### PR TITLE
LPD-99950 Prevent page loss from duplicate layout reference codes

### DIFF
--- a/modules/apps/portal/portal-upgrade-test-util/src/main/java/com/liferay/portal/upgrade/test/util/UpgradeTestUtil.java
+++ b/modules/apps/portal/portal-upgrade-test-util/src/main/java/com/liferay/portal/upgrade/test/util/UpgradeTestUtil.java
@@ -5,17 +5,40 @@
 
 package com.liferay.portal.upgrade.test.util;
 
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
+import java.sql.Connection;
+
+import java.util.List;
+
 /**
  * @author Adam Brandizzi
  * @author Alberto Chaparro
  */
 public class UpgradeTestUtil {
+
+	public static List<IndexMetadata> dropUniqueIndexes(
+			Connection connection, String tableName, String columnName)
+		throws Exception {
+
+		DB db = DBManagerUtil.getDB();
+
+		List<IndexMetadata> indexMetadatas = db.getIndexMetadatas(
+			connection, tableName, columnName, true);
+
+		for (IndexMetadata indexMetadata : indexMetadatas) {
+			db.runSQL(connection, indexMetadata.getDropSQL());
+		}
+
+		return indexMetadatas;
+	}
 
 	public static UpgradeProcess getUpgradeStep(
 		UpgradeStepRegistrator upgradeStepRegistrator,

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DeleteDuplicateUniqueFinderRowsUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DeleteDuplicateUniqueFinderRowsUpgradeProcessTest.java
@@ -8,9 +8,7 @@ package com.liferay.portal.upgrade.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.db.index.IndexUpdaterUtil;
-import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
-import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
@@ -28,6 +26,7 @@ import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
 import com.liferay.social.kernel.model.SocialActivitySetting;
 import com.liferay.social.kernel.service.SocialActivitySettingLocalService;
 
@@ -61,7 +60,6 @@ public class DeleteDuplicateUniqueFinderRowsUpgradeProcessTest {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_connection = DataAccess.getConnection();
-		_db = DBManagerUtil.getDB();
 
 		_dbInspector = new DBInspector(_connection);
 	}
@@ -73,8 +71,8 @@ public class DeleteDuplicateUniqueFinderRowsUpgradeProcessTest {
 
 	@Test
 	public void testUpgradePortalPreferences() throws Exception {
-		List<IndexMetadata> indexMetadatas = _dropUniqueIndexes(
-			"PortalPreferences", "ownerId");
+		List<IndexMetadata> indexMetadatas = UpgradeTestUtil.dropUniqueIndexes(
+			_connection, "PortalPreferences", "ownerId");
 
 		PortalPreferences portalPreferences1 =
 			_portalPreferencesLocalService.createPortalPreferences(1);
@@ -112,8 +110,8 @@ public class DeleteDuplicateUniqueFinderRowsUpgradeProcessTest {
 
 	@Test
 	public void testUpgradePortletItem() throws Exception {
-		List<IndexMetadata> indexMetadatas = _dropUniqueIndexes(
-			"PortletItem", "groupId");
+		List<IndexMetadata> indexMetadatas = UpgradeTestUtil.dropUniqueIndexes(
+			_connection, "PortletItem", "groupId");
 
 		PortletItem portletItem1 = _portletItemLocalService.createPortletItem(
 			1);
@@ -152,8 +150,8 @@ public class DeleteDuplicateUniqueFinderRowsUpgradeProcessTest {
 
 	@Test
 	public void testUpgradeSocialActivitySetting() throws Exception {
-		List<IndexMetadata> indexMetadatas = _dropUniqueIndexes(
-			"SocialActivitySetting", "groupId");
+		List<IndexMetadata> indexMetadatas = UpgradeTestUtil.dropUniqueIndexes(
+			_connection, "SocialActivitySetting", "groupId");
 
 		SocialActivitySetting socialActivitySetting1 =
 			_socialActivitySettingLocalService.createSocialActivitySetting(1);
@@ -194,8 +192,8 @@ public class DeleteDuplicateUniqueFinderRowsUpgradeProcessTest {
 
 	@Test
 	public void testUpgradeTicket() throws Exception {
-		List<IndexMetadata> indexMetadatas = _dropUniqueIndexes(
-			"Ticket", "key_");
+		List<IndexMetadata> indexMetadatas = UpgradeTestUtil.dropUniqueIndexes(
+			_connection, "Ticket", "key_");
 
 		Ticket ticket1 = _ticketLocalService.createTicket(1);
 
@@ -256,20 +254,6 @@ public class DeleteDuplicateUniqueFinderRowsUpgradeProcessTest {
 		}
 	}
 
-	private List<IndexMetadata> _dropUniqueIndexes(
-			String tableName, String columnName)
-		throws Exception {
-
-		List<IndexMetadata> indexMetadatas = _db.getIndexMetadatas(
-			_connection, tableName, columnName, true);
-
-		for (IndexMetadata indexMetadata : indexMetadatas) {
-			_db.runSQL(_connection, indexMetadata.getDropSQL());
-		}
-
-		return indexMetadatas;
-	}
-
 	private void _runUpgrade(
 			String tableName, String[] columnNames, String orderByClause)
 		throws Exception {
@@ -295,7 +279,6 @@ public class DeleteDuplicateUniqueFinderRowsUpgradeProcessTest {
 	}
 
 	private static Connection _connection;
-	private static DB _db;
 	private static DBInspector _dbInspector;
 
 	@Inject

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutDuplicateExternalReferenceCodeUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutDuplicateExternalReferenceCodeUpgradeProcessTest.java
@@ -1,0 +1,309 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.upgrade.v7_4_x.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.change.tracking.test.util.BaseCTUpgradeProcessTestCase;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.portal.db.index.IndexUpdaterUtil;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.db.IndexMetadata;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.change.tracking.CTModel;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.change.tracking.CTService;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+import com.liferay.portal.upgrade.v7_4_x.LayoutDuplicateExternalReferenceCodeUpgradeProcess;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Georgel Pop
+ */
+@RunWith(Arquillian.class)
+public class LayoutDuplicateExternalReferenceCodeUpgradeProcessTest
+	extends BaseCTUpgradeProcessTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_connection = DataAccess.getConnection();
+		_group = GroupTestUtil.addGroup();
+
+		_dbInspector = new DBInspector(_connection);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		try {
+			for (IndexMetadata indexMetadata : _indexMetadatas) {
+				if (!_dbInspector.hasIndex(
+						"Layout", indexMetadata.getIndexName())) {
+
+					IndexUpdaterUtil.updatePortalIndexes();
+
+					break;
+				}
+			}
+		}
+		finally {
+			DataAccess.cleanUp(_connection);
+		}
+	}
+
+	@Override
+	@Test
+	public void testMissingCtCollectionId() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				IndexUpdaterUtil.class.getName(), LoggerTestUtil.OFF)) {
+
+			super.testMissingCtCollectionId();
+		}
+	}
+
+	@Test
+	@TestInfo("LPD-99950")
+	public void testUpgrade() throws Exception {
+		Layout[] layouts1 = _addDuplicateExternalReferenceCodeLayouts();
+		Layout[] layouts2 = _addDuplicateExternalReferenceCodeLayouts();
+
+		Layout collidingLayout = LayoutTestUtil.addTypePortletLayout(
+			_group, false);
+		Layout customLayout = LayoutTestUtil.addTypePortletLayout(
+			_group, false);
+		Layout uniqueLayout = LayoutTestUtil.addTypePortletLayout(
+			_group, false);
+
+		Group group2 = GroupTestUtil.addGroup();
+
+		Layout group2Layout = LayoutTestUtil.addTypePortletLayout(
+			group2, false);
+
+		long minPlid1 = Math.min(layouts1[0].getPlid(), layouts1[1].getPlid());
+		long maxPlid1 = Math.max(layouts1[0].getPlid(), layouts1[1].getPlid());
+		long minPlid2 = Math.min(layouts2[0].getPlid(), layouts2[1].getPlid());
+		long maxPlid2 = Math.max(layouts2[0].getPlid(), layouts2[1].getPlid());
+
+		String externalReferenceCode1 = _getExternalReferenceCode(minPlid1);
+		String externalReferenceCode2 = _getExternalReferenceCode(minPlid2);
+
+		_updateExternalReferenceCode(
+			collidingLayout.getPlid(), String.valueOf(minPlid2));
+
+		String customExternalReferenceCode = RandomTestUtil.randomString();
+
+		_updateExternalReferenceCode(
+			customLayout.getPlid(), customExternalReferenceCode);
+
+		String uniqueExternalReferenceCode = PortalUUIDUtil.generate();
+
+		_updateExternalReferenceCode(
+			uniqueLayout.getPlid(), uniqueExternalReferenceCode);
+
+		_updateExternalReferenceCode(
+			group2Layout.getPlid(), externalReferenceCode1);
+
+		_clearCaches();
+
+		runUpgrade();
+
+		Assert.assertEquals(
+			String.valueOf(minPlid1), _getExternalReferenceCode(minPlid1));
+		Assert.assertEquals(
+			externalReferenceCode1, _getExternalReferenceCode(maxPlid1));
+
+		String externalReferenceCode3 = _getExternalReferenceCode(minPlid2);
+
+		Assert.assertNotEquals(
+			String.valueOf(minPlid2), externalReferenceCode3);
+		Assert.assertNotEquals(externalReferenceCode2, externalReferenceCode3);
+
+		Assert.assertEquals(
+			externalReferenceCode2, _getExternalReferenceCode(maxPlid2));
+		Assert.assertEquals(
+			String.valueOf(minPlid2),
+			_getExternalReferenceCode(collidingLayout.getPlid()));
+		Assert.assertEquals(
+			customExternalReferenceCode,
+			_getExternalReferenceCode(customLayout.getPlid()));
+		Assert.assertEquals(
+			uniqueExternalReferenceCode,
+			_getExternalReferenceCode(uniqueLayout.getPlid()));
+		Assert.assertEquals(
+			externalReferenceCode1,
+			_getExternalReferenceCode(group2Layout.getPlid()));
+
+		IndexUpdaterUtil.updatePortalIndexes();
+
+		for (IndexMetadata indexMetadata : _indexMetadatas) {
+			Assert.assertTrue(
+				_dbInspector.hasIndex("Layout", indexMetadata.getIndexName()));
+		}
+
+		Assert.assertNotNull(_layoutLocalService.fetchLayout(minPlid1));
+		Assert.assertNotNull(_layoutLocalService.fetchLayout(maxPlid1));
+		Assert.assertNotNull(_layoutLocalService.fetchLayout(minPlid2));
+		Assert.assertNotNull(_layoutLocalService.fetchLayout(maxPlid2));
+		Assert.assertNotNull(
+			_layoutLocalService.fetchLayout(collidingLayout.getPlid()));
+		Assert.assertNotNull(
+			_layoutLocalService.fetchLayout(customLayout.getPlid()));
+		Assert.assertNotNull(
+			_layoutLocalService.fetchLayout(uniqueLayout.getPlid()));
+		Assert.assertNotNull(
+			_layoutLocalService.fetchLayout(group2Layout.getPlid()));
+
+		runUpgrade();
+
+		Assert.assertEquals(
+			String.valueOf(minPlid1), _getExternalReferenceCode(minPlid1));
+		Assert.assertEquals(
+			externalReferenceCode1, _getExternalReferenceCode(maxPlid1));
+		Assert.assertEquals(
+			externalReferenceCode3, _getExternalReferenceCode(minPlid2));
+	}
+
+	@Override
+	protected CTModel<?> addCTModel() throws Exception {
+		Layout[] layouts = _addDuplicateExternalReferenceCodeLayouts();
+
+		return _layoutLocalService.getLayout(
+			Math.min(layouts[0].getPlid(), layouts[1].getPlid()));
+	}
+
+	@Override
+	protected void deleteCTModel(long primaryKey) throws Exception {
+		_layoutLocalService.deleteLayout(
+			_layoutLocalService.getLayout(primaryKey));
+	}
+
+	@Override
+	protected CTService<?> getCTService() {
+		return _layoutLocalService;
+	}
+
+	@Override
+	protected void runUpgrade() throws Exception {
+		UpgradeProcess upgradeProcess =
+			new LayoutDuplicateExternalReferenceCodeUpgradeProcess();
+
+		upgradeProcess.upgrade();
+
+		_clearCaches();
+	}
+
+	@Override
+	protected CTModel<?> updateCTModel(CTModel<?> ctModel) throws Exception {
+		Layout layout = (Layout)ctModel;
+
+		layout.setPriority(RandomTestUtil.randomInt());
+
+		return _layoutLocalService.updateLayout(layout);
+	}
+
+	private Layout[] _addDuplicateExternalReferenceCodeLayouts()
+		throws Exception {
+
+		if (_indexMetadatas.isEmpty()) {
+			_indexMetadatas = UpgradeTestUtil.dropUniqueIndexes(
+				_connection, "Layout", "externalReferenceCode");
+		}
+
+		Layout publicLayout = LayoutTestUtil.addTypePortletLayout(
+			_group, false);
+		Layout privateLayout = LayoutTestUtil.addTypePortletLayout(
+			_group, true);
+
+		String externalReferenceCode = PortalUUIDUtil.generate();
+
+		_updateExternalReferenceCode(
+			publicLayout.getPlid(), externalReferenceCode);
+		_updateExternalReferenceCode(
+			privateLayout.getPlid(), externalReferenceCode);
+
+		_clearCaches();
+
+		return new Layout[] {publicLayout, privateLayout};
+	}
+
+	private void _clearCaches() {
+		_entityCache.clearCache();
+
+		_multiVMPool.clear();
+	}
+
+	private String _getExternalReferenceCode(long plid) throws Exception {
+		Layout layout = _layoutLocalService.getLayout(plid);
+
+		return layout.getExternalReferenceCode();
+	}
+
+	private void _updateExternalReferenceCode(
+			long plid, String externalReferenceCode)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = _connection.prepareStatement(
+				"update Layout set externalReferenceCode = ? where plid = ?")) {
+
+			preparedStatement.setString(1, externalReferenceCode);
+			preparedStatement.setLong(2, plid);
+
+			preparedStatement.executeUpdate();
+		}
+	}
+
+	private Connection _connection;
+	private DBInspector _dbInspector;
+
+	@Inject
+	private EntityCache _entityCache;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private List<IndexMetadata> _indexMetadatas = Collections.emptyList();
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/LayoutDuplicateExternalReferenceCodeUpgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/LayoutDuplicateExternalReferenceCodeUpgradeProcess.java
@@ -1,0 +1,116 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.upgrade.v7_4_x;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Georgel Pop
+ */
+public class LayoutDuplicateExternalReferenceCodeUpgradeProcess
+	extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		Map<Long, Set<String>> externalReferenceCodesMap =
+			_getExternalReferenceCodesMap();
+
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+				StringBundler.concat(
+					"select distinct Layout1.externalReferenceCode, ",
+					"Layout1.plid, Layout1.groupId from Layout Layout1 inner ",
+					"join (select ctCollectionId, externalReferenceCode, ",
+					"groupId, max(plid) maxPlid from Layout group by ",
+					"ctCollectionId, externalReferenceCode, groupId having ",
+					"count(*) > 1) Layout2 on Layout2.ctCollectionId = ",
+					"Layout1.ctCollectionId and Layout2.externalReferenceCode ",
+					"= Layout1.externalReferenceCode and Layout2.groupId = ",
+					"Layout1.groupId where Layout1.plid != Layout2.maxPlid ",
+					"order by Layout1.plid"));
+
+			ResultSet resultSet = preparedStatement1.executeQuery();
+
+			PreparedStatement preparedStatement2 =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"update Layout set externalReferenceCode = ? where " +
+						"externalReferenceCode = ? and plid = ?")) {
+
+			while (resultSet.next()) {
+				long plid = resultSet.getLong("plid");
+
+				Set<String> externalReferenceCodes =
+					externalReferenceCodesMap.get(resultSet.getLong("groupId"));
+
+				String externalReferenceCode = _getUniqueExternalReferenceCode(
+					externalReferenceCodes, plid);
+
+				externalReferenceCodes.add(externalReferenceCode);
+
+				preparedStatement2.setString(1, externalReferenceCode);
+
+				preparedStatement2.setString(
+					2, resultSet.getString("externalReferenceCode"));
+				preparedStatement2.setLong(3, plid);
+
+				preparedStatement2.addBatch();
+			}
+
+			preparedStatement2.executeBatch();
+		}
+	}
+
+	private Map<Long, Set<String>> _getExternalReferenceCodesMap()
+		throws Exception {
+
+		Map<Long, Set<String>> externalReferenceCodesMap = new HashMap<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select Layout1.externalReferenceCode, Layout1.groupId ",
+					"from Layout Layout1 inner join (select distinct groupId ",
+					"from Layout group by ctCollectionId, ",
+					"externalReferenceCode, groupId having count(*) > 1) ",
+					"Layout2 on Layout2.groupId = Layout1.groupId"));
+
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				Set<String> externalReferenceCodes =
+					externalReferenceCodesMap.computeIfAbsent(
+						resultSet.getLong("groupId"), key -> new HashSet<>());
+
+				externalReferenceCodes.add(
+					resultSet.getString("externalReferenceCode"));
+			}
+		}
+
+		return externalReferenceCodesMap;
+	}
+
+	private String _getUniqueExternalReferenceCode(
+		Set<String> externalReferenceCodes, long plid) {
+
+		String externalReferenceCode = String.valueOf(plid);
+
+		while (externalReferenceCodes.contains(externalReferenceCode)) {
+			externalReferenceCode = String.valueOf(increment());
+		}
+
+		return externalReferenceCode;
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -814,6 +814,10 @@ public class PortalUpgradeProcessRegistryImpl
 		upgradeVersionTreeMap.put(
 			new Version(38, 7, 6),
 			new LayoutStagingExternalReferenceCodeUpgradeProcess());
+
+		upgradeVersionTreeMap.put(
+			new Version(38, 7, 7),
+			new LayoutDuplicateExternalReferenceCodeUpgradeProcess());
 	}
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99950

## What Is Being Fixed

Upgrading to 2026.Q1 silently deletes Layout rows, losing pages. The 2024.Q3 upgrade populated `Layout.externalReferenceCode` from each row's own `uuid_`, and layouts propagated from a `layoutSetPrototype` deliberately reuse the source layout's uuid, so applying one site template to both the public and the private page sets of a site gives two layouts the same code in the same group. The uuid index includes `privateLayout` but the external reference code index does not, so those rows are duplicates under the latter. When the upgrade builds that unique index, the duplicate cleaner deletes every row of the group except the highest plid. The delete is raw SQL against the primary key, so child layouts are orphaned rather than removed and the visible symptom is a broken page tree. Generation was corrected later, but no step repairs the rows that were already written.

## How It Is Being Fixed

A new upgrade process renames the external reference code of exactly the rows the cleaner would delete, before the index is built, so nothing is deleted and no other code is touched. Each row takes its plid, which is what the corrected generation already produces, or a counter value when that string is already used in the group. The update matches on the plid and the old code rather than on a single change tracking collection, so a row copied into an open publication is renamed too and publishing that draft cannot reintroduce the duplicate.

## PR Check

**pr-check: PASS** — tested on `aa093cf22976e6febf9954b7b76367808078ffac`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "aa093cf22976e6febf9954b7b76367808078ffac"} -->
