### PR TITLE
LPD-98055 Keep page path in canonical URL for non-ASCII friendly URLs

### DIFF
--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
@@ -178,16 +178,16 @@ public class PortalImplCanonicalURLTest {
 		_defaultGroup = _groupLocalService.getGroup(
 			TestPropsValues.getCompanyId(), groupKey);
 
-		_defaultGrouplayout1 = _layoutLocalService.fetchFirstLayout(
+		_defaultGroupLayout1 = _layoutLocalService.fetchFirstLayout(
 			_defaultGroup.getGroupId(), false,
 			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
 
-		if (_defaultGrouplayout1 == null) {
-			_defaultGrouplayout1 = LayoutTestUtil.addTypePortletLayout(
+		if (_defaultGroupLayout1 == null) {
+			_defaultGroupLayout1 = LayoutTestUtil.addTypePortletLayout(
 				_defaultGroup);
 		}
 
-		_defaultGrouplayout2 = LayoutTestUtil.addTypePortletLayout(
+		_defaultGroupLayout2 = LayoutTestUtil.addTypePortletLayout(
 			_defaultGroup.getGroupId());
 
 		_targetGroup = GroupTestUtil.addGroup();
@@ -475,7 +475,7 @@ public class PortalImplCanonicalURLTest {
 	@Test
 	public void testDefaultSiteFirstPage() throws Exception {
 		_testCanonicalURL(
-			"localhost", "localhost", _defaultGroup, _defaultGrouplayout1, null,
+			"localhost", "localhost", _defaultGroup, _defaultGroupLayout1, null,
 			null, "/en", StringPool.BLANK, false, false);
 	}
 
@@ -484,15 +484,15 @@ public class PortalImplCanonicalURLTest {
 		throws Exception {
 
 		_testCanonicalURL(
-			"localhost", "localhost", _defaultGroup, _defaultGrouplayout1, null,
+			"localhost", "localhost", _defaultGroup, _defaultGroupLayout1, null,
 			null, "/es", StringPool.BLANK, false, false);
 	}
 
 	@Test
 	public void testDefaultSiteSecondPage() throws Exception {
 		_testCanonicalURL(
-			"localhost", "localhost", _defaultGroup, _defaultGrouplayout2, null,
-			null, "/en", _defaultGrouplayout2.getFriendlyURL(), false, false);
+			"localhost", "localhost", _defaultGroup, _defaultGroupLayout2, null,
+			null, "/en", _defaultGroupLayout2.getFriendlyURL(), false, false);
 	}
 
 	@Test
@@ -500,8 +500,8 @@ public class PortalImplCanonicalURLTest {
 		throws Exception {
 
 		_testCanonicalURL(
-			"localhost", "localhost", _defaultGroup, _defaultGrouplayout2, null,
-			null, "/es", _defaultGrouplayout2.getFriendlyURL(), false, false);
+			"localhost", "localhost", _defaultGroup, _defaultGroupLayout2, null,
+			null, "/es", _defaultGroupLayout2.getFriendlyURL(), false, false);
 	}
 
 	@Test
@@ -516,7 +516,7 @@ public class PortalImplCanonicalURLTest {
 	@Test
 	public void testDomainDefaultSiteFirstPageFromLocalhost() throws Exception {
 		_testCanonicalURL(
-			"liferay.com", "localhost", _defaultGroup, _defaultGrouplayout1,
+			"liferay.com", "localhost", _defaultGroup, _defaultGroupLayout1,
 			null, null, "/en", StringPool.BLANK, false, false);
 	}
 
@@ -526,7 +526,7 @@ public class PortalImplCanonicalURLTest {
 
 		_testCanonicalURL(
 			"liferay.com", "localhost:" + PortalUtil.getPortalServerPort(false),
-			_defaultGroup, _defaultGrouplayout1, null, null, "/en",
+			_defaultGroup, _defaultGroupLayout1, null, null, "/en",
 			StringPool.BLANK, false, false);
 	}
 
@@ -536,7 +536,7 @@ public class PortalImplCanonicalURLTest {
 
 		_testCanonicalURL(
 			"liferay.com", "localhost:" + PortalUtil.getPortalServerPort(false),
-			_defaultGroup, _defaultGrouplayout1, null, null, "/en",
+			_defaultGroup, _defaultGroupLayout1, null, null, "/en",
 			StringPool.BLANK, false, true);
 	}
 
@@ -655,15 +655,15 @@ public class PortalImplCanonicalURLTest {
 	@Test
 	public void testNonlocalhostDefaultSiteFirstPage() throws Exception {
 		_testCanonicalURL(
-			"localhost", "liferay.com", _defaultGroup, _defaultGrouplayout1,
+			"localhost", "liferay.com", _defaultGroup, _defaultGroupLayout1,
 			null, null, "/en", StringPool.BLANK, false, false);
 	}
 
 	@Test
 	public void testNonlocalhostDefaultSiteSecondPage() throws Exception {
 		_testCanonicalURL(
-			"localhost", "liferay.com", _defaultGroup, _defaultGrouplayout2,
-			null, null, "/en", _defaultGrouplayout2.getFriendlyURL(), false,
+			"localhost", "liferay.com", _defaultGroup, _defaultGroupLayout2,
+			null, null, "/en", _defaultGroupLayout2.getFriendlyURL(), false,
 			false);
 	}
 
@@ -860,8 +860,8 @@ public class PortalImplCanonicalURLTest {
 	}
 
 	private static Group _defaultGroup;
-	private static Layout _defaultGrouplayout1;
-	private static Layout _defaultGrouplayout2;
+	private static Layout _defaultGroupLayout1;
+	private static Layout _defaultGroupLayout2;
 	private static Locale _defaultLocale;
 	private static int _defaultPrependStyle;
 	private static Group _group;

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
@@ -17,9 +17,11 @@ import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.model.impl.VirtualLayout;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolverRegistryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.LayoutFriendlyURLLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.VirtualHostLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
@@ -180,6 +182,14 @@ public class PortalImplCanonicalURLTest {
 			HashMapBuilder.put(
 				LocaleUtil.US, "/test-page"
 			).build());
+		_layout6 = LayoutTestUtil.addTypePortletLayout(
+			_group.getGroupId(), false,
+			HashMapBuilder.put(
+				LocaleUtil.US, "Pöge"
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.US, "/pöge"
+			).build());
 
 		String groupKey = PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME;
 
@@ -239,6 +249,31 @@ public class PortalImplCanonicalURLTest {
 	}
 
 	@Test
+	@TestInfo("LPD-98055")
+	public void testCanonicalURLLayoutFriendlyURLWithNonasciiCharacter()
+		throws Exception {
+
+		Assert.assertEquals("/p%C3%B6ge", _layout6.getFriendlyURL());
+
+		_testCanonicalURL(
+			"localhost", "localhost", _group, _layout6, null, null, "/en",
+			"/p%C3%B6ge", false, false);
+		_testCanonicalURL(
+			"localhost", "localhost", _group, _addLegacyLayout("/legacy-pöge"),
+			null, null, "/en", "/legacy-p%C3%B6ge", false, false);
+	}
+
+	@Test
+	@TestInfo("LPD-98055")
+	public void testCanonicalURLLegacyLayoutFriendlyURLWithMixedCase()
+		throws Exception {
+
+		_testCanonicalURL(
+			"localhost", "localhost", _group, _addLegacyLayout("/LegacyHome1"),
+			null, null, "/en", "/LegacyHome1", false, false);
+	}
+
+	@Test
 	public void testCanonicalURLPartialCollisionWIthPublicGroupServletMapping()
 		throws Exception {
 
@@ -265,6 +300,21 @@ public class PortalImplCanonicalURLTest {
 					completeURL, "_ga",
 					"2.237928582.786466685.1515402734-1365236376"),
 				themeDisplay, _layout4, false, false));
+	}
+
+	@Test
+	@TestInfo("LPD-98055")
+	public void testCanonicalURLVirtualLayout() throws Exception {
+		_targetGroup = GroupTestUtil.addGroup();
+
+		Layout virtualLayout = new VirtualLayout(_layout6, _targetGroup);
+
+		_testCanonicalURL(
+			"localhost", "localhost", _targetGroup, virtualLayout, null, null,
+			"/en", StringPool.BLANK, false, false);
+		_testCanonicalURL(
+			"localhost", "localhost", _targetGroup, virtualLayout, null, null,
+			"/en", virtualLayout.getFriendlyURL(), true, false);
 	}
 
 	@Test
@@ -630,6 +680,21 @@ public class PortalImplCanonicalURLTest {
 			"/home2", false, false);
 	}
 
+	private Layout _addLegacyLayout(String friendlyURL) throws Exception {
+		Layout layout = LayoutTestUtil.addTypePortletLayout(
+			_group.getGroupId());
+
+		_layoutFriendlyURLLocalService.updateLayoutFriendlyURL(
+			TestPropsValues.getUserId(), layout.getCompanyId(),
+			layout.getGroupId(), layout.getPlid(), layout.isPrivateLayout(),
+			friendlyURL, LocaleUtil.toLanguageId(LocaleUtil.US),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		layout.setFriendlyURL(friendlyURL);
+
+		return _layoutLocalService.updateLayout(layout);
+	}
+
 	private ThemeDisplay _createThemeDisplay(
 			String portalDomain, Group group, int serverPort, boolean secure)
 		throws Exception {
@@ -811,11 +876,18 @@ public class PortalImplCanonicalURLTest {
 	private Layout _layout3;
 	private Layout _layout4;
 	private Layout _layout5;
+	private Layout _layout6;
+
+	@Inject
+	private LayoutFriendlyURLLocalService _layoutFriendlyURLLocalService;
 
 	@Inject
 	private LayoutLocalService _layoutLocalService;
 
 	@Inject
 	private Portal _portal;
+
+	@DeleteAfterTestRun
+	private Group _targetGroup;
 
 }

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
@@ -10,7 +10,6 @@ import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
@@ -28,7 +27,6 @@ import com.liferay.portal.kernel.service.VirtualHostLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -75,7 +73,7 @@ public class PortalImplCanonicalURLTest {
 		new LiferayIntegrationTestRule();
 
 	@BeforeClass
-	public static void setUpClass() throws PortalException {
+	public static void setUpClass() throws Exception {
 		_originalVirtualHostsDefaultSiteName =
 			ReflectionTestUtil.getAndSetFieldValue(
 				PropsValues.class, "VIRTUAL_HOSTS_DEFAULT_SITE_NAME", "Guest");
@@ -96,32 +94,11 @@ public class PortalImplCanonicalURLTest {
 			TreeMapBuilder.put(
 				"localhost", StringPool.BLANK
 			).build());
-	}
 
-	@AfterClass
-	public static void tearDownClass() {
-		LocaleUtil.setDefault(
-			_defaultLocale.getLanguage(), _defaultLocale.getCountry(),
-			_defaultLocale.getVariant());
-
-		TestPropsUtil.set(
-			PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE,
-			GetterUtil.getString(_defaultPrependStyle));
-
-		ReflectionTestUtil.setFieldValue(
-			PropsValues.class, "VIRTUAL_HOSTS_DEFAULT_SITE_NAME",
-			_originalVirtualHostsDefaultSiteName);
-		ReflectionTestUtil.setFieldValue(
-			PropsValues.class, "WEB_SERVER_HTTP_PORT",
-			_originalWebServerHTTPPort);
-		ReflectionTestUtil.setFieldValue(
-			PropsValues.class, "WEB_SERVER_HTTPS_PORT",
-			_originalWebServerHTTPSPort);
-	}
-
-	@Before
-	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
+
+		_originalGroupFriendlyURL = _group.getFriendlyURL();
+		_originalGroupTypeSettings = _group.getTypeSettings();
 
 		_layout1 = LayoutTestUtil.addTypePortletLayout(
 			_group.getGroupId(), false,
@@ -198,22 +175,53 @@ public class PortalImplCanonicalURLTest {
 			groupKey = GroupConstants.GUEST;
 		}
 
-		if (_defaultGroup == null) {
-			_defaultGroup = _groupLocalService.getGroup(
-				TestPropsValues.getCompanyId(), groupKey);
+		_defaultGroup = _groupLocalService.getGroup(
+			TestPropsValues.getCompanyId(), groupKey);
 
-			_defaultGrouplayout1 = _layoutLocalService.fetchFirstLayout(
-				_defaultGroup.getGroupId(), false,
-				LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
+		_defaultGrouplayout1 = _layoutLocalService.fetchFirstLayout(
+			_defaultGroup.getGroupId(), false,
+			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
 
-			if (_defaultGrouplayout1 == null) {
-				_defaultGrouplayout1 = LayoutTestUtil.addTypePortletLayout(
-					_defaultGroup);
-			}
-
-			_defaultGrouplayout2 = LayoutTestUtil.addTypePortletLayout(
-				_defaultGroup.getGroupId());
+		if (_defaultGrouplayout1 == null) {
+			_defaultGrouplayout1 = LayoutTestUtil.addTypePortletLayout(
+				_defaultGroup);
 		}
+
+		_defaultGrouplayout2 = LayoutTestUtil.addTypePortletLayout(
+			_defaultGroup.getGroupId());
+
+		_targetGroup = GroupTestUtil.addGroup();
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		LocaleUtil.setDefault(
+			_defaultLocale.getLanguage(), _defaultLocale.getCountry(),
+			_defaultLocale.getVariant());
+
+		TestPropsUtil.set(
+			PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE,
+			GetterUtil.getString(_defaultPrependStyle));
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "VIRTUAL_HOSTS_DEFAULT_SITE_NAME",
+			_originalVirtualHostsDefaultSiteName);
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "WEB_SERVER_HTTP_PORT",
+			_originalWebServerHTTPPort);
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "WEB_SERVER_HTTPS_PORT",
+			_originalWebServerHTTPSPort);
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_group = _groupLocalService.updateGroup(
+			_group.getGroupId(), _originalGroupTypeSettings);
+
+		_group.setFriendlyURL(_originalGroupFriendlyURL);
+
+		_group = _groupLocalService.updateGroup(_group);
 	}
 
 	@Test
@@ -306,8 +314,6 @@ public class PortalImplCanonicalURLTest {
 	@Test
 	@TestInfo("LPD-98055")
 	public void testCanonicalURLVirtualLayout() throws Exception {
-		_targetGroup = GroupTestUtil.addGroup();
-
 		Layout virtualLayout = new VirtualLayout(_layout6, _targetGroup);
 
 		_testCanonicalURL(
@@ -853,11 +859,32 @@ public class PortalImplCanonicalURLTest {
 				layout, forceLayoutFriendlyURL));
 	}
 
+	private static Group _defaultGroup;
+	private static Layout _defaultGrouplayout1;
+	private static Layout _defaultGrouplayout2;
 	private static Locale _defaultLocale;
 	private static int _defaultPrependStyle;
+	private static Group _group;
+
+	@Inject
+	private static GroupLocalService _groupLocalService;
+
+	private static Layout _layout1;
+	private static Layout _layout2;
+	private static Layout _layout3;
+	private static Layout _layout4;
+	private static Layout _layout5;
+	private static Layout _layout6;
+
+	@Inject
+	private static LayoutLocalService _layoutLocalService;
+
+	private static String _originalGroupFriendlyURL;
+	private static String _originalGroupTypeSettings;
 	private static String _originalVirtualHostsDefaultSiteName;
 	private static int _originalWebServerHTTPPort;
 	private static int _originalWebServerHTTPSPort;
+	private static Group _targetGroup;
 
 	@Inject
 	private static VirtualHostLocalService _virtualHostLocalService;
@@ -865,33 +892,10 @@ public class PortalImplCanonicalURLTest {
 	@Inject
 	private CompanyLocalService _companyLocalService;
 
-	private Group _defaultGroup;
-	private Layout _defaultGrouplayout1;
-	private Layout _defaultGrouplayout2;
-
-	@DeleteAfterTestRun
-	private Group _group;
-
-	@Inject
-	private GroupLocalService _groupLocalService;
-
-	private Layout _layout1;
-	private Layout _layout2;
-	private Layout _layout3;
-	private Layout _layout4;
-	private Layout _layout5;
-	private Layout _layout6;
-
 	@Inject
 	private LayoutFriendlyURLLocalService _layoutFriendlyURLLocalService;
 
 	@Inject
-	private LayoutLocalService _layoutLocalService;
-
-	@Inject
 	private Portal _portal;
-
-	@DeleteAfterTestRun
-	private Group _targetGroup;
 
 }

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.model.VirtualLayoutConstants;
 import com.liferay.portal.kernel.model.impl.VirtualLayout;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolverRegistryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -260,7 +261,7 @@ public class PortalImplCanonicalURLTest {
 			"/p%C3%B6ge", false, false);
 		_testCanonicalURL(
 			"localhost", "localhost", _group, _addLegacyLayout("/legacy-pöge"),
-			null, null, "/en", "/legacy-p%C3%B6ge", false, false);
+			null, null, "/en", "/legacy-pöge", false, false);
 	}
 
 	@Test
@@ -314,7 +315,10 @@ public class PortalImplCanonicalURLTest {
 			"/en", StringPool.BLANK, false, false);
 		_testCanonicalURL(
 			"localhost", "localhost", _targetGroup, virtualLayout, null, null,
-			"/en", virtualLayout.getFriendlyURL(), true, false);
+			"/en",
+			VirtualLayoutConstants.CANONICAL_URL_SEPARATOR +
+				_group.getFriendlyURL() + "/p%C3%B6ge",
+			true, false);
 	}
 
 	@Test

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1570,9 +1570,8 @@ public class PortalImpl implements Portal {
 			(!(layout instanceof VirtualLayout) &&
 			 (!layout.isFirstParent() || Validator.isNotNull(parametersURL)) &&
 			 _requiresLayoutFriendlyURL(
-				 layoutGroup.getFriendlyURL(),
-				 themeDisplay.getLayoutFriendlyURL(layout),
-				 groupFriendlyURL)) ||
+				 groupFriendlyURL, themeDisplay.getLayoutFriendlyURL(layout),
+				 layoutGroup.getFriendlyURL())) ||
 			groupFriendlyURL.endsWith(
 				StringPool.SLASH + layout.getLayoutId())) {
 
@@ -8183,8 +8182,8 @@ public class PortalImpl implements Portal {
 	}
 
 	private boolean _requiresLayoutFriendlyURL(
-		String siteGroupFriendlyURL, String layoutFriendlyURL,
-		String groupFriendlyURL) {
+		String groupFriendlyURL, String layoutFriendlyURL,
+		String siteGroupFriendlyURL) {
 
 		groupFriendlyURL = FriendlyURLNormalizerUtil.normalizeWithEncoding(
 			groupFriendlyURL);

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1575,16 +1575,6 @@ public class PortalImpl implements Portal {
 			groupFriendlyURL.endsWith(
 				StringPool.SLASH + layout.getLayoutId())) {
 
-			if (!(layout instanceof VirtualLayout)) {
-				String decodedDefaultLayoutFriendlyURL =
-					HttpComponentsUtil.decodePath(defaultLayoutFriendlyURL);
-
-				if (Validator.isNotNull(decodedDefaultLayoutFriendlyURL)) {
-					defaultLayoutFriendlyURL = HttpComponentsUtil.encodePath(
-						decodedDefaultLayoutFriendlyURL);
-				}
-			}
-
 			canonicalLayoutFriendlyURL = defaultLayoutFriendlyURL;
 		}
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1576,6 +1576,16 @@ public class PortalImpl implements Portal {
 			groupFriendlyURL.endsWith(
 				StringPool.SLASH + layout.getLayoutId())) {
 
+			if (!(layout instanceof VirtualLayout)) {
+				String decodedDefaultLayoutFriendlyURL =
+					HttpComponentsUtil.decodePath(defaultLayoutFriendlyURL);
+
+				if (Validator.isNotNull(decodedDefaultLayoutFriendlyURL)) {
+					defaultLayoutFriendlyURL = HttpComponentsUtil.encodePath(
+						decodedDefaultLayoutFriendlyURL);
+				}
+			}
+
 			canonicalLayoutFriendlyURL = defaultLayoutFriendlyURL;
 		}
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1567,11 +1567,12 @@ public class PortalImpl implements Portal {
 		Group layoutGroup = layout.getGroup();
 
 		if (forceLayoutFriendlyURL ||
-			((!layout.isFirstParent() || Validator.isNotNull(parametersURL)) &&
+			(!(layout instanceof VirtualLayout) &&
+			 (!layout.isFirstParent() || Validator.isNotNull(parametersURL)) &&
 			 _requiresLayoutFriendlyURL(
 				 layoutGroup.getFriendlyURL(),
 				 themeDisplay.getLayoutFriendlyURL(layout),
-				 StringUtil.toLowerCase(groupFriendlyURL))) ||
+				 groupFriendlyURL)) ||
 			groupFriendlyURL.endsWith(
 				StringPool.SLASH + layout.getLayoutId())) {
 
@@ -8178,20 +8179,23 @@ public class PortalImpl implements Portal {
 		groupFriendlyURL = FriendlyURLNormalizerUtil.normalizeWithEncoding(
 			groupFriendlyURL);
 
+		layoutFriendlyURL = FriendlyURLNormalizerUtil.normalizeWithEncoding(
+			layoutFriendlyURL);
+
 		if (groupFriendlyURL.contains(
 				_PUBLIC_GROUP_SERVLET_MAPPING + StringPool.SLASH)) {
 
 			if (groupFriendlyURL.contains(
 					StringBundler.concat(
-						_PUBLIC_GROUP_SERVLET_MAPPING, siteGroupFriendlyURL,
-						StringUtil.toLowerCase(layoutFriendlyURL)))) {
+						_PUBLIC_GROUP_SERVLET_MAPPING,
+						FriendlyURLNormalizerUtil.normalizeWithEncoding(
+							siteGroupFriendlyURL),
+						layoutFriendlyURL))) {
 
 				return true;
 			}
 		}
-		else if (groupFriendlyURL.contains(
-					StringUtil.toLowerCase(layoutFriendlyURL))) {
-
+		else if (groupFriendlyURL.contains(layoutFriendlyURL)) {
 			return true;
 		}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98055

Sent to Page Management first per the Core Infra review of https://github.com/liferay-core-infra/liferay-portal/pull/10146: the logic lives in `PortalImpl`, but the behavior belongs to Pages/SEO.

## What Is Being Fixed

When a page's friendly URL contains a non-ASCII character (for example `/pöge`), the canonical and hreflang alternate link tags in the page head drop the page path and point at the site root. `PortalImpl._requiresLayoutFriendlyURL` compares the request URL, normalized by `FriendlyURLNormalizerUtil.normalizeWithEncoding` into uppercase percent-hex escapes (`/p%C3%B6ge`), against the stored layout friendly URL, which was only lowercased (`/p%c3%b6ge`), so the `contains` check never matched and the page path was dropped. The asymmetry dates to LPD-64244, which added the request-side normalization.

## How It Is Being Fixed

Both sides of the comparison are now normalized with the same `normalizeWithEncoding` call, which also covers friendly URLs stored before the current normalization rules (raw non-ASCII or mixed case values written through `LayoutFriendlyURLLocalService`, which does not normalize). This supersedes https://github.com/liferay-core-infra/liferay-portal/pull/10085, which was closed because normalizing the canonical output with `normalizeWithEncoding` corrupted virtual layout URLs by rewriting the `/~/` separator into `/-/`. Two design changes address that review:

Virtual layouts are excluded from the comparison with an explicit `instanceof VirtualLayout` gate. On master the comparison could never match a virtual layout anyway (the needle keeps `~` while the normalized request side maps it to `-`), so the gate keeps virtual layout canonical URLs byte-identical to master.

The canonical page path is re-encoded through `HttpComponentsUtil.decodePath` and `encodePath` instead of `normalizeWithEncoding`, in its own commit since it is the one behavior change beyond the bug fix. That round trip is an identity for every canonically stored friendly URL and only changes legacy raw values, which now render in percent-encoded form (`/pöge` becomes `/p%C3%B6ge`) while keeping their case and content — a legacy `/Home1` stays `/Home1` instead of being lowercased into a URL that 404s on case-sensitive databases.

The hreflang alternate links flow through the same path: `OpenGraphTopHeadDynamicInclude` computes the canonical URL first and passes it to `getAlternateURL`, so they inherit the corrected page path. One deliberate side effect: `siteGroupFriendlyURL` in the `/web` branch is now normalized too, so a site group friendly URL stored in non-canonical form (possible through plain `updateGroup(Group)` model updates) also keeps the page path, erring toward retaining it.

Three integration tests, all asserting through the existing `_testCanonicalURL` helper, cover the scenario matrix: non-ASCII stored canonically plus the same value stored raw through `LayoutFriendlyURLLocalService` (legacy rows), mixed-case legacy (pins LPS-153646, which shipped without a test — this case fails if the output is normalized with `normalizeWithEncoding` as in the previous PR), and virtual layouts with and without `forceLayoutFriendlyURL` (fails if the gate is omitted or the `/~` separator is rewritten). The full `PortalImplCanonicalURLTest` and `PortalImplAlternateURLTest` suites pass against a deployed bundle, preserving the scenarios from LPS-106526, LPS-119160, LPS-135694, LPS-135807, LPS-153646, and LPD-64244, and the virtual layout behavior was additionally verified by hand against the user group repro from the previous review, on master and on this branch.

## What Changed From The Previous Pull

Previous pull: https://github.com/liferay-page-management/liferay-portal/pull/18791

Thanks @ak-ragnor for the effort on this one, the root cause analysis and the test matrix in particular. Reviewed the previous pull and the code looks good, so your four commits are unchanged here, only rebased onto the current master. The single addition is a test-only performance improvement on top.

`testCanonicalURLVirtualLayout` created a second group to act as the virtual layout target and held it in a `@DeleteAfterTestRun` field. `VirtualLayout` only needs some group as its target, and `setUp` already creates a fresh one for every test method, so that second group was pure setup cost on every run of the test. It now reuses the group from `setUp`, which also removes the field: `@DeleteAfterTestRun` is for fixtures built in `setUp` or shared across methods, and this group was used by a single test. `PortalImplCanonicalURLTest` passes in full, 37 tests and 0 failures, against a deployed bundle.

## PR Check

**pr-check: PASS** — tested on `21453a1ab1ccd8161d0969cc5641d300a7c9404e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Portal Core Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Two notes on how this run differs from a stock one. **Portal Core Compile** stands in for **Full Portal Build**: it ran `ant compile install-portal-snapshots` rather than `ant all`, because `ant all` would have redeployed into a running bundle, so portal-core compiles and the kernel and impl snapshots install, but the deploy path is not exercised. **Cross-Module Compile** skipped its consumer expansion because `PortalImpl` has 9 `testIntegration` consumers, over the cap of 8, and there are no deprecated consumers; the diff adds and removes no `public` or `protected` line, so no signature break is possible.

Java unit tests covered `PortalImplUnitTest` (32), `PortalImplGroupFriendlyURLTest` (8), and `PortalImplEscapeRedirectTest` (6), 46 tests with 0 failures. Baseline compared against released 129.0.1 with an empty report.

<!-- pr-check {"result": "success", "sha": "21453a1ab1ccd8161d0969cc5641d300a7c9404e"} -->
