### PR TITLE
LPD-100303 Skip unpublished layouts as the default landing

### DIFF
--- a/modules/apps/portal/portal-events-test/src/testIntegration/java/com/liferay/portal/events/test/ServicePreActionTest.java
+++ b/modules/apps/portal/portal-events-test/src/testIntegration/java/com/liferay/portal/events/test/ServicePreActionTest.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -257,6 +258,42 @@ public class ServicePreActionTest {
 		Assert.assertNotNull(serviceContext);
 		Assert.assertEquals(
 			_group.getGroupId(), serviceContext.getScopeGroupId());
+	}
+
+	@Test
+	@TestInfo("LPD-100303")
+	public void testInitThemeDisplayDefaultLayoutIsPublished()
+		throws Exception {
+
+		List<Layout> layouts = _layoutLocalService.getLayouts(
+			_group.getGroupId(), false);
+
+		Layout publishedLayout = layouts.get(0);
+
+		long plid = _getThemeDisplayPlid(true, false);
+
+		Assert.assertEquals(publishedLayout.getPlid(), plid);
+
+		Layout contentPageLayout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Assert.assertFalse(contentPageLayout.isPublished());
+
+		contentPageLayout = _layoutLocalService.updatePriority(
+			contentPageLayout, publishedLayout.getPriority());
+
+		plid = _getThemeDisplayPlid(true, false);
+
+		Assert.assertEquals(publishedLayout.getPlid(), plid);
+
+		int count = layouts.size();
+
+		layouts = _layoutLocalService.getLayouts(_group.getGroupId(), false);
+
+		Layout firstLayout = layouts.get(0);
+
+		Assert.assertEquals(firstLayout.getPlid(), contentPageLayout.getPlid());
+
+		Assert.assertEquals(layouts.toString(), count + 1, layouts.size());
 	}
 
 	@Test

--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -691,7 +691,9 @@ public class ServicePreAction extends Action {
 
 		boolean hasViewLayoutPermission = false;
 
-		if (_hasAccessPermission(permissionChecker, layout, false)) {
+		if (layout.isPublished() &&
+			_hasAccessPermission(permissionChecker, layout, false)) {
+
 			hasViewLayoutPermission = true;
 		}
 
@@ -699,6 +701,7 @@ public class ServicePreAction extends Action {
 
 		for (Layout curLayout : layouts) {
 			if ((ignoreHiddenLayouts || !curLayout.isHidden()) &&
+				curLayout.isPublished() &&
 				_hasAccessPermission(permissionChecker, curLayout, false)) {
 
 				if (accessibleLayouts.isEmpty() && !hasViewLayoutPermission) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100303

## What Is Being Fixed

When the first root layout of a virtual host's layout set is a Content Page that has never been published, the default-landing selection in `ServicePreAction` picks it as the layout to render and the render pipeline produces a 404. The most visible symptom is the logout redirect, which routes through `/html/common/referer_js.jsp` under the portal pipeline instead of a friendly URL — the friendly URL path was already guarded by LPD-24489, but the composite chain that fires when the request has no layout resolved was not.

## How It Is Being Fixed

Inside `ServicePreAction._getViewableLayoutComposite`, `Layout.isPublished()` is added to both the `hasViewLayoutPermission` gate on the caller-picked layout and the accessible-layout filter in the loop, so a draft never survives as either the single "chosen" layout or a member of the accessible list. The check runs before the permission lookup so it short-circuits cheaply on the layouts that are already known to be non-renderable.

## PR Check

**pr-check: PASS** — tested on `01ca7746e07ee7b7d4d73c3a87483337681de5a8`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "01ca7746e07ee7b7d4d73c3a87483337681de5a8"} -->
