### PR TITLE
LPD-99742 Fix disappearing referenced structure field

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
@@ -207,6 +207,129 @@ public class UpdateStructureStrutsActionTest {
 				objectRelationship.getObjectRelationshipId()));
 	}
 
+	@Test
+	@TestInfo("LPD-99742")
+	public void testExecuteDoesNotDeleteRelationshipWhenSavingReferencedStructure()
+		throws Exception {
+
+		// Mirrors buildObjectDefinition.ts's buildRelationships(), which is
+		// what a "Referenced Content Structure" field actually builds:
+		// objectDefinitionId1 is the structure that owns the field
+		// (_objectDefinition1), objectDefinitionId2 is the referenced/target
+		// structure (_objectDefinition2), and deletionType is cascade. This
+		// is the opposite side assignment from a plain, non-multiselect
+		// related-content field, which buildObjectRelationships.ts builds
+		// with objectDefinitionId1 as the referenced/target structure.
+
+		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
+		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		com.liferay.object.model.ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				null, TestPropsValues.getUserId(),
+				_objectDefinition1.getObjectDefinitionId(),
+				_objectDefinition2.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_CASCADE, true,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				StringUtil.randomId(), false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		Assert.assertTrue(objectRelationship.isEdge());
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		// Simulate editing and republishing the referenced/target structure
+		// (_objectDefinition2), not the owner - exactly the LPD-99742 repro
+		// steps ("go to Edit mode in Referenced Structure and simply publish
+		// it again").
+
+		_updateStructureStrutsAction.execute(
+			_getMockHttpServletRequest(_objectDefinition2),
+			mockHttpServletResponse);
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject(
+			mockHttpServletResponse.getContentAsString());
+
+		Assert.assertEquals(jsonObject.toString(), 0, jsonObject.length());
+
+		Assert.assertNotNull(
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				objectRelationship.getObjectRelationshipId()));
+	}
+
+	@Test
+	@TestInfo("LPD-99742")
+	public void testExecuteRecreatesOwnedEdgeRelationshipWhenSavingOwner()
+		throws Exception {
+
+		// Mirrors buildObjectRelationships.ts's convention for a
+		// non-multiselect related-content field: objectDefinitionId1 is the
+		// referenced/target structure, objectDefinitionId2 is the owner.
+		// Saving the owner (_objectDefinition2) while resending this same
+		// relationship's name must still replace it with a fresh row, not
+		// leave the stale one in place.
+
+		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
+		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		String name = StringUtil.randomId();
+
+		com.liferay.object.model.ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				null, TestPropsValues.getUserId(),
+				_objectDefinition1.getObjectDefinitionId(),
+				_objectDefinition2.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE, true,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				name, false, ObjectRelationshipConstants.TYPE_ONE_TO_MANY,
+				null);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			(MockHttpServletRequest)_getMockHttpServletRequest(
+				_objectDefinition2);
+
+		mockHttpServletRequest.setParameter(
+			"objectRelationships",
+			JSONUtil.putAll(
+				JSONUtil.put(
+					"deletionType", "disassociate"
+				).put(
+					"edge", true
+				).put(
+					"name", name
+				).put(
+					"objectDefinitionExternalReferenceCode1",
+					_objectDefinition1.getExternalReferenceCode()
+				).put(
+					"objectDefinitionExternalReferenceCode2",
+					_objectDefinition2.getExternalReferenceCode()
+				).put(
+					"type", "oneToMany"
+				)
+			).toString());
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		_updateStructureStrutsAction.execute(
+			mockHttpServletRequest, mockHttpServletResponse);
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject(
+			mockHttpServletResponse.getContentAsString());
+
+		Assert.assertEquals(jsonObject.toString(), 0, jsonObject.length());
+
+		Assert.assertNull(
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				objectRelationship.getObjectRelationshipId()));
+
+		Assert.assertNotNull(
+			_objectRelationshipLocalService.
+				fetchObjectRelationshipByObjectDefinitionId(
+					_objectDefinition2.getObjectDefinitionId(), name));
+	}
+
 	private HttpServletRequest _getMockHttpServletRequest(
 			com.liferay.object.model.ObjectDefinition objectDefinition)
 		throws Exception {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
@@ -38,9 +38,11 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 import org.osgi.service.component.annotations.Component;
@@ -120,8 +122,28 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 		return null;
 	}
 
-	private void _deleteRelationships(long objectDefinitionId)
+	private void _deleteRelationships(
+			long objectDefinitionId,
+			List<ObjectRelationship> objectRelationships)
 		throws Exception {
+
+		// Only relationships whose name is about to be recreated from
+		// objectRelationships are deleted here. A blanket delete of every
+		// edge where this structure is objectDefinitionId2 also catches
+		// relationships this structure never owns in the first place - a
+		// "Referenced Content Structure" field's edge has the *referenced*
+		// structure as objectDefinitionId2 (see buildObjectDefinition.ts's
+		// buildRelationships), so simply republishing the referenced
+		// structure with no changes of its own would otherwise delete the
+		// referencing structure's field, with nothing to recreate it, since
+		// that edge is never part of this structure's own
+		// objectRelationships.
+
+		Set<String> names = new HashSet<>();
+
+		for (ObjectRelationship objectRelationship : objectRelationships) {
+			names.add(objectRelationship.getName());
+		}
 
 		for (com.liferay.object.model.ObjectRelationship
 				serviceBuilderObjectRelationship :
@@ -129,7 +151,9 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 						getObjectRelationshipsByObjectDefinitionId2(
 							objectDefinitionId, true)) {
 
-			if (serviceBuilderObjectRelationship.isReverse()) {
+			if (serviceBuilderObjectRelationship.isReverse() ||
+				!names.contains(serviceBuilderObjectRelationship.getName())) {
+
 				continue;
 			}
 
@@ -408,7 +432,8 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 
 			if (serviceBuilderObjectDefinition != null) {
 				_deleteRelationships(
-					serviceBuilderObjectDefinition.getObjectDefinitionId());
+					serviceBuilderObjectDefinition.getObjectDefinitionId(),
+					_objectRelationships);
 			}
 
 			if (ListUtil.isNotEmpty(_objectRelationships)) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99742

## What Is Being Fixed

A structure with a "Referenced Content Structure" field pointing at another, already-published structure loses that reference field after the referenced structure is edited and republished with no changes of its own.

This was previously attempted in #8711/#8712 (merged as `brianchandotcom#179367`, then reverted by liferay-page-management#18816 for breaking 7 e2e tests: structures and repeatable groups no longer persisted correctly on save).

## Root Cause

`UpdateStructureStrutsAction._deleteRelationships` runs on every structure save and deletes every edge relationship where the saved structure is `objectDefinitionId2`, then relies on the request's own `objectRelationships` list to recreate them.

That blanket query does not account for two separate, opposite conventions used by the frontend for building these relationships:

- `buildObjectRelationships.ts` (plain, non-multiselect related-content fields): `objectDefinitionId1` is the referenced/target structure, `objectDefinitionId2` is the owner.
- `buildObjectDefinition.ts`'s `buildRelationships()` (the "Referenced Content Structure" field type this ticket is about): `objectDefinitionId1` is the owner, `objectDefinitionId2` is the referenced/target structure - the opposite assignment.

For a "Referenced Content Structure" field, the saved structure being `objectDefinitionId2` means it is the *referenced* structure, not the owner. That edge is never part of the referenced structure's own `objectRelationships` list - its lifecycle is managed entirely by `ObjectDefinitionResourceImpl.putObjectDefinition`'s own embedded-DTO diff, which only fires when the *owning* structure is saved. So republishing the referenced structure alone deletes the edge with nothing to recreate it, and the referencing structure's field silently disappears on the next reload.

The previous attempt (#8711/#8712) queried by `objectDefinitionId1` instead, based on an inverted understanding of which side owns the relationship. That broke the opposite, more common direction: saving the *owning* structure no longer replaced its own related-content edges, since that convention has `objectDefinitionId1` as the referenced structure, not the owner - hence the revert.

## How It Is Being Fixed

`_deleteRelationships` now only deletes a relationship whose name is present in the request's own `objectRelationships` list - i.e., only ones that are actually about to be recreated by the same request's POST step right after. This naturally excludes "Referenced Content Structure" edges (never part of that list) while still correctly replacing related-content edges the saved structure genuinely owns.

Two new integration tests cover both directions:

- `testExecuteDoesNotDeleteRelationshipWhenSavingReferencedStructure` reproduces the actual reported bug (fails on the reverted code, passes with this fix).
- `testExecuteRecreatesOwnedEdgeRelationshipWhenSavingOwner` guards against regressing the direction the revert protected (owner resaves its own edge, gets replaced with a fresh row).

## Verification

- All 5 tests in `UpdateStructureStrutsActionTest` pass together.
- Ran the exact Playwright e2e suites the revert PR used as evidence (`referencedStructures.spec.ts`, `repeatableGroups.spec.ts`, `structureBuilder.spec.ts`, `uploadField.spec.ts`): all tests tied to this bug pass, including the 7 that the revert reported as broken by the previous attempt.
