### PR TITLE
LPD-99652 Exclude and delete fragment usages with a missing layout

### DIFF
--- a/modules/apps/fragment/fragment-api/bnd.bnd
+++ b/modules/apps/fragment/fragment-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Fragment API
 Bundle-SymbolicName: com.liferay.fragment.api
-Bundle-Version: 62.2.1
+Bundle-Version: 62.3.0
 Export-Package:\
 	com.liferay.fragment.cache,\
 	com.liferay.fragment.configuration,\

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalService.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalService.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import java.io.Serializable;
 
 import java.util.List;
+import java.util.Map;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -165,6 +166,10 @@ public interface FragmentEntryLinkLocalService
 	public List<FragmentEntryLink>
 		deleteLayoutPageTemplateEntryFragmentEntryLinks(
 			long groupId, long[] segmentsExperienceIds, long plid);
+
+	public void deleteMissingLayoutFragmentEntryLinksByFragmentEntry(
+			FragmentEntry fragmentEntry)
+		throws PortalException;
 
 	/**
 	 * @throws PortalException
@@ -439,6 +444,11 @@ public interface FragmentEntryLinkLocalService
 	public int getFragmentEntryLinksCountByPlid(long groupId, long plid);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Map<Long, Integer> getGroupFragmentEntryUsageCounts(
+			FragmentEntry fragmentEntry)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public IndexableActionableDynamicQuery getIndexableActionableDynamicQuery();
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -464,6 +474,11 @@ public interface FragmentEntryLinkLocalService
 	public int getLayoutPageTemplateFragmentEntryLinksCountByFragmentEntry(
 			long groupId, FragmentEntry fragmentEntry,
 			int layoutPageTemplateType)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Map<String, List<Long>> getMissingLayoutPlidsMap(
+			long fragmentCollectionId)
 		throws PortalException;
 
 	/**
@@ -538,4 +553,4 @@ public interface FragmentEntryLinkLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1523302530
+// LIFERAY-SERVICE-BUILDER-HASH:2090890009

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceUtil.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceUtil.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import java.io.Serializable;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Provides the local service utility for FragmentEntryLink. This utility wraps
@@ -187,6 +188,14 @@ public class FragmentEntryLinkLocalServiceUtil {
 
 		return getService().deleteLayoutPageTemplateEntryFragmentEntryLinks(
 			groupId, segmentsExperienceIds, plid);
+	}
+
+	public static void deleteMissingLayoutFragmentEntryLinksByFragmentEntry(
+			com.liferay.fragment.model.FragmentEntry fragmentEntry)
+		throws PortalException {
+
+		getService().deleteMissingLayoutFragmentEntryLinksByFragmentEntry(
+			fragmentEntry);
 	}
 
 	/**
@@ -580,6 +589,13 @@ public class FragmentEntryLinkLocalServiceUtil {
 		return getService().getFragmentEntryLinksCountByPlid(groupId, plid);
 	}
 
+	public static Map<Long, Integer> getGroupFragmentEntryUsageCounts(
+			com.liferay.fragment.model.FragmentEntry fragmentEntry)
+		throws PortalException {
+
+		return getService().getGroupFragmentEntryUsageCounts(fragmentEntry);
+	}
+
 	public static
 		com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery
 			getIndexableActionableDynamicQuery() {
@@ -632,6 +648,13 @@ public class FragmentEntryLinkLocalServiceUtil {
 		return getService().
 			getLayoutPageTemplateFragmentEntryLinksCountByFragmentEntry(
 				groupId, fragmentEntry, layoutPageTemplateType);
+	}
+
+	public static Map<String, List<Long>> getMissingLayoutPlidsMap(
+			long fragmentCollectionId)
+		throws PortalException {
+
+		return getService().getMissingLayoutPlidsMap(fragmentCollectionId);
 	}
 
 	/**
@@ -728,4 +751,4 @@ public class FragmentEntryLinkLocalServiceUtil {
 			FragmentEntryLinkLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1331238008
+// LIFERAY-SERVICE-BUILDER-HASH:1331499408

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceWrapper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceWrapper.java
@@ -204,6 +204,15 @@ public class FragmentEntryLinkLocalServiceWrapper
 				groupId, segmentsExperienceIds, plid);
 	}
 
+	@Override
+	public void deleteMissingLayoutFragmentEntryLinksByFragmentEntry(
+			com.liferay.fragment.model.FragmentEntry fragmentEntry)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_fragmentEntryLinkLocalService.
+			deleteMissingLayoutFragmentEntryLinksByFragmentEntry(fragmentEntry);
+	}
+
 	/**
 	 * @throws PortalException
 	 */
@@ -665,6 +674,15 @@ public class FragmentEntryLinkLocalServiceWrapper
 	}
 
 	@Override
+	public java.util.Map<Long, Integer> getGroupFragmentEntryUsageCounts(
+			com.liferay.fragment.model.FragmentEntry fragmentEntry)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _fragmentEntryLinkLocalService.getGroupFragmentEntryUsageCounts(
+			fragmentEntry);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery
 		getIndexableActionableDynamicQuery() {
 
@@ -724,6 +742,15 @@ public class FragmentEntryLinkLocalServiceWrapper
 		return _fragmentEntryLinkLocalService.
 			getLayoutPageTemplateFragmentEntryLinksCountByFragmentEntry(
 				groupId, fragmentEntry, layoutPageTemplateType);
+	}
+
+	@Override
+	public java.util.Map<String, java.util.List<Long>> getMissingLayoutPlidsMap(
+			long fragmentCollectionId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _fragmentEntryLinkLocalService.getMissingLayoutPlidsMap(
+			fragmentCollectionId);
 	}
 
 	/**
@@ -863,4 +890,4 @@ public class FragmentEntryLinkLocalServiceWrapper
 	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:564296629
+// LIFERAY-SERVICE-BUILDER-HASH:-347092745

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
@@ -1,1 +1,1 @@
-version 17.1.0
+version 17.2.0

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -336,6 +336,20 @@ public class FragmentEntryLinkLocalServiceImpl
 	}
 
 	@Override
+	public void deleteMissingLayoutFragmentEntryLinksByFragmentEntry(
+			FragmentEntry fragmentEntry)
+		throws PortalException {
+
+		for (FragmentEntryLink fragmentEntryLink :
+				_getMissingLayoutFragmentEntryLinksByFragmentEntry(
+					fragmentEntry)) {
+
+			fragmentEntryLinkLocalService.deleteFragmentEntryLink(
+				fragmentEntryLink);
+		}
+	}
+
+	@Override
 	public FragmentEntryLink fetchFragmentEntryLink(
 		long groupId, String originalFragmentEntryLinkERC, long plid) {
 
@@ -567,7 +581,8 @@ public class FragmentEntryLinkLocalServiceImpl
 		for (Object[] result : results) {
 			Number count = (Number)result[1];
 
-			groupFragmentEntryUsageCounts.put((Long)result[0], count.intValue());
+			groupFragmentEntryUsageCounts.put(
+				(Long)result[0], count.intValue());
 		}
 
 		return groupFragmentEntryUsageCounts;
@@ -688,7 +703,7 @@ public class FragmentEntryLinkLocalServiceImpl
 
 		for (Object[] result : results) {
 			List<Long> plids = missingLayoutPlidsMap.computeIfAbsent(
-				(String)result[0], key -> new ArrayList<>());
+				(String)result[0], fragmentEntryERC -> new ArrayList<>());
 
 			plids.add((Long)result[1]);
 		}
@@ -1130,6 +1145,29 @@ public class FragmentEntryLinkLocalServiceImpl
 			FragmentEntryLinkTable.INSTANCE.plid.notIn(
 				layoutRevisionIdsDSLQuery)
 		);
+	}
+
+	private List<FragmentEntryLink>
+			_getMissingLayoutFragmentEntryLinksByFragmentEntry(
+				FragmentEntry fragmentEntry)
+		throws PortalException {
+
+		return fragmentEntryLinkPersistence.dslQuery(
+			DSLQueryFactoryUtil.select(
+				FragmentEntryLinkTable.INSTANCE
+			).from(
+				FragmentEntryLinkTable.INSTANCE
+			).where(
+				FragmentEntryLinkTable.INSTANCE.fragmentEntryERC.eq(
+					fragmentEntry.getExternalReferenceCode()
+				).and(
+					_getFragmentEntryGroupScopePredicate(
+						FragmentEntryLinkTable.INSTANCE,
+						_groupLocalService.getGroup(fragmentEntry.getGroupId()))
+				).and(
+					_getLayoutPredicate(false)
+				)
+			));
 	}
 
 	private Function<OrderByStep, LimitStep> _getOrderByStepLimitStepFunction(

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -16,6 +16,7 @@ import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.model.FragmentEntryLinkTable;
+import com.liferay.fragment.model.FragmentEntryTable;
 import com.liferay.fragment.processor.DefaultFragmentEntryProcessorContext;
 import com.liferay.fragment.processor.FragmentEntryProcessorContext;
 import com.liferay.fragment.processor.FragmentEntryProcessorRegistry;
@@ -44,6 +45,7 @@ import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutRevisionTable;
@@ -73,6 +75,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -636,6 +639,64 @@ public class FragmentEntryLinkLocalServiceImpl
 	}
 
 	@Override
+	public Map<String, List<Long>> getMissingLayoutPlidsMap(
+			long fragmentCollectionId)
+		throws PortalException {
+
+		Map<String, List<Long>> missingLayoutPlidsMap = new HashMap<>();
+
+		FragmentCollection fragmentCollection =
+			_fragmentCollectionPersistence.fetchByPrimaryKey(
+				fragmentCollectionId);
+
+		if ((fragmentCollection == null) ||
+			(fragmentCollection.getGroupId() == CompanyConstants.SYSTEM)) {
+
+			return missingLayoutPlidsMap;
+		}
+
+		List<Object[]> results = fragmentEntryLinkPersistence.dslQuery(
+			DSLQueryFactoryUtil.selectDistinct(
+				FragmentEntryLinkTable.INSTANCE.fragmentEntryERC,
+				FragmentEntryLinkTable.INSTANCE.plid
+			).from(
+				FragmentEntryLinkTable.INSTANCE
+			).innerJoinON(
+				FragmentEntryTable.INSTANCE,
+				FragmentEntryTable.INSTANCE.externalReferenceCode.eq(
+					FragmentEntryLinkTable.INSTANCE.fragmentEntryERC
+				).and(
+					FragmentEntryTable.INSTANCE.groupId.eq(
+						fragmentCollection.getGroupId())
+				)
+			).where(
+				FragmentEntryTable.INSTANCE.fragmentCollectionId.eq(
+					fragmentCollectionId
+				).and(
+					_getFragmentEntryGroupScopePredicate(
+						FragmentEntryLinkTable.INSTANCE,
+						_groupLocalService.getGroup(
+							fragmentCollection.getGroupId()))
+				).and(
+					FragmentEntryLinkTable.INSTANCE.deleted.eq(false)
+				).and(
+					_getLayoutPredicate(false)
+				)
+			).orderBy(
+				FragmentEntryLinkTable.INSTANCE.plid.ascending()
+			));
+
+		for (Object[] result : results) {
+			List<Long> plids = missingLayoutPlidsMap.computeIfAbsent(
+				(String)result[0], key -> new ArrayList<>());
+
+			plids.add((Long)result[1]);
+		}
+
+		return missingLayoutPlidsMap;
+	}
+
+	@Override
 	public void updateClassedModel(long userId, long plid) {
 		if (UpdateLayoutStatusThreadLocal.isUpdateLayoutStatus()) {
 			try {
@@ -866,25 +927,30 @@ public class FragmentEntryLinkLocalServiceImpl
 			FragmentEntryLinkTable fragmentEntryLinkTable)
 		throws PortalException {
 
-		Group group = _groupLocalService.getGroup(fragmentEntry.getGroupId());
-
 		return fragmentEntryLinkTable.fragmentEntryERC.eq(
 			fragmentEntry.getExternalReferenceCode()
 		).and(
-			Predicate.withParentheses(
-				fragmentEntryLinkTable.fragmentEntryScopeERC.eq(
-					group.getExternalReferenceCode()
-				).or(
-					Predicate.withParentheses(
-						fragmentEntryLinkTable.fragmentEntryScopeERC.isNull(
-						).and(
-							fragmentEntryLinkTable.groupId.eq(
-								group.getGroupId())
-						))
-				))
+			_getFragmentEntryGroupScopePredicate(
+				fragmentEntryLinkTable,
+				_groupLocalService.getGroup(fragmentEntry.getGroupId()))
 		).and(
 			fragmentEntryLinkTable.deleted.eq(false)
 		);
+	}
+
+	private Predicate _getFragmentEntryGroupScopePredicate(
+		FragmentEntryLinkTable fragmentEntryLinkTable, Group group) {
+
+		return Predicate.withParentheses(
+			fragmentEntryLinkTable.fragmentEntryScopeERC.eq(
+				group.getExternalReferenceCode()
+			).or(
+				Predicate.withParentheses(
+					fragmentEntryLinkTable.fragmentEntryScopeERC.isNull(
+					).and(
+						fragmentEntryLinkTable.groupId.eq(group.getGroupId())
+					))
+			));
 	}
 
 	private Predicate _getFragmentEntryLinksByFragmentEntryPredicate(
@@ -928,20 +994,16 @@ public class FragmentEntryLinkLocalServiceImpl
 	private Predicate _getFragmentEntryScopePredicate(Group group)
 		throws PortalException {
 
+		if (!group.isDepot()) {
+			return _getFragmentEntryGroupScopePredicate(
+				FragmentEntryLinkTable.INSTANCE, group);
+		}
+
 		Predicate emptyScopePredicate = Predicate.withParentheses(
 			FragmentEntryLinkTable.INSTANCE.fragmentEntryScopeERC.isNull(
 			).and(
 				FragmentEntryLinkTable.INSTANCE.groupId.eq(group.getGroupId())
 			));
-
-		if (!group.isDepot()) {
-			return Predicate.withParentheses(
-				FragmentEntryLinkTable.INSTANCE.fragmentEntryScopeERC.eq(
-					group.getExternalReferenceCode()
-				).or(
-					emptyScopePredicate
-				));
-		}
 
 		Long[] connectedSiteGroupIds = TransformUtil.transformToArray(
 			_depotEntryGroupRelLocalService.getDepotEntryGroupRels(

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -46,6 +46,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutRevisionTable;
 import com.liferay.portal.kernel.model.LayoutTable;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
@@ -353,7 +354,10 @@ public class FragmentEntryLinkLocalServiceImpl
 			).where(
 				_getLatestFragmentEntryLinkPredicate(
 					_getAllFragmentEntryLinksByFragmentEntryPredicate(
-						fragmentEntry, FragmentEntryLinkTable.INSTANCE))
+						fragmentEntry, FragmentEntryLinkTable.INSTANCE)
+				).and(
+					_getLayoutPredicate(true)
+				)
 			).orderBy(
 				_getOrderByStepLimitStepFunction(orderByComparator)
 			).limit(
@@ -375,7 +379,10 @@ public class FragmentEntryLinkLocalServiceImpl
 					FragmentEntryLinkTable.INSTANCE
 				).where(
 					_getAllFragmentEntryLinksByFragmentEntryPredicate(
-						fragmentEntry, FragmentEntryLinkTable.INSTANCE)
+						fragmentEntry, FragmentEntryLinkTable.INSTANCE
+					).and(
+						_getLayoutPredicate(true)
+					)
 				).as(
 					"tempFragmentEntryLinkTable"
 				)
@@ -547,6 +554,8 @@ public class FragmentEntryLinkLocalServiceImpl
 						_groupLocalService.getGroup(fragmentEntry.getGroupId()))
 				).and(
 					FragmentEntryLinkTable.INSTANCE.deleted.eq(false)
+				).and(
+					_getLayoutPredicate(true)
 				)
 			).groupBy(
 				FragmentEntryLinkTable.INSTANCE.groupId
@@ -979,7 +988,11 @@ public class FragmentEntryLinkLocalServiceImpl
 
 		Predicate predicate = _getFragmentEntryLinksByFragmentEntryPredicate(
 			fragmentEntry,
-			FragmentEntryLinkTable.INSTANCE.plid.notIn(_getPlidsDSLQuery(null)),
+			FragmentEntryLinkTable.INSTANCE.plid.notIn(
+				_getPlidsDSLQuery(null)
+			).and(
+				_getLayoutPredicate(true)
+			),
 			scopeGroupId);
 
 		if (latest) {
@@ -1023,6 +1036,37 @@ public class FragmentEntryLinkLocalServiceImpl
 			FragmentEntryLinkTable.INSTANCE
 		).where(
 			predicate
+		);
+	}
+
+	private Predicate _getLayoutPredicate(boolean layoutExists) {
+		DSLQuery layoutPlidsDSLQuery = DSLQueryFactoryUtil.select(
+			LayoutTable.INSTANCE.plid
+		).from(
+			LayoutTable.INSTANCE
+		);
+
+		DSLQuery layoutRevisionIdsDSLQuery = DSLQueryFactoryUtil.select(
+			LayoutRevisionTable.INSTANCE.layoutRevisionId
+		).from(
+			LayoutRevisionTable.INSTANCE
+		);
+
+		if (layoutExists) {
+			return Predicate.withParentheses(
+				FragmentEntryLinkTable.INSTANCE.plid.in(
+					layoutPlidsDSLQuery
+				).or(
+					FragmentEntryLinkTable.INSTANCE.plid.in(
+						layoutRevisionIdsDSLQuery)
+				));
+		}
+
+		return FragmentEntryLinkTable.INSTANCE.plid.notIn(
+			layoutPlidsDSLQuery
+		).and(
+			FragmentEntryLinkTable.INSTANCE.plid.notIn(
+				layoutRevisionIdsDSLQuery)
 		);
 	}
 

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -5,6 +5,9 @@
 
 package com.liferay.fragment.service.impl;
 
+import com.liferay.depot.model.DepotEntryGroupRel;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.fragment.constants.FragmentEntryLinkConstants;
 import com.liferay.fragment.listener.FragmentEntryLinkListener;
@@ -55,6 +58,7 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -69,7 +73,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.regex.Matcher;
@@ -517,6 +523,45 @@ public class FragmentEntryLinkLocalServiceImpl
 	}
 
 	@Override
+	public Map<Long, Integer> getGroupFragmentEntryUsageCounts(
+			FragmentEntry fragmentEntry)
+		throws PortalException {
+
+		Map<Long, Integer> groupFragmentEntryUsageCounts = new HashMap<>();
+
+		List<Object[]> results = fragmentEntryLinkPersistence.dslQuery(
+			DSLQueryFactoryUtil.select(
+				FragmentEntryLinkTable.INSTANCE.groupId,
+				DSLFunctionFactoryUtil.countDistinct(
+					FragmentEntryLinkTable.INSTANCE.classPK
+				).as(
+					"allUsageCount"
+				)
+			).from(
+				FragmentEntryLinkTable.INSTANCE
+			).where(
+				FragmentEntryLinkTable.INSTANCE.fragmentEntryERC.eq(
+					fragmentEntry.getExternalReferenceCode()
+				).and(
+					_getFragmentEntryScopePredicate(
+						_groupLocalService.getGroup(fragmentEntry.getGroupId()))
+				).and(
+					FragmentEntryLinkTable.INSTANCE.deleted.eq(false)
+				)
+			).groupBy(
+				FragmentEntryLinkTable.INSTANCE.groupId
+			));
+
+		for (Object[] result : results) {
+			Number count = (Number)result[1];
+
+			groupFragmentEntryUsageCounts.put((Long)result[0], count.intValue());
+		}
+
+		return groupFragmentEntryUsageCounts;
+	}
+
+	@Override
 	public List<FragmentEntryLink> getLayoutFragmentEntryLinksByFragmentEntry(
 			long groupId, FragmentEntry fragmentEntry, int start, int end,
 			OrderByComparator<FragmentEntryLink> orderByComparator)
@@ -871,6 +916,46 @@ public class FragmentEntryLinkLocalServiceImpl
 		);
 	}
 
+	private Predicate _getFragmentEntryScopePredicate(Group group)
+		throws PortalException {
+
+		Predicate emptyScopePredicate = Predicate.withParentheses(
+			FragmentEntryLinkTable.INSTANCE.fragmentEntryScopeERC.isNull(
+			).and(
+				FragmentEntryLinkTable.INSTANCE.groupId.eq(group.getGroupId())
+			));
+
+		if (!group.isDepot()) {
+			return Predicate.withParentheses(
+				FragmentEntryLinkTable.INSTANCE.fragmentEntryScopeERC.eq(
+					group.getExternalReferenceCode()
+				).or(
+					emptyScopePredicate
+				));
+		}
+
+		Long[] connectedSiteGroupIds = TransformUtil.transformToArray(
+			_depotEntryGroupRelLocalService.getDepotEntryGroupRels(
+				_depotEntryLocalService.getGroupDepotEntry(group.getGroupId())),
+			DepotEntryGroupRel::getToGroupId, Long.class);
+
+		if (ArrayUtil.isEmpty(connectedSiteGroupIds)) {
+			return emptyScopePredicate;
+		}
+
+		return Predicate.withParentheses(
+			Predicate.withParentheses(
+				FragmentEntryLinkTable.INSTANCE.fragmentEntryScopeERC.eq(
+					group.getExternalReferenceCode()
+				).and(
+					FragmentEntryLinkTable.INSTANCE.groupId.in(
+						connectedSiteGroupIds)
+				)
+			).or(
+				emptyScopePredicate
+			));
+	}
+
 	private Predicate _getLatestFragmentEntryLinkPredicate(
 		Predicate predicate) {
 
@@ -1087,6 +1172,12 @@ public class FragmentEntryLinkLocalServiceImpl
 
 	private static final Pattern _pattern = Pattern.compile(
 		"\\[resources:(.+?)\\]");
+
+	@Reference
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Reference
 	private DLURLHelper _dlURLHelper;

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
@@ -330,6 +330,17 @@ public class FragmentEntryLocalServiceImpl
 		_fragmentEntryLinkLocalService.deleteFragmentEntryLinksByFragmentEntry(
 			fragmentEntry, true);
 
+		FragmentEntry headFragmentEntry =
+			fragmentEntryPersistence.fetchByERC_G_Head(
+				fragmentEntry.getExternalReferenceCode(),
+				fragmentEntry.getGroupId(), true);
+
+		if (fragmentEntry.isHead() || (headFragmentEntry == null)) {
+			_fragmentEntryLinkLocalService.
+				deleteMissingLayoutFragmentEntryLinksByFragmentEntry(
+					fragmentEntry);
+		}
+
 		if (fragmentEntry.getPreviewFileEntryId() > 0) {
 			boolean deletePreviewFileEntry = true;
 

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLinkLocalServiceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLinkLocalServiceTest.java
@@ -68,6 +68,7 @@ import java.io.InputStream;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -421,12 +422,17 @@ public class FragmentEntryLinkLocalServiceTest {
 	}
 
 	@Test
+	@TestInfo("LPD-99652")
 	public void testGetAllFragmentEntryLinksByFragmentEntry() throws Exception {
 		FragmentEntryLink fragmentEntryLink1 = _addFragmentEntryLinkToLayout();
 		FragmentEntryLink fragmentEntryLink2 =
 			_addFragmentEntryLinkToLayoutPageTemplateEntry();
 		FragmentEntryLink fragmentEntryLink3 =
 			_addFragmentEntryLinkFromGlobalToLayout();
+		FragmentEntryLink fragmentEntryLink4 =
+			_addFragmentEntryLinkToMissingLayout();
+		FragmentEntryLink fragmentEntryLink5 =
+			_addFragmentEntryLinkFromGlobalToMissingLayout();
 
 		List<FragmentEntryLink> fragmentEntryLinks =
 			_fragmentEntryLinkLocalService.
@@ -442,21 +448,28 @@ public class FragmentEntryLinkLocalServiceTest {
 		Assert.assertTrue(fragmentEntryLinks.contains(fragmentEntryLink1));
 		Assert.assertTrue(fragmentEntryLinks.contains(fragmentEntryLink2));
 		Assert.assertFalse(fragmentEntryLinks.contains(fragmentEntryLink3));
+		Assert.assertFalse(fragmentEntryLinks.contains(fragmentEntryLink4));
+		Assert.assertFalse(fragmentEntryLinks.contains(fragmentEntryLink5));
 		Assert.assertFalse(
 			globalFragmentEntryLinks.contains(fragmentEntryLink1));
 		Assert.assertFalse(
 			globalFragmentEntryLinks.contains(fragmentEntryLink2));
 		Assert.assertTrue(
 			globalFragmentEntryLinks.contains(fragmentEntryLink3));
+		Assert.assertFalse(
+			globalFragmentEntryLinks.contains(fragmentEntryLink5));
 	}
 
 	@Test
+	@TestInfo("LPD-99652")
 	public void testGetAllFragmentEntryLinksCountByFragmentEntry()
 		throws Exception {
 
 		_addFragmentEntryLinkToLayout();
 		_addFragmentEntryLinkToLayoutPageTemplateEntry();
 		_addFragmentEntryLinkFromGlobalToLayout();
+		_addFragmentEntryLinkToMissingLayout();
+		_addFragmentEntryLinkFromGlobalToMissingLayout();
 
 		Assert.assertEquals(
 			2,
@@ -470,6 +483,38 @@ public class FragmentEntryLinkLocalServiceTest {
 	}
 
 	@Test
+	@TestInfo("LPD-99652")
+	public void testGetGroupFragmentEntryUsageCounts() throws Exception {
+		_addFragmentEntryLinkToLayout();
+		_addFragmentEntryLinkToMissingLayout();
+		_addFragmentEntryLinkFromGlobalToLayout();
+		_addFragmentEntryLinkFromGlobalToMissingLayout();
+
+		Map<Long, Integer> groupFragmentEntryUsageCounts1 =
+			_fragmentEntryLinkLocalService.getGroupFragmentEntryUsageCounts(
+				_fragmentEntry, _group);
+		Map<Long, Integer> groupFragmentEntryUsageCounts2 =
+			_fragmentEntryLinkLocalService.getGroupFragmentEntryUsageCounts(
+				_globalFragmentEntry,
+				_groupLocalService.getCompanyGroup(
+					TestPropsValues.getCompanyId()));
+
+		Assert.assertEquals(
+			groupFragmentEntryUsageCounts1.toString(), 1,
+			groupFragmentEntryUsageCounts1.size());
+		Assert.assertEquals(
+			Integer.valueOf(1),
+			groupFragmentEntryUsageCounts1.get(_group.getGroupId()));
+		Assert.assertEquals(
+			groupFragmentEntryUsageCounts2.toString(), 1,
+			groupFragmentEntryUsageCounts2.size());
+		Assert.assertEquals(
+			Integer.valueOf(1),
+			groupFragmentEntryUsageCounts2.get(_group.getGroupId()));
+	}
+
+	@Test
+	@TestInfo("LPD-99652")
 	public void testGetLayoutFragmentEntryLinksByFragmentEntry()
 		throws Exception {
 
@@ -478,6 +523,10 @@ public class FragmentEntryLinkLocalServiceTest {
 			_addFragmentEntryLinkToLayoutPageTemplateEntry();
 		FragmentEntryLink fragmentEntryLink3 =
 			_addFragmentEntryLinkFromGlobalToLayout();
+		FragmentEntryLink fragmentEntryLink4 =
+			_addFragmentEntryLinkToMissingLayout();
+		FragmentEntryLink fragmentEntryLink5 =
+			_addFragmentEntryLinkFromGlobalToMissingLayout();
 
 		List<FragmentEntryLink> fragmentEntryLinks =
 			_fragmentEntryLinkLocalService.
@@ -494,21 +543,28 @@ public class FragmentEntryLinkLocalServiceTest {
 		Assert.assertTrue(fragmentEntryLinks.contains(fragmentEntryLink1));
 		Assert.assertFalse(fragmentEntryLinks.contains(fragmentEntryLink2));
 		Assert.assertFalse(fragmentEntryLinks.contains(fragmentEntryLink3));
+		Assert.assertFalse(fragmentEntryLinks.contains(fragmentEntryLink4));
+		Assert.assertFalse(fragmentEntryLinks.contains(fragmentEntryLink5));
 		Assert.assertFalse(
 			globalFragmentEntryLinks.contains(fragmentEntryLink1));
 		Assert.assertFalse(
 			globalFragmentEntryLinks.contains(fragmentEntryLink2));
 		Assert.assertTrue(
 			globalFragmentEntryLinks.contains(fragmentEntryLink3));
+		Assert.assertFalse(
+			globalFragmentEntryLinks.contains(fragmentEntryLink5));
 	}
 
 	@Test
+	@TestInfo("LPD-99652")
 	public void testGetLayoutFragmentEntryLinksCountByFragmentEntry()
 		throws Exception {
 
 		_addFragmentEntryLinkToLayout();
 		_addFragmentEntryLinkToLayoutPageTemplateEntry();
 		_addFragmentEntryLinkFromGlobalToLayout();
+		_addFragmentEntryLinkToMissingLayout();
+		_addFragmentEntryLinkFromGlobalToMissingLayout();
 
 		Assert.assertEquals(
 			1,
@@ -1023,6 +1079,14 @@ public class FragmentEntryLinkLocalServiceTest {
 			layout.getPlid(), StringPool.BLANK, 0, null);
 	}
 
+	private FragmentEntryLink _addFragmentEntryLinkFromGlobalToMissingLayout()
+		throws Exception {
+
+		return _addFragmentEntryLink(
+			_globalFragmentEntry, null, 0, RandomTestUtil.randomLong(),
+			StringPool.BLANK, 0, null);
+	}
+
 	private FragmentEntryLink _addFragmentEntryLinkToLayout() throws Exception {
 		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
 
@@ -1050,6 +1114,14 @@ public class FragmentEntryLinkLocalServiceTest {
 		return _addFragmentEntryLink(
 			_fragmentEntry, null, defaultSegmentsExperienceId,
 			layoutPageTemplateEntry.getPlid(), StringPool.BLANK, 0, null);
+	}
+
+	private FragmentEntryLink _addFragmentEntryLinkToMissingLayout()
+		throws Exception {
+
+		return _addFragmentEntryLink(
+			_fragmentEntry, null, 0, RandomTestUtil.randomLong(),
+			StringPool.BLANK, 0, null);
 	}
 
 	private void _assertDeleteFragmentEntryLink(FragmentEntry fragmentEntry)

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLinkLocalServiceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLinkLocalServiceTest.java
@@ -66,6 +66,7 @@ import com.liferay.segments.service.SegmentsExperienceLocalService;
 
 import java.io.InputStream;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -633,6 +634,31 @@ public class FragmentEntryLinkLocalServiceTest {
 				getLayoutPageTemplateFragmentEntryLinksCountByFragmentEntry(
 					_group.getGroupId(), _globalFragmentEntry,
 					LayoutPageTemplateEntryTypeConstants.BASIC));
+	}
+
+	@Test
+	@TestInfo("LPD-99652")
+	public void testGetMissingLayoutPlidsMap()
+		throws Exception {
+
+		_addFragmentEntryLinkToLayout();
+
+		FragmentEntryLink fragmentEntryLink =
+			_addFragmentEntryLinkToMissingLayout();
+
+		_fragmentEntryLocalService.getDraft(
+			_fragmentEntry.getFragmentEntryId());
+
+		Map<String, List<Long>> missingLayoutPlidsMap =
+			_fragmentEntryLinkLocalService.
+				getMissingLayoutPlidsMap(
+					_fragmentCollection.getFragmentCollectionId());
+
+		Assert.assertEquals(
+			missingLayoutPlidsMap.toString(), 1, missingLayoutPlidsMap.size());
+		Assert.assertEquals(
+			Collections.singletonList(fragmentEntryLink.getPlid()),
+			missingLayoutPlidsMap.get(_fragmentEntry.getExternalReferenceCode()));
 	}
 
 	@Test

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLinkLocalServiceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLinkLocalServiceTest.java
@@ -417,6 +417,89 @@ public class FragmentEntryLinkLocalServiceTest {
 	}
 
 	@Test
+	@TestInfo("LPD-99652")
+	public void testDeleteFragmentEntryLinksByFragmentEntry() throws Exception {
+		FragmentEntryLink fragmentEntryLink1 = _addFragmentEntryLinkToLayout();
+		FragmentEntryLink fragmentEntryLink2 =
+			_addFragmentEntryLinkFromGlobalToLayout();
+		FragmentEntryLink fragmentEntryLink3 =
+			_addFragmentEntryLinkToMissingLayout();
+
+		_fragmentEntryLinkLocalService.deleteFragmentEntryLinksByFragmentEntry(
+			_fragmentEntry, true);
+
+		Assert.assertNotNull(
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				fragmentEntryLink1.getFragmentEntryLinkId()));
+		Assert.assertNotNull(
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				fragmentEntryLink2.getFragmentEntryLinkId()));
+		Assert.assertNotNull(
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				fragmentEntryLink3.getFragmentEntryLinkId()));
+
+		_fragmentEntryLinkLocalService.deleteFragmentEntryLinksByFragmentEntry(
+			_fragmentEntry, false);
+
+		Assert.assertNull(
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				fragmentEntryLink1.getFragmentEntryLinkId()));
+		Assert.assertNotNull(
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				fragmentEntryLink2.getFragmentEntryLinkId()));
+		Assert.assertNull(
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				fragmentEntryLink3.getFragmentEntryLinkId()));
+
+		_fragmentEntryLinkLocalService.deleteFragmentEntryLinksByFragmentEntry(
+			_globalFragmentEntry, false);
+
+		Assert.assertNull(
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				fragmentEntryLink2.getFragmentEntryLinkId()));
+	}
+
+	@Test
+	@TestInfo("LPD-99652")
+	public void testDeleteMissingLayoutFragmentEntryLinksByFragmentEntry()
+		throws Exception {
+
+		FragmentEntryLink fragmentEntryLink1 = _addFragmentEntryLinkToLayout();
+		FragmentEntryLink fragmentEntryLink2 =
+			_addFragmentEntryLinkToMissingLayout();
+		FragmentEntryLink fragmentEntryLink3 =
+			_addFragmentEntryLinkFromGlobalToMissingLayout();
+
+		fragmentEntryLink2.setDeleted(true);
+
+		fragmentEntryLink2 =
+			_fragmentEntryLinkLocalService.updateFragmentEntryLink(
+				fragmentEntryLink2);
+
+		_fragmentEntryLinkLocalService.
+			deleteMissingLayoutFragmentEntryLinksByFragmentEntry(
+				_fragmentEntry);
+
+		Assert.assertNotNull(
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				fragmentEntryLink1.getFragmentEntryLinkId()));
+		Assert.assertNull(
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				fragmentEntryLink2.getFragmentEntryLinkId()));
+		Assert.assertNotNull(
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				fragmentEntryLink3.getFragmentEntryLinkId()));
+
+		_fragmentEntryLinkLocalService.
+			deleteMissingLayoutFragmentEntryLinksByFragmentEntry(
+				_globalFragmentEntry);
+
+		Assert.assertNull(
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				fragmentEntryLink3.getFragmentEntryLinkId()));
+	}
+
+	@Test
 	public void testFragmentEntryLinksDeleted() throws PortalException {
 		_assertFragmentEntryLinksDeleted(_fragmentEntry);
 		_assertFragmentEntryLinksDeleted(_globalFragmentEntry);
@@ -493,12 +576,10 @@ public class FragmentEntryLinkLocalServiceTest {
 
 		Map<Long, Integer> groupFragmentEntryUsageCounts1 =
 			_fragmentEntryLinkLocalService.getGroupFragmentEntryUsageCounts(
-				_fragmentEntry, _group);
+				_fragmentEntry);
 		Map<Long, Integer> groupFragmentEntryUsageCounts2 =
 			_fragmentEntryLinkLocalService.getGroupFragmentEntryUsageCounts(
-				_globalFragmentEntry,
-				_groupLocalService.getCompanyGroup(
-					TestPropsValues.getCompanyId()));
+				_globalFragmentEntry);
 
 		Assert.assertEquals(
 			groupFragmentEntryUsageCounts1.toString(), 1,
@@ -638,9 +719,7 @@ public class FragmentEntryLinkLocalServiceTest {
 
 	@Test
 	@TestInfo("LPD-99652")
-	public void testGetMissingLayoutPlidsMap()
-		throws Exception {
-
+	public void testGetMissingLayoutPlidsMap() throws Exception {
 		_addFragmentEntryLinkToLayout();
 
 		FragmentEntryLink fragmentEntryLink =
@@ -650,15 +729,15 @@ public class FragmentEntryLinkLocalServiceTest {
 			_fragmentEntry.getFragmentEntryId());
 
 		Map<String, List<Long>> missingLayoutPlidsMap =
-			_fragmentEntryLinkLocalService.
-				getMissingLayoutPlidsMap(
-					_fragmentCollection.getFragmentCollectionId());
+			_fragmentEntryLinkLocalService.getMissingLayoutPlidsMap(
+				_fragmentCollection.getFragmentCollectionId());
 
 		Assert.assertEquals(
 			missingLayoutPlidsMap.toString(), 1, missingLayoutPlidsMap.size());
 		Assert.assertEquals(
 			Collections.singletonList(fragmentEntryLink.getPlid()),
-			missingLayoutPlidsMap.get(_fragmentEntry.getExternalReferenceCode()));
+			missingLayoutPlidsMap.get(
+				_fragmentEntry.getExternalReferenceCode()));
 	}
 
 	@Test

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
@@ -126,11 +126,15 @@ public class FragmentEntryLocalServiceTest {
 	}
 
 	@Test
+	@TestInfo("LPD-99652")
 	public void testDeleteFragmentEntry() throws Exception {
 		_testDeleteFragmentEntry();
 		_testDeleteFragmentEntryByExternalReferenceCode();
 		_testDeleteFragmentEntryDraftByExternalReferenceCode();
+		_testDeleteFragmentEntryDraftWithMissingLayoutFragmentEntryLink();
+		_testDeleteFragmentEntryDraftWithoutHeadWithMissingLayoutFragmentEntryLink();
 		_testDeleteFragmentEntryNonexistentByExternalReferenceCode();
+		_testDeleteFragmentEntryWithMissingLayoutFragmentEntryLink();
 	}
 
 	@Test
@@ -884,6 +888,58 @@ public class FragmentEntryLocalServiceTest {
 				fragmentEntry.getFragmentEntryId()));
 	}
 
+	private void _testDeleteFragmentEntryDraftWithMissingLayoutFragmentEntryLink()
+		throws Exception {
+
+		FragmentEntry fragmentEntry =
+			FragmentEntryTestUtil.addFragmentEntryByStatus(
+				_fragmentCollection.getFragmentCollectionId(),
+				WorkflowConstants.STATUS_APPROVED);
+
+		FragmentEntryLink fragmentEntryLink =
+			FragmentTestUtil.addFragmentEntryLink(
+				fragmentEntry, RandomTestUtil.randomLong());
+
+		FragmentEntry draftFragmentEntry = _fragmentEntryLocalService.getDraft(
+			fragmentEntry.getFragmentEntryId());
+
+		_fragmentEntryLocalService.deleteFragmentEntry(draftFragmentEntry);
+
+		Assert.assertNull(
+			_fragmentEntryLocalService.fetchFragmentEntry(
+				draftFragmentEntry.getFragmentEntryId()));
+
+		Assert.assertNotNull(
+			_fragmentEntryLocalService.fetchFragmentEntry(
+				fragmentEntry.getFragmentEntryId()));
+		Assert.assertNotNull(
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				fragmentEntryLink.getFragmentEntryLinkId()));
+	}
+
+	private void _testDeleteFragmentEntryDraftWithoutHeadWithMissingLayoutFragmentEntryLink()
+		throws Exception {
+
+		FragmentEntry fragmentEntry =
+			FragmentEntryTestUtil.addFragmentEntryByStatus(
+				_fragmentCollection.getFragmentCollectionId(),
+				WorkflowConstants.STATUS_DRAFT);
+
+		FragmentEntryLink fragmentEntryLink =
+			FragmentTestUtil.addFragmentEntryLink(
+				fragmentEntry, RandomTestUtil.randomLong());
+
+		_fragmentEntryLocalService.deleteFragmentEntry(fragmentEntry);
+
+		Assert.assertNull(
+			_fragmentEntryLocalService.fetchFragmentEntry(
+				fragmentEntry.getFragmentEntryId()));
+
+		Assert.assertNull(
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				fragmentEntryLink.getFragmentEntryLinkId()));
+	}
+
 	private void _testDeleteFragmentEntryNonexistentByExternalReferenceCode()
 		throws Exception {
 
@@ -891,6 +947,28 @@ public class FragmentEntryLocalServiceTest {
 			NoSuchEntryException.class,
 			() -> _fragmentEntryLocalService.deleteFragmentEntry(
 				RandomTestUtil.randomString(), _group.getGroupId()));
+	}
+
+	private void _testDeleteFragmentEntryWithMissingLayoutFragmentEntryLink()
+		throws Exception {
+
+		FragmentEntry fragmentEntry = FragmentEntryTestUtil.addFragmentEntry(
+			_fragmentCollection.getFragmentCollectionId());
+
+		FragmentEntryLink fragmentEntryLink =
+			FragmentTestUtil.addFragmentEntryLink(
+				fragmentEntry, RandomTestUtil.randomLong());
+
+		_fragmentEntryLocalService.deleteFragmentEntry(
+			fragmentEntry.getFragmentEntryId());
+
+		Assert.assertNull(
+			_fragmentEntryLocalService.fetchFragmentEntry(
+				fragmentEntry.getFragmentEntryId()));
+
+		Assert.assertNull(
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				fragmentEntryLink.getFragmentEntryLinkId()));
 	}
 
 	private void _testFetchFragmentEntryByFragmentEntryId() throws Exception {

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/test/util/DisplayContextTestUtil.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/test/util/DisplayContextTestUtil.java
@@ -1,0 +1,95 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.test.util;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.module.util.BundleUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletURL;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import jakarta.portlet.RenderRequest;
+import jakarta.portlet.RenderResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.lang.reflect.Constructor;
+
+import java.util.Map;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Georgel Pop
+ */
+public class DisplayContextTestUtil {
+
+	public static Object createDisplayContext(
+			Constructor<?> constructor, Group group,
+			Map<String, String> parameters)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			CompanyLocalServiceUtil.getCompany(group.getCompanyId()));
+		themeDisplay.setLocale(LocaleUtil.getDefault());
+		themeDisplay.setPermissionChecker(
+			PermissionThreadLocal.getPermissionChecker());
+		themeDisplay.setScopeGroupId(group.getGroupId());
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		for (Map.Entry<String, String> entry : parameters.entrySet()) {
+			mockHttpServletRequest.setParameter(
+				entry.getKey(), entry.getValue());
+		}
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			new MockLiferayPortletRenderRequest(mockHttpServletRequest);
+
+		mockLiferayPortletRenderRequest.setAttribute(
+			StringBundler.concat(
+				mockLiferayPortletRenderRequest.getPortletName(), "-",
+				WebKeys.CURRENT_PORTLET_URL),
+			new MockLiferayPortletURL());
+
+		return constructor.newInstance(
+			mockHttpServletRequest, mockLiferayPortletRenderRequest,
+			new MockLiferayPortletRenderResponse());
+	}
+
+	public static Constructor<?> getConstructor(String className)
+		throws Exception {
+
+		Bundle bundle = FrameworkUtil.getBundle(DisplayContextTestUtil.class);
+
+		bundle = BundleUtil.getBundle(
+			bundle.getBundleContext(), "com.liferay.fragment.web");
+
+		Class<?> clazz = bundle.loadClass(className);
+
+		return clazz.getConstructor(
+			HttpServletRequest.class, RenderRequest.class,
+			RenderResponse.class);
+	}
+
+}

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/web/internal/display/context/test/FragmentDisplayContextTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/web/internal/display/context/test/FragmentDisplayContextTest.java
@@ -1,0 +1,136 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.web.internal.display.context.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.test.util.DisplayContextTestUtil;
+import com.liferay.fragment.test.util.FragmentEntryTestUtil;
+import com.liferay.fragment.test.util.FragmentTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.lang.reflect.Constructor;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Georgel Pop
+ */
+@RunWith(Arquillian.class)
+public class FragmentDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_constructor = DisplayContextTestUtil.getConstructor(_CLASS_NAME);
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_fragmentCollection = FragmentTestUtil.addFragmentCollection(
+			_group.getGroupId());
+	}
+
+	@Test
+	@TestInfo("LPD-99652")
+	public void testLogMissingLayoutPlids() throws Exception {
+		FragmentEntry fragmentEntry1 = FragmentEntryTestUtil.addFragmentEntry(
+			_fragmentCollection.getFragmentCollectionId());
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		FragmentTestUtil.addFragmentEntryLink(fragmentEntry1, layout.getPlid());
+
+		FragmentEntry fragmentEntry2 = FragmentEntryTestUtil.addFragmentEntry(
+			_fragmentCollection.getFragmentCollectionId());
+
+		long missingLayoutPlid1 = RandomTestUtil.randomLong();
+
+		long missingLayoutPlid2 = missingLayoutPlid1 + 1;
+
+		FragmentTestUtil.addFragmentEntryLink(
+			fragmentEntry2, missingLayoutPlid2);
+
+		FragmentTestUtil.addFragmentEntryLink(
+			fragmentEntry2, missingLayoutPlid1);
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME, LoggerTestUtil.DEBUG)) {
+
+			ReflectionTestUtil.invoke(
+				_getFragmentDisplayContext(),
+				"getFragmentEntriesSearchContainer", new Class<?>[0]);
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(
+				StringBundler.concat(
+					"Fragment entry ",
+					fragmentEntry2.getExternalReferenceCode(),
+					" references missing layouts ", missingLayoutPlid1, ", ",
+					missingLayoutPlid2),
+				logEntry.getMessage());
+		}
+	}
+
+	private Object _getFragmentDisplayContext() throws Exception {
+		return DisplayContextTestUtil.createDisplayContext(
+			_constructor, _group,
+			HashMapBuilder.put(
+				"fragmentCollectionId",
+				String.valueOf(_fragmentCollection.getFragmentCollectionId())
+			).build());
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.fragment.web.internal.display.context." +
+			"FragmentDisplayContext";
+
+	private static Constructor<?> _constructor;
+
+	@DeleteAfterTestRun
+	private FragmentCollection _fragmentCollection;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/web/internal/display/context/test/FragmentEntryLinkDisplayContextTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/web/internal/display/context/test/FragmentEntryLinkDisplayContextTest.java
@@ -12,6 +12,9 @@ import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.test.util.DisplayContextTestUtil;
 import com.liferay.fragment.test.util.FragmentEntryTestUtil;
 import com.liferay.fragment.test.util.FragmentTestUtil;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.test.util.LayoutPageTemplateTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
@@ -24,6 +27,8 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
@@ -69,16 +74,43 @@ public class FragmentEntryLinkDisplayContextTest {
 	public void testGetFragmentEntryLinkName() throws Exception {
 		FragmentEntry fragmentEntry = _addFragmentEntry();
 
-		FragmentEntryLink fragmentEntryLink =
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		FragmentEntryLink fragmentEntryLink1 =
+			FragmentTestUtil.addFragmentEntryLink(
+				fragmentEntry, layout.getPlid());
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			LayoutPageTemplateTestUtil.addLayoutPageTemplateEntry(
+				_group.getGroupId(), LayoutPageTemplateEntryTypeConstants.BASIC,
+				WorkflowConstants.STATUS_APPROVED);
+
+		FragmentEntryLink fragmentEntryLink2 =
+			FragmentTestUtil.addFragmentEntryLink(
+				fragmentEntry, layoutPageTemplateEntry.getPlid());
+
+		FragmentEntryLink fragmentEntryLink3 =
 			FragmentTestUtil.addFragmentEntryLink(
 				fragmentEntry, RandomTestUtil.randomLong());
 
+		Object fragmentEntryLinkDisplayContext =
+			_getFragmentEntryLinkDisplayContext(fragmentEntry);
+
+		Assert.assertEquals(
+			layout.getName(LocaleUtil.getDefault()),
+			ReflectionTestUtil.invoke(
+				fragmentEntryLinkDisplayContext, "getFragmentEntryLinkName",
+				new Class<?>[] {FragmentEntryLink.class}, fragmentEntryLink1));
+		Assert.assertEquals(
+			layoutPageTemplateEntry.getName(),
+			ReflectionTestUtil.invoke(
+				fragmentEntryLinkDisplayContext, "getFragmentEntryLinkName",
+				new Class<?>[] {FragmentEntryLink.class}, fragmentEntryLink2));
 		Assert.assertEquals(
 			StringPool.BLANK,
 			ReflectionTestUtil.invoke(
-				_getFragmentEntryLinkDisplayContext(fragmentEntry),
-				"getFragmentEntryLinkName",
-				new Class<?>[] {FragmentEntryLink.class}, fragmentEntryLink));
+				fragmentEntryLinkDisplayContext, "getFragmentEntryLinkName",
+				new Class<?>[] {FragmentEntryLink.class}, fragmentEntryLink3));
 	}
 
 	@Test
@@ -86,16 +118,64 @@ public class FragmentEntryLinkDisplayContextTest {
 	public void testGetFragmentEntryLinkTypeLabel() throws Exception {
 		FragmentEntry fragmentEntry = _addFragmentEntry();
 
-		FragmentEntryLink fragmentEntryLink =
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		FragmentEntryLink fragmentEntryLink1 =
+			FragmentTestUtil.addFragmentEntryLink(
+				fragmentEntry, layout.getPlid());
+
+		FragmentEntryLink fragmentEntryLink2 =
+			FragmentTestUtil.addFragmentEntryLink(
+				fragmentEntry,
+				_addLayoutPageTemplateEntryPlid(
+					LayoutPageTemplateEntryTypeConstants.BASIC));
+		FragmentEntryLink fragmentEntryLink3 =
+			FragmentTestUtil.addFragmentEntryLink(
+				fragmentEntry,
+				_addLayoutPageTemplateEntryPlid(
+					LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE));
+		FragmentEntryLink fragmentEntryLink4 =
+			FragmentTestUtil.addFragmentEntryLink(
+				fragmentEntry,
+				_addLayoutPageTemplateEntryPlid(
+					LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT));
+		FragmentEntryLink fragmentEntryLink5 =
 			FragmentTestUtil.addFragmentEntryLink(
 				fragmentEntry, RandomTestUtil.randomLong());
 
+		Object fragmentEntryLinkDisplayContext =
+			_getFragmentEntryLinkDisplayContext(fragmentEntry);
+
+		Assert.assertEquals(
+			"page",
+			ReflectionTestUtil.invoke(
+				fragmentEntryLinkDisplayContext,
+				"getFragmentEntryLinkTypeLabel",
+				new Class<?>[] {FragmentEntryLink.class}, fragmentEntryLink1));
+		Assert.assertEquals(
+			"page-template",
+			ReflectionTestUtil.invoke(
+				fragmentEntryLinkDisplayContext,
+				"getFragmentEntryLinkTypeLabel",
+				new Class<?>[] {FragmentEntryLink.class}, fragmentEntryLink2));
+		Assert.assertEquals(
+			"display-page-template",
+			ReflectionTestUtil.invoke(
+				fragmentEntryLinkDisplayContext,
+				"getFragmentEntryLinkTypeLabel",
+				new Class<?>[] {FragmentEntryLink.class}, fragmentEntryLink3));
+		Assert.assertEquals(
+			"master-page",
+			ReflectionTestUtil.invoke(
+				fragmentEntryLinkDisplayContext,
+				"getFragmentEntryLinkTypeLabel",
+				new Class<?>[] {FragmentEntryLink.class}, fragmentEntryLink4));
 		Assert.assertEquals(
 			StringPool.BLANK,
 			ReflectionTestUtil.invoke(
-				_getFragmentEntryLinkDisplayContext(fragmentEntry),
+				fragmentEntryLinkDisplayContext,
 				"getFragmentEntryLinkTypeLabel",
-				new Class<?>[] {FragmentEntryLink.class}, fragmentEntryLink));
+				new Class<?>[] {FragmentEntryLink.class}, fragmentEntryLink5));
 	}
 
 	@Test
@@ -133,6 +213,14 @@ public class FragmentEntryLinkDisplayContextTest {
 
 		return FragmentEntryTestUtil.addFragmentEntry(
 			fragmentCollection.getFragmentCollectionId());
+	}
+
+	private long _addLayoutPageTemplateEntryPlid(int type) throws Exception {
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			LayoutPageTemplateTestUtil.addLayoutPageTemplateEntry(
+				_group.getGroupId(), type, WorkflowConstants.STATUS_APPROVED);
+
+		return layoutPageTemplateEntry.getPlid();
 	}
 
 	private Object _getFragmentEntryLinkDisplayContext(

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/web/internal/display/context/test/FragmentEntryLinkDisplayContextTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/web/internal/display/context/test/FragmentEntryLinkDisplayContextTest.java
@@ -1,0 +1,155 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.web.internal.display.context.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.test.util.DisplayContextTestUtil;
+import com.liferay.fragment.test.util.FragmentEntryTestUtil;
+import com.liferay.fragment.test.util.FragmentTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.lang.reflect.Constructor;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Georgel Pop
+ */
+@RunWith(Arquillian.class)
+public class FragmentEntryLinkDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_constructor = DisplayContextTestUtil.getConstructor(
+			"com.liferay.fragment.web.internal.display.context." +
+				"FragmentEntryLinkDisplayContext");
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	@TestInfo("LPD-99652")
+	public void testGetFragmentEntryLinkName() throws Exception {
+		FragmentEntry fragmentEntry = _addFragmentEntry();
+
+		FragmentEntryLink fragmentEntryLink =
+			FragmentTestUtil.addFragmentEntryLink(
+				fragmentEntry, RandomTestUtil.randomLong());
+
+		Assert.assertEquals(
+			StringPool.BLANK,
+			ReflectionTestUtil.invoke(
+				_getFragmentEntryLinkDisplayContext(fragmentEntry),
+				"getFragmentEntryLinkName",
+				new Class<?>[] {FragmentEntryLink.class}, fragmentEntryLink));
+	}
+
+	@Test
+	@TestInfo("LPD-99652")
+	public void testGetFragmentEntryLinkTypeLabel() throws Exception {
+		FragmentEntry fragmentEntry = _addFragmentEntry();
+
+		FragmentEntryLink fragmentEntryLink =
+			FragmentTestUtil.addFragmentEntryLink(
+				fragmentEntry, RandomTestUtil.randomLong());
+
+		Assert.assertEquals(
+			StringPool.BLANK,
+			ReflectionTestUtil.invoke(
+				_getFragmentEntryLinkDisplayContext(fragmentEntry),
+				"getFragmentEntryLinkTypeLabel",
+				new Class<?>[] {FragmentEntryLink.class}, fragmentEntryLink));
+	}
+
+	@Test
+	@TestInfo("LPD-99652")
+	public void testGetSearchContainer() throws Exception {
+		FragmentEntry fragmentEntry = _addFragmentEntry();
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		FragmentEntryLink fragmentEntryLink =
+			FragmentTestUtil.addFragmentEntryLink(
+				fragmentEntry, layout.getPlid());
+
+		FragmentTestUtil.addFragmentEntryLink(
+			fragmentEntry, RandomTestUtil.randomLong());
+
+		SearchContainer<FragmentEntryLink> searchContainer =
+			ReflectionTestUtil.invoke(
+				_getFragmentEntryLinkDisplayContext(fragmentEntry),
+				"getSearchContainer", new Class<?>[0]);
+
+		List<FragmentEntryLink> fragmentEntryLinks =
+			searchContainer.getResults();
+
+		Assert.assertEquals(
+			fragmentEntryLinks.toString(), 1, fragmentEntryLinks.size());
+		Assert.assertEquals(fragmentEntryLink, fragmentEntryLinks.get(0));
+
+		Assert.assertEquals(1, searchContainer.getTotal());
+	}
+
+	private FragmentEntry _addFragmentEntry() throws Exception {
+		FragmentCollection fragmentCollection =
+			FragmentTestUtil.addFragmentCollection(_group.getGroupId());
+
+		return FragmentEntryTestUtil.addFragmentEntry(
+			fragmentCollection.getFragmentCollectionId());
+	}
+
+	private Object _getFragmentEntryLinkDisplayContext(
+			FragmentEntry fragmentEntry)
+		throws Exception {
+
+		return DisplayContextTestUtil.createDisplayContext(
+			_constructor, _group,
+			HashMapBuilder.put(
+				"fragmentEntryId",
+				String.valueOf(fragmentEntry.getFragmentEntryId())
+			).build());
+	}
+
+	private static Constructor<?> _constructor;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
@@ -13,6 +13,7 @@ import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentComposition;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.service.FragmentCollectionLocalServiceUtil;
+import com.liferay.fragment.service.FragmentEntryLinkLocalServiceUtil;
 import com.liferay.fragment.service.FragmentEntryServiceUtil;
 import com.liferay.fragment.util.comparator.FragmentCollectionContributorNameComparator;
 import com.liferay.fragment.util.comparator.FragmentCompositionFragmentEntryNameComparator;
@@ -28,6 +29,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemListBu
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemList;
 import com.liferay.marketplace.constants.MarketplaceActionKeys;
 import com.liferay.marketplace.constants.MarketplacePortletKeys;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
@@ -38,6 +40,8 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletURL;
@@ -579,6 +583,8 @@ public class FragmentDisplayContext {
 		fragmentEntriesSearchContainer.setRowChecker(
 			new EmptyOnClickRowChecker(_renderResponse));
 
+		_logMissingLayoutPlids();
+
 		_fragmentEntriesSearchContainer = fragmentEntriesSearchContainer;
 
 		return _fragmentEntriesSearchContainer;
@@ -1092,6 +1098,30 @@ public class FragmentDisplayContext {
 		return true;
 	}
 
+	private void _logMissingLayoutPlids() {
+		if (_log.isDebugEnabled()) {
+			try {
+				Map<String, List<Long>> missingLayoutPlidsMap =
+					FragmentEntryLinkLocalServiceUtil.getMissingLayoutPlidsMap(
+						getFragmentCollectionId());
+
+				for (Map.Entry<String, List<Long>> entry :
+						missingLayoutPlidsMap.entrySet()) {
+
+					_log.debug(
+						StringBundler.concat(
+							"Fragment entry ", entry.getKey(),
+							" references missing layouts ",
+							StringUtil.merge(
+								entry.getValue(), StringPool.COMMA_AND_SPACE)));
+				}
+			}
+			catch (Exception exception) {
+				_log.debug(exception);
+			}
+		}
+	}
+
 	private void _updatePortletDisplay() {
 		if (!DesignLibraryUtil.isDesignLibraryScope(
 				_themeDisplay.getScopeGroup())) {
@@ -1117,6 +1147,9 @@ public class FragmentDisplayContext {
 
 		portletDisplay.setURLBack(backURL);
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		FragmentDisplayContext.class);
 
 	private SearchContainer<Object> _contributedEntriesSearchContainer;
 	private FragmentCollection _fragmentCollection;

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentEntryLinkDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentEntryLinkDisplayContext.java
@@ -102,10 +102,14 @@ public class FragmentEntryLinkDisplayContext {
 	public String getFragmentEntryLinkName(
 		FragmentEntryLink fragmentEntryLink) {
 
-		long layoutPageTemplateEntryPlid = fragmentEntryLink.getPlid();
-
 		Layout layout = LayoutLocalServiceUtil.fetchLayout(
 			fragmentEntryLink.getPlid());
+
+		if (layout == null) {
+			return StringPool.BLANK;
+		}
+
+		long layoutPageTemplateEntryPlid = fragmentEntryLink.getPlid();
 
 		if (layout.isDraftLayout()) {
 			layoutPageTemplateEntryPlid = layout.getClassPK();
@@ -138,10 +142,14 @@ public class FragmentEntryLinkDisplayContext {
 	public String getFragmentEntryLinkTypeLabel(
 		FragmentEntryLink fragmentEntryLink) {
 
-		long layoutPageTemplateEntryPlid = fragmentEntryLink.getPlid();
-
 		Layout layout = LayoutLocalServiceUtil.fetchLayout(
 			fragmentEntryLink.getPlid());
+
+		if (layout == null) {
+			return StringPool.BLANK;
+		}
+
+		long layoutPageTemplateEntryPlid = fragmentEntryLink.getPlid();
 
 		if (layout.isDraftLayout()) {
 			layoutPageTemplateEntryPlid = layout.getClassPK();

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentEntryLinkDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentEntryLinkDisplayContext.java
@@ -109,15 +109,8 @@ public class FragmentEntryLinkDisplayContext {
 			return StringPool.BLANK;
 		}
 
-		long layoutPageTemplateEntryPlid = fragmentEntryLink.getPlid();
-
-		if (layout.isDraftLayout()) {
-			layoutPageTemplateEntryPlid = layout.getClassPK();
-		}
-
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
-			LayoutPageTemplateEntryLocalServiceUtil.
-				fetchLayoutPageTemplateEntryByPlid(layoutPageTemplateEntryPlid);
+			_fetchLayoutPageTemplateEntry(layout);
 
 		ThemeDisplay themeDisplay = _getThemeDisplay();
 
@@ -149,15 +142,8 @@ public class FragmentEntryLinkDisplayContext {
 			return StringPool.BLANK;
 		}
 
-		long layoutPageTemplateEntryPlid = fragmentEntryLink.getPlid();
-
-		if (layout.isDraftLayout()) {
-			layoutPageTemplateEntryPlid = layout.getClassPK();
-		}
-
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
-			LayoutPageTemplateEntryLocalServiceUtil.
-				fetchLayoutPageTemplateEntryByPlid(layoutPageTemplateEntryPlid);
+			_fetchLayoutPageTemplateEntry(layout);
 
 		if (layoutPageTemplateEntry != null) {
 			if (layoutPageTemplateEntry.getType() ==
@@ -468,6 +454,19 @@ public class FragmentEntryLinkDisplayContext {
 				verticalNavItem.setLabel(name);
 			}
 		).build();
+	}
+
+	private LayoutPageTemplateEntry _fetchLayoutPageTemplateEntry(
+		Layout layout) {
+
+		long layoutPageTemplateEntryPlid = layout.getPlid();
+
+		if (layout.isDraftLayout()) {
+			layoutPageTemplateEntryPlid = layout.getClassPK();
+		}
+
+		return LayoutPageTemplateEntryLocalServiceUtil.
+			fetchLayoutPageTemplateEntryByPlid(layoutPageTemplateEntryPlid);
 	}
 
 	private long _getScopeGroupId() {

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/GroupFragmentEntryLinkDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/GroupFragmentEntryLinkDisplayContext.java
@@ -5,21 +5,12 @@
 
 package com.liferay.fragment.web.internal.display.context;
 
-import com.liferay.depot.model.DepotEntryGroupRel;
-import com.liferay.depot.service.DepotEntryGroupRelLocalService;
-import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.constants.FragmentActionKeys;
 import com.liferay.fragment.constants.FragmentPortletKeys;
 import com.liferay.fragment.model.FragmentEntry;
-import com.liferay.fragment.model.FragmentEntryLinkTable;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.fragment.service.FragmentEntryLocalService;
 import com.liferay.fragment.web.internal.security.permission.resource.FragmentPermission;
-import com.liferay.petra.function.transform.TransformUtil;
-import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
-import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
-import com.liferay.petra.sql.dsl.expression.Predicate;
-import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -27,7 +18,6 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.SearchOrderByUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -49,15 +39,11 @@ import java.util.Objects;
 public class GroupFragmentEntryLinkDisplayContext {
 
 	public GroupFragmentEntryLinkDisplayContext(
-		DepotEntryGroupRelLocalService depotEntryGroupRelLocalService,
-		DepotEntryLocalService depotEntryLocalService,
 		FragmentEntryLinkLocalService fragmentEntryLinkLocalService,
 		FragmentEntryLocalService fragmentEntryLocalService,
 		GroupLocalService groupLocalService, RenderRequest renderRequest,
 		RenderResponse renderResponse) {
 
-		_depotEntryGroupRelLocalService = depotEntryGroupRelLocalService;
-		_depotEntryLocalService = depotEntryLocalService;
 		_fragmentEntryLinkLocalService = fragmentEntryLinkLocalService;
 		_fragmentEntryLocalService = fragmentEntryLocalService;
 		_groupLocalService = groupLocalService;
@@ -192,46 +178,6 @@ public class GroupFragmentEntryLinkDisplayContext {
 		return _searchContainer;
 	}
 
-	private Predicate _getFragmentEntryScopePredicate(Group group)
-		throws PortalException {
-
-		Predicate emptyScopePredicate = Predicate.withParentheses(
-			FragmentEntryLinkTable.INSTANCE.fragmentEntryScopeERC.isNull(
-			).and(
-				FragmentEntryLinkTable.INSTANCE.groupId.eq(group.getGroupId())
-			));
-
-		if (!group.isDepot()) {
-			return Predicate.withParentheses(
-				FragmentEntryLinkTable.INSTANCE.fragmentEntryScopeERC.eq(
-					group.getExternalReferenceCode()
-				).or(
-					emptyScopePredicate
-				));
-		}
-
-		Long[] connectedSiteGroupIds = TransformUtil.transformToArray(
-			_depotEntryGroupRelLocalService.getDepotEntryGroupRels(
-				_depotEntryLocalService.getGroupDepotEntry(group.getGroupId())),
-			DepotEntryGroupRel::getToGroupId, Long.class);
-
-		if (ArrayUtil.isEmpty(connectedSiteGroupIds)) {
-			return emptyScopePredicate;
-		}
-
-		return Predicate.withParentheses(
-			Predicate.withParentheses(
-				FragmentEntryLinkTable.INSTANCE.fragmentEntryScopeERC.eq(
-					group.getExternalReferenceCode()
-				).and(
-					FragmentEntryLinkTable.INSTANCE.groupId.in(
-						connectedSiteGroupIds)
-				)
-			).or(
-				emptyScopePredicate
-			));
-	}
-
 	private Map<Group, Integer> _getGroupFragmentEntryUsages()
 		throws PortalException {
 
@@ -239,42 +185,17 @@ public class GroupFragmentEntryLinkDisplayContext {
 			return _groupFragmentEntryUsages;
 		}
 
-		FragmentEntry fragmentEntry = getFragmentEntry();
-
-		Group group = _groupLocalService.getGroup(fragmentEntry.getGroupId());
-
 		Map<Group, Integer> groupFragmentEntryUsages = new HashMap<>();
 
-		DSLQuery dslQuery = DSLQueryFactoryUtil.select(
-			FragmentEntryLinkTable.INSTANCE.groupId,
-			DSLFunctionFactoryUtil.countDistinct(
-				FragmentEntryLinkTable.INSTANCE.classPK
-			).as(
-				"allUsageCount"
-			)
-		).from(
-			FragmentEntryLinkTable.INSTANCE
-		).where(
-			FragmentEntryLinkTable.INSTANCE.fragmentEntryERC.eq(
-				fragmentEntry.getExternalReferenceCode()
-			).and(
-				_getFragmentEntryScopePredicate(group)
-			).and(
-				FragmentEntryLinkTable.INSTANCE.deleted.eq(false)
-			)
-		).groupBy(
-			FragmentEntryLinkTable.INSTANCE.groupId
-		);
+		Map<Long, Integer> groupFragmentEntryUsageCounts =
+			_fragmentEntryLinkLocalService.getGroupFragmentEntryUsageCounts(
+				getFragmentEntry());
 
-		List<Object[]> results = _fragmentEntryLinkLocalService.dslQuery(
-			dslQuery);
-
-		for (Object[] result : results) {
-			long groupId = (Long)result[0];
-			Number count = (Number)result[1];
+		for (Map.Entry<Long, Integer> entry :
+				groupFragmentEntryUsageCounts.entrySet()) {
 
 			groupFragmentEntryUsages.put(
-				_groupLocalService.getGroup(groupId), count.intValue());
+				_groupLocalService.getGroup(entry.getKey()), entry.getValue());
 		}
 
 		_groupFragmentEntryUsages = groupFragmentEntryUsages;
@@ -282,9 +203,6 @@ public class GroupFragmentEntryLinkDisplayContext {
 		return _groupFragmentEntryUsages;
 	}
 
-	private final DepotEntryGroupRelLocalService
-		_depotEntryGroupRelLocalService;
-	private final DepotEntryLocalService _depotEntryLocalService;
 	private Long _fragmentCollectionId;
 	private FragmentEntry _fragmentEntry;
 	private Long _fragmentEntryId;

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/frontend/taglib/clay/servlet/taglib/BasicFragmentEntryVerticalCard.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/frontend/taglib/clay/servlet/taglib/BasicFragmentEntryVerticalCard.java
@@ -50,7 +50,8 @@ public class BasicFragmentEntryVerticalCard
 		BasicFragmentEntryActionDropdownItemsProvider
 			basicFragmentEntryActionDropdownItemsProvider =
 				new BasicFragmentEntryActionDropdownItemsProvider(
-					fragmentEntry, _renderRequest, _renderResponse);
+					fragmentEntry, _renderRequest, _renderResponse,
+					_getUsageCount());
 
 		try {
 			return basicFragmentEntryActionDropdownItemsProvider.
@@ -151,7 +152,7 @@ public class BasicFragmentEntryVerticalCard
 	@Override
 	public String getSubtitle() {
 		return LanguageUtil.format(
-			_httpServletRequest, "x-usages", fragmentEntry.getUsageCount());
+			_httpServletRequest, "x-usages", _getUsageCount());
 	}
 
 	@Override
@@ -163,11 +164,20 @@ public class BasicFragmentEntryVerticalCard
 		return super.isSelectable();
 	}
 
+	private int _getUsageCount() {
+		if (_usageCount == null) {
+			_usageCount = fragmentEntry.getUsageCount();
+		}
+
+		return _usageCount;
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		BasicFragmentEntryVerticalCard.class);
 
 	private final HttpServletRequest _httpServletRequest;
 	private final RenderRequest _renderRequest;
 	private final RenderResponse _renderResponse;
+	private Integer _usageCount;
 
 }

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/ViewGroupFragmentEntryUsagesMVCRenderCommand.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/ViewGroupFragmentEntryUsagesMVCRenderCommand.java
@@ -5,8 +5,6 @@
 
 package com.liferay.fragment.web.internal.portlet.action;
 
-import com.liferay.depot.service.DepotEntryGroupRelLocalService;
-import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.fragment.constants.FragmentPortletKeys;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.fragment.service.FragmentEntryLocalService;
@@ -40,18 +38,11 @@ public class ViewGroupFragmentEntryUsagesMVCRenderCommand
 		renderRequest.setAttribute(
 			GroupFragmentEntryLinkDisplayContext.class.getName(),
 			new GroupFragmentEntryLinkDisplayContext(
-				_depotEntryGroupRelLocalService, _depotEntryLocalService,
 				_fragmentEntryLinkLocalService, _fragmentEntryLocalService,
 				_groupLocalService, renderRequest, renderResponse));
 
 		return "/view_group_fragment_entry_usages.jsp";
 	}
-
-	@Reference
-	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
-
-	@Reference
-	private DepotEntryLocalService _depotEntryLocalService;
 
 	@Reference
 	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProvider.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProvider.java
@@ -45,10 +45,11 @@ public class BasicFragmentEntryActionDropdownItemsProvider {
 
 	public BasicFragmentEntryActionDropdownItemsProvider(
 		FragmentEntry fragmentEntry, RenderRequest renderRequest,
-		RenderResponse renderResponse) {
+		RenderResponse renderResponse, int usageCount) {
 
 		_fragmentEntry = fragmentEntry;
 		_renderResponse = renderResponse;
+		_usageCount = usageCount;
 
 		_httpServletRequest = PortalUtil.getHttpServletRequest(renderRequest);
 
@@ -492,7 +493,7 @@ public class BasicFragmentEntryActionDropdownItemsProvider {
 		boolean viewSiteUsages = _isViewSiteUsages();
 
 		return dropdownItem -> {
-			dropdownItem.setDisabled(_fragmentEntry.getUsageCount() == 0);
+			dropdownItem.setDisabled(_usageCount == 0);
 			dropdownItem.setHref(
 				_renderResponse.createRenderURL(), "mvcRenderCommandName",
 				viewSiteUsages ? "/fragment/view_group_fragment_entry_usages" :
@@ -527,5 +528,6 @@ public class BasicFragmentEntryActionDropdownItemsProvider {
 	private final ItemSelector _itemSelector;
 	private final RenderResponse _renderResponse;
 	private final ThemeDisplay _themeDisplay;
+	private final int _usageCount;
 
 }

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/BaseActionDropdownItemsProviderTestCase.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/BaseActionDropdownItemsProviderTestCase.java
@@ -66,7 +66,7 @@ public abstract class BaseActionDropdownItemsProviderTestCase {
 	protected void assertDropdownItemsInCorrectOrder(
 		List<DropdownItem> dropdownItems, String... labels) {
 
-		dropdownItems = _getActionDropdownItems(dropdownItems);
+		dropdownItems = getAllDropdownItems(dropdownItems);
 
 		Assert.assertEquals(
 			dropdownItems.toString(), labels.length, dropdownItems.size());
@@ -78,23 +78,7 @@ public abstract class BaseActionDropdownItemsProviderTestCase {
 		}
 	}
 
-	protected void setUpFragmentPermission(boolean contains) {
-		Mockito.when(
-			FragmentPermission.contains(
-				Mockito.any(), Mockito.anyLong(), Mockito.anyString())
-		).thenReturn(
-			contains
-		);
-	}
-
-	protected final HttpServletRequest httpServletRequest = Mockito.mock(
-		HttpServletRequest.class);
-	protected final RenderRequest renderRequest = Mockito.mock(
-		RenderRequest.class);
-	protected final RenderResponse renderResponse = Mockito.mock(
-		RenderResponse.class);
-
-	private List<DropdownItem> _getActionDropdownItems(
+	protected List<DropdownItem> getAllDropdownItems(
 		List<DropdownItem> dropdownItems) {
 
 		List<DropdownItem> allDropdownItems = new ArrayList<>();
@@ -112,6 +96,22 @@ public abstract class BaseActionDropdownItemsProviderTestCase {
 
 		return allDropdownItems;
 	}
+
+	protected void setUpFragmentPermission(boolean contains) {
+		Mockito.when(
+			FragmentPermission.contains(
+				Mockito.any(), Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			contains
+		);
+	}
+
+	protected final HttpServletRequest httpServletRequest = Mockito.mock(
+		HttpServletRequest.class);
+	protected final RenderRequest renderRequest = Mockito.mock(
+		RenderRequest.class);
+	protected final RenderResponse renderResponse = Mockito.mock(
+		RenderResponse.class);
 
 	private void _setUpFragmentPortletConfiguration() {
 		Mockito.when(

--- a/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProviderTest.java
+++ b/modules/apps/fragment/fragment-web/src/test/java/com/liferay/fragment/web/internal/servlet/taglib/util/BasicFragmentEntryActionDropdownItemsProviderTest.java
@@ -7,12 +7,17 @@ package com.liferay.fragment.web.internal.servlet.taglib.util;
 
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.web.internal.util.DesignLibraryUtil;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
+import java.util.List;
+
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,7 +46,8 @@ public class BasicFragmentEntryActionDropdownItemsProviderTest
 		BasicFragmentEntryActionDropdownItemsProvider
 			basicFragmentEntryActionDropdownItemsProvider =
 				new BasicFragmentEntryActionDropdownItemsProvider(
-					_fragmentEntry, renderRequest, renderResponse);
+					_fragmentEntry, renderRequest, renderResponse,
+					RandomTestUtil.randomInt());
 
 		assertDropdownItemsInCorrectOrder(
 			basicFragmentEntryActionDropdownItemsProvider.
@@ -67,7 +73,8 @@ public class BasicFragmentEntryActionDropdownItemsProviderTest
 		BasicFragmentEntryActionDropdownItemsProvider
 			basicFragmentEntryActionDropdownItemsProvider =
 				new BasicFragmentEntryActionDropdownItemsProvider(
-					_fragmentEntry, renderRequest, renderResponse);
+					_fragmentEntry, renderRequest, renderResponse,
+					RandomTestUtil.randomInt());
 
 		assertDropdownItemsInCorrectOrder(
 			basicFragmentEntryActionDropdownItemsProvider.
@@ -86,7 +93,8 @@ public class BasicFragmentEntryActionDropdownItemsProviderTest
 		BasicFragmentEntryActionDropdownItemsProvider
 			basicFragmentEntryActionDropdownItemsProvider =
 				new BasicFragmentEntryActionDropdownItemsProvider(
-					_fragmentEntry, renderRequest, renderResponse);
+					_fragmentEntry, renderRequest, renderResponse,
+					RandomTestUtil.randomInt());
 
 		assertDropdownItemsInCorrectOrder(
 			basicFragmentEntryActionDropdownItemsProvider.
@@ -105,7 +113,8 @@ public class BasicFragmentEntryActionDropdownItemsProviderTest
 		BasicFragmentEntryActionDropdownItemsProvider
 			basicFragmentEntryActionDropdownItemsProvider =
 				new BasicFragmentEntryActionDropdownItemsProvider(
-					_fragmentEntry, renderRequest, renderResponse);
+					_fragmentEntry, renderRequest, renderResponse,
+					RandomTestUtil.randomInt());
 
 		assertDropdownItemsInCorrectOrder(
 			basicFragmentEntryActionDropdownItemsProvider.
@@ -130,7 +139,8 @@ public class BasicFragmentEntryActionDropdownItemsProviderTest
 		BasicFragmentEntryActionDropdownItemsProvider
 			basicFragmentEntryActionDropdownItemsProvider =
 				new BasicFragmentEntryActionDropdownItemsProvider(
-					_fragmentEntry, renderRequest, renderResponse);
+					_fragmentEntry, renderRequest, renderResponse,
+					RandomTestUtil.randomInt());
 
 		try (MockedStatic<DesignLibraryUtil> designLibraryUtilMockedStatic =
 				Mockito.mockStatic(DesignLibraryUtil.class);
@@ -189,7 +199,8 @@ public class BasicFragmentEntryActionDropdownItemsProviderTest
 		BasicFragmentEntryActionDropdownItemsProvider
 			basicFragmentEntryActionDropdownItemsProvider =
 				new BasicFragmentEntryActionDropdownItemsProvider(
-					_fragmentEntry, renderRequest, renderResponse);
+					_fragmentEntry, renderRequest, renderResponse,
+					RandomTestUtil.randomInt());
 
 		assertDropdownItemsInCorrectOrder(
 			basicFragmentEntryActionDropdownItemsProvider.
@@ -208,21 +219,59 @@ public class BasicFragmentEntryActionDropdownItemsProviderTest
 		BasicFragmentEntryActionDropdownItemsProvider
 			basicFragmentEntryActionDropdownItemsProvider =
 				new BasicFragmentEntryActionDropdownItemsProvider(
-					_fragmentEntry, renderRequest, renderResponse);
+					_fragmentEntry, renderRequest, renderResponse,
+					RandomTestUtil.randomInt());
 
 		assertDropdownItemsInCorrectOrder(
 			basicFragmentEntryActionDropdownItemsProvider.
 				getActionDropdownItems());
 	}
 
+	@Test
+	@TestInfo("LPD-99652")
+	public void testGetActionDropdownItemsWithUsageCount() throws Exception {
+		_testGetActionDropdownItemsWithoutUsageCount();
+		_testGetActionDropdownItemsWithUsageCount();
+	}
+
+	private void _assertViewSiteUsagesDropdownItemDisabled(
+			int usageCount, boolean disabled)
+		throws Exception {
+
+		setUpFragmentPermission(true);
+		_setUpFragmentEntry(false, false, false);
+
+		BasicFragmentEntryActionDropdownItemsProvider
+			basicFragmentEntryActionDropdownItemsProvider =
+				new BasicFragmentEntryActionDropdownItemsProvider(
+					_fragmentEntry, renderRequest, renderResponse, usageCount);
+
+		DropdownItem dropdownItem = _getViewSiteUsagesDropdownItem(
+			basicFragmentEntryActionDropdownItemsProvider.
+				getActionDropdownItems());
+
+		Assert.assertEquals("view-site-usages", dropdownItem.get("label"));
+		Assert.assertEquals(disabled, dropdownItem.get("disabled"));
+	}
+
+	private DropdownItem _getViewSiteUsagesDropdownItem(
+		List<DropdownItem> dropdownItems) {
+
+		for (DropdownItem dropdownItem : getAllDropdownItems(dropdownItems)) {
+			if (StringUtil.equals(
+					(String)dropdownItem.get("label"), "view-site-usages")) {
+
+				return dropdownItem;
+			}
+		}
+
+		throw new AssertionError(
+			"Unable to find the \"view-site-usages\" dropdown item in " +
+				dropdownItems);
+	}
+
 	private void _setUpFragmentEntry(
 		boolean draft, boolean readOnly, boolean typeReact) {
-
-		Mockito.when(
-			_fragmentEntry.getUsageCount()
-		).thenReturn(
-			0
-		);
 
 		Mockito.when(
 			_fragmentEntry.isDraft()
@@ -241,6 +290,17 @@ public class BasicFragmentEntryActionDropdownItemsProviderTest
 		).thenReturn(
 			typeReact
 		);
+	}
+
+	private void _testGetActionDropdownItemsWithoutUsageCount()
+		throws Exception {
+
+		_assertViewSiteUsagesDropdownItemDisabled(0, true);
+	}
+
+	private void _testGetActionDropdownItemsWithUsageCount() throws Exception {
+		_assertViewSiteUsagesDropdownItemDisabled(
+			RandomTestUtil.randomInt(), false);
 	}
 
 	private final FragmentEntry _fragmentEntry = Mockito.mock(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99652

## What Is Being Fixed

The fragment Usages screen threw an NPE when a `FragmentEntryLink` pointed at a `Layout` that no longer existed. The usage count and the usages list both counted those orphan links, so a fragment could report usages that no page actually had, and `deleteFragmentEntry` refused to delete a fragment whose only remaining usages were orphans.

## How It Is Being Fixed

Fragment usage counts and usage lists now exclude `FragmentEntryLink` rows whose `Layout` is gone, and `deleteFragmentEntry` deletes those rows when it removes the fragment. The filtering lives in one place, `_getLayoutPredicate`, which every query call site shares, and it carries a `LayoutRevision` carve-out so a plid that matches a `layoutRevisionId` is never treated as an orphan. That mirrors the product's own orphan cleanup in `LayoutDataCleanupPreupgradeProcess`, and it is what keeps staging's live references safe.

The group usages query moved from `GroupFragmentEntryLinkDisplayContext` into `FragmentEntryLinkLocalService`, so the count the card shows and the list the page shows come from the same service method rather than two divergent queries. The card now memoizes its usage count instead of querying once for the subtitle and again for the dropdown. A DEBUG log reports the orphan plids it finds, since the orphans have no user-visible effect and INFO would pay the query cost on every visit to the landing page.

## PR Check

**pr-check: PASS** — tested on `a195e87267bcdd984606226e4e4f6cb5b3aab4f9`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a195e87267bcdd984606226e4e4f6cb5b3aab4f9"} -->
