### PR TITLE
LPD-101125 Scope the styles tab assertions to the configuration panel

### DIFF
--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/permissions.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/permissions.spec.ts
@@ -90,10 +90,14 @@ test(
 
 		await pageEditorPage.goToConfigurationTab('Styles');
 
-		await expect(page.getByText('Background')).not.toBeAttached();
-		await expect(page.getByText('Borders')).not.toBeAttached();
-		await expect(page.getByText('Effects')).not.toBeAttached();
-		await expect(page.getByText('Text')).not.toBeAttached();
+		const stylesPanel = page.getByRole('tabpanel', {name: 'Styles'});
+
+		await expect(stylesPanel).toBeAttached();
+
+		await expect(stylesPanel.getByText('Background')).not.toBeAttached();
+		await expect(stylesPanel.getByText('Borders')).not.toBeAttached();
+		await expect(stylesPanel.getByText('Effects')).not.toBeAttached();
+		await expect(stylesPanel.getByText('Text')).not.toBeAttached();
 
 		// Assert in advanced tab
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101125
https://liferay.atlassian.net/browse/LPD-100889

## What Is Being Fixed

`layout-content-page-editor-web/main/permissions.spec.ts > User with Update - Basic and Update - Advanced Options permission cannot define custom css of fragment` fails with a strict mode violation:

```
expect.not.toBeAttached: Error: strict mode violation: getByText('Text') resolved to 4 elements:
    1) <div class="title">Inline Text</div>
    2) <div class="title">Rich Text</div>
    3) <div class="title">Text</div>
    4) <div class="title">Textarea</div>
```

All four matches are fragment names in the sidebar, so the assertion was never checking the styles tab at all. It asserted that the restricted user cannot reach the Background, Borders, Effects and Text style sections, but looked them up across the whole page.

This is a real regression rather than flakiness. The test passed 28 times and then failed on every run from 2026-07-31 onward, across `EE Development Acceptance (master)`, `[master] ci:test:page-management` and the package tester. The window is `9798acc26da5` (last pass) to `64381be64815` (first failure), which contains `a57a60eb394d0` LPD-99210, removing the LPD-17564 feature flag check from `BasicComponentFragmentCollectionContributor`. With the filter gone the sidebar offers more fragments, and enough of their names contain "Text" to break the unscoped lookup.

## How It Is Being Fixed

The four lookups are scoped to the styles tab panel with `getByRole('tabpanel', {name: 'Styles'})`, the pattern `PageEditorPage` already uses for configuration tab contents. That makes them assert what they claim to and makes them independent of whatever fragments the sidebar happens to offer. The panel is asserted attached first, so an absence cannot be satisfied by a panel that never rendered, which is the failure mode that let the original assertion look healthy while checking nothing.

Verified by reproducing and fixing: the test fails deterministically on a u152 bundle before the change and passes after it. The other two tests in the file fail locally both before and after, in-file only and passing in isolation, which matches the known local `performUserSwitch` login flake; both are green on CI in the same build.

## PR Check

**pr-check: PASS** — tested on `3bbdbe11bf53de9f79c843323e0e0f6d8dfa6faf`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

Per-Module Compile and JavaScript Unit Tests are inapplicable to this diff: `modules/test/playwright` applies only the `com.liferay.node` plugin and exposes no `deploy` task, and its `test` script is `playwright test` with no jest suite. The change was type-checked (`npx tsc --noEmit`), format-checked, and exercised by the runs described above.

<!-- pr-check {"result": "success", "sha": "3bbdbe11bf53de9f79c843323e0e0f6d8dfa6faf"} -->
