### PR TITLE
LPD-100568 Stop the URL tests leaking company state

### DIFF
--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplAlternateURLTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplAlternateURLTest.java
@@ -19,6 +19,7 @@ import com.liferay.layout.page.template.test.util.DisplayPageTemplateTestUtil;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutFriendlyURLRandomizerBumper;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -40,6 +41,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.ClassTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.PrefsPropsTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsUtil;
@@ -262,64 +264,46 @@ public class PortalImplAlternateURLTest {
 
 		themeDisplay.setPortalDomain(defaultVirtualHostname);
 
-		PortletPreferences portletPreferences = PrefsPropsUtil.getPreferences(
-			themeDisplay.getCompanyId());
+		try (SafeCloseable safeCloseable =
+				PrefsPropsTestUtil.swapWithSafeCloseable(
+					themeDisplay.getCompanyId(),
+					PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE, 1)) {
 
-		String previousLocalePrependFriendlyURLStyle =
-			portletPreferences.getValue(
-				PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE, null);
-
-		portletPreferences.setValue(
-			PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE, "1");
-
-		portletPreferences.store();
-
-		String canonicalURL = StringBundler.concat(
-			"http://", defaultVirtualHostname, ":",
-			PortalUtil.getPortalServerPort(false),
-			PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
-			_group.getFriendlyURL(), layout.getFriendlyURL());
-
-		Map<Locale, String> alternateURLs = _portal.getAlternateURLs(
-			canonicalURL, themeDisplay, layout);
-
-		Assert.assertEquals(
-			StringBundler.concat(
+			String canonicalURL = StringBundler.concat(
 				"http://", defaultVirtualHostname, ":",
-				PortalUtil.getPortalServerPort(false), "/fr",
+				PortalUtil.getPortalServerPort(false),
 				PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
-				_group.getFriendlyURL(),
-				layout.getFriendlyURL(LocaleUtil.FRANCE)),
-			alternateURLs.get(LocaleUtil.FRANCE));
-		Assert.assertEquals(
-			StringBundler.concat(
-				"http://", germanVirtualHostname, ":",
-				PortalUtil.getPortalServerPort(false), "/de",
-				PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
-				_group.getFriendlyURL(),
-				layout.getFriendlyURL(LocaleUtil.GERMANY)),
-			alternateURLs.get(LocaleUtil.GERMANY));
-		Assert.assertEquals(
-			StringBundler.concat(
-				"http://", spanishVirtualHostname, ":",
-				PortalUtil.getPortalServerPort(false), "/es",
-				PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
-				_group.getFriendlyURL(),
-				layout.getFriendlyURL(LocaleUtil.SPAIN)),
-			alternateURLs.get(LocaleUtil.SPAIN));
-		Assert.assertEquals(canonicalURL, alternateURLs.get(LocaleUtil.US));
+				_group.getFriendlyURL(), layout.getFriendlyURL());
 
-		if (previousLocalePrependFriendlyURLStyle == null) {
-			portletPreferences.reset(
-				PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE);
-		}
-		else {
-			portletPreferences.setValue(
-				PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE,
-				previousLocalePrependFriendlyURLStyle);
-		}
+			Map<Locale, String> alternateURLs = _portal.getAlternateURLs(
+				canonicalURL, themeDisplay, layout);
 
-		portletPreferences.store();
+			Assert.assertEquals(
+				StringBundler.concat(
+					"http://", defaultVirtualHostname, ":",
+					PortalUtil.getPortalServerPort(false), "/fr",
+					PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
+					_group.getFriendlyURL(),
+					layout.getFriendlyURL(LocaleUtil.FRANCE)),
+				alternateURLs.get(LocaleUtil.FRANCE));
+			Assert.assertEquals(
+				StringBundler.concat(
+					"http://", germanVirtualHostname, ":",
+					PortalUtil.getPortalServerPort(false), "/de",
+					PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
+					_group.getFriendlyURL(),
+					layout.getFriendlyURL(LocaleUtil.GERMANY)),
+				alternateURLs.get(LocaleUtil.GERMANY));
+			Assert.assertEquals(
+				StringBundler.concat(
+					"http://", spanishVirtualHostname, ":",
+					PortalUtil.getPortalServerPort(false), "/es",
+					PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
+					_group.getFriendlyURL(),
+					layout.getFriendlyURL(LocaleUtil.SPAIN)),
+				alternateURLs.get(LocaleUtil.SPAIN));
+			Assert.assertEquals(canonicalURL, alternateURLs.get(LocaleUtil.US));
+		}
 	}
 
 	@Test
@@ -803,15 +787,14 @@ public class PortalImplAlternateURLTest {
 			long resourcePrimKey, ThemeDisplay themeDisplay)
 		throws Exception {
 
-		PortletPreferences portletPreferences = PrefsPropsUtil.getPreferences(
-			themeDisplay.getCompanyId());
+		try (SafeCloseable safeCloseable =
+				PrefsPropsTestUtil.swapWithSafeCloseable(
+					themeDisplay.getCompanyId(),
+					PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE,
+					prependFriendlyURLStyle)) {
 
-		try {
-			portletPreferences.setValue(
-				PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE,
-				String.valueOf(prependFriendlyURLStyle));
-
-			portletPreferences.store();
+			PortletPreferences portletPreferences =
+				PrefsPropsUtil.getPreferences(themeDisplay.getCompanyId());
 
 			for (Locale alternateLocale : availableLocales) {
 				String expectedAlternateURL = _generateAssetDisplayPageEntryURL(
@@ -832,10 +815,6 @@ public class PortalImplAlternateURLTest {
 						canonicalURL, themeDisplay, alternateLocale,
 						themeDisplay.getLayout()));
 			}
-		}
-		finally {
-			portletPreferences.reset(
-				PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE);
 		}
 	}
 
@@ -910,15 +889,14 @@ public class PortalImplAlternateURLTest {
 			ThemeDisplay themeDisplay, int prependFriendlyURLStyle)
 		throws Exception {
 
-		PortletPreferences portletPreferences = PrefsPropsUtil.getPreferences(
-			themeDisplay.getCompanyId());
+		try (SafeCloseable safeCloseable =
+				PrefsPropsTestUtil.swapWithSafeCloseable(
+					themeDisplay.getCompanyId(),
+					PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE,
+					prependFriendlyURLStyle)) {
 
-		try {
-			portletPreferences.setValue(
-				PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE,
-				String.valueOf(prependFriendlyURLStyle));
-
-			portletPreferences.store();
+			PortletPreferences portletPreferences =
+				PrefsPropsUtil.getPreferences(themeDisplay.getCompanyId());
 
 			String canonicalURL = _generateHomeLayoutURL(
 				defaultLocale, defaultLocale, themeDisplay.getPortalURL(),
@@ -935,10 +913,6 @@ public class PortalImplAlternateURLTest {
 						canonicalURL, themeDisplay, alternateLocale,
 						themeDisplay.getLayout()));
 			}
-		}
-		finally {
-			portletPreferences.reset(
-				PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE);
 		}
 	}
 
@@ -976,15 +950,14 @@ public class PortalImplAlternateURLTest {
 			ThemeDisplay themeDisplay)
 		throws Exception {
 
-		PortletPreferences portletPreferences = PrefsPropsUtil.getPreferences(
-			themeDisplay.getCompanyId());
+		try (SafeCloseable safeCloseable =
+				PrefsPropsTestUtil.swapWithSafeCloseable(
+					themeDisplay.getCompanyId(),
+					PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE,
+					prependFriendlyURLStyle)) {
 
-		try {
-			portletPreferences.setValue(
-				PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE,
-				String.valueOf(prependFriendlyURLStyle));
-
-			portletPreferences.store();
+			PortletPreferences portletPreferences =
+				PrefsPropsUtil.getPreferences(themeDisplay.getCompanyId());
 
 			String canonicalURL = _generateLayoutURL(
 				defaultLocale, friendlyURLMap.get(defaultLocale), _group,
@@ -1002,10 +975,6 @@ public class PortalImplAlternateURLTest {
 						canonicalURL, themeDisplay, alternateLocale,
 						themeDisplay.getLayout()));
 			}
-		}
-		finally {
-			portletPreferences.reset(
-				PropsKeys.LOCALE_PREPEND_FRIENDLY_URL_STYLE);
 		}
 	}
 

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplAlternateURLTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplAlternateURLTest.java
@@ -28,13 +28,16 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.model.VirtualHost;
 import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.VirtualHostLocalService;
+import com.liferay.portal.kernel.service.VirtualHostLocalServiceUtil;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.ClassTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -66,6 +69,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -74,6 +78,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -87,7 +92,41 @@ public class PortalImplAlternateURLTest {
 	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+		new AggregateTestRule(
+			false,
+			new ClassTestRule<TreeMap<String, String>>() {
+
+				@Override
+				public void afterClass(
+						Description description,
+						TreeMap<String, String> virtualHostnames)
+					throws PortalException {
+
+					VirtualHostLocalServiceUtil.updateVirtualHosts(
+						TestPropsValues.getCompanyId(), 0, virtualHostnames);
+				}
+
+				@Override
+				public TreeMap<String, String> beforeClass(
+						Description description)
+					throws PortalException {
+
+					TreeMap<String, String> virtualHostnames = new TreeMap<>();
+
+					for (VirtualHost virtualHost :
+							VirtualHostLocalServiceUtil.getVirtualHosts(
+								TestPropsValues.getCompanyId(), 0)) {
+
+						virtualHostnames.put(
+							virtualHost.getHostname(),
+							GetterUtil.getString(virtualHost.getLanguageId()));
+					}
+
+					return virtualHostnames;
+				}
+
+			},
+			new LiferayIntegrationTestRule());
 
 	@BeforeClass
 	public static void setUpClass() throws PortalException {

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
@@ -43,7 +43,6 @@ import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -340,7 +339,7 @@ public class PortalImplCanonicalURLTest {
 
 		String completeURL = StringBundler.concat(
 			Http.HTTP_WITH_SLASH, "test.com:",
-			PortalUtil.getPortalServerPort(false), _layout4.getFriendlyURL());
+			_portal.getPortalServerPort(false), _layout4.getFriendlyURL());
 
 		Assert.assertEquals(
 			completeURL,
@@ -565,7 +564,7 @@ public class PortalImplCanonicalURLTest {
 		throws Exception {
 
 		_testCanonicalURL(
-			"liferay.com", "localhost:" + PortalUtil.getPortalServerPort(false),
+			"liferay.com", "localhost:" + _portal.getPortalServerPort(false),
 			_defaultGroup, _defaultGroupLayout1, null, null, "/en",
 			StringPool.BLANK, false, false);
 	}
@@ -575,7 +574,7 @@ public class PortalImplCanonicalURLTest {
 		throws Exception {
 
 		_testCanonicalURL(
-			"liferay.com", "localhost:" + PortalUtil.getPortalServerPort(false),
+			"liferay.com", "localhost:" + _portal.getPortalServerPort(false),
 			_defaultGroup, _defaultGroupLayout1, null, null, "/en",
 			StringPool.BLANK, false, true);
 	}

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
@@ -327,7 +327,7 @@ public class PortalImplCanonicalURLTest {
 		throws Exception {
 
 		ThemeDisplay themeDisplay = _createThemeDisplay(
-			"localhost", _group, 8080, false);
+			"localhost", _group, _portal.getPortalServerPort(false), false);
 
 		LayoutSet layoutSet = _layout4.getLayoutSet();
 

--- a/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
+++ b/modules/apps/portal/portal-util-test/src/testIntegration/java/com/liferay/portal/util/test/PortalImplCanonicalURLTest.java
@@ -10,12 +10,14 @@ import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.model.VirtualHost;
 import com.liferay.portal.kernel.model.VirtualLayoutConstants;
 import com.liferay.portal.kernel.model.impl.VirtualLayout;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolverRegistryUtil;
@@ -24,9 +26,11 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutFriendlyURLLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.VirtualHostLocalService;
+import com.liferay.portal.kernel.service.VirtualHostLocalServiceUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.ClassTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -51,6 +55,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
+import java.util.TreeMap;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -59,6 +64,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 
 /**
@@ -70,7 +76,41 @@ public class PortalImplCanonicalURLTest {
 	@ClassRule
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
-		new LiferayIntegrationTestRule();
+		new AggregateTestRule(
+			false,
+			new ClassTestRule<TreeMap<String, String>>() {
+
+				@Override
+				public void afterClass(
+						Description description,
+						TreeMap<String, String> virtualHostnames)
+					throws PortalException {
+
+					VirtualHostLocalServiceUtil.updateVirtualHosts(
+						TestPropsValues.getCompanyId(), 0, virtualHostnames);
+				}
+
+				@Override
+				public TreeMap<String, String> beforeClass(
+						Description description)
+					throws PortalException {
+
+					TreeMap<String, String> virtualHostnames = new TreeMap<>();
+
+					for (VirtualHost virtualHost :
+							VirtualHostLocalServiceUtil.getVirtualHosts(
+								TestPropsValues.getCompanyId(), 0)) {
+
+						virtualHostnames.put(
+							virtualHost.getHostname(),
+							GetterUtil.getString(virtualHost.getLanguageId()));
+					}
+
+					return virtualHostnames;
+				}
+
+			},
+			new LiferayIntegrationTestRule());
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100568

## What Is Being Fixed

`PortalImplCanonicalURLTest` and `PortalImplAlternateURLTest` both leaked state onto the **company**, which outlives the test class and corrupts every later suite in the same bundle.

The company virtual host was set in `setUpClass` and never restored. `VirtualHostLocalServiceImpl.updateVirtualHosts` removes any row not present in its map, and `DataGuardTestRule` then deletes the replacement as leftover data, so the company ended the run with **zero** `VirtualHost` rows. Every later suite rendered its portal URL with an empty host: 13 of 53 failures in `OpenGraphTopHeadDynamicIncludeTest` and 4 of 8 across the layout-seo canonical URL suites, 17 assertions in total. Because the damage is a deleted database row it survived restarts, and rerunning the affected suites in isolation did not clear it. It broke Playwright too: `pageConfiguration.spec.ts` "User can customize canonical url" got `/en/web/<site>` instead of `/web/<site>`.

Separately, `PortalImplAlternateURLTest` wrote `LOCALE_PREPEND_FRIENDLY_URL_STYLE` into company preferences with `store()` inside the `try`, but called `reset()` **without** `store()` in the `finally`, so the undo never reached the database and the style stayed at whatever the last test set. A fourth copy of that block had no `finally` at all.

## How It Is Being Fixed

Each class captures every company-level (`layoutSetId 0`) virtual host as hostname to `languageId` in an anonymous `ClassTestRule` and restores the whole map in `afterClass`.

Ordering is the crux. The rule goes to `AggregateTestRule`'s unsorted constructor ahead of `LiferayIntegrationTestRule`, the same shape `CounterLocalServiceProcessTest` uses. `apply` wraps from the last element to the first, so the rule sits outermost and its `afterClass` runs **after** `DataGuardTestRule` has finished deleting leftovers. That is the only window in which a restored row survives, because the original row is destroyed during the class and the restore has to insert a fresh primary key, which `DataGuardTestRuleUtil._autoDeleteLeftovers` deletes on sight when it runs inside DataGuard's window.

The preference leak is fixed by `PrefsPropsTestUtil.swapWithSafeCloseable` in try-with-resources at all four sites, which persists the restore, puts the previous value back rather than resetting to the default, and stops a cleanup failure from replacing the assertion failure that triggered it.

## Test Evidence

115 tests across the two changed suites and the previously broken victims, run in that order against one bundle so the victims see whatever the URL suites leave behind: `PortalImplCanonicalURLTest` 37, `PortalImplAlternateURLTest` 17, `OpenGraphTopHeadDynamicIncludeTest` 53, `LayoutSEOCanonicalURLProviderTest` + `LayoutSEOLinkManagerCanonicalLayoutSEOLinkTest` 8. All pass, and the company `VirtualHost` row is present after the run where it was previously left empty.

Restoring from `setUpClass` and `tearDownClass` instead of a rule was tried and measured: 37 of 37 tests still pass, but the `virtualhost` table is left with **zero rows**, because `@AfterClass` runs inside the `@ClassRule` chain and DataGuard deletes the reinserted row. The rule is what places the restore outside that window.

One unrelated pre-existing failure appears when the bundle does not run on port 8080: `testCanonicalURLPartialCollisionWIthPublicGroupServletMapping` builds its `ThemeDisplay` with a hardcoded `8080` but derives its expected URL from the live `PortalUtil.getPortalServerPort(false)`. Those agree only on a default-port bundle. The hardcoded value predates this branch and no test method body is modified here.


