### PR TITLE
LPD-98095 Insulate page publishing from LayoutContentVersionCreator startup

### DIFF
--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
@@ -56,6 +56,7 @@ import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactory;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
@@ -147,8 +148,18 @@ public class LayoutLocalServiceWrapper
 			targetSegmentsExperiencesIds);
 
 		if (sourceLayout.getClassPK() == targetLayout.getPlid()) {
-			_layoutContentVersionCreator.createLayoutContentVersion(
-				sourceLayout);
+			LayoutContentVersionCreator layoutContentVersionCreator =
+				_layoutContentVersionCreatorSnapshot.get();
+
+			if (layoutContentVersionCreator == null) {
+				if (_log.isDebugEnabled()) {
+					_log.debug("Layout content version creator is null");
+				}
+			}
+			else {
+				layoutContentVersionCreator.createLayoutContentVersion(
+					sourceLayout);
+			}
 		}
 
 		return layout;
@@ -1396,6 +1407,10 @@ public class LayoutLocalServiceWrapper
 	private static final Log _log = LogFactoryUtil.getLog(
 		LayoutLocalServiceWrapper.class);
 
+	private static final Snapshot<LayoutContentVersionCreator>
+		_layoutContentVersionCreatorSnapshot = new Snapshot<>(
+			LayoutLocalServiceWrapper.class, LayoutContentVersionCreator.class,
+			null, true);
 	private static final TransactionConfig _transactionConfig =
 		TransactionConfig.Factory.create(
 			Propagation.REQUIRED, new Class<?>[] {Exception.class});
@@ -1431,9 +1446,6 @@ public class LayoutLocalServiceWrapper
 	@Reference
 	private LayoutClassedModelUsageLocalService
 		_layoutClassedModelUsageLocalService;
-
-	@Reference
-	private LayoutContentVersionCreator _layoutContentVersionCreator;
 
 	@Reference
 	private LayoutFriendlyURLEntryHelper _layoutFriendlyURLEntryHelper;

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
@@ -148,18 +148,7 @@ public class LayoutLocalServiceWrapper
 			targetSegmentsExperiencesIds);
 
 		if (sourceLayout.getClassPK() == targetLayout.getPlid()) {
-			LayoutContentVersionCreator layoutContentVersionCreator =
-				_layoutContentVersionCreatorSnapshot.get();
-
-			if (layoutContentVersionCreator == null) {
-				if (_log.isDebugEnabled()) {
-					_log.debug("Layout content version creator is null");
-				}
-			}
-			else {
-				layoutContentVersionCreator.createLayoutContentVersion(
-					sourceLayout);
-			}
+			_createLayoutContentVersion(sourceLayout);
 		}
 
 		return layout;
@@ -800,6 +789,21 @@ public class LayoutLocalServiceWrapper
 						String.class),
 					segmentsExperienceERC);
 		}
+	}
+
+	private void _createLayoutContentVersion(Layout sourceLayout) {
+		LayoutContentVersionCreator layoutContentVersionCreator =
+			_layoutContentVersionCreatorSnapshot.get();
+
+		if (layoutContentVersionCreator == null) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Layout content version creator is null");
+			}
+
+			return;
+		}
+
+		layoutContentVersionCreator.createLayoutContentVersion(sourceLayout);
 	}
 
 	private void _deleteLayoutClassedModelUsages(

--- a/modules/apps/layout/layout-service/src/test/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapperTest.java
+++ b/modules/apps/layout/layout-service/src/test/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapperTest.java
@@ -1,0 +1,133 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.internal.service;
+
+import com.liferay.layout.content.creator.LayoutContentVersionCreator;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.module.service.Snapshot;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public class LayoutLocalServiceWrapperTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_originalLayoutContentVersionCreatorSnapshot =
+			ReflectionTestUtil.getAndSetFieldValue(
+				LayoutLocalServiceWrapper.class,
+				"_layoutContentVersionCreatorSnapshot",
+				_layoutContentVersionCreatorSnapshot);
+
+		_originalLog = ReflectionTestUtil.getAndSetFieldValue(
+			LayoutLocalServiceWrapper.class, "_log", _log);
+	}
+
+	@After
+	public void tearDown() {
+		ReflectionTestUtil.setFieldValue(
+			LayoutLocalServiceWrapper.class,
+			"_layoutContentVersionCreatorSnapshot",
+			_originalLayoutContentVersionCreatorSnapshot);
+
+		ReflectionTestUtil.setFieldValue(
+			LayoutLocalServiceWrapper.class, "_log", _originalLog);
+	}
+
+	@Test
+	@TestInfo("LPD-98095")
+	public void testCreateLayoutContentVersion() {
+		Layout sourceLayout = Mockito.mock(Layout.class);
+
+		ReflectionTestUtil.invoke(
+			_layoutLocalServiceWrapper, "_createLayoutContentVersion",
+			new Class<?>[] {Layout.class}, sourceLayout);
+
+		Mockito.verify(
+			_log
+		).isDebugEnabled();
+
+		Mockito.verify(
+			_log, Mockito.never()
+		).debug(
+			Mockito.anyString()
+		);
+
+		Mockito.when(
+			_log.isDebugEnabled()
+		).thenReturn(
+			true
+		);
+
+		ReflectionTestUtil.invoke(
+			_layoutLocalServiceWrapper, "_createLayoutContentVersion",
+			new Class<?>[] {Layout.class}, sourceLayout);
+
+		Mockito.verify(
+			_log
+		).debug(
+			"Layout content version creator is null"
+		);
+
+		Mockito.reset(_layoutContentVersionCreatorSnapshot, _log);
+
+		LayoutContentVersionCreator layoutContentVersionCreator = Mockito.mock(
+			LayoutContentVersionCreator.class);
+
+		Mockito.when(
+			_layoutContentVersionCreatorSnapshot.get()
+		).thenReturn(
+			layoutContentVersionCreator
+		);
+
+		ReflectionTestUtil.invoke(
+			_layoutLocalServiceWrapper, "_createLayoutContentVersion",
+			new Class<?>[] {Layout.class}, sourceLayout);
+
+		Mockito.verify(
+			layoutContentVersionCreator
+		).createLayoutContentVersion(
+			sourceLayout
+		);
+
+		Mockito.verify(
+			_log, Mockito.never()
+		).isDebugEnabled();
+
+		Mockito.verify(
+			_log, Mockito.never()
+		).debug(
+			Mockito.anyString()
+		);
+	}
+
+	private static final Log _log = Mockito.mock(Log.class);
+
+	private final Snapshot<LayoutContentVersionCreator>
+		_layoutContentVersionCreatorSnapshot = Mockito.mock(Snapshot.class);
+	private final LayoutLocalServiceWrapper _layoutLocalServiceWrapper =
+		new LayoutLocalServiceWrapper();
+	private Object _originalLayoutContentVersionCreatorSnapshot;
+	private Object _originalLog;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98095

## What Is Being Fixed

`LayoutLocalServiceWrapper` reached `LayoutContentVersionCreator` — implemented in `headless-admin-site-impl` — through a hard `@Reference`, so a failure to start that module took the wrapper down with it and, with it, page publishing itself. `LayoutContentVersionCreatorImpl` already swallows exceptions to avoid breaking publishing when version creation goes wrong; that guarantee only held once the reference had resolved, not when it never did.

## How It Is Being Fixed

The wrapper now looks the collaborator up through `Snapshot<LayoutContentVersionCreator>`, applying the pattern Javier Moral suggested in the review of https://github.com/lfbesada/liferay-portal/pull/292#discussion_r3567785059. The call site in `_createLayoutContentVersion` no-ops with a debug log when the snapshot resolves to `null`, so a broken or unavailable `headless-admin-site-impl` no longer blocks the wrapper's activation or page publishing. The version-creation call is extracted to `_createLayoutContentVersion` to make the lookup easy to test in isolation, and `LayoutLocalServiceWrapperTest` covers both the resolved and unresolved snapshot cases.

## PR Check

**pr-check: PASS** — tested on `fc17155845fc8ad3bef30d8702ca04c6832d5d88`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "fc17155845fc8ad3bef30d8702ca04c6832d5d88"} -->
