### PR TITLE
LPD-101044 Stamp last-import date and publisher on headless publish

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LastImportSettingsUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LastImportSettingsUtil.java
@@ -1,0 +1,45 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.resource.v1_0.util;
+
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public class LastImportSettingsUtil {
+
+	public static Map<String, String> getLastImportSettingsMap(long userId) {
+		if (!ExportImportThreadLocal.isStagingInProcess() ||
+			!ExportImportThreadLocal.isLayoutImportInProcess()) {
+
+			return Collections.emptyMap();
+		}
+
+		User user = UserLocalServiceUtil.fetchUser(userId);
+
+		if (user == null) {
+			return HashMapBuilder.put(
+				"last-import-date", String.valueOf(System.currentTimeMillis())
+			).build();
+		}
+
+		return HashMapBuilder.put(
+			"last-import-date", String.valueOf(System.currentTimeMillis())
+		).put(
+			"last-import-user-name", user::getFullName
+		).put(
+			"last-import-user-uuid", user::getUuid
+		).build();
+	}
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LastImportSettingsUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LastImportSettingsUtil.java
@@ -19,8 +19,8 @@ import java.util.Map;
 public class LastImportSettingsUtil {
 
 	public static Map<String, String> getLastImportSettingsMap(long userId) {
-		if (!ExportImportThreadLocal.isStagingInProcess() ||
-			!ExportImportThreadLocal.isLayoutImportInProcess()) {
+		if (!ExportImportThreadLocal.isLayoutImportInProcess() ||
+			!ExportImportThreadLocal.isStagingInProcess()) {
 
 			return Collections.emptyMap();
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
@@ -432,6 +432,10 @@ public class LayoutUtil {
 			ServiceContext serviceContext)
 		throws Exception {
 
+		typeSettingsUnicodeProperties.putAll(
+			LastImportSettingsUtil.getLastImportSettingsMap(
+				serviceContext.getUserId()));
+
 		if (!Objects.equals(
 				typeSettingsUnicodeProperties,
 				layout.getTypeSettingsProperties())) {
@@ -549,6 +553,10 @@ public class LayoutUtil {
 		throws Exception {
 
 		_setExpandoBridgeAttributes(pageSpecification, serviceContext);
+
+		typeSettingsUnicodeProperties.putAll(
+			LastImportSettingsUtil.getLastImportSettingsMap(
+				serviceContext.getUserId()));
 
 		if (!Objects.equals(
 				typeSettingsUnicodeProperties,
@@ -1295,6 +1303,10 @@ public class LayoutUtil {
 
 		UnicodeProperties unicodeProperties =
 			layout.getTypeSettingsProperties();
+
+		unicodeProperties.putAll(
+			LastImportSettingsUtil.getLastImportSettingsMap(
+				serviceContext.getUserId()));
 
 		if (widgetPageSpecification == null) {
 			return LayoutServiceUtil.updateTypeSettings(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -16,6 +16,7 @@ import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.test.util.DLTestUtil;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.test.rule.LazyReferencingTestRule;
 import com.liferay.exportimport.test.util.LazyReferencingTestUtil;
 import com.liferay.fragment.constants.FragmentConstants;
@@ -107,6 +108,7 @@ import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.lang.CentralizedThreadLocal;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -129,6 +131,7 @@ import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -178,6 +181,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -434,7 +438,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		{
 			"LPD-72013", "LPD-74331", "LPD-75450", "LPD-77124", "LPD-77505",
 			"LPD-77576", "LPD-77852", "LPD-78667", "LPD-79415", "LPD-80061",
-			"LPD-81793", "LPD-83094", "LPD-97454"
+			"LPD-81793", "LPD-83094", "LPD-97454", "LPD-101044"
 		}
 	)
 	public void testPutSiteSitePage() throws Exception {
@@ -471,6 +475,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		_testPutSiteSitePageWithPageSpecifications();
 		_testPutSiteSitePageWithParentLayout();
 		_testPutSiteSitePageWithPriority();
+		_testPutSiteSitePageWithStagingImport(serviceContext);
 		_testPutSiteSitePageWithWidgetPageSettings();
 		_testPutSiteSitePageWithWidgetPageSettingsWithWidgetPageTemplate();
 
@@ -1755,6 +1760,16 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 	}
 
 	private SitePage _getRandomSitePage(
+			ServiceContext serviceContext, SitePage sitePage)
+		throws Exception {
+
+		return _getRandomSitePage(
+			sitePage.getExternalReferenceCode(),
+			sitePage.getParentSitePageExternalReferenceCode(), serviceContext,
+			sitePage.getType(), sitePage.getUuid());
+	}
+
+	private SitePage _getRandomSitePage(
 			ServiceContext serviceContext, SitePage.Type type)
 		throws Exception {
 
@@ -2109,6 +2124,29 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		}
 
 		return draftFragmentOrWidgetInstanceExternalReferenceCodes;
+	}
+
+	private SafeCloseable _setExportImportThreadLocalWithSafeCloseable(
+		String fieldName, boolean value) {
+
+		CentralizedThreadLocal<Boolean> originalCentralizedThreadLocal =
+			ReflectionTestUtil.getFieldValue(
+				ExportImportThreadLocal.class, fieldName);
+
+		Boolean originalValue = originalCentralizedThreadLocal.get();
+
+		originalCentralizedThreadLocal.set(value);
+
+		Supplier<Boolean> originalSupplier =
+			ReflectionTestUtil.getAndSetFieldValue(
+				originalCentralizedThreadLocal, "_supplier", () -> value);
+
+		return () -> {
+			originalCentralizedThreadLocal.set(originalValue);
+
+			ReflectionTestUtil.setFieldValue(
+				originalCentralizedThreadLocal, "_supplier", originalSupplier);
+		};
 	}
 
 	private void _testDeleteSiteSitePage(Layout... layouts) throws Exception {
@@ -4530,6 +4568,87 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 						testGroup.getGroupId()),
 					putSitePage);
 			});
+	}
+
+	private void _testPutSiteSitePageWithStagingImport(
+			ServiceContext serviceContext)
+		throws Exception {
+
+		_testPutSiteSitePageWithStagingImport(
+			serviceContext, SitePage.Type.CONTENT_PAGE);
+		_testPutSiteSitePageWithStagingImport(
+			serviceContext, SitePage.Type.EMBEDDED_PAGE);
+		_testPutSiteSitePageWithStagingImport(
+			serviceContext, SitePage.Type.LINK_TO_PAGE_PAGE);
+		_testPutSiteSitePageWithStagingImport(
+			serviceContext, SitePage.Type.LINK_TO_URL_PAGE);
+		_testPutSiteSitePageWithStagingImport(
+			serviceContext, SitePage.Type.PAGE_SET_PAGE);
+		_testPutSiteSitePageWithStagingImport(
+			serviceContext, SitePage.Type.WIDGET_PAGE);
+	}
+
+	private void _testPutSiteSitePageWithStagingImport(
+			ServiceContext serviceContext, SitePage.Type type)
+		throws Exception {
+
+		SitePage sitePage = sitePageResource.postSiteSitePage(
+			irrelevantGroup.getExternalReferenceCode(), false,
+			_getRandomSitePage(
+				ServiceContextTestUtil.getServiceContext(
+					irrelevantGroup, TestPropsValues.getUserId()),
+				type));
+
+		_testPutSiteSitePageWithStagingImport(
+			null, false, false, _getRandomSitePage(serviceContext, sitePage));
+		_testPutSiteSitePageWithStagingImport(
+			null, false, true, _getRandomSitePage(serviceContext, sitePage));
+		_testPutSiteSitePageWithStagingImport(
+			null, true, false, _getRandomSitePage(serviceContext, sitePage));
+		_testPutSiteSitePageWithStagingImport(
+			TestPropsValues.getUser(), true, true,
+			_getRandomSitePage(serviceContext, sitePage));
+	}
+
+	private void _testPutSiteSitePageWithStagingImport(
+			User lastImportUser, boolean layoutImportInProcess,
+			boolean layoutStagingInProcess, SitePage sitePage)
+		throws Exception {
+
+		try (SafeCloseable safeCloseable1 =
+				_setExportImportThreadLocalWithSafeCloseable(
+					"_layoutImportInProcess", layoutImportInProcess);
+			SafeCloseable safeCloseable2 =
+				_setExportImportThreadLocalWithSafeCloseable(
+					"_layoutStagingInProcess", layoutStagingInProcess)) {
+
+			_testPutSiteSitePage(sitePage, testGroup, sitePage);
+
+			Layout layout =
+				_layoutLocalService.getLayoutByExternalReferenceCode(
+					sitePage.getExternalReferenceCode(),
+					testGroup.getGroupId());
+
+			if (lastImportUser == null) {
+				Assert.assertNull(
+					layout.getTypeSettingsProperty("last-import-date"));
+				Assert.assertNull(
+					layout.getTypeSettingsProperty("last-import-user-name"));
+				Assert.assertNull(
+					layout.getTypeSettingsProperty("last-import-user-uuid"));
+
+				return;
+			}
+
+			Assert.assertNotNull(
+				layout.getTypeSettingsProperty("last-import-date"));
+			Assert.assertEquals(
+				lastImportUser.getFullName(),
+				layout.getTypeSettingsProperty("last-import-user-name"));
+			Assert.assertEquals(
+				lastImportUser.getUuid(),
+				layout.getTypeSettingsProperty("last-import-user-uuid"));
+		}
 	}
 
 	private void _testPutSiteSitePageWithWidgetPageSettings() throws Exception {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -452,6 +452,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		_testPutSiteSitePage(true, serviceContext, SitePage.Type.CONTENT_PAGE);
 		_testPutSiteSitePage(true, serviceContext, SitePage.Type.WIDGET_PAGE);
 
+		_testPutSiteSitePageWithContentPageSpecification();
 		_testPutSiteSitePageWithDefaultAssetPublisher();
 		_testPutSiteSitePageWithEmptyLayout(serviceContext);
 		_testPutSiteSitePageWithExportedPageSetSitePageAsFirstPage(
@@ -470,7 +471,6 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		_testPutSiteSitePageWithPageSpecifications();
 		_testPutSiteSitePageWithParentLayout();
 		_testPutSiteSitePageWithPriority();
-		_testPutSiteSitePageWithContentPageSpecification();
 		_testPutSiteSitePageWithWidgetPageSettings();
 		_testPutSiteSitePageWithWidgetPageSettingsWithWidgetPageTemplate();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101044

## What Is Being Fixed

When a content page is published through the headless staging import path (`SitePageResource.putSiteSitePage` / `patchSiteSitePage`), the last-import banner in the Pages admin (date and publisher) stays empty because the layout is persisted without the three `last-import-*` typeSettings keys that the banner reads. Publishing through the regular staging flow populates them via `StagingImpl`, but the headless entry point never did.

## How It Is Being Fixed

A new `LastImportSettingsUtil` centralizes the check — stamp only when both `ExportImportThreadLocal.isStagingInProcess()` and `isLayoutImportInProcess()` are set — and returns the three typeSettings keys populated with the current timestamp and the effective user. Every headless update path in `LayoutUtil` that persists typeSettings now merges that map before saving, matching what `StagingImpl` already does for the regular staging flow.

## PR Check

**pr-check: PASS** — tested on `a27f301395785803aacd920761509d4a10352440`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a27f301395785803aacd920761509d4a10352440"} -->
