### PR TITLE
LPD-99706 Skip the fragment entry lookup when the key cannot fit

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
@@ -392,9 +392,18 @@ public class FragmentEntryLocalServiceImpl
 	public FragmentEntry fetchFragmentEntry(
 		long groupId, String fragmentEntryKey) {
 
+		fragmentEntryKey = _getFragmentEntryKey(fragmentEntryKey);
+
+		int fragmentEntryKeyMaxLength = ModelHintsUtil.getMaxLength(
+			FragmentEntry.class.getName(), "fragmentEntryKey");
+
+		if (fragmentEntryKey.length() > fragmentEntryKeyMaxLength) {
+			return null;
+		}
+
 		FragmentEntry fragmentEntry =
 			fragmentEntryPersistence.fetchByG_FEK_First(
-				groupId, _getFragmentEntryKey(fragmentEntryKey), null);
+				groupId, fragmentEntryKey, null);
 
 		if (fragmentEntry == null) {
 			return null;

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
@@ -919,7 +919,10 @@ public class FragmentEntryLocalServiceTest {
 				ServiceContextTestUtil.getServiceContext(
 					_group.getGroupId(), TestPropsValues.getUserId()));
 
-		Assert.assertEquals(fragmentEntry, fragmentEntry);
+		Assert.assertEquals(
+			fragmentEntry,
+			_fragmentEntryLocalService.fetchFragmentEntry(
+				_group.getGroupId(), fragmentEntryKey));
 	}
 
 	private void _testGetFragmentEntriesByFragmentCollectionId()


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99706

## What Is Being Fixed

Site initialization fails on DB2 with `SQLCODE=-302, SQLSTATE=22001`, aborting with an `InitializationException`. Site initializers bind `FragmentRenderer` class names as fragment keys, and those run from 100 to 123 characters while `FragmentEntry.fragmentEntryKey` is `VARCHAR(75)`.

DB2 types an untyped parameter marker from the other operand, so the marker in `where fragmentEntryKey = ?` becomes `VARCHAR(75)` and binding a longer key is rejected before any row is examined. MySQL and PostgreSQL place no such constraint on the bind, return no rows, and reach the fragment renderer fallback, which is why this only appears on DB2.

This is not specific to DSR. Twelve site initializers ship over-long keys, 118 distinct ones in total, with `site-initializer-cms` carrying the most at 44.

## How It Is Being Fixed

A key wider than the column cannot match any stored value on any vendor, so `fetchFragmentEntry` now returns `null` without querying when the normalized key exceeds the column width. That is the same answer MySQL and PostgreSQL already give, so the change is a no-op there, and it removes the query DB2 refuses to prepare.

Guarding in the service rather than in the layout importer covers every caller: both importer call sites, the drop zone importer, the content page editor, and the fragments importer. The width comes from `ModelHintsUtil` rather than a literal, matching how `_validate` already checks the `name` field in the same class.

A separate commit repairs `FragmentEntryLocalServiceTest`, where the by-key assertion compared the added fragment entry against itself and never called `fetchFragmentEntry` at all.

## Why Are There No Tests?

The failure is already covered by `LocalFile.DBMigrationImport#CanImportDatabaseToPostgreSQL`, which runs on DB2 and is the test that caught it. A new test could not reproduce it, since every other vendor returns no rows for an over-long key and passes with or without the fix.

Instead, the first commit restores the existing coverage of the normal fetch path, which had been dead since LPD-18437. `FragmentEntryLocalServiceTest`, `FragmentEntryServiceTest`, `FragmentEntryLinkStagingTest`, and `FragmentsImporterTest` were run locally and pass, confirming the guard does not affect normal-length lookups.

## PR Check

**pr-check: PASS** — tested on `c22ee629144263fe6d1089337b386bfea67d772b`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c22ee629144263fe6d1089337b386bfea67d772b"} -->
