### PR TITLE
LPD-101070 Reach spaces that the product menu does not list

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditorPreview.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/contentEditorPreview.spec.ts
@@ -939,7 +939,7 @@ test(
 					trigger: page.getByLabel('Select Display Page'),
 				});
 
-				const iframe = page.frameLocator('iframe');
+				const iframe = page.frameLocator('iframe[title="Preview"]');
 
 				await expect(iframe.getByText(englishTitle)).toBeVisible();
 			});
@@ -947,7 +947,7 @@ test(
 			await test.step('Switch to Spanish and verify the preview updates', async () => {
 				await localizationSelectPage.switchLanguage('es-ES');
 
-				const iframe = page.frameLocator('iframe');
+				const iframe = page.frameLocator('iframe[title="Preview"]');
 
 				await expect(iframe.getByText(spanishTitle)).toBeVisible();
 				await expect(iframe.getByText(englishTitle)).not.toBeVisible();
@@ -980,7 +980,7 @@ test(
 					trigger: page.getByLabel('Select Display Page'),
 				});
 
-				const iframe = page.frameLocator('iframe');
+				const iframe = page.frameLocator('iframe[title="Preview"]');
 
 				await expect(iframe.getByText(catalanTitle)).toBeVisible();
 				await expect(iframe.getByText(spanishTitle)).not.toBeVisible();

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/pages/SpaceSummaryPage.ts
@@ -8,11 +8,14 @@ import {Locator, Page, expect} from '@playwright/test';
 import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
 import {PORTLET_URLS} from '../../../../utils/portletUrls';
 import {waitForAlert} from '../../../../utils/waitForAlert';
+import {DataSetPage} from './DataSetPage';
 
 type UserOrUserGroupType = 'groups' | 'users';
 
 export class SpaceSummaryPage {
 	readonly page: Page;
+
+	readonly dataSetFragmentPage: DataSetPage;
 
 	readonly addContentButton: Locator;
 	readonly addFileButton: Locator;
@@ -28,6 +31,8 @@ export class SpaceSummaryPage {
 
 	constructor(page: Page) {
 		this.page = page;
+
+		this.dataSetFragmentPage = new DataSetPage(page);
 
 		this.addContentButton = page.getByRole('button', {name: `Add Content`});
 
@@ -67,16 +72,46 @@ export class SpaceSummaryPage {
 
 	async goto(spaceName: string) {
 		await expect(async () => {
-			await this.page.goto(PORTLET_URLS.cms);
 
-			await this.page
-				.getByRole('menuitem', {name: spaceName})
-				.click({timeout: 3000});
+			// All Spaces renders the product menu as well, so landing here
+			// keeps both routes to the space one navigation away.
+
+			await this.page.goto(PORTLET_URLS.cmsAllSpaces);
+
+			const spaceMenuItem = this.page.getByRole('menuitem', {
+				name: spaceName,
+			});
+
+			// The product menu only lists the first few spaces, so the space is
+			// missing from it once enough of them exist. Wait for the menu to
+			// render, anchoring on the Home entry it always contains, so that
+			// the space entry is present by then if the menu lists it at all.
+
+			await spaceMenuItem
+				.or(
+					this.page.getByRole('menuitem', {exact: true, name: 'Home'})
+				)
+				.first()
+				.waitFor();
+
+			// Open the space from the menu when it is listed, and search the
+			// data set when it is not.
+
+			if (await spaceMenuItem.isVisible()) {
+				await spaceMenuItem.click({timeout: 3000});
+			}
+			else {
+				await this.dataSetFragmentPage.search(spaceName);
+
+				await this.page
+					.getByRole('link', {exact: true, name: spaceName})
+					.click({timeout: 3000});
+			}
 
 			await this.page
 				.getByRole('heading', {exact: true, name: spaceName})
 				.waitFor({timeout: 3000});
-		}).toPass();
+		}).toPass({timeout: 60000});
 	}
 
 	async closeMembersDialog() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101070
https://liferay.atlassian.net/browse/LPD-100765

## What Is Being Fixed

`contentEditorPreview.spec.ts > Switching the editing language updates the content preview` fails intermittently on master, and was reported as a U152 failure in LPD-100765. All three recorded failures die the same way: `Test timeout of 90000ms exceeded` inside the `Create a space and connect sites` step, with no assertion message to work from.

The cause is `SpaceSummaryPage.goto`, which located the space in the CMS product menu. That menu only ever lists five spaces, ordered by name (`ViewSpacesDisplayContext`, `Pagination.of(1, 5)`), so a space named `Space <random>` drops out of it once enough spaces exist in the instance. Since the spaces accumulate across a shard, the space becomes unreachable and the lookup retries until the test budget is gone. That also explains the intermittency: with N spaces the new one lands in the top five with probability of roughly 5/N.

The missing error message has its own cause. The retry used a bare `toPass()`, and `toPass` reads `expect.toPass.timeout`, not the configured `expect.timeout` of 15s. With no `toPass` entry in the config it defaults to no timeout at all, so it retried until the test itself expired.

## How It Is Being Fixed

`goto` now lands on All Spaces, which renders the product menu as well, so both routes are one navigation away. It opens the space from the menu when the menu lists it, and searches the data set when it does not. Keeping the menu as the primary path matters because `goto` has around forty callers across four projects, some of which reach it as a restricted user who only sees their own spaces; those callers keep their existing behavior. The retry is also given an explicit 60s bound so this class of failure reports a real error instead of consuming the test.

The preview iframe lookups in the affected test are scoped to `iframe[title="Preview"]`, matching the call already scoped that way in the same file. That addresses the `locator('iframe') resolved to 2 elements` strict mode violation reported on LPD-100765.

Verified by reproducing the original failure and confirming it is fixed. With eight alphabetically earlier spaces present, the test failed 3 out of 3 before this change and passes after it; the previously hanging step drops from a 90s hang to 7s. A same-state A/B shows no runtime change (baseline 78s and 84s, with the fix 72s and 84s). `permissions/spaceSettings.spec.ts`, which calls `goto` right after switching user, gives identical results before and after: the two failures there are a pre-existing local `Login via API failed` and are unrelated.

## PR Check

**pr-check: PASS** — tested on `d036c111930243b584dd9e58b1dae9a52f259052`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

Per-Module Compile and JavaScript Unit Tests are inapplicable to this diff: `modules/test/playwright` applies only the `com.liferay.node` plugin and exposes no `deploy` task, and its `test` script is `playwright test` with no jest suite. The change was type-checked (`npx tsc --noEmit`), format-checked, and exercised through the runs described above.

<!-- pr-check {"result": "success", "sha": "d036c111930243b584dd9e58b1dae9a52f259052"} -->
