### PR TITLE
LPD-101044 Stamp the last import settings on a staging publish

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LastImportSettingsUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LastImportSettingsUtil.java
@@ -1,0 +1,45 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.admin.site.internal.resource.v1_0.util;
+
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+public class LastImportSettingsUtil {
+
+	public static Map<String, String> getLastImportSettingsMap(long userId) {
+		if (!ExportImportThreadLocal.isStagingInProcess() ||
+			!ExportImportThreadLocal.isLayoutImportInProcess()) {
+
+			return Collections.emptyMap();
+		}
+
+		User user = UserLocalServiceUtil.fetchUser(userId);
+
+		if (user == null) {
+			return HashMapBuilder.put(
+				"last-import-date", String.valueOf(System.currentTimeMillis())
+			).build();
+		}
+
+		return HashMapBuilder.put(
+			"last-import-date", String.valueOf(System.currentTimeMillis())
+		).put(
+			"last-import-user-name", user::getFullName
+		).put(
+			"last-import-user-uuid", user::getUuid
+		).build();
+	}
+
+}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LastImportSettingsUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LastImportSettingsUtil.java
@@ -19,8 +19,8 @@ import java.util.Map;
 public class LastImportSettingsUtil {
 
 	public static Map<String, String> getLastImportSettingsMap(long userId) {
-		if (!ExportImportThreadLocal.isStagingInProcess() ||
-			!ExportImportThreadLocal.isLayoutImportInProcess()) {
+		if (!ExportImportThreadLocal.isLayoutImportInProcess() ||
+			!ExportImportThreadLocal.isStagingInProcess()) {
 
 			return Collections.emptyMap();
 		}

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
@@ -432,6 +432,10 @@ public class LayoutUtil {
 			ServiceContext serviceContext)
 		throws Exception {
 
+		typeSettingsUnicodeProperties.putAll(
+			LastImportSettingsUtil.getLastImportSettingsMap(
+				serviceContext.getUserId()));
+
 		if (!Objects.equals(
 				typeSettingsUnicodeProperties,
 				layout.getTypeSettingsProperties())) {
@@ -549,6 +553,10 @@ public class LayoutUtil {
 		throws Exception {
 
 		_setExpandoBridgeAttributes(pageSpecification, serviceContext);
+
+		typeSettingsUnicodeProperties.putAll(
+			LastImportSettingsUtil.getLastImportSettingsMap(
+				serviceContext.getUserId()));
 
 		if (!Objects.equals(
 				typeSettingsUnicodeProperties,
@@ -1295,6 +1303,10 @@ public class LayoutUtil {
 
 		UnicodeProperties unicodeProperties =
 			layout.getTypeSettingsProperties();
+
+		unicodeProperties.putAll(
+			LastImportSettingsUtil.getLastImportSettingsMap(
+				serviceContext.getUserId()));
 
 		if (widgetPageSpecification == null) {
 			return LayoutServiceUtil.updateTypeSettings(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -131,6 +131,7 @@ import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -4586,6 +4587,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			serviceContext, SitePage.Type.PAGE_SET_PAGE);
 		_testPutSiteSitePageWithStagingImport(
 			serviceContext, SitePage.Type.WIDGET_PAGE);
+
+		_testPutSiteSitePageWithStagingImportByAnotherUser(serviceContext);
 	}
 
 	private void _testPutSiteSitePageWithStagingImport(
@@ -4649,6 +4652,58 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 				lastImportUser.getUuid(),
 				layout.getTypeSettingsProperty("last-import-user-uuid"));
 		}
+	}
+
+	private void _testPutSiteSitePageWithStagingImportByAnotherUser(
+			ServiceContext serviceContext)
+		throws Exception {
+
+		User user = UserTestUtil.addCompanyAdminUser(testCompany);
+
+		String password = RandomTestUtil.randomString();
+
+		_userLocalService.updatePassword(
+			user.getUserId(), password, password, false, true);
+
+		SitePageResource userSitePageResource = SitePageResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+
+		SitePage sitePage = sitePageResource.postSiteSitePage(
+			testGroup.getExternalReferenceCode(), false,
+			_getRandomSitePage(serviceContext, SitePage.Type.CONTENT_PAGE));
+
+		SitePage randomSitePage = _getRandomSitePage(serviceContext, sitePage);
+
+		try (SafeCloseable safeCloseable1 =
+				_setExportImportThreadLocalWithSafeCloseable(
+					"_layoutImportInProcess", true);
+			SafeCloseable safeCloseable2 =
+				_setExportImportThreadLocalWithSafeCloseable(
+					"_layoutStagingInProcess", true)) {
+
+			userSitePageResource.putSiteSitePage(
+				testGroup.getExternalReferenceCode(),
+				randomSitePage.getExternalReferenceCode(), false,
+				randomSitePage);
+		}
+
+		Layout layout = _layoutLocalService.getLayoutByExternalReferenceCode(
+			randomSitePage.getExternalReferenceCode(), testGroup.getGroupId());
+
+		Assert.assertEquals(TestPropsValues.getUserId(), layout.getUserId());
+		Assert.assertEquals(
+			user.getFullName(),
+			layout.getTypeSettingsProperty("last-import-user-name"));
+		Assert.assertEquals(
+			user.getUuid(),
+			layout.getTypeSettingsProperty("last-import-user-uuid"));
 	}
 
 	private void _testPutSiteSitePageWithWidgetPageSettings() throws Exception {
@@ -4913,5 +4968,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 	@Inject
 	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -16,6 +16,7 @@ import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.test.util.DLTestUtil;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.test.rule.LazyReferencingTestRule;
 import com.liferay.exportimport.test.util.LazyReferencingTestUtil;
 import com.liferay.fragment.constants.FragmentConstants;
@@ -107,6 +108,7 @@ import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.lang.CentralizedThreadLocal;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -129,6 +131,7 @@ import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -178,6 +181,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -434,7 +438,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		{
 			"LPD-72013", "LPD-74331", "LPD-75450", "LPD-77124", "LPD-77505",
 			"LPD-77576", "LPD-77852", "LPD-78667", "LPD-79415", "LPD-80061",
-			"LPD-81793", "LPD-83094", "LPD-97454"
+			"LPD-81793", "LPD-83094", "LPD-97454", "LPD-101044"
 		}
 	)
 	public void testPutSiteSitePage() throws Exception {
@@ -471,6 +475,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		_testPutSiteSitePageWithPageSpecifications();
 		_testPutSiteSitePageWithParentLayout();
 		_testPutSiteSitePageWithPriority();
+		_testPutSiteSitePageWithStagingImport(serviceContext);
 		_testPutSiteSitePageWithWidgetPageSettings();
 		_testPutSiteSitePageWithWidgetPageSettingsWithWidgetPageTemplate();
 
@@ -1755,6 +1760,16 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 	}
 
 	private SitePage _getRandomSitePage(
+			ServiceContext serviceContext, SitePage sitePage)
+		throws Exception {
+
+		return _getRandomSitePage(
+			sitePage.getExternalReferenceCode(),
+			sitePage.getParentSitePageExternalReferenceCode(), serviceContext,
+			sitePage.getType(), sitePage.getUuid());
+	}
+
+	private SitePage _getRandomSitePage(
 			ServiceContext serviceContext, SitePage.Type type)
 		throws Exception {
 
@@ -2109,6 +2124,29 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		}
 
 		return draftFragmentOrWidgetInstanceExternalReferenceCodes;
+	}
+
+	private SafeCloseable _setExportImportThreadLocalWithSafeCloseable(
+		String fieldName, boolean value) {
+
+		CentralizedThreadLocal<Boolean> originalCentralizedThreadLocal =
+			ReflectionTestUtil.getFieldValue(
+				ExportImportThreadLocal.class, fieldName);
+
+		Boolean originalValue = originalCentralizedThreadLocal.get();
+
+		originalCentralizedThreadLocal.set(value);
+
+		Supplier<Boolean> originalSupplier =
+			ReflectionTestUtil.getAndSetFieldValue(
+				originalCentralizedThreadLocal, "_supplier", () -> value);
+
+		return () -> {
+			originalCentralizedThreadLocal.set(originalValue);
+
+			ReflectionTestUtil.setFieldValue(
+				originalCentralizedThreadLocal, "_supplier", originalSupplier);
+		};
 	}
 
 	private void _testDeleteSiteSitePage(Layout... layouts) throws Exception {
@@ -4530,6 +4568,87 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 						testGroup.getGroupId()),
 					putSitePage);
 			});
+	}
+
+	private void _testPutSiteSitePageWithStagingImport(
+			ServiceContext serviceContext)
+		throws Exception {
+
+		_testPutSiteSitePageWithStagingImport(
+			serviceContext, SitePage.Type.CONTENT_PAGE);
+		_testPutSiteSitePageWithStagingImport(
+			serviceContext, SitePage.Type.EMBEDDED_PAGE);
+		_testPutSiteSitePageWithStagingImport(
+			serviceContext, SitePage.Type.LINK_TO_PAGE_PAGE);
+		_testPutSiteSitePageWithStagingImport(
+			serviceContext, SitePage.Type.LINK_TO_URL_PAGE);
+		_testPutSiteSitePageWithStagingImport(
+			serviceContext, SitePage.Type.PAGE_SET_PAGE);
+		_testPutSiteSitePageWithStagingImport(
+			serviceContext, SitePage.Type.WIDGET_PAGE);
+	}
+
+	private void _testPutSiteSitePageWithStagingImport(
+			ServiceContext serviceContext, SitePage.Type type)
+		throws Exception {
+
+		SitePage sitePage = sitePageResource.postSiteSitePage(
+			irrelevantGroup.getExternalReferenceCode(), false,
+			_getRandomSitePage(
+				ServiceContextTestUtil.getServiceContext(
+					irrelevantGroup, TestPropsValues.getUserId()),
+				type));
+
+		_testPutSiteSitePageWithStagingImport(
+			null, false, false, _getRandomSitePage(serviceContext, sitePage));
+		_testPutSiteSitePageWithStagingImport(
+			null, false, true, _getRandomSitePage(serviceContext, sitePage));
+		_testPutSiteSitePageWithStagingImport(
+			null, true, false, _getRandomSitePage(serviceContext, sitePage));
+		_testPutSiteSitePageWithStagingImport(
+			TestPropsValues.getUser(), true, true,
+			_getRandomSitePage(serviceContext, sitePage));
+	}
+
+	private void _testPutSiteSitePageWithStagingImport(
+			User lastImportUser, boolean layoutImportInProcess,
+			boolean layoutStagingInProcess, SitePage sitePage)
+		throws Exception {
+
+		try (SafeCloseable safeCloseable1 =
+				_setExportImportThreadLocalWithSafeCloseable(
+					"_layoutImportInProcess", layoutImportInProcess);
+			SafeCloseable safeCloseable2 =
+				_setExportImportThreadLocalWithSafeCloseable(
+					"_layoutStagingInProcess", layoutStagingInProcess)) {
+
+			_testPutSiteSitePage(sitePage, testGroup, sitePage);
+
+			Layout layout =
+				_layoutLocalService.getLayoutByExternalReferenceCode(
+					sitePage.getExternalReferenceCode(),
+					testGroup.getGroupId());
+
+			if (lastImportUser == null) {
+				Assert.assertNull(
+					layout.getTypeSettingsProperty("last-import-date"));
+				Assert.assertNull(
+					layout.getTypeSettingsProperty("last-import-user-name"));
+				Assert.assertNull(
+					layout.getTypeSettingsProperty("last-import-user-uuid"));
+
+				return;
+			}
+
+			Assert.assertNotNull(
+				layout.getTypeSettingsProperty("last-import-date"));
+			Assert.assertEquals(
+				lastImportUser.getFullName(),
+				layout.getTypeSettingsProperty("last-import-user-name"));
+			Assert.assertEquals(
+				lastImportUser.getUuid(),
+				layout.getTypeSettingsProperty("last-import-user-uuid"));
+		}
 	}
 
 	private void _testPutSiteSitePageWithWidgetPageSettings() throws Exception {

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -452,6 +452,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		_testPutSiteSitePage(true, serviceContext, SitePage.Type.CONTENT_PAGE);
 		_testPutSiteSitePage(true, serviceContext, SitePage.Type.WIDGET_PAGE);
 
+		_testPutSiteSitePageWithContentPageSpecification();
 		_testPutSiteSitePageWithDefaultAssetPublisher();
 		_testPutSiteSitePageWithEmptyLayout(serviceContext);
 		_testPutSiteSitePageWithExportedPageSetSitePageAsFirstPage(
@@ -470,7 +471,6 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		_testPutSiteSitePageWithPageSpecifications();
 		_testPutSiteSitePageWithParentLayout();
 		_testPutSiteSitePageWithPriority();
-		_testPutSiteSitePageWithContentPageSpecification();
 		_testPutSiteSitePageWithWidgetPageSettings();
 		_testPutSiteSitePageWithWidgetPageSettingsWithWidgetPageTemplate();
 


### PR DESCRIPTION
Supersedes https://github.com/liferay-page-management/liferay-portal/pull/18844 by @lfbesada, whose four commits are carried here unchanged and with her authorship.

Stamps `last-import-date`, `last-import-user-name`, and `last-import-user-uuid` onto a layout when a publish runs during staging, so the staging bar's "last published from" banner renders again. The banner regressed silently when publishing moved to the headless API and the old stamping was not carried over.

On top of her commits:

- **Sort the export import thread local checks** so the cheaper `isLayoutImportInProcess()` short-circuits first.
- **Assert the last import user is the publishing user.** A new `_testPutSiteSitePageWithStagingImportByAnotherUser` creates the page as the company admin and publishes as a second user, so the assertion fails if the code ever recorded the page author instead of the executing user. Her matrix is untouched and still runs on a single user. With one user the two are the same principal, so the assertion could not fail.

Reviewed with @lfbesada, who rejected a third commit (building the settings map once): with the early `return` only one map is built at runtime anyway, and the fluent `HashMapBuilder` form is the convention, 3527 uses against 16. It is not included.

Known gap, left deliberately and worth a separate decision: only the update paths stamp. `SitePageResourceImpl:551,573,586` builds type settings on the create branch without merging the map, while only `:1066,1083,1092` merges it, so a publish that creates a page on live leaves it unstamped.

**pr-check: PASS** — tested on `6a02fda08cc13b8e848f207b68029f6709d9354f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

`SitePageResourceTest.testPutSiteSitePage` passes: 368s, `tests="1" failures="0" errors="0"`.

<!-- pr-check {"result": "success", "sha": "6a02fda08cc13b8e848f207b68029f6709d9354f"} -->