### PR TITLE
LPD-100960 Reject layout history mode outside production mode

### DIFF
--- a/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/layout/type/controller/ContentLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/layout/type/controller/ContentLayoutTypeController.java
@@ -13,6 +13,7 @@ import com.liferay.layout.security.permission.resource.LayoutContentModelResourc
 import com.liferay.layout.type.controller.BaseLayoutTypeControllerImpl;
 import com.liferay.petra.io.unsync.UnsyncStringWriter;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
@@ -158,6 +159,10 @@ public class ContentLayoutTypeController extends BaseLayoutTypeControllerImpl {
 		else if (layoutMode.equals(Constants.HISTORY)) {
 			FeatureFlagManagerUtil.checkEnabled(
 				themeDisplay.getCompanyId(), "LPD-10622");
+
+			if (!CTCollectionThreadLocal.isProductionMode()) {
+				throw new NoSuchLayoutException();
+			}
 
 			if (hasUpdatePermissions == null) {
 				hasUpdatePermissions = _hasUpdatePermissions(

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/content/internal/layout/type/controller/test/ContentLayoutTypeControllerTest.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/content/internal/layout/type/controller/test/ContentLayoutTypeControllerTest.java
@@ -21,6 +21,8 @@ import com.liferay.layout.provider.LayoutStructureProvider;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.layout.util.LayoutServiceContextHelper;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -416,7 +418,7 @@ public class ContentLayoutTypeControllerTest {
 
 	@FeatureFlag("LPD-10622")
 	@Test
-	@TestInfo("LPD-90027")
+	@TestInfo({"LPD-90027", "LPD-100960"})
 	public void testContentLayoutTypeControllerWithHistoryMode()
 		throws Exception {
 
@@ -457,6 +459,23 @@ public class ContentLayoutTypeControllerTest {
 			if (_log.isDebugEnabled()) {
 				_log.debug(principalException);
 			}
+		}
+
+		MockHttpServletRequest ctMockHttpServletRequest =
+			_getMockHttpServletRequest(
+				Constants.HISTORY, TestPropsValues.getUser());
+
+		ctMockHttpServletRequest.setMethod(HttpMethods.GET);
+
+		try (SafeCloseable safeCloseable =
+				CTCollectionThreadLocal.setCTCollectionIdWithSafeCloseable(
+					RandomTestUtil.randomLong())) {
+
+			Assert.assertThrows(
+				NoSuchLayoutException.class,
+				() -> _layoutTypeController.includeLayoutContent(
+					ctMockHttpServletRequest, new MockHttpServletResponse(),
+					_layout.fetchDraftLayout()));
 		}
 	}
 

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/content/internal/layout/type/controller/test/ContentLayoutTypeControllerTest.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/content/internal/layout/type/controller/test/ContentLayoutTypeControllerTest.java
@@ -24,8 +24,6 @@ import com.liferay.layout.util.LayoutServiceContextHelper;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.exception.NoSuchLayoutException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -136,17 +134,10 @@ public class ContentLayoutTypeControllerTest {
 	public void testContentLayoutTypeControllerDraftPreviewPermission()
 		throws Exception {
 
-		try {
-			_includeLayoutContent(
-				ActionKeys.PREVIEW_DRAFT, _layout, Constants.EDIT);
-
-			Assert.fail();
-		}
-		catch (PrincipalException principalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(principalException);
-			}
-		}
+		Assert.assertThrows(
+			PrincipalException.class,
+			() -> _includeLayoutContent(
+				ActionKeys.PREVIEW_DRAFT, _layout, Constants.EDIT));
 
 		Assert.assertFalse(
 			_includeLayoutContent(
@@ -155,16 +146,10 @@ public class ContentLayoutTypeControllerTest {
 			_includeLayoutContent(
 				ActionKeys.UPDATE, _layout, Constants.PREVIEW));
 
-		try {
-			_includeLayoutContent(ActionKeys.VIEW, _layout, Constants.PREVIEW);
-
-			Assert.fail();
-		}
-		catch (PrincipalException principalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(principalException);
-			}
-		}
+		Assert.assertThrows(
+			PrincipalException.class,
+			() -> _includeLayoutContent(
+				ActionKeys.VIEW, _layout, Constants.PREVIEW));
 	}
 
 	@Test
@@ -176,19 +161,12 @@ public class ContentLayoutTypeControllerTest {
 
 		User guestUser = _userLocalService.getGuestUser(_group.getCompanyId());
 
-		try {
-			_layoutTypeController.includeLayoutContent(
+		Assert.assertThrows(
+			NoSuchLayoutException.class,
+			() -> _layoutTypeController.includeLayoutContent(
 				_getMockHttpServletRequest(null, guestUser),
 				new MockHttpServletResponse(),
-				LayoutTestUtil.addTypeContentLayout(_group));
-
-			Assert.fail();
-		}
-		catch (NoSuchLayoutException noSuchLayoutException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(noSuchLayoutException);
-			}
-		}
+				LayoutTestUtil.addTypeContentLayout(_group)));
 
 		Layout draftLayout = _layout.fetchDraftLayout();
 
@@ -376,44 +354,24 @@ public class ContentLayoutTypeControllerTest {
 
 		Layout layout = _addTypePageTemplateEntryLayout();
 
-		try {
-			_includeLayoutContent(
-				ActionKeys.PREVIEW_DRAFT, layout, Constants.EDIT);
+		Assert.assertThrows(
+			PrincipalException.class,
+			() -> _includeLayoutContent(
+				ActionKeys.PREVIEW_DRAFT, layout, Constants.EDIT));
 
-			Assert.fail();
-		}
-		catch (PrincipalException principalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(principalException);
-			}
-		}
-
-		try {
-			_includeLayoutContent(
-				ActionKeys.PREVIEW_DRAFT, layout, Constants.PREVIEW);
-
-			Assert.fail();
-		}
-		catch (PrincipalException principalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(principalException);
-			}
-		}
+		Assert.assertThrows(
+			PrincipalException.class,
+			() -> _includeLayoutContent(
+				ActionKeys.PREVIEW_DRAFT, layout, Constants.PREVIEW));
 
 		Assert.assertFalse(
 			_includeLayoutContent(
 				ActionKeys.UPDATE, layout, Constants.PREVIEW));
 
-		try {
-			_includeLayoutContent(ActionKeys.VIEW, layout, Constants.PREVIEW);
-
-			Assert.fail();
-		}
-		catch (PrincipalException principalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(principalException);
-			}
-		}
+		Assert.assertThrows(
+			PrincipalException.class,
+			() -> _includeLayoutContent(
+				ActionKeys.VIEW, layout, Constants.PREVIEW));
 	}
 
 	@FeatureFlag("LPD-10622")
@@ -450,16 +408,10 @@ public class ContentLayoutTypeControllerTest {
 
 		Assert.assertFalse(content.contains("layout-content-version"));
 
-		try {
-			_includeLayoutContent(ActionKeys.VIEW, _layout, Constants.HISTORY);
-
-			Assert.fail();
-		}
-		catch (PrincipalException principalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(principalException);
-			}
-		}
+		Assert.assertThrows(
+			PrincipalException.class,
+			() -> _includeLayoutContent(
+				ActionKeys.VIEW, _layout, Constants.HISTORY));
 
 		MockHttpServletRequest ctMockHttpServletRequest =
 			_getMockHttpServletRequest(
@@ -709,9 +661,6 @@ public class ContentLayoutTypeControllerTest {
 			expectedRedirectURL, _layout.fetchDraftLayout(),
 			mockHttpServletRequest);
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		ContentLayoutTypeControllerTest.class);
 
 	@Inject
 	private CompanyLocalService _companyLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100960

## What Is Being Fixed

`ContentLayoutTypeController` accepted the layout history request mode (`p_l_mode=history`) even when the visitor was inside a change-tracking collection, that is, outside production mode. Layout content versions only exist for pages published to production, so serving the history view under a change-tracking collection would render entries that never applied in that frame.

## How It Is Being Fixed

The controller now throws `NoSuchLayoutException` when the request asks for history mode while `CTCollectionThreadLocal.isProductionMode()` is false, matching the sibling gate used for other invalid history states in the same class (unpublished layouts, missing versions). The gate lives inside the `HISTORY` branch, after the feature-flag check and before the permission checks, so it fires only for the specific mode being restricted. `ContentLayoutTypeControllerTest` covers the new case, and the same test class was migrated from `try/catch/Assert.fail` to `Assert.assertThrows` to keep the assertion shape consistent across the file.

## PR Check

**pr-check: PASS** — tested on `74e8cf87fb5147b77141425a656babbe37a1acdd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "74e8cf87fb5147b77141425a656babbe37a1acdd"} -->
