### PR TITLE
LPD-101550 Preserve SVG sprite and accessibility attributes

### DIFF
--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryLinkModelListenerTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryLinkModelListenerTest.java
@@ -111,6 +111,7 @@ public class FragmentEntryLinkModelListenerTest {
 		_testAddFragmentEntryLinkDoesNotEscapeLinkFieldHTMLContent();
 		_testAddFragmentEntryLinkEscapeTextField();
 		_testAddFragmentEntryLinkPreservesInlineSVGInLinkField();
+		_testAddFragmentEntryLinkPreservesSpriteReferenceInLinkField();
 		_testAddFragmentEntryLinkSanitizesLinkFieldScriptContent();
 		_testAddFragmentEntryLinkSanitizesScriptInInlineSVGLinkField();
 		_testAddFragmentEntryLinkWithEmbeddedPortlet();
@@ -265,6 +266,31 @@ public class FragmentEntryLinkModelListenerTest {
 		Assert.assertTrue(editableValues, editableValues.contains("Read More"));
 	}
 
+	private void _testAddFragmentEntryLinkPreservesSpriteReferenceInLinkField()
+		throws Exception {
+
+		String hrefURL = "/o/classic-theme/images/clay/icons.svg#home";
+		String xlinkHrefURL =
+			"/o/classic-theme/images/clay/icons.svg#social-linkedin";
+
+		String editableFieldValue = StringBundler.concat(
+			"<svg viewBox=\"0 0 512 512\"><use href=\"", hrefURL,
+			"\"></use><use xlink:href=\"", xlinkHrefURL,
+			"\"></use></svg> Read More");
+
+		FragmentEntryLink fragmentEntryLink = _addFragmentEntryLink(
+			_fragmentCollectionContributorRegistry.getFragmentEntry(
+				"BASIC_COMPONENT-button"),
+			_createEditableValues("link", editableFieldValue), _serviceContext);
+
+		String editableValues = fragmentEntryLink.getEditableValues();
+
+		Assert.assertTrue(editableValues, editableValues.contains(hrefURL));
+		Assert.assertTrue(
+			editableValues, editableValues.contains(xlinkHrefURL));
+		Assert.assertTrue(editableValues, editableValues.contains("Read More"));
+	}
+
 	private void _testAddFragmentEntryLinkSanitizesLinkFieldScriptContent()
 		throws Exception {
 
@@ -290,13 +316,15 @@ public class FragmentEntryLinkModelListenerTest {
 	private void _testAddFragmentEntryLinkSanitizesScriptInInlineSVGLinkField()
 		throws Exception {
 
-		String expectedURL = "https://example.com/sprite#x";
+		String crossOriginURL = "https://example.com/sprite.svg#x";
+		String protocolRelativeURL = "//example.com/sprite.svg#x";
 
 		String editableFieldValue = StringBundler.concat(
 			"<svg onload=\"alert('xss');\" viewBox=\"0 0 24 24\">",
 			"<script>alert('xss');</script>",
 			"<foreignObject><script>alert('xss');</script></foreignObject>",
-			"<use href=\"", expectedURL, "\"></use>",
+			"<use href=\"", crossOriginURL, "\"></use><use xlink:href=\"",
+			protocolRelativeURL, "\"></use>",
 			"<path d=\"M12 2L2 7l10 5 10-5-10-5z\"></path></svg>");
 
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
@@ -317,7 +345,9 @@ public class FragmentEntryLinkModelListenerTest {
 			Assert.assertFalse(
 				editableValues, editableValues.contains("alert"));
 			Assert.assertFalse(
-				editableValues, editableValues.contains(expectedURL));
+				editableValues, editableValues.contains(crossOriginURL));
+			Assert.assertFalse(
+				editableValues, editableValues.contains(protocolRelativeURL));
 			Assert.assertFalse(
 				editableValues, editableValues.contains("onload"));
 			Assert.assertFalse(

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryLinkModelListenerTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryLinkModelListenerTest.java
@@ -112,6 +112,7 @@ public class FragmentEntryLinkModelListenerTest {
 		_testAddFragmentEntryLinkEscapeTextField();
 		_testAddFragmentEntryLinkPreservesInlineSVGInLinkField();
 		_testAddFragmentEntryLinkPreservesSpriteReferenceInLinkField();
+		_testAddFragmentEntryLinkPreservesSVGAccessibilityAttributes();
 		_testAddFragmentEntryLinkSanitizesLinkFieldScriptContent();
 		_testAddFragmentEntryLinkSanitizesScriptInInlineSVGLinkField();
 		_testAddFragmentEntryLinkWithEmbeddedPortlet();
@@ -273,15 +274,16 @@ public class FragmentEntryLinkModelListenerTest {
 		String xlinkHrefURL =
 			"/o/classic-theme/images/clay/icons.svg#social-linkedin";
 
-		String editableFieldValue = StringBundler.concat(
-			"<svg viewBox=\"0 0 512 512\"><use href=\"", hrefURL,
-			"\"></use><use xlink:href=\"", xlinkHrefURL,
-			"\"></use></svg> Read More");
-
 		FragmentEntryLink fragmentEntryLink = _addFragmentEntryLink(
 			_fragmentCollectionContributorRegistry.getFragmentEntry(
 				"BASIC_COMPONENT-button"),
-			_createEditableValues("link", editableFieldValue), _serviceContext);
+			_createEditableValues(
+				"link",
+				StringBundler.concat(
+					"<svg viewBox=\"0 0 512 512\"><use href=\"", hrefURL,
+					"\"></use><use xlink:href=\"", xlinkHrefURL,
+					"\"></use></svg> Read More")),
+			_serviceContext);
 
 		String editableValues = fragmentEntryLink.getEditableValues();
 
@@ -289,6 +291,28 @@ public class FragmentEntryLinkModelListenerTest {
 		Assert.assertTrue(
 			editableValues, editableValues.contains(xlinkHrefURL));
 		Assert.assertTrue(editableValues, editableValues.contains("Read More"));
+	}
+
+	private void _testAddFragmentEntryLinkPreservesSVGAccessibilityAttributes()
+		throws Exception {
+
+		FragmentEntryLink fragmentEntryLink = _addFragmentEntryLink(
+			_fragmentCollectionContributorRegistry.getFragmentEntry(
+				"BASIC_COMPONENT-button"),
+			_createEditableValues(
+				"link",
+				StringBundler.concat(
+					"<svg aria-hidden=\"true\" focusable=\"false\" ",
+					"role=\"presentation\" viewBox=\"0 0 24 24\">",
+					"<path d=\"M12 2L2 7l10 5 10-5-10-5z\"></path></svg>")),
+			_serviceContext);
+
+		String editableValues = fragmentEntryLink.getEditableValues();
+
+		Assert.assertTrue(
+			editableValues, editableValues.contains("aria-hidden"));
+		Assert.assertTrue(editableValues, editableValues.contains("focusable"));
+		Assert.assertTrue(editableValues, editableValues.contains("role="));
 	}
 
 	private void _testAddFragmentEntryLinkSanitizesLinkFieldScriptContent()

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryLinkModelListenerTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/model/listener/test/FragmentEntryLinkModelListenerTest.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -107,6 +108,7 @@ public class FragmentEntryLinkModelListenerTest {
 	}
 
 	@Test
+	@TestInfo({"LPD-97145", "LPD-101550"})
 	public void testAddFragmentEntryLink() throws Exception {
 		_testAddFragmentEntryLinkDoesNotEscapeLinkFieldHTMLContent();
 		_testAddFragmentEntryLinkEscapeTextField();
@@ -123,6 +125,7 @@ public class FragmentEntryLinkModelListenerTest {
 	}
 
 	@Test
+	@TestInfo("LPD-97145")
 	public void testUpdateFragmentEntryLink() throws Exception {
 		_testUpdateFragmentEntryLinkEscapeTextField();
 		_testUpdateFragmentEntryLinkWithHTMLField();

--- a/modules/apps/portal-security/portal-security-antisamy/build.gradle
+++ b/modules/apps/portal-security/portal-security-antisamy/build.gradle
@@ -1056,6 +1056,24 @@ private String _filterFragmentSanitizer(String line) {
 			|					<literal value="http://www.w3.org/1999/xlink"/>
 			|				</literal-list>
 			|			</attribute>
+			|			<attribute name="aria-hidden" onInvalid="removeAttribute">
+			|				<literal-list>
+			|					<literal value="false"/>
+			|					<literal value="true"/>
+			|				</literal-list>
+			|			</attribute>
+			|			<attribute name="focusable" onInvalid="removeAttribute">
+			|				<literal-list>
+			|					<literal value="auto"/>
+			|					<literal value="false"/>
+			|					<literal value="true"/>
+			|				</literal-list>
+			|			</attribute>
+			|			<attribute name="role" onInvalid="removeAttribute">
+			|				<regexp-list>
+			|					<regexp name="svgKeyword"/>
+			|				</regexp-list>
+			|			</attribute>
 			|			<attribute name="fill"/>
 			|			<attribute name="fill-opacity"/>
 			|			<attribute name="fill-rule"/>

--- a/modules/apps/portal-security/portal-security-antisamy/build.gradle
+++ b/modules/apps/portal-security/portal-security-antisamy/build.gradle
@@ -474,6 +474,7 @@ private String _filterFragmentSanitizer(String line) {
 			|		<regexp name="svgPaint" value="(none|currentColor|transparent|inherit|context-fill|context-stroke|#[0-9a-fA-F]{3,8}|rgba?\\([0-9,.\\s%]*\\)|hsla?\\([0-9,.\\s%]*\\)|url\\(\\s*#[a-zA-Z0-9\\-_:.]+\\s*\\)(\\s+(none|currentColor|#[0-9a-fA-F]{3,8}))?|[a-zA-Z]+)"/>
 			|		<regexp name="svgLocalRef" value="(none|url\\(\\s*#[a-zA-Z0-9\\-_:.]+\\s*\\))"/>
 			|		<regexp name="svgHrefLocal" value="#[a-zA-Z0-9\\-_:.]+"/>
+			|		<regexp name="svgHrefSameOrigin" value="(#[a-zA-Z0-9\\-_:.]+|/?[a-zA-Z0-9\\-_.][a-zA-Z0-9\\-_./]*\\.svg#[a-zA-Z0-9\\-_:.]+)"/>
 			|		<regexp name="svgKeyword" value="[a-zA-Z][a-zA-Z\\-]*"/>
 			|		<regexp name="svgPreserveAspectRatio" value="(none|x(Min|Mid|Max)Y(Min|Mid|Max))(\\s+(meet|slice))?"/>
 			|${line}""".stripMargin()
@@ -1321,10 +1322,14 @@ private String _filterFragmentSanitizer(String line) {
 			|			</attribute>
 			|			<attribute name="href" onInvalid="removeAttribute">
 			|				<regexp-list>
-			|					<regexp name="svgHrefLocal"/>
+			|					<regexp name="svgHrefSameOrigin"/>
 			|				</regexp-list>
 			|			</attribute>
-			|			<attribute name="xlink:href"/>
+			|			<attribute name="xlink:href" onInvalid="removeAttribute">
+			|				<regexp-list>
+			|					<regexp name="svgHrefSameOrigin"/>
+			|				</regexp-list>
+			|			</attribute>
 			|			<attribute name="fill"/>
 			|			<attribute name="fill-opacity"/>
 			|			<attribute name="fill-rule"/>

--- a/modules/apps/portal-security/portal-security-antisamy/src/main/resources/META-INF/resources/fragment-sanitizer-configuration.xml
+++ b/modules/apps/portal-security/portal-security-antisamy/src/main/resources/META-INF/resources/fragment-sanitizer-configuration.xml
@@ -125,6 +125,7 @@ http://www.w3.org/TR/html401/struct/global.html
 		<regexp name="svgPaint" value="(none|currentColor|transparent|inherit|context-fill|context-stroke|#[0-9a-fA-F]{3,8}|rgba?\([0-9,.\s%]*\)|hsla?\([0-9,.\s%]*\)|url\(\s*#[a-zA-Z0-9\-_:.]+\s*\)(\s+(none|currentColor|#[0-9a-fA-F]{3,8}))?|[a-zA-Z]+)"/>
 		<regexp name="svgLocalRef" value="(none|url\(\s*#[a-zA-Z0-9\-_:.]+\s*\))"/>
 		<regexp name="svgHrefLocal" value="#[a-zA-Z0-9\-_:.]+"/>
+		<regexp name="svgHrefSameOrigin" value="(#[a-zA-Z0-9\-_:.]+|/?[a-zA-Z0-9\-_.][a-zA-Z0-9\-_./]*\.svg#[a-zA-Z0-9\-_:.]+)"/>
 		<regexp name="svgKeyword" value="[a-zA-Z][a-zA-Z\-]*"/>
 		<regexp name="svgPreserveAspectRatio" value="(none|x(Min|Mid|Max)Y(Min|Mid|Max))(\s+(meet|slice))?"/>
 	</common-regexps>
@@ -1534,6 +1535,24 @@ http://www.w3.org/TR/html401/struct/global.html
 					<literal value="http://www.w3.org/1999/xlink"/>
 				</literal-list>
 			</attribute>
+			<attribute name="aria-hidden" onInvalid="removeAttribute">
+				<literal-list>
+					<literal value="false"/>
+					<literal value="true"/>
+				</literal-list>
+			</attribute>
+			<attribute name="focusable" onInvalid="removeAttribute">
+				<literal-list>
+					<literal value="auto"/>
+					<literal value="false"/>
+					<literal value="true"/>
+				</literal-list>
+			</attribute>
+			<attribute name="role" onInvalid="removeAttribute">
+				<regexp-list>
+					<regexp name="svgKeyword"/>
+				</regexp-list>
+			</attribute>
 			<attribute name="fill"/>
 			<attribute name="fill-opacity"/>
 			<attribute name="fill-rule"/>
@@ -1800,10 +1819,14 @@ http://www.w3.org/TR/html401/struct/global.html
 			</attribute>
 			<attribute name="href" onInvalid="removeAttribute">
 				<regexp-list>
-					<regexp name="svgHrefLocal"/>
+					<regexp name="svgHrefSameOrigin"/>
 				</regexp-list>
 			</attribute>
-			<attribute name="xlink:href"/>
+			<attribute name="xlink:href" onInvalid="removeAttribute">
+				<regexp-list>
+					<regexp name="svgHrefSameOrigin"/>
+				</regexp-list>
+			</attribute>
 			<attribute name="fill"/>
 			<attribute name="fill-opacity"/>
 			<attribute name="fill-rule"/>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101550

## What Is Being Fixed

An SVG icon that references a sprite through `<use xlink:href>` inside a `data-lfr-editable-type="link"` element renders in the Fragment editor preview but is invisible once the fragment is placed on a page. Reported by a customer as LPP-65113 and reproducible on master.

The fragment sanitizer policy gates `href` and `xlink:href` with the `svgHrefLocal` regexp, which only accepts a same-document `#id`. A Clay sprite reference is a same-origin path plus a fragment identifier, so it fails the regexp and `onInvalid="removeAttribute"` deletes the attribute. The `<use>` element survives with nothing to reference and draws nothing.

Merely dropping the fragment on a page is enough to trigger it: `EditableDefaultEditableValuesFragmentEntryProcessor` copies the editable element's inner HTML into `defaultValue`, `FragmentEntryLinkModelListener.onBeforeCreate` sanitizes it, and `FragmentEntryProcessorHelperImpl.getEditableValue` falls back to that sanitized value when rendering. The editor preview renders the raw fragment HTML, which is why the icon appears there.

A second defect surfaced while diagnosing the first: `role`, `aria-hidden` and `focusable` are stripped from `<svg>` because the generated SVG attribute allow-list never declared them. That is the markup the platform itself emits for every Clay icon, so a decorative icon was exposed to screen readers as an unlabeled graphic.

## How It Is Being Fixed

Both changes are made in `_filterFragmentSanitizer`, which generates the policy, and the regenerated policy is committed on its own.

A new `svgHrefSameOrigin` regexp accepts either a same-document `#id` or a scheme-less path ending in an SVG resource, and it is applied only to `<use>`. Its `xlink:href` needed a tag-local definition to override the common attribute. Cross-origin `<use>` references are blocked by browsers, so allowing a same-origin sprite path adds no XSS surface; absolute URLs, protocol-relative `//host` paths, and `javascript:` and `data:` values stay rejected, the last guarded by requiring a non-slash character after the leading slash. `<pattern>`, `<linearGradient>` and `<radialGradient>` keep `svgHrefLocal`, since their `href` is a same-document template reference where a sprite is meaningless.

The `<svg>` rule now declares `aria-hidden`, `focusable` and `role`, each with a closed set of valid values, so the SVG allow-list stays fully typed and an unexpected value still drops the attribute. `aria-label` and `aria-labelledby` are deliberately left out: they are not part of the decorative-icon markup, and `aria-label` is free text, which would be the only untyped attribute in the block.

Note for whoever picks this up for a hotfix: the sanitizer is destructive in the database, so editable values saved before the fix must be re-saved to recover the attribute.

## PR Check

**pr-check: PASS** — tested on `2afecaaa9d3ef6e4761826e05097e5493ac9d8ea`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "2afecaaa9d3ef6e4761826e05097e5493ac9d8ea"} -->
