### PR TITLE
LPD-100503 Fix FragmentCollectionManagerTest after the CMS release

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/manager/test/FragmentCollectionManagerTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/manager/test/FragmentCollectionManagerTest.java
@@ -19,9 +19,7 @@ import com.liferay.portal.kernel.feature.flag.constants.FeatureFlagConstants;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
@@ -32,7 +30,6 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
-import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -114,58 +111,6 @@ public class FragmentCollectionManagerTest {
 					_company.getGroupId(), designLibraryDepotEntry.getGroupId(),
 					_group.getGroupId(), CompanyConstants.SYSTEM
 				});
-		}
-	}
-
-	@Test
-	@TestInfo("LPS-162848")
-	public void testGetLayoutElementMapsListMapWithoutApprovedObjectDefinition() {
-		Map<String, List<Map<String, Object>>> layoutElementMapsListMap =
-			ReflectionTestUtil.invoke(
-				_fragmentCollectionManager, "getLayoutElementMapsListMap",
-				new Class<?>[] {PermissionChecker.class},
-				PermissionThreadLocal.getPermissionChecker());
-
-		Assert.assertFalse(layoutElementMapsListMap.containsKey("INPUTS"));
-	}
-
-	@Test
-	@TestInfo("LPS-162848")
-	public void testGetLayoutElementMapsListMapWithoutPermissions()
-		throws Exception {
-
-		ObjectDefinition objectDefinition =
-			ObjectDefinitionTestUtil.publishObjectDefinition(
-				Collections.singletonList(
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-						ObjectFieldConstants.DB_TYPE_STRING, "First Name",
-						"firstName")),
-				false);
-
-		User user = UserTestUtil.addUser();
-
-		PermissionChecker originalPermissionChecker =
-			PermissionThreadLocal.getPermissionChecker();
-
-		try {
-			PermissionThreadLocal.setPermissionChecker(
-				PermissionCheckerFactoryUtil.create(user));
-
-			Map<String, List<Map<String, Object>>> layoutElementMapsListMap =
-				ReflectionTestUtil.invoke(
-					_fragmentCollectionManager, "getLayoutElementMapsListMap",
-					new Class<?>[] {PermissionChecker.class},
-					PermissionThreadLocal.getPermissionChecker());
-
-			Assert.assertFalse(layoutElementMapsListMap.containsKey("INPUTS"));
-		}
-		finally {
-			PermissionThreadLocal.setPermissionChecker(
-				originalPermissionChecker);
-
-			_objectDefinitionLocalService.deleteObjectDefinition(
-				objectDefinition);
 		}
 	}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/test/java/com/liferay/layout/content/page/editor/web/internal/manager/FragmentCollectionManagerTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/test/java/com/liferay/layout/content/page/editor/web/internal/manager/FragmentCollectionManagerTest.java
@@ -1,0 +1,164 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.page.editor.web.internal.manager;
+
+import com.liferay.info.item.InfoItemClassDetails;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.permission.provider.InfoPermissionProvider;
+import com.liferay.layout.page.template.info.item.capability.EditPageInfoItemCapability;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Víctor Galán
+ */
+public class FragmentCollectionManagerTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	@TestInfo("LPS-162848")
+	public void testGetLayoutElementMapsListMap() {
+		ReflectionTestUtil.setFieldValue(
+			_fragmentCollectionManager, "_infoItemServiceRegistry",
+			_infoItemServiceRegistry);
+
+		_testGetLayoutElementMapsListMapWithoutEditPageInfoItemCapability();
+		_testGetLayoutElementMapsListMapWithoutInfoPermissionProvider();
+		_testGetLayoutElementMapsListMapWithoutViewPermission();
+		_testGetLayoutElementMapsListMapWithViewPermission();
+	}
+
+	private void _setUpInfoItemClassDetails() {
+		InfoItemClassDetails infoItemClassDetails = Mockito.mock(
+			InfoItemClassDetails.class);
+
+		Mockito.when(
+			infoItemClassDetails.getClassName()
+		).thenReturn(
+			_CLASS_NAME
+		);
+
+		Mockito.when(
+			_infoItemServiceRegistry.getInfoItemClassDetails(
+				EditPageInfoItemCapability.KEY)
+		).thenReturn(
+			ListUtil.fromArray(infoItemClassDetails)
+		);
+	}
+
+	private void _testGetLayoutElementMapsListMapWithoutEditPageInfoItemCapability() {
+		Mockito.when(
+			_infoItemServiceRegistry.getInfoItemClassDetails(
+				EditPageInfoItemCapability.KEY)
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		Map<String, List<Map<String, Object>>> layoutElementMapsListMap =
+			_fragmentCollectionManager.getLayoutElementMapsListMap(
+				_permissionChecker);
+
+		Assert.assertFalse(layoutElementMapsListMap.containsKey("INPUTS"));
+	}
+
+	private void _testGetLayoutElementMapsListMapWithoutInfoPermissionProvider() {
+		_setUpInfoItemClassDetails();
+
+		Mockito.when(
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoPermissionProvider.class, _CLASS_NAME)
+		).thenReturn(
+			null
+		);
+
+		Map<String, List<Map<String, Object>>> layoutElementMapsListMap =
+			_fragmentCollectionManager.getLayoutElementMapsListMap(
+				_permissionChecker);
+
+		Assert.assertTrue(layoutElementMapsListMap.containsKey("INPUTS"));
+	}
+
+	private void _testGetLayoutElementMapsListMapWithoutViewPermission() {
+		_setUpInfoItemClassDetails();
+
+		InfoPermissionProvider<?> infoPermissionProvider = Mockito.mock(
+			InfoPermissionProvider.class);
+
+		Mockito.when(
+			infoPermissionProvider.hasViewPermission(_permissionChecker)
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoPermissionProvider.class, _CLASS_NAME)
+		).thenReturn(
+			infoPermissionProvider
+		);
+
+		Map<String, List<Map<String, Object>>> layoutElementMapsListMap =
+			_fragmentCollectionManager.getLayoutElementMapsListMap(
+				_permissionChecker);
+
+		Assert.assertFalse(layoutElementMapsListMap.containsKey("INPUTS"));
+	}
+
+	private void _testGetLayoutElementMapsListMapWithViewPermission() {
+		_setUpInfoItemClassDetails();
+
+		InfoPermissionProvider<?> infoPermissionProvider = Mockito.mock(
+			InfoPermissionProvider.class);
+
+		Mockito.when(
+			infoPermissionProvider.hasViewPermission(_permissionChecker)
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_infoItemServiceRegistry.getFirstInfoItemService(
+				InfoPermissionProvider.class, _CLASS_NAME)
+		).thenReturn(
+			infoPermissionProvider
+		);
+
+		Map<String, List<Map<String, Object>>> layoutElementMapsListMap =
+			_fragmentCollectionManager.getLayoutElementMapsListMap(
+				_permissionChecker);
+
+		Assert.assertTrue(layoutElementMapsListMap.containsKey("INPUTS"));
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.object.model.ObjectEntry";
+
+	private final FragmentCollectionManager _fragmentCollectionManager =
+		new FragmentCollectionManager();
+	private final InfoItemServiceRegistry _infoItemServiceRegistry =
+		Mockito.mock(InfoItemServiceRegistry.class);
+	private final PermissionChecker _permissionChecker = Mockito.mock(
+		PermissionChecker.class);
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100503

## What Is Being Fixed

`FragmentCollectionManagerTest` started failing on the page management routine on 2026-08-01. Two methods, `testGetLayoutElementMapsListMapWithoutApprovedObjectDefinition` and `testGetLayoutElementMapsListMapWithoutPermissions`, both assert that the INPUTS fragment collection is absent, and both now fail.

LPD-99210 removed the LPD-17564 gate, so every company provisions the CMS site unconditionally. The CMS site initializer publishes `CMSBasicWebContent`, `CMSBlog`, `CMSBasicDocument` and `CMSExternalVideo` with a form container enabled, and grants the Guest and User roles view permission on them. `ObjectEntryInfoPermissionProvider` therefore reports view permission for every user, `FragmentCollectionManager._hideInputFragments` always returns false, and INPUTS is always present.

Neither assertion can be satisfied any more. They depend on global portal state the test does not control, and a fresh company does not isolate them either: a company created mid-test through `CompanyTestUtil.addCompany()` is provisioned the same way, and INPUTS is still present for a plain user in it.

## How It Is Being Fixed

The behavior under test is unchanged and still worth covering, so the coverage moves to a unit test that stubs `InfoItemServiceRegistry` instead of depending on what the portal happens to publish. It asserts all four branches of `_hideInputFragments`: no edit page info item capability, no `InfoPermissionProvider`, a provider denying view, and a provider granting view. The two unsatisfiable integration assertions are then removed. `testGetLayoutElementMapsListMapWithPermissions` stays, since it still passes and exercises the real wiring end to end.

Worth flagging for the team: after LPD-99210, `_hideInputFragments` can never return true in a provisioned portal, so the LPS-162848 behavior of hiding the Inputs collection is effectively inert at runtime. That may be the intended consequence of the CMS release, but it is worth a deliberate decision rather than inheriting it by accident.

## PR Check

**pr-check: PASS** — tested on `f28214132525a6d33b424e746df645464034d405`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f28214132525a6d33b424e746df645464034d405"} -->
