### PR TITLE
LPD-100529 Fix EditableFragmentEntryProcessorTest

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable-test/build.gradle
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable-test/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:asset:asset-api")
 	testIntegrationImplementation project(":apps:asset:asset-test-util")
 	testIntegrationImplementation project(":apps:data-engine:data-engine-rest-api")
+	testIntegrationImplementation project(":apps:depot:depot-api")
 	testIntegrationImplementation project(":apps:document-library:document-library-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-form-field-type-api")

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable-test/src/testIntegration/java/com/liferay/fragment/entry/processor/editable/test/EditableFragmentEntryProcessorTest.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable-test/src/testIntegration/java/com/liferay/fragment/entry/processor/editable/test/EditableFragmentEntryProcessorTest.java
@@ -11,6 +11,9 @@ import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.dynamic.data.mapping.constants.DDMStructureConstants;
@@ -59,8 +62,11 @@ import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.object.constants.ObjectActionExecutorConstants;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectDefinitionSettingConstants;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.definition.setting.builder.ObjectDefinitionSettingBuilder;
 import com.liferay.object.field.builder.TextObjectFieldBuilder;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectAction;
@@ -1135,7 +1141,8 @@ public class EditableFragmentEntryProcessorTest {
 			ObjectDefinitionTestUtil.publishObjectDefinition(
 				Collections.singletonList(
 					ObjectFieldUtil.createObjectField(
-						"Text", "String", true, true, null,
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
 						RandomTestUtil.randomString(), "title", false)),
 				false);
 
@@ -2378,18 +2385,44 @@ public class EditableFragmentEntryProcessorTest {
 		}
 
 		ObjectDefinition objectDefinition =
-			ObjectDefinitionTestUtil.publishObjectDefinition(
-				ObjectDefinitionTestUtil.getRandomName(),
+			_objectDefinitionLocalService.addCustomObjectDefinition(
+				null, TestPropsValues.getUserId(),
+				objectFolder.getObjectFolderId(), null, true, false, true,
+				false, true, false, false, false, false, null,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				ObjectDefinitionTestUtil.getRandomName(), null, null,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				true, ObjectDefinitionConstants.SCOPE_DEPOT,
+				ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
+				Collections.singletonList(
+					new ObjectDefinitionSettingBuilder(
+					).name(
+						ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS
+					).value(
+						StringPool.TRUE
+					).build()),
 				Collections.singletonList(
 					ObjectFieldUtil.createObjectField(
-						"Text", "String", true, true, null,
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, true, null,
 						RandomTestUtil.randomString(), "title", false)),
-				objectFolder.getObjectFolderId(),
-				ObjectDefinitionConstants.SCOPE_COMPANY,
-				TestPropsValues.getUserId());
+				Collections.emptyList(), new ServiceContext());
+
+		objectDefinition =
+			_objectDefinitionLocalService.publishCustomObjectDefinition(
+				TestPropsValues.getUserId(),
+				objectDefinition.getObjectDefinitionId());
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			Collections.emptyMap(), DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
 
 		ObjectEntry objectEntry = ObjectEntryTestUtil.addObjectEntry(
-			objectDefinition, "title", "titleValue");
+			depotEntry.getGroupId(), objectDefinition,
+			HashMapBuilder.<String, Serializable>put(
+				"title", RandomTestUtil.randomString()
+			).build());
 
 		FragmentEntryLink fragmentEntryLink =
 			_fragmentEntryLinkLocalService.addFragmentEntryLink(
@@ -2758,6 +2791,9 @@ public class EditableFragmentEntryProcessorTest {
 
 	@Inject
 	private DDMFormValuesToFieldsConverter _ddmFormValuesToFieldsConverter;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Inject
 	private DLURLHelper _dlURLHelper;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100529

## What Is Being Fixed

`EditableFragmentEntryProcessorTest` started failing on the page management routine on 2026-08-01. Two methods fail, `testFragmentEntryProcessorEditableAssertAnalyticsObjectTypeForContentStructuresFolder` and `testFragmentEntryProcessorEditableAssertAnalyticsObjectTypeForFileTypesFolder`, both during fixture setup rather than on an assertion:

```
ModelListenerException: ObjectDefinitionScopeException:
  CMS object definitions can only have scope "depot"
	at ObjectDefinitionModelListener._validateCMSObjectDefinitionScope
```

Both methods publish an object definition inside the CMS Content Structures or File Types object folder, because `AnalyticsAttributesUtil._getAnalyticsObjectType` only derives a value from those two folder external reference codes. The definition was company scoped.

The rule that CMS definitions must be depot scoped is not new. LPD-83357 added it in March and it was already present when the test last passed. What changed is `ObjectDefinitionImpl.isCMS()`. Commit `a57a60eb394d0` ("LPD-99210 Remove the LPD-17564 feature flag checks") deleted its early return, so with the flag off in CI `isCMS()` used to return false unconditionally and the listener never fired. Now that the CMS feature is released the check is purely folder based, and the long standing rule finally applies.

## How It Is Being Fixed

The product behaviour is correct, so the fixture is what needed updating. The definition is now built the way the rest of the codebase builds CMS folder definitions, matching `BulkActionResourceTest`: `addCustomObjectDefinition` with `SCOPE_DEPOT` and the `acceptAllGroups` setting, followed by `publishCustomObjectDefinition`. Depot scoped entries reject a group id of zero, so the object entry goes into a `DepotConstants.TYPE_SPACE` depot entry created by the test, which is why the module gains a `depot-api` dependency.

Two small cleanups ride along in the same helper: the title value was asserted nowhere, so it is randomized, and the raw `"Text"` and `"String"` arguments to `ObjectFieldUtil.createObjectField` are replaced with `ObjectFieldConstants.BUSINESS_TYPE_TEXT` and `ObjectFieldConstants.DB_TYPE_STRING` at both call sites in the class.

## PR Check

**pr-check: PASS** — tested on `19282518f0fc86deb3a5cfa9bd6ee80cd44db105`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "19282518f0fc86deb3a5cfa9bd6ee80cd44db105"} -->
