### PR TITLE
LPD-101040 Show the file preview in the top assets View modal

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/performance/components/TopAssets.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/dashboard/performance/components/TopAssets.tsx
@@ -36,7 +36,8 @@ const TREND_RENDERER = 'TopAssetsTrendRenderer';
 const API_URL = '/o/analytics-cms-rest/v1.0/performance-top-asset';
 
 const NESTED_FIELDS =
-	'nestedFields=embedded,systemProperties.objectDefinitionBrief';
+	'nestedFields=embedded,file.metadata,file.previewURL,file.thumbnailURL,' +
+	'systemProperties.objectDefinitionBrief';
 
 function TitleCell({itemData, value}: {itemData: any; value: string}) {
 	const {additionalProps} = useContext(PerformanceContext);

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/TopAssets.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/dashboard/TopAssets.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+import {render} from '@testing-library/react';
+import React from 'react';
+
+import {PerformanceContextProvider} from '../../../../src/main/resources/META-INF/resources/js/main_view/dashboard/performance/PerformanceContext';
+import {TopAssets} from '../../../../src/main/resources/META-INF/resources/js/main_view/dashboard/performance/components/TopAssets';
+
+const mockFrontendDataSet = jest.fn();
+
+jest.mock('@liferay/frontend-data-set-web', () => ({
+	...(jest.requireActual('@liferay/frontend-data-set-web') as any),
+	FrontendDataSet: (props: any) => mockFrontendDataSet(props),
+}));
+
+describe('TopAssets', () => {
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('requests the file preview fields so the View modal can render file previews', () => {
+		render(
+			<PerformanceContextProvider additionalProps={{} as any}>
+				<TopAssets />
+			</PerformanceContextProvider>
+		);
+
+		const {additionalAPIURLParameters} =
+			mockFrontendDataSet.mock.calls[0][0];
+
+		expect(additionalAPIURLParameters).toContain('file.metadata');
+		expect(additionalAPIURLParameters).toContain('file.previewURL');
+		expect(additionalAPIURLParameters).toContain('file.thumbnailURL');
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101040

## What Is Being Fixed

In the CMS performance dashboard, under Content Consumption > Top Assets, using the row action View on a file asset (Basic Document / image) showed "No Preview Available", even though the same asset previewed correctly in the CMS All section.

## How It Is Being Fixed

The Top Assets frontend data set only requested `nestedFields=embedded,systemProperties.objectDefinitionBrief`, so the embedded asset came back without the file preview fields. The FilePreview component needs `file.metadata`, `file.previewURL` and `file.thumbnailURL` to render an image or document preview, so it fell back to the empty state. Those fields are now added to the data set's nested fields, following the same pattern already used for `systemProperties.objectDefinitionBrief` (the backend scopes them within `embedded`), which is what the All section already requests. A unit test asserts the data set requests the file preview fields.

## PR Check

**pr-check: PASS** — tested on `e1497f4b1137daa2debe5baa535f0836c139d5fc`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "e1497f4b1137daa2debe5baa535f0836c139d5fc"} -->
