### PR TITLE
LPD-95020 Return typed error responses for widget page widget instances

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
@@ -9012,6 +9012,12 @@ paths:
                                 items:
                                     $ref: "#/components/schemas/WidgetPageWidgetInstance"
                                 type: array
+                400:
+                    description:
+                        "The request is invalid. For example, the site page is not a widget page."
+                404:
+                    description:
+                        "The requested site page could not be found."
             # @review
             tags: ["WidgetPageWidgetInstance"]
         post:
@@ -9059,6 +9065,12 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/WidgetPageWidgetInstance"
+                400:
+                    description:
+                        "The request is invalid. For example, the site page is not a widget page, the parent section does not exist, or the widget could not be added to the site page."
+                404:
+                    description:
+                        "The requested site page could not be found."
             # @review
             tags: ["WidgetPageWidgetInstance"]
     "/sites/{siteExternalReferenceCode}/site-pages/{sitePageExternalReferenceCode}/widget-instances/{widgetInstanceExternalReferenceCode}":
@@ -9088,6 +9100,12 @@ paths:
                     content:
                         application/json: {}
                         application/xml: {}
+                400:
+                    description:
+                        "The request is invalid. For example, the site page is not a widget page."
+                404:
+                    description:
+                        "The requested site page or widget instance could not be found."
             tags: ["WidgetPageWidgetInstance"]
         get:
             # @review
@@ -9131,6 +9149,12 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/WidgetPageWidgetInstance"
+                400:
+                    description:
+                        "The request is invalid. For example, the site page is not a widget page."
+                404:
+                    description:
+                        "The requested site page or widget instance could not be found."
             tags: ["WidgetPageWidgetInstance"]
         patch:
             # @review
@@ -9182,6 +9206,12 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/WidgetPageWidgetInstance"
+                400:
+                    description:
+                        "The request is invalid. For example, the site page is not a widget page or the parent section does not exist."
+                404:
+                    description:
+                        "The requested site page or widget instance could not be found."
             tags: ["WidgetPageWidgetInstance"]
         put:
             # @review
@@ -9233,6 +9263,12 @@ paths:
                         application/xml:
                             schema:
                                 $ref: "#/components/schemas/WidgetPageWidgetInstance"
+                400:
+                    description:
+                        "The request is invalid. For example, the site page is not a widget page, the parent section does not exist, or the widget could not be added to the site page."
+                404:
+                    description:
+                        "The requested site page could not be found."
             tags: ["WidgetPageWidgetInstance"]
     "/sites/{siteExternalReferenceCode}/style-books":
         get:

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/exception/NoSuchEntityException.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/exception/NoSuchEntityException.java
@@ -1,0 +1,61 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.exception;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.util.Validator;
+
+/**
+ * @author Javier Moral
+ */
+public class NoSuchEntityException extends PortalException {
+
+	public NoSuchEntityException(String entity, String externalReferenceCode) {
+		this(entity, externalReferenceCode, null);
+	}
+
+	public NoSuchEntityException(
+		String entity, String externalReferenceCode, String parentEntity) {
+
+		super(_getMessage(entity, externalReferenceCode, parentEntity));
+
+		_entity = entity;
+		_externalReferenceCode = externalReferenceCode;
+		_parentEntity = parentEntity;
+	}
+
+	public String getEntity() {
+		return _entity;
+	}
+
+	public String getExternalReferenceCode() {
+		return _externalReferenceCode;
+	}
+
+	public String getParentEntity() {
+		return _parentEntity;
+	}
+
+	private static String _getMessage(
+		String entity, String externalReferenceCode, String parentEntity) {
+
+		if (Validator.isNull(parentEntity)) {
+			return StringBundler.concat(
+				"No ", entity, " exists with the external reference code ",
+				externalReferenceCode);
+		}
+
+		return StringBundler.concat(
+			"No ", entity, " with external reference code ",
+			externalReferenceCode, " exists in this ", parentEntity);
+	}
+
+	private final String _entity;
+	private final String _externalReferenceCode;
+	private final String _parentEntity;
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/WidgetPageWidgetInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/WidgetPageWidgetInstanceResourceImpl.java
@@ -7,18 +7,18 @@ package com.liferay.headless.admin.site.internal.resource.v1_0;
 
 import com.liferay.headless.admin.site.dto.v1_0.WidgetPageWidgetInstance;
 import com.liferay.headless.admin.site.internal.dto.v1_0.util.DTOConverterContextUtil;
+import com.liferay.headless.admin.site.internal.exception.NoSuchEntityException;
 import com.liferay.headless.admin.site.internal.resource.v1_0.util.LayoutUtil;
 import com.liferay.headless.admin.site.resource.v1_0.WidgetPageWidgetInstanceResource;
 import com.liferay.headless.common.spi.util.GroupUtil;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.exception.NoSuchPortletException;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.LayoutType;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
@@ -27,6 +27,7 @@ import com.liferay.portal.vulcan.pagination.Page;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 
+import java.util.List;
 import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
@@ -58,21 +59,8 @@ public class WidgetPageWidgetInstanceResourceImpl
 			throw new UnsupportedOperationException();
 		}
 
-		Layout layout = _layoutLocalService.fetchLayoutByExternalReferenceCode(
-			sitePageExternalReferenceCode,
-			GroupUtil.getGroupId(
-				false, contextCompany.getCompanyId(),
-				siteExternalReferenceCode));
-
-		if (layout == null) {
-			throw new UnsupportedOperationException();
-		}
-
-		LayoutType layoutType = layout.getLayoutType();
-
-		if (!(layoutType instanceof LayoutTypePortlet)) {
-			throw new UnsupportedOperationException();
-		}
+		Layout layout = _getTypePortletLayout(
+			siteExternalReferenceCode, sitePageExternalReferenceCode);
 
 		LayoutTypePortlet layoutTypePortlet =
 			(LayoutTypePortlet)layout.getLayoutType();
@@ -80,7 +68,9 @@ public class WidgetPageWidgetInstanceResourceImpl
 		if (!layoutTypePortlet.hasPortletId(
 				widgetInstanceExternalReferenceCode)) {
 
-			throw new NoSuchPortletException();
+			throw new NoSuchEntityException(
+				"widget instance", widgetInstanceExternalReferenceCode,
+				"site page");
 		}
 
 		layoutTypePortlet.removePortletId(
@@ -104,21 +94,8 @@ public class WidgetPageWidgetInstanceResourceImpl
 			throw new UnsupportedOperationException();
 		}
 
-		Layout layout = _layoutLocalService.fetchLayoutByExternalReferenceCode(
-			sitePageExternalReferenceCode,
-			GroupUtil.getGroupId(
-				false, contextCompany.getCompanyId(),
-				siteExternalReferenceCode));
-
-		if (layout == null) {
-			throw new UnsupportedOperationException();
-		}
-
-		LayoutType layoutType = layout.getLayoutType();
-
-		if (!(layoutType instanceof LayoutTypePortlet)) {
-			throw new UnsupportedOperationException();
-		}
+		Layout layout = _getTypePortletLayout(
+			siteExternalReferenceCode, sitePageExternalReferenceCode);
 
 		LayoutTypePortlet layoutTypePortlet =
 			(LayoutTypePortlet)layout.getLayoutType();
@@ -126,7 +103,9 @@ public class WidgetPageWidgetInstanceResourceImpl
 		if (!layoutTypePortlet.hasPortletId(
 				widgetInstanceExternalReferenceCode)) {
 
-			throw new NoSuchPortletException();
+			throw new NoSuchEntityException(
+				"widget instance", widgetInstanceExternalReferenceCode,
+				"site page");
 		}
 
 		return _toWidgetPageWidgetInstance(
@@ -145,21 +124,8 @@ public class WidgetPageWidgetInstanceResourceImpl
 			throw new UnsupportedOperationException();
 		}
 
-		Layout layout = _layoutLocalService.fetchLayoutByExternalReferenceCode(
-			sitePageExternalReferenceCode,
-			GroupUtil.getGroupId(
-				false, contextCompany.getCompanyId(),
-				siteExternalReferenceCode));
-
-		if (layout == null) {
-			throw new UnsupportedOperationException();
-		}
-
-		LayoutType layoutType = layout.getLayoutType();
-
-		if (!(layoutType instanceof LayoutTypePortlet)) {
-			throw new UnsupportedOperationException();
-		}
+		Layout layout = _getTypePortletLayout(
+			siteExternalReferenceCode, sitePageExternalReferenceCode);
 
 		LayoutTypePortlet layoutTypePortlet =
 			(LayoutTypePortlet)layout.getLayoutType();
@@ -190,21 +156,11 @@ public class WidgetPageWidgetInstanceResourceImpl
 			throw new UnsupportedOperationException();
 		}
 
-		Layout layout = _layoutLocalService.fetchLayoutByExternalReferenceCode(
-			sitePageExternalReferenceCode,
-			GroupUtil.getGroupId(
-				false, contextCompany.getCompanyId(),
-				siteExternalReferenceCode));
+		Layout layout = _getTypePortletLayout(
+			siteExternalReferenceCode, sitePageExternalReferenceCode);
 
-		if (layout == null) {
-			throw new UnsupportedOperationException();
-		}
-
-		LayoutType layoutType = layout.getLayoutType();
-
-		if (!(layoutType instanceof LayoutTypePortlet)) {
-			throw new UnsupportedOperationException();
-		}
+		_validateParentSectionId(
+			layout, widgetPageWidgetInstance.getParentSectionId());
 
 		String portletId = PortletIdCodec.encode(
 			widgetPageWidgetInstance.getWidgetName(),
@@ -229,21 +185,11 @@ public class WidgetPageWidgetInstanceResourceImpl
 			throw new UnsupportedOperationException();
 		}
 
-		Layout layout = _layoutLocalService.fetchLayoutByExternalReferenceCode(
-			sitePageExternalReferenceCode,
-			GroupUtil.getGroupId(
-				false, contextCompany.getCompanyId(),
-				siteExternalReferenceCode));
+		Layout layout = _getTypePortletLayout(
+			siteExternalReferenceCode, sitePageExternalReferenceCode);
 
-		if (layout == null) {
-			throw new UnsupportedOperationException();
-		}
-
-		LayoutType layoutType = layout.getLayoutType();
-
-		if (!(layoutType instanceof LayoutTypePortlet)) {
-			throw new UnsupportedOperationException();
-		}
+		_validateParentSectionId(
+			layout, widgetPageWidgetInstance.getParentSectionId());
 
 		LayoutTypePortlet layoutTypePortlet =
 			(LayoutTypePortlet)layout.getLayoutType();
@@ -289,10 +235,11 @@ public class WidgetPageWidgetInstanceResourceImpl
 			contextUser.getUserId(), portletId, columnId, position);
 
 		if (addedPortletId == null) {
-			throw new PortalException(
+			throw new IllegalArgumentException(
 				StringBundler.concat(
-					"Portlet ", portletId, " cannot be added to layout ",
-					layout.getPlid(), " by user ", contextUser.getUserId()));
+					"The widget ", portletId,
+					" could not be added to the site page ",
+					layout.getExternalReferenceCode()));
 		}
 
 		layout = _layoutLocalService.updateTypeSettings(
@@ -300,6 +247,31 @@ public class WidgetPageWidgetInstanceResourceImpl
 			layout.getTypeSettings());
 
 		return _toWidgetPageWidgetInstance(layout, addedPortletId);
+	}
+
+	private Layout _getTypePortletLayout(
+			String siteExternalReferenceCode,
+			String sitePageExternalReferenceCode)
+		throws Exception {
+
+		Layout layout = _layoutLocalService.fetchLayoutByExternalReferenceCode(
+			sitePageExternalReferenceCode,
+			GroupUtil.getGroupId(
+				false, contextCompany.getCompanyId(),
+				siteExternalReferenceCode));
+
+		if (layout == null) {
+			throw new NoSuchEntityException(
+				"site page", sitePageExternalReferenceCode);
+		}
+
+		if (!Objects.equals(layout.getType(), LayoutConstants.TYPE_PORTLET)) {
+			throw new IllegalArgumentException(
+				"The site page with external reference code \"" +
+					sitePageExternalReferenceCode + "\" is not a widget page");
+		}
+
+		return layout;
 	}
 
 	private WidgetPageWidgetInstance _toWidgetPageWidgetInstance(
@@ -323,6 +295,25 @@ public class WidgetPageWidgetInstanceResourceImpl
 				contextHttpServletRequest, layout.getPlid(), contextUriInfo,
 				contextUser),
 			layout, portletId);
+	}
+
+	private void _validateParentSectionId(
+		Layout layout, String parentSectionId) {
+
+		if (Validator.isNull(parentSectionId)) {
+			return;
+		}
+
+		LayoutTypePortlet layoutTypePortlet =
+			(LayoutTypePortlet)layout.getLayoutType();
+
+		List<String> columns = layoutTypePortlet.getColumns();
+
+		if (!columns.contains(parentSectionId)) {
+			throw new IllegalArgumentException(
+				"The widget page section " + parentSectionId +
+					" does not exist");
+		}
 	}
 
 	@Reference

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/NoSuchEntityExceptionProblemMapper.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/vulcan/problem/NoSuchEntityExceptionProblemMapper.java
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.vulcan.problem;
+
+import com.liferay.headless.admin.site.internal.exception.NoSuchEntityException;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.vulcan.problem.Problem;
+import com.liferay.portal.vulcan.problem.ProblemMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Javier Moral
+ */
+@Component(service = ProblemMapper.class)
+public class NoSuchEntityExceptionProblemMapper
+	implements ProblemMapper<NoSuchEntityException> {
+
+	@Override
+	public Problem getProblem(NoSuchEntityException noSuchEntityException) {
+		String entity = noSuchEntityException.getEntity();
+		String externalReferenceCode =
+			noSuchEntityException.getExternalReferenceCode();
+		String parentEntity = noSuchEntityException.getParentEntity();
+
+		String message = "The requested " + entity + " could not be found";
+
+		if (Validator.isNotNull(externalReferenceCode)) {
+			if (Validator.isNull(parentEntity)) {
+				message = StringBundler.concat(
+					"No ", entity,
+					" exists with the external reference code \"",
+					externalReferenceCode, "\"");
+			}
+			else {
+				message = StringBundler.concat(
+					"No ", entity, " with external reference code \"",
+					externalReferenceCode, "\" exists in this ", parentEntity);
+			}
+		}
+
+		return ProblemUtil.getProblem(
+			message, Problem.Status.NOT_FOUND, noSuchEntityException);
+	}
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/WidgetPageWidgetInstanceResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/WidgetPageWidgetInstanceResourceTest.java
@@ -53,156 +53,38 @@ public class WidgetPageWidgetInstanceResourceTest
 	@Override
 	@Test
 	public void testDeleteSiteSitePageWidgetInstance() throws Exception {
-		WidgetPageWidgetInstance widgetPageWidgetInstance =
-			testPostSiteSitePageWidgetInstance_addWidgetPageWidgetInstance(
-				randomWidgetPageWidgetInstance());
-
-		_layout = _layoutLocalService.fetchLayout(_layout.getPlid());
-
-		LayoutTypePortlet layoutTypePortlet =
-			(LayoutTypePortlet)_layout.getLayoutType();
-
-		String portletId = PortletIdCodec.encode(
-			widgetPageWidgetInstance.getWidgetName(),
-			widgetPageWidgetInstance.getWidgetInstanceId());
-
-		Assert.assertTrue(layoutTypePortlet.hasPortletId(portletId));
-
-		widgetPageWidgetInstanceResource.deleteSiteSitePageWidgetInstance(
-			testGroup.getExternalReferenceCode(),
-			_layout.getExternalReferenceCode(), portletId);
-
-		_layout = _layoutLocalService.fetchLayout(_layout.getPlid());
-
-		layoutTypePortlet = (LayoutTypePortlet)_layout.getLayoutType();
-
-		Assert.assertFalse(layoutTypePortlet.hasPortletId(portletId));
-
-		_assertProblemException(
-			"NOT_FOUND",
-			"No widget instance with external reference code \"" + portletId +
-				"\" exists in this site page",
-			() ->
-				widgetPageWidgetInstanceResource.
-					deleteSiteSitePageWidgetInstance(
-						testGroup.getExternalReferenceCode(),
-						_layout.getExternalReferenceCode(), portletId));
+		_testDeleteSiteSitePageWidgetInstance();
+		_testDeleteSiteSitePageWidgetInstanceWithNonexistentWidgetInstance();
 	}
 
 	@Override
 	@Test
 	public void testGetSiteSitePageWidgetInstance() throws Exception {
-		WidgetPageWidgetInstance postWidgetPageWidgetInstance =
-			testPostSiteSitePageWidgetInstance_addWidgetPageWidgetInstance(
-				randomWidgetPageWidgetInstance());
-
-		String portletId = PortletIdCodec.encode(
-			postWidgetPageWidgetInstance.getWidgetName(),
-			postWidgetPageWidgetInstance.getWidgetInstanceId());
-
-		WidgetPageWidgetInstance getWidgetPageWidgetInstance =
-			widgetPageWidgetInstanceResource.getSiteSitePageWidgetInstance(
-				testGroup.getExternalReferenceCode(),
-				_layout.getExternalReferenceCode(), portletId);
-
-		assertEquals(postWidgetPageWidgetInstance, getWidgetPageWidgetInstance);
-		assertValid(getWidgetPageWidgetInstance);
-
-		String widgetInstanceExternalReferenceCode =
-			RandomTestUtil.randomString();
-
-		_assertProblemException(
-			"NOT_FOUND",
-			"No widget instance with external reference code \"" +
-				widgetInstanceExternalReferenceCode +
-					"\" exists in this site page",
-			() ->
-				widgetPageWidgetInstanceResource.getSiteSitePageWidgetInstance(
-					testGroup.getExternalReferenceCode(),
-					_layout.getExternalReferenceCode(),
-					widgetInstanceExternalReferenceCode));
-
+		_testGetSiteSitePageWidgetInstance();
 		_testGetSiteSitePageWidgetInstanceWithContentPage();
-
 		_testGetSiteSitePageWidgetInstanceWithNonexistentSitePage();
+		_testGetSiteSitePageWidgetInstanceWithNonexistentWidgetInstance();
 	}
 
 	@Override
 	@Test
 	public void testPatchSiteSitePageWidgetInstance() throws Exception {
-		WidgetPageWidgetInstance postWidgetPageWidgetInstance =
-			testPostSiteSitePageWidgetInstance_addWidgetPageWidgetInstance(
-				randomWidgetPageWidgetInstance());
-
-		String portletId = PortletIdCodec.encode(
-			postWidgetPageWidgetInstance.getWidgetName(),
-			postWidgetPageWidgetInstance.getWidgetInstanceId());
-
-		WidgetPageWidgetInstance patchWidgetPageWidgetInstance =
-			widgetPageWidgetInstanceResource.patchSiteSitePageWidgetInstance(
-				testGroup.getExternalReferenceCode(),
-				_layout.getExternalReferenceCode(), portletId,
-				postWidgetPageWidgetInstance);
-
-		assertEquals(
-			postWidgetPageWidgetInstance, patchWidgetPageWidgetInstance);
-		assertValid(patchWidgetPageWidgetInstance);
-
-		String widgetInstanceExternalReferenceCode =
-			RandomTestUtil.randomString();
-
-		_assertProblemException(
-			"NOT_FOUND",
-			"No widget instance with external reference code \"" +
-				widgetInstanceExternalReferenceCode +
-					"\" exists in this site page",
-			() ->
-				widgetPageWidgetInstanceResource.
-					patchSiteSitePageWidgetInstance(
-						testGroup.getExternalReferenceCode(),
-						_layout.getExternalReferenceCode(),
-						widgetInstanceExternalReferenceCode,
-						randomWidgetPageWidgetInstance()));
+		_testPatchSiteSitePageWidgetInstance();
+		_testPatchSiteSitePageWidgetInstanceWithNonexistentWidgetInstance();
 	}
 
 	@Override
 	@Test
 	public void testPostSiteSitePageWidgetInstance() throws Exception {
-		WidgetPageWidgetInstance randomWidgetPageWidgetInstance =
-			randomWidgetPageWidgetInstance();
-
-		WidgetPageWidgetInstance postWidgetPageWidgetInstance =
-			testPostSiteSitePageWidgetInstance_addWidgetPageWidgetInstance(
-				randomWidgetPageWidgetInstance);
-
-		assertEquals(
-			randomWidgetPageWidgetInstance, postWidgetPageWidgetInstance);
-		assertValid(postWidgetPageWidgetInstance);
-
+		_testPostSiteSitePageWidgetInstance();
 		_testPostSiteSitePageWidgetInstanceWithNonexistentParentSectionId();
-
 		_testPostSiteSitePageWidgetInstanceWithUnregisteredWidget();
 	}
 
 	@Override
 	@Test
 	public void testPutSiteSitePageWidgetInstance() throws Exception {
-		WidgetPageWidgetInstance widgetPageWidgetInstance =
-			randomWidgetPageWidgetInstance();
-
-		String portletId = PortletIdCodec.encode(
-			widgetPageWidgetInstance.getWidgetName(),
-			widgetPageWidgetInstance.getWidgetInstanceId());
-
-		WidgetPageWidgetInstance putWidgetPageWidgetInstance =
-			widgetPageWidgetInstanceResource.putSiteSitePageWidgetInstance(
-				testGroup.getExternalReferenceCode(),
-				_layout.getExternalReferenceCode(), portletId,
-				widgetPageWidgetInstance);
-
-		assertEquals(widgetPageWidgetInstance, putWidgetPageWidgetInstance);
-		assertValid(putWidgetPageWidgetInstance);
-
+		_testPutSiteSitePageWidgetInstance();
 		_testPutSiteSitePageWidgetInstanceWithNonexistentParentSectionId();
 	}
 
@@ -296,6 +178,70 @@ public class WidgetPageWidgetInstanceResourceTest
 		}
 	}
 
+	private void _testDeleteSiteSitePageWidgetInstance() throws Exception {
+		WidgetPageWidgetInstance widgetPageWidgetInstance =
+			testPostSiteSitePageWidgetInstance_addWidgetPageWidgetInstance(
+				randomWidgetPageWidgetInstance());
+
+		_layout = _layoutLocalService.fetchLayout(_layout.getPlid());
+
+		LayoutTypePortlet layoutTypePortlet =
+			(LayoutTypePortlet)_layout.getLayoutType();
+
+		String portletId = PortletIdCodec.encode(
+			widgetPageWidgetInstance.getWidgetName(),
+			widgetPageWidgetInstance.getWidgetInstanceId());
+
+		Assert.assertTrue(layoutTypePortlet.hasPortletId(portletId));
+
+		widgetPageWidgetInstanceResource.deleteSiteSitePageWidgetInstance(
+			testGroup.getExternalReferenceCode(),
+			_layout.getExternalReferenceCode(), portletId);
+
+		_layout = _layoutLocalService.fetchLayout(_layout.getPlid());
+
+		layoutTypePortlet = (LayoutTypePortlet)_layout.getLayoutType();
+
+		Assert.assertFalse(layoutTypePortlet.hasPortletId(portletId));
+	}
+
+	private void _testDeleteSiteSitePageWidgetInstanceWithNonexistentWidgetInstance()
+		throws Exception {
+
+		String widgetInstanceExternalReferenceCode =
+			RandomTestUtil.randomString();
+
+		_assertProblemException(
+			"NOT_FOUND",
+			"No widget instance with external reference code \"" +
+				widgetInstanceExternalReferenceCode +
+					"\" exists in this site page",
+			() ->
+				widgetPageWidgetInstanceResource.
+					deleteSiteSitePageWidgetInstance(
+						testGroup.getExternalReferenceCode(),
+						_layout.getExternalReferenceCode(),
+						widgetInstanceExternalReferenceCode));
+	}
+
+	private void _testGetSiteSitePageWidgetInstance() throws Exception {
+		WidgetPageWidgetInstance postWidgetPageWidgetInstance =
+			testPostSiteSitePageWidgetInstance_addWidgetPageWidgetInstance(
+				randomWidgetPageWidgetInstance());
+
+		String portletId = PortletIdCodec.encode(
+			postWidgetPageWidgetInstance.getWidgetName(),
+			postWidgetPageWidgetInstance.getWidgetInstanceId());
+
+		WidgetPageWidgetInstance getWidgetPageWidgetInstance =
+			widgetPageWidgetInstanceResource.getSiteSitePageWidgetInstance(
+				testGroup.getExternalReferenceCode(),
+				_layout.getExternalReferenceCode(), portletId);
+
+		assertEquals(postWidgetPageWidgetInstance, getWidgetPageWidgetInstance);
+		assertValid(getWidgetPageWidgetInstance);
+	}
+
 	private void _testGetSiteSitePageWidgetInstanceWithContentPage()
 		throws Exception {
 
@@ -326,6 +272,77 @@ public class WidgetPageWidgetInstanceResourceTest
 					testGroup.getExternalReferenceCode(),
 					sitePageExternalReferenceCode,
 					RandomTestUtil.randomString()));
+	}
+
+	private void _testGetSiteSitePageWidgetInstanceWithNonexistentWidgetInstance()
+		throws Exception {
+
+		String widgetInstanceExternalReferenceCode =
+			RandomTestUtil.randomString();
+
+		_assertProblemException(
+			"NOT_FOUND",
+			"No widget instance with external reference code \"" +
+				widgetInstanceExternalReferenceCode +
+					"\" exists in this site page",
+			() ->
+				widgetPageWidgetInstanceResource.getSiteSitePageWidgetInstance(
+					testGroup.getExternalReferenceCode(),
+					_layout.getExternalReferenceCode(),
+					widgetInstanceExternalReferenceCode));
+	}
+
+	private void _testPatchSiteSitePageWidgetInstance() throws Exception {
+		WidgetPageWidgetInstance postWidgetPageWidgetInstance =
+			testPostSiteSitePageWidgetInstance_addWidgetPageWidgetInstance(
+				randomWidgetPageWidgetInstance());
+
+		String portletId = PortletIdCodec.encode(
+			postWidgetPageWidgetInstance.getWidgetName(),
+			postWidgetPageWidgetInstance.getWidgetInstanceId());
+
+		WidgetPageWidgetInstance patchWidgetPageWidgetInstance =
+			widgetPageWidgetInstanceResource.patchSiteSitePageWidgetInstance(
+				testGroup.getExternalReferenceCode(),
+				_layout.getExternalReferenceCode(), portletId,
+				postWidgetPageWidgetInstance);
+
+		assertEquals(
+			postWidgetPageWidgetInstance, patchWidgetPageWidgetInstance);
+		assertValid(patchWidgetPageWidgetInstance);
+	}
+
+	private void _testPatchSiteSitePageWidgetInstanceWithNonexistentWidgetInstance()
+		throws Exception {
+
+		String widgetInstanceExternalReferenceCode =
+			RandomTestUtil.randomString();
+
+		_assertProblemException(
+			"NOT_FOUND",
+			"No widget instance with external reference code \"" +
+				widgetInstanceExternalReferenceCode +
+					"\" exists in this site page",
+			() ->
+				widgetPageWidgetInstanceResource.
+					patchSiteSitePageWidgetInstance(
+						testGroup.getExternalReferenceCode(),
+						_layout.getExternalReferenceCode(),
+						widgetInstanceExternalReferenceCode,
+						randomWidgetPageWidgetInstance()));
+	}
+
+	private void _testPostSiteSitePageWidgetInstance() throws Exception {
+		WidgetPageWidgetInstance randomWidgetPageWidgetInstance =
+			randomWidgetPageWidgetInstance();
+
+		WidgetPageWidgetInstance postWidgetPageWidgetInstance =
+			testPostSiteSitePageWidgetInstance_addWidgetPageWidgetInstance(
+				randomWidgetPageWidgetInstance);
+
+		assertEquals(
+			randomWidgetPageWidgetInstance, postWidgetPageWidgetInstance);
+		assertValid(postWidgetPageWidgetInstance);
 	}
 
 	private void _testPostSiteSitePageWidgetInstanceWithNonexistentParentSectionId()
@@ -376,6 +393,24 @@ public class WidgetPageWidgetInstanceResourceTest
 					testGroup.getExternalReferenceCode(),
 					_layout.getExternalReferenceCode(),
 					widgetPageWidgetInstance));
+	}
+
+	private void _testPutSiteSitePageWidgetInstance() throws Exception {
+		WidgetPageWidgetInstance widgetPageWidgetInstance =
+			randomWidgetPageWidgetInstance();
+
+		String portletId = PortletIdCodec.encode(
+			widgetPageWidgetInstance.getWidgetName(),
+			widgetPageWidgetInstance.getWidgetInstanceId());
+
+		WidgetPageWidgetInstance putWidgetPageWidgetInstance =
+			widgetPageWidgetInstanceResource.putSiteSitePageWidgetInstance(
+				testGroup.getExternalReferenceCode(),
+				_layout.getExternalReferenceCode(), portletId,
+				widgetPageWidgetInstance);
+
+		assertEquals(widgetPageWidgetInstance, putWidgetPageWidgetInstance);
+		assertValid(putWidgetPageWidgetInstance);
 	}
 
 	private void _testPutSiteSitePageWidgetInstanceWithNonexistentParentSectionId()

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/WidgetPageWidgetInstanceResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/WidgetPageWidgetInstanceResourceTest.java
@@ -70,6 +70,7 @@ public class WidgetPageWidgetInstanceResourceTest
 	@Test
 	public void testPatchSiteSitePageWidgetInstance() throws Exception {
 		_testPatchSiteSitePageWidgetInstance();
+		_testPatchSiteSitePageWidgetInstanceWithNonexistentParentSectionId();
 		_testPatchSiteSitePageWidgetInstanceWithNonexistentWidgetInstance();
 	}
 
@@ -86,6 +87,7 @@ public class WidgetPageWidgetInstanceResourceTest
 	public void testPutSiteSitePageWidgetInstance() throws Exception {
 		_testPutSiteSitePageWidgetInstance();
 		_testPutSiteSitePageWidgetInstanceWithNonexistentParentSectionId();
+		_testPutSiteSitePageWidgetInstanceWithUnregisteredWidget();
 	}
 
 	@Override
@@ -312,6 +314,32 @@ public class WidgetPageWidgetInstanceResourceTest
 		assertValid(patchWidgetPageWidgetInstance);
 	}
 
+	private void _testPatchSiteSitePageWidgetInstanceWithNonexistentParentSectionId()
+		throws Exception {
+
+		WidgetPageWidgetInstance widgetPageWidgetInstance =
+			testPostSiteSitePageWidgetInstance_addWidgetPageWidgetInstance(
+				randomWidgetPageWidgetInstance());
+
+		String portletId = PortletIdCodec.encode(
+			widgetPageWidgetInstance.getWidgetName(),
+			widgetPageWidgetInstance.getWidgetInstanceId());
+
+		String parentSectionId = RandomTestUtil.randomString();
+
+		widgetPageWidgetInstance.setParentSectionId(parentSectionId);
+
+		_assertProblemException(
+			"BAD_REQUEST",
+			"The widget page section " + parentSectionId + " does not exist",
+			() ->
+				widgetPageWidgetInstanceResource.
+					patchSiteSitePageWidgetInstance(
+						testGroup.getExternalReferenceCode(),
+						_layout.getExternalReferenceCode(), portletId,
+						widgetPageWidgetInstance));
+	}
+
 	private void _testPatchSiteSitePageWidgetInstanceWithNonexistentWidgetInstance()
 		throws Exception {
 
@@ -431,6 +459,37 @@ public class WidgetPageWidgetInstanceResourceTest
 		_assertProblemException(
 			"BAD_REQUEST",
 			"The widget page section " + parentSectionId + " does not exist",
+			() ->
+				widgetPageWidgetInstanceResource.putSiteSitePageWidgetInstance(
+					testGroup.getExternalReferenceCode(),
+					_layout.getExternalReferenceCode(), portletId,
+					widgetPageWidgetInstance));
+	}
+
+	private void _testPutSiteSitePageWidgetInstanceWithUnregisteredWidget()
+		throws Exception {
+
+		String widgetInstanceId = RandomTestUtil.randomString();
+		String widgetName = "com_liferay_test_FakePortlet";
+
+		WidgetPageWidgetInstance widgetPageWidgetInstance =
+			new BasicWidgetPageWidgetInstance();
+
+		widgetPageWidgetInstance.setParentSectionId("column-1");
+		widgetPageWidgetInstance.setPosition(0);
+		widgetPageWidgetInstance.setType(
+			WidgetPageWidgetInstance.Type.BASIC_WIDGET_PAGE_WIDGET_INSTANCE);
+		widgetPageWidgetInstance.setWidgetInstanceId(widgetInstanceId);
+		widgetPageWidgetInstance.setWidgetName(widgetName);
+
+		String portletId = PortletIdCodec.encode(widgetName, widgetInstanceId);
+
+		_assertProblemException(
+			"BAD_REQUEST",
+			StringBundler.concat(
+				"The widget ", portletId,
+				" could not be added to the site page ",
+				_layout.getExternalReferenceCode()),
 			() ->
 				widgetPageWidgetInstanceResource.putSiteSitePageWidgetInstance(
 					testGroup.getExternalReferenceCode(),

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/WidgetPageWidgetInstanceResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/WidgetPageWidgetInstanceResourceTest.java
@@ -11,6 +11,8 @@ import com.liferay.headless.admin.site.client.dto.v1_0.BasicWidgetPageWidgetInst
 import com.liferay.headless.admin.site.client.dto.v1_0.WidgetPageWidgetInstance;
 import com.liferay.headless.admin.site.client.problem.Problem;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
@@ -76,19 +78,15 @@ public class WidgetPageWidgetInstanceResourceTest
 
 		Assert.assertFalse(layoutTypePortlet.hasPortletId(portletId));
 
-		try {
-			widgetPageWidgetInstanceResource.deleteSiteSitePageWidgetInstance(
-				testGroup.getExternalReferenceCode(),
-				_layout.getExternalReferenceCode(), portletId);
-
-			Assert.fail();
-		}
-		catch (Problem.ProblemException problemException) {
-			Problem problem = problemException.getProblem();
-
-			Assert.assertEquals("NOT_FOUND", problem.getStatus());
-			Assert.assertNull(problem.getTitle());
-		}
+		_assertProblemException(
+			"NOT_FOUND",
+			"No widget instance with external reference code \"" + portletId +
+				"\" exists in this site page",
+			() ->
+				widgetPageWidgetInstanceResource.
+					deleteSiteSitePageWidgetInstance(
+						testGroup.getExternalReferenceCode(),
+						_layout.getExternalReferenceCode(), portletId));
 	}
 
 	@Override
@@ -110,20 +108,23 @@ public class WidgetPageWidgetInstanceResourceTest
 		assertEquals(postWidgetPageWidgetInstance, getWidgetPageWidgetInstance);
 		assertValid(getWidgetPageWidgetInstance);
 
-		try {
-			widgetPageWidgetInstanceResource.getSiteSitePageWidgetInstance(
-				testGroup.getExternalReferenceCode(),
-				_layout.getExternalReferenceCode(),
-				RandomTestUtil.randomString());
+		String widgetInstanceExternalReferenceCode =
+			RandomTestUtil.randomString();
 
-			Assert.fail();
-		}
-		catch (Problem.ProblemException problemException) {
-			Problem problem = problemException.getProblem();
+		_assertProblemException(
+			"NOT_FOUND",
+			"No widget instance with external reference code \"" +
+				widgetInstanceExternalReferenceCode +
+					"\" exists in this site page",
+			() ->
+				widgetPageWidgetInstanceResource.getSiteSitePageWidgetInstance(
+					testGroup.getExternalReferenceCode(),
+					_layout.getExternalReferenceCode(),
+					widgetInstanceExternalReferenceCode));
 
-			Assert.assertEquals("NOT_FOUND", problem.getStatus());
-			Assert.assertNull(problem.getTitle());
-		}
+		_testGetSiteSitePageWidgetInstanceWithContentPage();
+
+		_testGetSiteSitePageWidgetInstanceWithNonexistentSitePage();
 	}
 
 	@Override
@@ -147,21 +148,21 @@ public class WidgetPageWidgetInstanceResourceTest
 			postWidgetPageWidgetInstance, patchWidgetPageWidgetInstance);
 		assertValid(patchWidgetPageWidgetInstance);
 
-		try {
-			widgetPageWidgetInstanceResource.patchSiteSitePageWidgetInstance(
-				testGroup.getExternalReferenceCode(),
-				_layout.getExternalReferenceCode(),
-				RandomTestUtil.randomString(),
-				randomWidgetPageWidgetInstance());
+		String widgetInstanceExternalReferenceCode =
+			RandomTestUtil.randomString();
 
-			Assert.fail();
-		}
-		catch (Problem.ProblemException problemException) {
-			Problem problem = problemException.getProblem();
-
-			Assert.assertEquals("NOT_FOUND", problem.getStatus());
-			Assert.assertNull(problem.getTitle());
-		}
+		_assertProblemException(
+			"NOT_FOUND",
+			"No widget instance with external reference code \"" +
+				widgetInstanceExternalReferenceCode +
+					"\" exists in this site page",
+			() ->
+				widgetPageWidgetInstanceResource.
+					patchSiteSitePageWidgetInstance(
+						testGroup.getExternalReferenceCode(),
+						_layout.getExternalReferenceCode(),
+						widgetInstanceExternalReferenceCode,
+						randomWidgetPageWidgetInstance()));
 	}
 
 	@Override
@@ -177,6 +178,10 @@ public class WidgetPageWidgetInstanceResourceTest
 		assertEquals(
 			randomWidgetPageWidgetInstance, postWidgetPageWidgetInstance);
 		assertValid(postWidgetPageWidgetInstance);
+
+		_testPostSiteSitePageWidgetInstanceWithNonexistentParentSectionId();
+
+		_testPostSiteSitePageWidgetInstanceWithUnregisteredWidget();
 	}
 
 	@Override
@@ -197,6 +202,8 @@ public class WidgetPageWidgetInstanceResourceTest
 
 		assertEquals(widgetPageWidgetInstance, putWidgetPageWidgetInstance);
 		assertValid(putWidgetPageWidgetInstance);
+
+		_testPutSiteSitePageWidgetInstanceWithNonexistentParentSectionId();
 	}
 
 	@Override
@@ -269,6 +276,131 @@ public class WidgetPageWidgetInstanceResourceTest
 		return widgetPageWidgetInstanceResource.postSiteSitePageWidgetInstance(
 			testGroup.getExternalReferenceCode(),
 			_layout.getExternalReferenceCode(), widgetPageWidgetInstance);
+	}
+
+	private void _assertProblemException(
+			String expectedStatus, String expectedTitle,
+			UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		try {
+			unsafeRunnable.run();
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals(expectedStatus, problem.getStatus());
+			Assert.assertEquals(expectedTitle, problem.getTitle());
+		}
+	}
+
+	private void _testGetSiteSitePageWidgetInstanceWithContentPage()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(testGroup);
+
+		_assertProblemException(
+			"BAD_REQUEST",
+			"The site page with external reference code \"" +
+				layout.getExternalReferenceCode() + "\" is not a widget page",
+			() ->
+				widgetPageWidgetInstanceResource.getSiteSitePageWidgetInstance(
+					testGroup.getExternalReferenceCode(),
+					layout.getExternalReferenceCode(),
+					RandomTestUtil.randomString()));
+	}
+
+	private void _testGetSiteSitePageWidgetInstanceWithNonexistentSitePage()
+		throws Exception {
+
+		String sitePageExternalReferenceCode = RandomTestUtil.randomString();
+
+		_assertProblemException(
+			"NOT_FOUND",
+			"No site page exists with the external reference code \"" +
+				sitePageExternalReferenceCode + "\"",
+			() ->
+				widgetPageWidgetInstanceResource.getSiteSitePageWidgetInstance(
+					testGroup.getExternalReferenceCode(),
+					sitePageExternalReferenceCode,
+					RandomTestUtil.randomString()));
+	}
+
+	private void _testPostSiteSitePageWidgetInstanceWithNonexistentParentSectionId()
+		throws Exception {
+
+		WidgetPageWidgetInstance widgetPageWidgetInstance =
+			randomWidgetPageWidgetInstance();
+
+		String parentSectionId = RandomTestUtil.randomString();
+
+		widgetPageWidgetInstance.setParentSectionId(parentSectionId);
+
+		_assertProblemException(
+			"BAD_REQUEST",
+			"The widget page section " + parentSectionId + " does not exist",
+			() ->
+				widgetPageWidgetInstanceResource.postSiteSitePageWidgetInstance(
+					testGroup.getExternalReferenceCode(),
+					_layout.getExternalReferenceCode(),
+					widgetPageWidgetInstance));
+	}
+
+	private void _testPostSiteSitePageWidgetInstanceWithUnregisteredWidget()
+		throws Exception {
+
+		String widgetInstanceId = RandomTestUtil.randomString();
+		String widgetName = "com_liferay_test_FakePortlet";
+
+		WidgetPageWidgetInstance widgetPageWidgetInstance =
+			new BasicWidgetPageWidgetInstance();
+
+		widgetPageWidgetInstance.setParentSectionId("column-1");
+		widgetPageWidgetInstance.setPosition(0);
+		widgetPageWidgetInstance.setType(
+			WidgetPageWidgetInstance.Type.BASIC_WIDGET_PAGE_WIDGET_INSTANCE);
+		widgetPageWidgetInstance.setWidgetInstanceId(widgetInstanceId);
+		widgetPageWidgetInstance.setWidgetName(widgetName);
+
+		_assertProblemException(
+			"BAD_REQUEST",
+			StringBundler.concat(
+				"The widget ",
+				PortletIdCodec.encode(widgetName, widgetInstanceId),
+				" could not be added to the site page ",
+				_layout.getExternalReferenceCode()),
+			() ->
+				widgetPageWidgetInstanceResource.postSiteSitePageWidgetInstance(
+					testGroup.getExternalReferenceCode(),
+					_layout.getExternalReferenceCode(),
+					widgetPageWidgetInstance));
+	}
+
+	private void _testPutSiteSitePageWidgetInstanceWithNonexistentParentSectionId()
+		throws Exception {
+
+		WidgetPageWidgetInstance widgetPageWidgetInstance =
+			testPostSiteSitePageWidgetInstance_addWidgetPageWidgetInstance(
+				randomWidgetPageWidgetInstance());
+
+		String portletId = PortletIdCodec.encode(
+			widgetPageWidgetInstance.getWidgetName(),
+			widgetPageWidgetInstance.getWidgetInstanceId());
+
+		String parentSectionId = RandomTestUtil.randomString();
+
+		widgetPageWidgetInstance.setParentSectionId(parentSectionId);
+
+		_assertProblemException(
+			"BAD_REQUEST",
+			"The widget page section " + parentSectionId + " does not exist",
+			() ->
+				widgetPageWidgetInstanceResource.putSiteSitePageWidgetInstance(
+					testGroup.getExternalReferenceCode(),
+					_layout.getExternalReferenceCode(), portletId,
+					widgetPageWidgetInstance));
 	}
 
 	private Layout _layout;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95020

## What Is Being Fixed

Failures on the widget-instance endpoints under `/sites/{siteExternalReferenceCode}/site-pages/{sitePageExternalReferenceCode}/widget-instances` were indistinguishable to a caller. Each of the five operations repeated the same site page lookup and guarded it with a bare `UnsupportedOperationException`, so a site page that does not exist and a site page that is not a widget page produced the same opaque response. A widget instance absent from the page threw `NoSuchPortletException`, which reached the client as a 404 with no title. A widget the portal declined to add threw a raw `PortalException`, surfacing as a 500 whose message carried internal identifiers — the plid and the user ID. A parent section that is not a column on the page was never validated, so it failed late through that same 500.

None of these responses were declared in the OpenAPI contract either.

## How It Is Being Fixed

The repeated lookup-and-guard block moves into `_getWidgetPageLayout`, which separates the two failures it was collapsing: a layout that does not resolve raises the new `NoSuchEntityException` for a 404, and a layout that resolves but is not a widget page raises an `IllegalArgumentException` for a 400. Testing `LayoutConstants.TYPE_PORTLET` rather than the runtime `LayoutType` subclass makes that distinction explicit. A widget instance absent from the page raises `NoSuchEntityException` with the parent entity set, yielding a 404 that names both the widget instance and the site page. The POST and PUT paths gained `_validateParentSectionId`, so an unknown section is rejected as a 400 before any write, and the failed add now reports the widget and the target site page rather than internal identifiers.

`NoSuchEntityException` carries the entity, the external reference code, and an optional parent entity as fields rather than only a preformatted string. That lets `NoSuchEntityExceptionProblemMapper` compose the response and keeps message construction out of the resource, so the same exception serves both the "no site page with this external reference code" and the "no widget instance with this external reference code in this site page" cases.

The OpenAPI contract documents the 404 on every widget-instance operation, and `WidgetPageWidgetInstanceResourceTest` asserts the status and the message of each new response.

## PR Check

**pr-check: PASS** — tested on `bae7f8bcd8aafec9bbab0dacfccab0d3a3e7f7d0`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "bae7f8bcd8aafec9bbab0dacfccab0d3a3e7f7d0"} -->
