### PR TITLE
LPD-100946 Order the utility page ERC upgrade after segments-service

### DIFF
--- a/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/internal/upgrade/registry/LayoutUtilityPageEntryUpgradeStepRegistrator.java
+++ b/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/internal/upgrade/registry/LayoutUtilityPageEntryUpgradeStepRegistrator.java
@@ -8,6 +8,7 @@ package com.liferay.layout.utility.page.internal.upgrade.registry;
 import com.liferay.layout.utility.page.internal.upgrade.v1_4_0.LayoutUtilityPageEntryUpgradeProcess;
 import com.liferay.layout.utility.page.internal.upgrade.v1_4_1.LayoutUtilityPageEntryLayoutFriendlyURLUpgradeProcess;
 import com.liferay.layout.utility.page.internal.upgrade.v1_4_2.LayoutUtilityPageEntryLayoutExternalReferenceCodeUpgradeProcess;
+import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
@@ -58,5 +59,10 @@ public class LayoutUtilityPageEntryUpgradeStepRegistrator
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;
+
+	@Reference(
+		target = "(&(release.bundle.symbolic.name=com.liferay.segments.service)(release.schema.version>=3.1.0))"
+	)
+	private Release _release;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100946

## What Is Being Fixed

`LayoutUtilityPageEntryLayoutExternalReferenceCodeUpgradeProcess` (layout-utility-page-service, schema step 1.4.1 to 1.4.2) issues raw JDBC against `SegmentsExperience`, a table owned by segments-service. The `externalReferenceCode` column it writes is created by segments-service's own 3.0.0 to 3.1.0 step, and neither `UpgradeStepRegistrator` declares a dependency on the other.

A module's upgrade runs the instant its `UpgradeStepRegistrator` service registers, with no sort and no dependency graph, so the effective order is OSGi bundle activation order. Whenever layout-utility-page-service activates first, every statement fails with "Unknown column 'externalReferenceCode' in 'field list'". The failure is caught and logged only at debug level, so the upgrade reports success while the upgrade report lists the failed SQLs. This is why the same binary against the same data reproduces in one environment and not another. Reported by LPP-65051, where a customer upgrade from 2024.Q1.12 to 2026.Q1.11 showed 12 failed SQLs on an otherwise successful upgrade.

## How It Is Being Fixed

`LayoutUtilityPageEntryUpgradeStepRegistrator` now holds a mandatory static `Release` reference filtered on `com.liferay.segments.service` at schema 3.1.0 or above. `ReleasePublisher.publish` registers the `Release` service only after a module's upgrade completes successfully, so the reference withholds Declarative Services activation, and therefore the whole module upgrade, until segments-service has really reached 3.1.0. `release.schema.version` is published as an `org.osgi.framework.Version`, so the `>=` comparison is semantic rather than lexicographic. This is the idiom `LayoutServiceUpgradeStepRegistrator` and `JournalServiceUpgradeStepRegistrator` already use; `SegmentsServiceUpgradeStepRegistrator` holds no `Release` references, so there is no cycle.

A `hasColumn` guard was deliberately not used. It would silence the failed SQLs while still skipping the backfill, leaving the default experiences with an external reference code that diverges from the convention the runtime applies. Ordering the two upgrades fixes the outcome rather than the symptom.

One note for review: the `_release` field is never read. That is intentional and is the whole mechanism — the field exists so Declarative Services delays activation until the dependency's `Release` is published. Eight or more places in the repository use the same pattern.

## Why Are There No Tests?

The fix is an OSGi Declarative Services wiring change, and the behavior it corrects, the order in which two modules' upgrade processes run, is decided by bundle activation order at portal boot. No unit or integration test can reach it.

It was verified at runtime instead: after a full restart the boot-time "Declarative Service Unsatisfied Component System Checker" reports no issues, which proves the mandatory `Release` reference resolves rather than silently blocking the module's upgrade forever. The generated component descriptor was also checked to confirm the reference is mandatory and static.

The same fix shape shipped without a test in 8fbe003103aa5 (LPD-64053).

## PR Check

**pr-check: PASS** — tested on `5aa3f44f10978eaa3f9dcc90f280cdfc309b1ac2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5aa3f44f10978eaa3f9dcc90f280cdfc309b1ac2"} -->
