### PR TITLE
LPD-99344 Skip page version creation outside production mode

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/helper/LayoutActionsHelper.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/helper/LayoutActionsHelper.java
@@ -8,6 +8,7 @@ package com.liferay.layout.admin.web.internal.helper;
 import com.liferay.exportimport.kernel.staging.StagingUtil;
 import com.liferay.layout.util.template.LayoutConverter;
 import com.liferay.layout.util.template.LayoutConverterRegistry;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -260,7 +261,8 @@ public class LayoutActionsHelper {
 	public boolean isShowViewHistoryAction(Layout layout)
 		throws PortalException {
 
-		if (!FeatureFlagManagerUtil.isEnabled(
+		if (!CTCollectionThreadLocal.isProductionMode() ||
+			!FeatureFlagManagerUtil.isEnabled(
 				_themeDisplay.getCompanyId(), "LPD-10622") ||
 			!layout.isTypeContent()) {
 

--- a/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/helper/LayoutActionsHelperTest.java
+++ b/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/helper/LayoutActionsHelperTest.java
@@ -200,12 +200,6 @@ public class LayoutActionsHelperTest {
 		);
 
 		Mockito.when(
-			layout.isPrivateLayout()
-		).thenReturn(
-			false
-		);
-
-		Mockito.when(
 			layout.isRootLayout()
 		).thenReturn(
 			true
@@ -276,12 +270,6 @@ public class LayoutActionsHelperTest {
 		_setUpFeatureFlag(true);
 
 		Layout layout = _getLayout(_getGroup());
-
-		Mockito.when(
-			layout.isTypeContent()
-		).thenReturn(
-			false
-		);
 
 		LayoutActionsHelper layoutActionsHelper = new LayoutActionsHelper(
 			null, _themeDisplay, null);

--- a/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/helper/LayoutActionsHelperTest.java
+++ b/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/helper/LayoutActionsHelperTest.java
@@ -5,6 +5,8 @@
 
 package com.liferay.layout.admin.web.internal.helper;
 
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -13,6 +15,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -166,10 +169,11 @@ public class LayoutActionsHelperTest {
 	}
 
 	@Test
-	@TestInfo("LPD-90027")
+	@TestInfo({"LPD-90027", "LPD-99344"})
 	public void testIsShowViewHistoryAction() throws PortalException {
 		_testIsShowViewHistoryActionWithFeatureFlagDisabled();
 		_testIsShowViewHistoryActionWithLayoutTypeNotContent();
+		_testIsShowViewHistoryActionWithoutProductionMode();
 		_testIsShowViewHistoryActionWithoutUpdatePermission();
 		_testIsShowViewHistoryActionWithUpdatePermission();
 	}
@@ -283,6 +287,31 @@ public class LayoutActionsHelperTest {
 			null, _themeDisplay, null);
 
 		Assert.assertFalse(layoutActionsHelper.isShowViewHistoryAction(layout));
+	}
+
+	private void _testIsShowViewHistoryActionWithoutProductionMode()
+		throws PortalException {
+
+		_setUpFeatureFlag(true);
+
+		Layout layout = _getLayout(_getGroup());
+
+		Mockito.when(
+			layout.isTypeContent()
+		).thenReturn(
+			true
+		);
+
+		LayoutActionsHelper layoutActionsHelper = new LayoutActionsHelper(
+			null, _themeDisplay, null);
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					RandomTestUtil.randomLong())) {
+
+			Assert.assertFalse(
+				layoutActionsHelper.isShowViewHistoryAction(layout));
+		}
 	}
 
 	private void _testIsShowViewHistoryActionWithoutUpdatePermission()

--- a/modules/apps/layout/layout-content-service/src/main/java/com/liferay/layout/content/internal/creator/LayoutContentVersionCreatorImpl.java
+++ b/modules/apps/layout/layout-content-service/src/main/java/com/liferay/layout/content/internal/creator/LayoutContentVersionCreatorImpl.java
@@ -12,6 +12,7 @@ import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -33,7 +34,8 @@ public class LayoutContentVersionCreatorImpl
 	@Override
 	public void createLayoutContentVersion(Layout layout) {
 		try {
-			if (!FeatureFlagManagerUtil.isEnabled(
+			if (!CTCollectionThreadLocal.isProductionMode() ||
+				!FeatureFlagManagerUtil.isEnabled(
 					layout.getCompanyId(), "LPD-10622") ||
 				!layout.isDraftLayout() || !layout.isTypeContent()) {
 

--- a/modules/apps/layout/layout-content-test/build.gradle
+++ b/modules/apps/layout/layout-content-test/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	testIntegrationImplementation project(":apps:change-tracking:change-tracking-api")
 	testIntegrationImplementation project(":apps:layout:layout-content-api")
 	testIntegrationImplementation project(":apps:layout:layout-page-template-api")
 	testIntegrationImplementation project(":apps:layout:layout-page-template-test-util")

--- a/modules/apps/layout/layout-content-test/src/testIntegration/java/com/liferay/layout/content/service/test/LayoutLocalServiceWrapperTest.java
+++ b/modules/apps/layout/layout-content-test/src/testIntegration/java/com/liferay/layout/content/service/test/LayoutLocalServiceWrapperTest.java
@@ -6,6 +6,8 @@
 package com.liferay.layout.content.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.layout.content.model.LayoutContentVersion;
 import com.liferay.layout.content.service.LayoutContentVersionLocalService;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
@@ -14,9 +16,12 @@ import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.layout.utility.page.kernel.constants.LayoutUtilityPageEntryConstants;
 import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -58,6 +63,7 @@ public class LayoutLocalServiceWrapperTest {
 	}
 
 	@Test
+	@TestInfo("LPD-99344")
 	public void testCopyLayoutContent() throws Exception {
 		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
 
@@ -94,6 +100,19 @@ public class LayoutLocalServiceWrapperTest {
 
 		_testCopyLayoutContent(
 			0, _layoutLocalService.getLayout(layoutUtilityPageEntry.getPlid()));
+
+		Layout typeContentLayout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		CTCollection ctCollection = _ctCollectionLocalService.addCTCollection(
+			null, TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			0, RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					ctCollection.getCtCollectionId())) {
+
+			_testCopyLayoutContent(0, typeContentLayout);
+		}
 	}
 
 	private List<LayoutContentVersion> _testCopyLayoutContent(
@@ -119,6 +138,9 @@ public class LayoutLocalServiceWrapperTest {
 
 		return layoutContentVersions2;
 	}
+
+	@Inject
+	private CTCollectionLocalService _ctCollectionLocalService;
 
 	@DeleteAfterTestRun
 	private Group _group;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99344

## What Is Being Fixed

Publishing a page while a change-tracking collection is active — i.e., in non-production mode — was still creating a layout content version. Layout content versions are meant to record the history of what shipped to production, so persisting them from within a change-tracking sandbox pollutes that history with entries that never went live. On top of that, the view-history dropdown action on the page administration UI stayed available in non-production mode, offering to browse a history that should not exist there.

## How It Is Being Fixed

`LayoutContentVersionCreatorImpl` now short-circuits when `CTCollectionThreadLocal.isProductionMode()` is false, so no version is persisted while a change-tracking collection is active. The corresponding view-history action in `LayoutActionsHelper` gains the same guard, so the dropdown item disappears outside production mode. The integration test `LayoutLocalServiceWrapperTest#testCopyLayoutContent` asserts that no version is created when the copy is triggered inside a change-tracking collection, and the unit test `LayoutActionsHelperTest#testIsShowViewHistoryAction` gains a `_testIsShowViewHistoryActionWithoutProductionMode` scenario. The `layout-content-test` module also picks up an explicit dependency on `change-tracking-api` to support the new integration test.

## PR Check

**pr-check: PASS** — tested on `cee448b10bf0aa529add2662f5283b6a35840f75`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "cee448b10bf0aa529add2662f5283b6a35840f75"} -->
