### PR TITLE
LPD-100959 Expect the creator name in the page template set fixture

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/PageTemplateResourceTest.java
@@ -1008,6 +1008,7 @@ public class PageTemplateResourceTest extends BasePageTemplateResourceTestCase {
 							{
 								setExternalReferenceCode(
 									user::getExternalReferenceCode);
+								setName(user::getFullName);
 							}
 						};
 					});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100959

## What Is Being Fixed

`PageTemplateResourceTest` fails on master. Four methods break: `testPatchSitePageTemplate`, `testPostSitePageTemplate`, `testPostSitePageTemplateSetPageTemplate`, and `testPutSitePageTemplate`. The test last passed on `9e74ff4aea3e` and first failed on `6f95e276278f` on the `[master] ci:test:page-management` routine.

Commit `bfe0929839f59` ("LPD-99956 Use CreatorUtil in the remaining site DTOs") routed `PageTemplateSetDTOConverter` through the new `CreatorUtil.toCreator`, which sets the creator name in addition to its external reference code. The test builds the expected `PageTemplateSet` by hand in `_getPageTemplateSet` and still mirrored the previous construction, which set only the external reference code. `PageTemplateSet` equality compares the JSON representation, so the extra field failed the comparison even though every asserted value matched:

    expected  "creator": {"externalReferenceCode": "d8efdc49-ef53-1190-3df8-b062a4e3e41a"}
    actual    "creator": {"externalReferenceCode": "d8efdc49-ef53-1190-3df8-b062a4e3e41a", "name": "Test Test"}

## How It Is Being Fixed

The expected creator now sets the name as well, matching what `CreatorUtil.toCreator` returns. The `image` branch is not mirrored because `CreatorUtil` returns no image when the user has no portrait, which is always the case for the test admin user.

The assertion is no weaker than before, only one field wider. Verified against master's converters: the four methods pass and the full class runs 25 tests with 0 failures and 0 errors, with the pre-existing `@Ignore` on `testBatchEngineDeleteImportTask` as the only skip.

## PR Check

**pr-check: PASS** — tested on `328d775beb447aa9c105b94c276e632b630ebade`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "328d775beb447aa9c105b94c276e632b630ebade"} -->
