### PR TITLE
LPD-101143 Fix the flaky Product Menu scope dropdown test

### DIFF
--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/widgets.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/widgets.spec.ts
@@ -518,26 +518,27 @@ test(
 			trigger: productMenuPage.contentAndDataButton,
 		});
 
+		// The Product Menu slides in with a CSS transition and the dropdown
+		// closes itself once the transition ends, so open it only after the
+		// Product Menu has settled
+
+		await expect(productMenuPage.productMenuWrapper).not.toHaveClass(
+			/sidenav-transition/
+		);
+
+		await dropdownButton.click({timeout: 5000});
+
 		const dropdownOption = page
 			.locator('.dropdown-menu')
 			.getByRole('menuitem', {name: layoutTitle});
 
-		await clickAndExpectToBeVisible({
-			target: dropdownOption,
-			timeout: 5000,
-			trigger: dropdownButton,
-		});
+		await expect(dropdownOption).toBeVisible({timeout: 5000});
 
 		await expect(dropdownOption).toContainText(/deprecated/i);
 
 		// Check that the page is set as scope
 
-		await clickAndExpectToBeVisible({
-			autoClick: true,
-			target: dropdownOption,
-			timeout: 5000,
-			trigger: dropdownButton,
-		});
+		await dropdownOption.click({timeout: 5000});
 
 		const scopeName = page.locator('.scope-name', {
 			hasText: `${layoutTitle} (Scope)`,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101143

## What Is Being Fixed

The Playwright test `layout-content-page-editor-web/main/widgets.spec.ts > Check that the scope dropdown in Product Menu have the deprecation badge and that the page is set as scope` (`@LPD-46225`) is flaky and burns its entire 90s budget when it loses the race, failing with `Test timeout of 90000ms exceeded at utils/clickAndExpectToBeVisible.ts:29` (Expect "toPass"). Most recent occurrence: Testray case result 505953367 on routine `[master] ci:test:page-management`, build SHA 6f95e276.

The test opened the Product Menu scope dropdown as soon as the "Choose Scope" cog became visible, which is normally well inside the 500ms sidebar slide-in transition. Clay tears the dropdown down when that transition ends, so the menu entry being asserted on was destroyed mid-flight. Frame-by-frame instrumentation showed the dropdown sliding from `left: 249px` to `left: 279px` and then losing its `show` class one frame after both transitions finished. Because `clickAndExpectToBeVisible` calls `target.click()` with no timeout in its `autoClick` branch, and `actionTimeout` is unset in `playwright.config.ts`, losing that race turned into a 90s hang rather than a fast failure, so the `toPass` loop never got the chance to reopen the dropdown.

This is not a regression. Ten of the last sixty-seven runs on that routine exceeded the 90s timeout on at least one attempt: it failed outright on 2026-06-15, 06-16, 06-17, 07-10, 07-18 and 08-03, and survived elsewhere only through the single CI retry on 07-15, 07-16, 07-22 and 08-01, which is why Testray still reported a recent last pass. The deprecation feature under test is working correctly; both badge assertions pass on every run.

## How It Is Being Fixed

The test now waits for the Product Menu wrapper to drop its `sidenav-transition` class before opening the dropdown, so the menu is anchored to a settled element and nothing tears it down afterwards. That removes the race rather than narrowing it. With the anchor settled, the retry-and-reopen behaviour is no longer needed, so opening the dropdown and selecting the scope both become plain clicks with an explicit 5s timeout. That also improves diagnosability: if the dropdown ever disappears for some other reason, the test fails in five seconds pointing at the exact click instead of hanging for the full test budget behind an opaque `toPass()` frame.

Both deprecation-badge assertions, on the dropdown entry and on the `.scope-name` label, are unchanged. The shared `clickAndExpectToBeVisible` helper is deliberately left untouched so none of its other call sites change behaviour.

Verified by reproducing the failure locally (two attempts, 182s), then three consecutive green runs at roughly 27s each. A full `widgets.spec.ts` run gives 8 passed and 1 failure, that failure being the pre-existing drag-and-drop Form Container test, which fails locally on the react-dnd drag itself and does not use this helper.

## PR Check

**pr-check: PASS** — tested on `78d9a3f766e1ebaee4a5ab4e9e83f88371cd523f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "78d9a3f766e1ebaee4a5ab4e9e83f88371cd523f"} -->
