### PR TITLE
LPD-97875 Detect all FreeMarker runtime tags in a fragment

### DIFF
--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/processor/PortletRegistryImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/processor/PortletRegistryImpl.java
@@ -7,6 +7,7 @@ package com.liferay.fragment.internal.processor;
 
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.processor.PortletRegistry;
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -17,7 +18,6 @@ import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.render.PortletRenderParts;
 import com.liferay.portal.kernel.portlet.render.PortletRenderUtil;
 import com.liferay.portal.kernel.service.PortletLocalService;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -33,8 +33,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -113,34 +111,7 @@ public class PortletRegistryImpl implements PortletRegistry {
 			portletIds.add(_portal.getJsSafePortletId(portletId));
 		}
 
-		Matcher liferayPortletRuntimeMatcher =
-			_liferayPortletRuntimePattern.matcher(fragmentEntryLink.getHtml());
-
-		while (liferayPortletRuntimeMatcher.find()) {
-			String portletName = _getAttributeValue(
-				"portletName", liferayPortletRuntimeMatcher.group(2));
-
-			if (Validator.isNull(portletName)) {
-				continue;
-			}
-
-			String instanceId = _getAttributeValue(
-				"instanceId", liferayPortletRuntimeMatcher.group(1));
-
-			if (Validator.isNull(instanceId)) {
-				instanceId = _getAttributeValue(
-					"instanceId", liferayPortletRuntimeMatcher.group(3));
-			}
-
-			String portletId = PortletIdCodec.encode(
-				PortletIdCodec.decodePortletName(portletName),
-				PortletIdCodec.decodeUserId(portletName),
-				StringUtil.replace(
-					instanceId, "fragmentEntryLinkNamespace",
-					fragmentEntryLink.getNamespace()));
-
-			portletIds.add(_portal.getJsSafePortletId(portletId));
-		}
+		_addRuntimeTagPortletIds(fragmentEntryLink, html, portletIds);
 
 		return portletIds;
 	}
@@ -221,22 +192,128 @@ public class PortletRegistryImpl implements PortletRegistry {
 		}
 	}
 
+	private void _addRuntimeTagPortletIds(
+		FragmentEntryLink fragmentEntryLink, String html,
+		List<String> portletIds) {
+
+		int index = html.indexOf(_LIFERAY_PORTLET_MACRO);
+
+		while (index != -1) {
+			int contentIndex = index + _LIFERAY_PORTLET_MACRO.length();
+
+			if (!html.startsWith(".runtime", contentIndex) &&
+				!html.startsWith("[\"runtime\"]", contentIndex) &&
+				!html.startsWith("['runtime']", contentIndex)) {
+
+				index = html.indexOf(_LIFERAY_PORTLET_MACRO, index + 1);
+
+				continue;
+			}
+
+			int endIndex = _getMacroEndIndex(html, contentIndex);
+
+			if (endIndex == -1) {
+				endIndex = html.indexOf("/]", contentIndex);
+			}
+
+			if (endIndex == -1) {
+				break;
+			}
+
+			String macro = html.substring(index, endIndex);
+
+			index = html.indexOf(_LIFERAY_PORTLET_MACRO, endIndex);
+
+			String portletName = _getAttributeValue("portletName", macro);
+
+			if (Validator.isNull(portletName)) {
+				continue;
+			}
+
+			String instanceId = _getAttributeValue("instanceId", macro);
+
+			String portletId = PortletIdCodec.encode(
+				PortletIdCodec.decodePortletName(portletName),
+				PortletIdCodec.decodeUserId(portletName),
+				StringUtil.replace(
+					instanceId, "fragmentEntryLinkNamespace",
+					fragmentEntryLink.getNamespace()));
+
+			portletIds.add(_portal.getJsSafePortletId(portletId));
+		}
+	}
+
 	private String _getAttributeValue(String attributeName, String string) {
-		String s = StringUtil.extractLast(
-			string, attributeName + StringPool.EQUAL);
+		int index = 0;
 
-		if (Validator.isNull(s)) {
-			return s;
-		}
+		while (index < string.length()) {
+			if (Character.isWhitespace(string.charAt(index))) {
+				index++;
 
-		if (s.startsWith(StringPool.QUOTE)) {
-			return StringUtil.extractFirst(s.substring(1), StringPool.QUOTE);
-		}
+				continue;
+			}
 
-		String[] strings = s.split("\\s+");
+			int startIndex = index;
 
-		if (ArrayUtil.isNotEmpty(strings)) {
-			return strings[0];
+			while ((index < string.length()) &&
+				   (string.charAt(index) != CharPool.EQUAL) &&
+				   !Character.isWhitespace(string.charAt(index))) {
+
+				index++;
+			}
+
+			String name = string.substring(startIndex, index);
+
+			while ((index < string.length()) &&
+				   Character.isWhitespace(string.charAt(index))) {
+
+				index++;
+			}
+
+			if ((index >= string.length()) ||
+				(string.charAt(index) != CharPool.EQUAL)) {
+
+				continue;
+			}
+
+			index++;
+
+			while ((index < string.length()) &&
+				   Character.isWhitespace(string.charAt(index))) {
+
+				index++;
+			}
+
+			String value = null;
+
+			if ((index < string.length()) &&
+				((string.charAt(index) == CharPool.APOSTROPHE) ||
+				 (string.charAt(index) == CharPool.QUOTE))) {
+
+				startIndex = index + 1;
+
+				index = _getQuotedStringEndIndex(
+					startIndex, string.charAt(index), string);
+
+				value = string.substring(startIndex, index);
+
+				index++;
+			}
+			else {
+				startIndex = index;
+
+				while ((index < string.length()) &&
+					   !Character.isWhitespace(string.charAt(index))) {
+
+					index++;
+				}
+
+				value = string.substring(startIndex, index);
+			}
+
+			if (name.equals(attributeName)) {
+				return value;
+			}
 		}
 
 		return null;
@@ -254,13 +331,47 @@ public class PortletRegistryImpl implements PortletRegistry {
 		return document;
 	}
 
+	private int _getMacroEndIndex(String html, int index) {
+		while (index < html.length()) {
+			char c = html.charAt(index);
+
+			if ((c == CharPool.APOSTROPHE) || (c == CharPool.QUOTE)) {
+				index = _getQuotedStringEndIndex(index + 1, c, html);
+			}
+			else if ((c == CharPool.FORWARD_SLASH) &&
+					 html.startsWith(StringPool.CLOSE_BRACKET, index + 1)) {
+
+				return index;
+			}
+
+			index++;
+		}
+
+		return -1;
+	}
+
+	private int _getQuotedStringEndIndex(int index, char quote, String string) {
+		while (index < string.length()) {
+			char c = string.charAt(index);
+
+			if (c == quote) {
+				return index;
+			}
+
+			if (c == CharPool.BACK_SLASH) {
+				index++;
+			}
+
+			index++;
+		}
+
+		return string.length();
+	}
+
+	private static final String _LIFERAY_PORTLET_MACRO = "[@liferay_portlet";
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		PortletRegistryImpl.class);
-
-	private static final Pattern _liferayPortletRuntimePattern =
-		Pattern.compile(
-			"\\[@liferay_portlet(?=\\.runtime|\\[\"runtime\"\\])([\\s\\S]*)?" +
-				"(portletName=\"\\w+\")([\\s\\S]*)?\\/\\]");
 
 	private final Map<String, String> _aliasPortletNames =
 		new ConcurrentHashMap<>();

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/processor/PortletRegistryImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/processor/PortletRegistryImpl.java
@@ -78,40 +78,8 @@ public class PortletRegistryImpl implements PortletRegistry {
 
 		String html = fragmentEntryLink.getHtml();
 
-		if (!html.contains("@liferay_portlet") &&
-			!html.contains("lfr-widget-")) {
-
-			return portletIds;
-		}
-
-		if (document == null) {
-			document = _getDocument(html);
-		}
-
-		for (Element element : document.select("*")) {
-			String tagName = element.tagName();
-
-			if (!StringUtil.startsWith(tagName, "lfr-widget-")) {
-				continue;
-			}
-
-			String alias = StringUtil.removeSubstring(tagName, "lfr-widget-");
-
-			String portletName = getPortletName(alias);
-
-			if (Validator.isNull(portletName)) {
-				continue;
-			}
-
-			String portletId = PortletIdCodec.encode(
-				PortletIdCodec.decodePortletName(portletName),
-				PortletIdCodec.decodeUserId(portletName),
-				fragmentEntryLink.getNamespace() + element.attr("id"));
-
-			portletIds.add(_portal.getJsSafePortletId(portletId));
-		}
-
 		_addRuntimeTagPortletIds(fragmentEntryLink, html, portletIds);
+		_addWidgetTagPortletIds(document, fragmentEntryLink, html, portletIds);
 
 		return portletIds;
 	}
@@ -238,6 +206,42 @@ public class PortletRegistryImpl implements PortletRegistry {
 				StringUtil.replace(
 					instanceId, "fragmentEntryLinkNamespace",
 					fragmentEntryLink.getNamespace()));
+
+			portletIds.add(_portal.getJsSafePortletId(portletId));
+		}
+	}
+
+	private void _addWidgetTagPortletIds(
+		Document document, FragmentEntryLink fragmentEntryLink, String html,
+		List<String> portletIds) {
+
+		if (!html.contains("lfr-widget-")) {
+			return;
+		}
+
+		if (document == null) {
+			document = _getDocument(html);
+		}
+
+		for (Element element : document.select("*")) {
+			String tagName = element.tagName();
+
+			if (!StringUtil.startsWith(tagName, "lfr-widget-")) {
+				continue;
+			}
+
+			String alias = StringUtil.removeSubstring(tagName, "lfr-widget-");
+
+			String portletName = getPortletName(alias);
+
+			if (Validator.isNull(portletName)) {
+				continue;
+			}
+
+			String portletId = PortletIdCodec.encode(
+				PortletIdCodec.decodePortletName(portletName),
+				PortletIdCodec.decodeUserId(portletName),
+				fragmentEntryLink.getNamespace() + element.attr("id"));
 
 			portletIds.add(_portal.getJsSafePortletId(portletId));
 		}

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/processor/PortletRegistryImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/processor/PortletRegistryImpl.java
@@ -215,7 +215,7 @@ public class PortletRegistryImpl implements PortletRegistry {
 		Document document, FragmentEntryLink fragmentEntryLink, String html,
 		List<String> portletIds) {
 
-		if (!html.contains("lfr-widget-")) {
+		if (!html.contains(_LFR_WIDGET_TAG_PREFIX)) {
 			return;
 		}
 
@@ -226,11 +226,12 @@ public class PortletRegistryImpl implements PortletRegistry {
 		for (Element element : document.select("*")) {
 			String tagName = element.tagName();
 
-			if (!StringUtil.startsWith(tagName, "lfr-widget-")) {
+			if (!StringUtil.startsWith(tagName, _LFR_WIDGET_TAG_PREFIX)) {
 				continue;
 			}
 
-			String alias = StringUtil.removeSubstring(tagName, "lfr-widget-");
+			String alias = StringUtil.removeSubstring(
+				tagName, _LFR_WIDGET_TAG_PREFIX);
 
 			String portletName = getPortletName(alias);
 
@@ -371,6 +372,8 @@ public class PortletRegistryImpl implements PortletRegistry {
 
 		return string.length();
 	}
+
+	private static final String _LFR_WIDGET_TAG_PREFIX = "lfr-widget-";
 
 	private static final String _LIFERAY_PORTLET_MACRO = "[@liferay_portlet";
 

--- a/modules/apps/fragment/fragment-impl/src/test/java/com/liferay/fragment/internal/processor/PortletRegistryImplTest.java
+++ b/modules/apps/fragment/fragment-impl/src/test/java/com/liferay/fragment/internal/processor/PortletRegistryImplTest.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -161,6 +162,198 @@ public class PortletRegistryImplTest {
 	}
 
 	@Test
+	@TestInfo("LPD-97875")
+	public void testGetFragmentEntryLinkPortletIdsFreeMarkerRuntimeTagAfterActionURLTags() {
+		String instanceId = RandomTestUtil.randomString();
+		String portletName = RandomTestUtil.randomString();
+
+		_assertGetFragmentEntryLinkPortletIds(
+			_getFragmentEntryLink(
+				StringBundler.concat(
+					"<div class=\"fragment_1\">",
+					"[@liferay_portlet.actionURL name=\"",
+					RandomTestUtil.randomString(), "\" /] ",
+					"[@liferay_portlet[\"actionURL\"] name=\"",
+					RandomTestUtil.randomString(), "\" /] ",
+					"[@liferay_portlet.runtime instanceId=\"", instanceId,
+					"\" portletName=\"", portletName, "\" /]</div>"),
+				RandomTestUtil.randomString()),
+			PortletIdCodec.encode(
+				PortletIdCodec.decodePortletName(portletName),
+				PortletIdCodec.decodeUserId(portletName), instanceId));
+	}
+
+	@Test
+	@TestInfo("LPD-97875")
+	public void testGetFragmentEntryLinkPortletIdsFreeMarkerRuntimeTagAfterUnterminatedQuote() {
+		String instanceId = RandomTestUtil.randomString();
+		String portletName = RandomTestUtil.randomString();
+
+		String expectedPortletId = PortletIdCodec.encode(
+			PortletIdCodec.decodePortletName(portletName),
+			PortletIdCodec.decodeUserId(portletName), instanceId);
+
+		_assertGetFragmentEntryLinkPortletIds(
+			_getFragmentEntryLink(
+				StringBundler.concat(
+					"<div class=\"fragment_1\">",
+					"<#-- [@liferay_portlet.runtime --> the author's note ",
+					RandomTestUtil.randomString(),
+					" [@liferay_portlet.runtime instanceId=\"", instanceId,
+					"\" portletName=\"", portletName, "\" /]</div>"),
+				RandomTestUtil.randomString()),
+			expectedPortletId);
+		_assertGetFragmentEntryLinkPortletIds(
+			_getFragmentEntryLink(
+				StringBundler.concat(
+					"<div class=\"fragment_1\">",
+					"<#-- [@liferay_portlet[\"runtime\"] --> the author's ",
+					RandomTestUtil.randomString(),
+					" [@liferay_portlet[\"runtime\"] instanceId=\"", instanceId,
+					"\" portletName=\"", portletName, "\" /]</div>"),
+				RandomTestUtil.randomString()),
+			expectedPortletId);
+	}
+
+	@Test
+	@TestInfo("LPD-97875")
+	public void testGetFragmentEntryLinkPortletIdsFreeMarkerRuntimeTagAttributeValueContainingClosingBrackets() {
+		String instanceId = RandomTestUtil.randomString();
+		String portletName = RandomTestUtil.randomString();
+
+		String expectedPortletId = PortletIdCodec.encode(
+			PortletIdCodec.decodePortletName(portletName),
+			PortletIdCodec.decodeUserId(portletName), instanceId);
+
+		_assertGetFragmentEntryLinkPortletIds(
+			_getFragmentEntryLink(
+				StringBundler.concat(
+					"<div class=\"fragment_1\">",
+					"[@liferay_portlet.runtime defaultPreferences='{\"key\": ",
+					"\"[#if x]/]\"}' instanceId=\"", instanceId,
+					"\" portletName=\"", portletName, "\" /]</div>"),
+				RandomTestUtil.randomString()),
+			expectedPortletId);
+		_assertGetFragmentEntryLinkPortletIds(
+			_getFragmentEntryLink(
+				StringBundler.concat(
+					"<div class=\"fragment_1\">",
+					"[@liferay_portlet[\"runtime\"] defaultPreferences='",
+					"{\"key\": \"[#if x]/]\"}' instanceId=\"", instanceId,
+					"\" portletName=\"", portletName, "\" /]</div>"),
+				RandomTestUtil.randomString()),
+			expectedPortletId);
+	}
+
+	@Test
+	@TestInfo("LPD-97875")
+	public void testGetFragmentEntryLinkPortletIdsFreeMarkerRuntimeTagAttributeValueContainingEscapedQuotes() {
+		String instanceId = RandomTestUtil.randomString();
+		String portletName = RandomTestUtil.randomString();
+
+		String expectedPortletId = PortletIdCodec.encode(
+			PortletIdCodec.decodePortletName(portletName),
+			PortletIdCodec.decodeUserId(portletName), instanceId);
+
+		_assertGetFragmentEntryLinkPortletIds(
+			_getFragmentEntryLink(
+				StringBundler.concat(
+					"<div class=\"fragment_1\">",
+					"[@liferay_portlet.runtime defaultPreferences=\"",
+					"{\\\"key\\\": \\\"/]\\\"}\" instanceId=\"", instanceId,
+					"\" portletName=\"", portletName, "\" /]</div>"),
+				RandomTestUtil.randomString()),
+			expectedPortletId);
+		_assertGetFragmentEntryLinkPortletIds(
+			_getFragmentEntryLink(
+				StringBundler.concat(
+					"<div class=\"fragment_1\">",
+					"[@liferay_portlet[\"runtime\"] defaultPreferences=\"",
+					"{\\\"key\\\": \\\"/]\\\"}\" instanceId=\"", instanceId,
+					"\" portletName=\"", portletName, "\" /]</div>"),
+				RandomTestUtil.randomString()),
+			expectedPortletId);
+	}
+
+	@Test
+	@TestInfo("LPD-97875")
+	public void testGetFragmentEntryLinkPortletIdsFreeMarkerRuntimeTagAttributeValueContainingPortletName() {
+		String instanceId = RandomTestUtil.randomString();
+		String portletName = RandomTestUtil.randomString();
+
+		String expectedPortletId = PortletIdCodec.encode(
+			PortletIdCodec.decodePortletName(portletName),
+			PortletIdCodec.decodeUserId(portletName), instanceId);
+
+		_assertGetFragmentEntryLinkPortletIds(
+			_getFragmentEntryLink(
+				StringBundler.concat(
+					"<div class=\"fragment_1\">",
+					"[@liferay_portlet.runtime instanceId=\"", instanceId,
+					"\" portletName=\"", portletName,
+					"\" defaultPreferences=\"portletName=",
+					RandomTestUtil.randomString(), "\" /]</div>"),
+				RandomTestUtil.randomString()),
+			expectedPortletId);
+		_assertGetFragmentEntryLinkPortletIds(
+			_getFragmentEntryLink(
+				StringBundler.concat(
+					"<div class=\"fragment_1\">",
+					"[@liferay_portlet[\"runtime\"] instanceId=\"", instanceId,
+					"\" portletName=\"", portletName,
+					"\" defaultPreferences=\"portletName=",
+					RandomTestUtil.randomString(), "\" /]</div>"),
+				RandomTestUtil.randomString()),
+			expectedPortletId);
+	}
+
+	@Test
+	@TestInfo("LPD-97875")
+	public void testGetFragmentEntryLinkPortletIdsFreeMarkerRuntimeTagAttributeValuesInSingleQuotes() {
+		String instanceId = RandomTestUtil.randomString();
+		String portletName = RandomTestUtil.randomString();
+
+		String expectedPortletId = PortletIdCodec.encode(
+			PortletIdCodec.decodePortletName(portletName),
+			PortletIdCodec.decodeUserId(portletName), instanceId);
+
+		_assertGetFragmentEntryLinkPortletIds(
+			_getFragmentEntryLink(
+				StringBundler.concat(
+					"<div class=\"fragment_1\">",
+					"[@liferay_portlet.runtime instanceId='", instanceId,
+					"' portletName='", portletName, "' /]</div>"),
+				RandomTestUtil.randomString()),
+			expectedPortletId);
+		_assertGetFragmentEntryLinkPortletIds(
+			_getFragmentEntryLink(
+				StringBundler.concat(
+					"<div class=\"fragment_1\">",
+					"[@liferay_portlet[\"runtime\"] instanceId='", instanceId,
+					"' portletName='", portletName, "' /]</div>"),
+				RandomTestUtil.randomString()),
+			expectedPortletId);
+	}
+
+	@Test
+	@TestInfo("LPD-97875")
+	public void testGetFragmentEntryLinkPortletIdsFreeMarkerRuntimeTagNameInSingleQuotes() {
+		String instanceId = RandomTestUtil.randomString();
+		String portletName = RandomTestUtil.randomString();
+
+		_assertGetFragmentEntryLinkPortletIds(
+			_getFragmentEntryLink(
+				StringBundler.concat(
+					"<div class=\"fragment_1\">",
+					"[@liferay_portlet['runtime'] instanceId=\"", instanceId,
+					"\" portletName=\"", portletName, "\" /]</div>"),
+				RandomTestUtil.randomString()),
+			PortletIdCodec.encode(
+				PortletIdCodec.decodePortletName(portletName),
+				PortletIdCodec.decodeUserId(portletName), instanceId));
+	}
+
+	@Test
 	public void testGetFragmentEntryLinkPortletIdsFreeMarkerRuntimeTagPortletNameAttributeFirst() {
 		String instanceId = RandomTestUtil.randomString();
 		String portletName = RandomTestUtil.randomString();
@@ -192,6 +385,98 @@ public class PortletRegistryImplTest {
 					RandomTestUtil.randomString(), "</div>"),
 				RandomTestUtil.randomString()),
 			expectedPortletId);
+	}
+
+	@Test
+	@TestInfo("LPD-97875")
+	public void testGetFragmentEntryLinkPortletIdsFreeMarkerRuntimeTagWhitespaceAroundEqualSign() {
+		String instanceId = RandomTestUtil.randomString();
+		String portletName = RandomTestUtil.randomString();
+
+		String expectedPortletId = PortletIdCodec.encode(
+			PortletIdCodec.decodePortletName(portletName),
+			PortletIdCodec.decodeUserId(portletName), instanceId);
+
+		_assertGetFragmentEntryLinkPortletIds(
+			_getFragmentEntryLink(
+				StringBundler.concat(
+					"<div class=\"fragment_1\">",
+					"[@liferay_portlet.runtime instanceId = \"", instanceId,
+					"\" portletName = \"", portletName, "\" /]</div>"),
+				RandomTestUtil.randomString()),
+			expectedPortletId);
+		_assertGetFragmentEntryLinkPortletIds(
+			_getFragmentEntryLink(
+				StringBundler.concat(
+					"<div class=\"fragment_1\">",
+					"[@liferay_portlet[\"runtime\"] instanceId =\n\t\"",
+					instanceId, "\" portletName =\n\t\"", portletName,
+					"\" /]</div>"),
+				RandomTestUtil.randomString()),
+			expectedPortletId);
+	}
+
+	@Test
+	@TestInfo("LPD-97875")
+	public void testGetFragmentEntryLinkPortletIdsMultipleFreeMarkerRuntimeTags() {
+		String instanceId1 = RandomTestUtil.randomString();
+		String instanceId2 = RandomTestUtil.randomString();
+		String instanceId3 = RandomTestUtil.randomString();
+		String portletName1 = RandomTestUtil.randomString();
+		String portletName2 = RandomTestUtil.randomString();
+		String portletName3 = RandomTestUtil.randomString();
+
+		_assertGetFragmentEntryLinkPortletIds(
+			_getFragmentEntryLink(
+				StringBundler.concat(
+					"<div class=\"fragment_1\">", RandomTestUtil.randomString(),
+					"[@liferay_portlet.runtime\n\tinstanceId=\"", instanceId1,
+					"\"\n\tportletName=\"", portletName1, "\"\n/]",
+					RandomTestUtil.randomString(),
+					"[@liferay_portlet.runtime instanceId=\"", instanceId2,
+					"\" portletName=\"", portletName2, "\" /]",
+					RandomTestUtil.randomString(),
+					"[@liferay_portlet[\"runtime\"] instanceId=\"", instanceId3,
+					"\" portletName=\"", portletName3, "\" /]",
+					RandomTestUtil.randomString(), "</div>"),
+				RandomTestUtil.randomString()),
+			PortletIdCodec.encode(
+				PortletIdCodec.decodePortletName(portletName1),
+				PortletIdCodec.decodeUserId(portletName1), instanceId1),
+			PortletIdCodec.encode(
+				PortletIdCodec.decodePortletName(portletName2),
+				PortletIdCodec.decodeUserId(portletName2), instanceId2),
+			PortletIdCodec.encode(
+				PortletIdCodec.decodePortletName(portletName3),
+				PortletIdCodec.decodeUserId(portletName3), instanceId3));
+	}
+
+	@Test
+	@TestInfo("LPD-97875")
+	public void testGetFragmentEntryLinkPortletIdsMultipleFreeMarkerRuntimeTagsAttributeValueContainingMacro() {
+		String instanceId1 = RandomTestUtil.randomString();
+		String instanceId2 = RandomTestUtil.randomString();
+		String portletName1 = RandomTestUtil.randomString();
+		String portletName2 = RandomTestUtil.randomString();
+
+		_assertGetFragmentEntryLinkPortletIds(
+			_getFragmentEntryLink(
+				StringBundler.concat(
+					"<div class=\"fragment_1\">",
+					"[@liferay_portlet.runtime defaultPreferences='",
+					"[@liferay_portlet.runtime portletName=\"",
+					RandomTestUtil.randomString(), "\" /]' instanceId=\"",
+					instanceId1, "\" portletName=\"", portletName1, "\" /]",
+					RandomTestUtil.randomString(),
+					"[@liferay_portlet[\"runtime\"] instanceId=\"", instanceId2,
+					"\" portletName=\"", portletName2, "\" /]</div>"),
+				RandomTestUtil.randomString()),
+			PortletIdCodec.encode(
+				PortletIdCodec.decodePortletName(portletName1),
+				PortletIdCodec.decodeUserId(portletName1), instanceId1),
+			PortletIdCodec.encode(
+				PortletIdCodec.decodePortletName(portletName2),
+				PortletIdCodec.decodeUserId(portletName2), instanceId2));
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97875

Supersedes https://github.com/liferay-page-management/liferay-portal/pull/18714, folding in the fixes for the weaknesses found in its review.

## What Is Being Fixed

`PortletRegistry.getFragmentEntryLinkPortletIds` finds the widgets a fragment embeds by scanning its HTML for `[@liferay_portlet.runtime /]` FreeMarker tags and `<lfr-widget-*>` HTML tags. The FreeMarker side used a greedy regex that merged every runtime tag in the fragment into 1 match, so a fragment with multiple runtime tags only registered the portlet of the last tag. The regex also truncated a tag at a `/]` inside a quoted attribute value, and the attribute extraction could be spoofed by an attribute value containing the text `portletName=`.

## How It Is Being Fixed

The regex is replaced with a manual scan that finds each `[@liferay_portlet` occurrence, accepts the `.runtime`, `["runtime"]`, and `['runtime']` spellings, and locates the closing `/]` with a quote aware walk that skips quoted attribute values, honoring backslash escapes. Attribute values are extracted by a tokenizer that parses name=value pairs left to right, supporting single quoted, double quoted, and bare values as well as whitespace around the equal sign, so a value that merely contains `portletName=` can no longer spoof the real attribute. When a quote is left unterminated, the scan falls back to a plain `indexOf("/]")` for that tag, so 1 malformed region degrades to the old worst case instead of dropping every later tag. The widget tag side is extracted to its own method, and the jsoup parse is skipped entirely when the HTML contains no `lfr-widget-` tag. 10 new unit tests cover multiple tags, quoted `/]`, escaped quotes, spoofed attribute names, single quoted values, whitespace around the equal sign, unterminated quotes, skipped `actionURL` tags, and the single quoted runtime spelling.

## PR Check

**pr-check: PASS** — tested on `c8c2ec668359483594bdae7ce041f4a84c35c74d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c8c2ec668359483594bdae7ce041f4a84c35c74d"} -->