### PR TITLE
LPD-101069 Wait for the panel switch before asserting schedule dates

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditor.spec.ts
@@ -1575,8 +1575,15 @@ test.describe('Schedule Publication', () => {
 
 			await page.getByRole('button', {name: 'Schedule'}).click();
 
-			// After the failed submit the side panel is closed. Reopen it
-			// and check that the expiration and review dates are preserved.
+			// The failed submit moves the side panel to Categorization. Wait
+			// for that switch before going back to Schedule, otherwise the
+			// assertions below race it and the date fields are removed from
+			// the DOM while they are still polling.
+
+			await contentsPage.waitForSidePanel('Categorization');
+
+			// Go back to the Schedule panel and check that the expiration and
+			// review dates are preserved.
 
 			await contentsPage.openSidePanel('Schedule');
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/ContentsPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/ContentsPage.ts
@@ -356,6 +356,13 @@ export class ContentsPage {
 		).toBeVisible();
 	}
 
+	async waitForSidePanel(panelName: SidePanelName) {
+		await expect(this.page.getByLabel(panelName)).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
+	}
+
 	async viewShowDetails(title: string) {
 		const card = this.page
 			.locator('tr', {hasText: title})


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101069
https://liferay.atlassian.net/browse/LPD-100762

## What Is Being Fixed

`contentEditor.spec.ts > Schedule Publication > Schedule dates are maintained after a failed publication` fails intermittently, roughly 6 times in 14 days on master, across `EE Development Acceptance (master)`, `[master] ci:test:cms`, and `[master] ci:test:content-management`, and it was reported as a U152 failure in LPD-100762. The trace shows the schedule dates are preserved correctly, so this is a test defect rather than a product regression.

When the publish fails because a mandatory vocabulary has no category, the content editor deliberately moves the side panel to Categorization to report the error. The test assumed the panel is simply closed and asserted the date fields straight away, so it raced that switch: the assertion started polling while Schedule was still the active panel, and the date inputs were then removed from the DOM as Categorization took over, leaving `<element(s) not found>` for either Expiration Date or Review Date depending on where the switch landed.

## How It Is Being Fixed

The test now waits for the Categorization panel to become active before going back to Schedule, so the assertions run against the panel state that follows the failed publish, which is the state the test intends to cover. Waiting on the panel rather than on the vocabulary error keeps the mandatory-vocabulary assertion in LPD-89784, which owns that behavior.

The wait is a new `ContentsPage.waitForSidePanel` that asserts `aria-selected="true"` on the named tab, mirroring the existing `closeSidePanel`. A side effect is stronger coverage: previously the test could pass by asserting before the switch, never exercising the post-switch state.

## PR Check

**pr-check: PASS** — tested on `c66c03bd13c7d69012c37a779866a609074c7cbc`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

Per-Module Compile and JavaScript Unit Tests are inapplicable to this diff: `modules/test/playwright` applies only the `com.liferay.node` plugin and exposes no `deploy` task, and its `test` script is `playwright test` with no jest suite. The change was type-checked (`npx tsc --noEmit`), format-checked, and the affected test was run 8 consecutive times plus the full spec file.

<!-- pr-check {"result": "success", "sha": "c66c03bd13c7d69012c37a779866a609074c7cbc"} -->
