### PR TITLE
LPD-100535 Keep CMS pages out of the layout search test queries

### DIFF
--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutIndexerIndexedFieldsTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutIndexerIndexedFieldsTest.java
@@ -13,6 +13,9 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.SearchEngineHelper;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -26,8 +29,9 @@ import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.model.uid.UIDFactory;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
+import com.liferay.portal.search.test.util.HitsAssert;
 import com.liferay.portal.search.test.util.IndexedFieldsFixture;
-import com.liferay.portal.search.test.util.IndexerFixture;
+import com.liferay.portal.search.test.util.SearchContextTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -68,8 +72,6 @@ public class LayoutIndexerIndexedFieldsTest {
 
 		setUpLayoutFixture();
 
-		setUpLayoutIndexerFixture();
-
 		defaultLocale = LocaleThreadLocal.getDefaultLocale();
 	}
 
@@ -88,8 +90,14 @@ public class LayoutIndexerIndexedFieldsTest {
 
 		String searchTerm = "新しい";
 
-		Document document = layoutIndexerFixture.searchOnlyOne(
-			searchTerm, locale);
+		Indexer<Layout> indexer = IndexerRegistryUtil.getIndexer(Layout.class);
+
+		Hits hits = indexer.search(
+			SearchContextTestUtil.getSearchContext(
+				TestPropsValues.getUserId(), new long[] {_group.getGroupId()},
+				searchTerm, locale));
+
+		Document document = HitsAssert.assertOnlyOne(searchTerm, hits);
 
 		indexedFieldsFixture.postProcessDocument(document);
 
@@ -119,10 +127,6 @@ public class LayoutIndexerIndexedFieldsTest {
 		_layouts = layoutFixture.getLayouts();
 	}
 
-	protected void setUpLayoutIndexerFixture() {
-		layoutIndexerFixture = new IndexerFixture<>(Layout.class);
-	}
-
 	protected void setUpUserSearchFixture() throws Exception {
 		userSearchFixture = new UserSearchFixture();
 
@@ -138,7 +142,6 @@ public class LayoutIndexerIndexedFieldsTest {
 	protected Locale defaultLocale;
 	protected IndexedFieldsFixture indexedFieldsFixture;
 	protected LayoutFixture layoutFixture;
-	protected IndexerFixture<Layout> layoutIndexerFixture;
 
 	@Inject
 	protected ResourcePermissionLocalService resourcePermissionLocalService;

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutMultiLanguageSearchTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutMultiLanguageSearchTest.java
@@ -24,7 +24,6 @@ import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.search.test.util.FieldValuesAssert;
 import com.liferay.portal.search.test.util.HitsAssert;
-import com.liferay.portal.search.test.util.IndexerFixture;
 import com.liferay.portal.search.test.util.SearchContextTestUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -61,8 +60,6 @@ public class LayoutMultiLanguageSearchTest {
 		setUpUserSearchFixture();
 
 		setUpLayoutFixture();
-
-		setUpLayoutIndexerFixture();
 
 		defaultLocale = LocaleThreadLocal.getDefaultLocale();
 	}
@@ -101,19 +98,32 @@ public class LayoutMultiLanguageSearchTest {
 
 		_addLayoutMultiLanguage();
 
-		Document document = layoutIndexerFixture.searchOnlyOne(
-			_ENGLISH_KEYWORD, LocaleUtil.US);
+		Indexer<Layout> indexer = IndexerRegistryUtil.getIndexer(Layout.class);
+
+		Hits hits = indexer.search(
+			SearchContextTestUtil.getSearchContext(
+				TestPropsValues.getUserId(), new long[] {_group.getGroupId()},
+				_ENGLISH_KEYWORD, LocaleUtil.US));
+
+		Document document = HitsAssert.assertOnlyOne(_ENGLISH_KEYWORD, hits);
 
 		Assert.assertEquals(
 			_ENGLISH_KEYWORD, document.get("localized_title_en_US"));
 	}
 
 	protected void assertFieldValues(
-		String prefix, Locale locale, Map<String, String> titleStrings,
-		String searchTerm) {
+			String prefix, Locale locale, Map<String, String> titleStrings,
+			String searchTerm)
+		throws Exception {
 
-		Document document = layoutIndexerFixture.searchOnlyOne(
-			searchTerm, locale);
+		Indexer<Layout> indexer = IndexerRegistryUtil.getIndexer(Layout.class);
+
+		Hits hits = indexer.search(
+			SearchContextTestUtil.getSearchContext(
+				TestPropsValues.getUserId(), new long[] {_group.getGroupId()},
+				searchTerm, locale));
+
+		Document document = HitsAssert.assertOnlyOne(searchTerm, hits);
 
 		FieldValuesAssert.assertFieldValues(
 			titleStrings, prefix, document, searchTerm);
@@ -131,10 +141,6 @@ public class LayoutMultiLanguageSearchTest {
 		_layouts = layoutFixture.getLayouts();
 	}
 
-	protected void setUpLayoutIndexerFixture() {
-		layoutIndexerFixture = new IndexerFixture<>(Layout.class);
-	}
-
 	protected void setUpUserSearchFixture() throws Exception {
 		userSearchFixture = new UserSearchFixture();
 
@@ -149,7 +155,6 @@ public class LayoutMultiLanguageSearchTest {
 
 	protected Locale defaultLocale;
 	protected LayoutFixture layoutFixture;
-	protected IndexerFixture<Layout> layoutIndexerFixture;
 	protected UserSearchFixture userSearchFixture;
 
 	private void _addLayoutMultiLanguage() throws Exception {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100535

## What Is Being Fixed

`LayoutIndexerIndexedFieldsTest` and `LayoutMultiLanguageSearchTest` started failing because they searched the Layout index company-wide and asserted exactly one hit.

LPD-99210 removed the LPD-17564 feature flag and now provisions the CMS site unconditionally, so the CMS site initializer's pages are always indexed. Their names and rendered fragment content collide with the tests' keywords: the Japanese page `新しいスペース` matches the search for `新しい`, and the page named `New Space` matches the `new item` keyword. `LayoutMultiLanguageSearchTest` failed on `testEnglishName`, `testEnglishTitle`, and `testLocalizedFields`; the Japanese cases survived only because `新規作成` happens to share no tokens with any CMS name.

## How It Is Being Fixed

Each search now builds a `SearchContext` scoped to the group the test creates, instead of going through `IndexerFixture.searchOnlyOne`, which always passes `null` group IDs and so can only ever search the whole company. The fixture had no group-scoped overload, so it is removed from both classes along with its now-unused setup.

No test data changed. Both classes keep their original page names and keywords, which is the point: choosing different keywords only moves the collision rather than removing it. An earlier attempt at that failed a second time, because the Home page indexes the fragment text `Recent Assets View All` in all 13 locales. Scoping by group confines results to what the test itself indexed, so it holds regardless of what the CMS ships later.

`LayoutMultiLanguageSearchTest` already contained this pattern in `_testJapaneseTitleWhitespaceSeparatedWord`, added by LPD-94755, which is exactly why that one case never broke. This generalizes it to the rest of the searches.

## PR Check

**pr-check: PASS** — tested on `40cf2fa9305c65f686ebdd69bd9a725ee26e36b1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "40cf2fa9305c65f686ebdd69bd9a725ee26e36b1"} -->
