### PR TITLE
LPD-101591 Configure the Select Related Content field before publishing

### DIFF
--- a/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/structureBuilder.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/structureBuilder.spec.ts
@@ -136,6 +136,11 @@ test(
 					picklist: picklist.name,
 				});
 			}
+			else if (type === 'Select Related Content') {
+				await structureBuilderPage.changeFieldSettings({
+					relatedContent: 'Basic Document',
+				});
+			}
 		}
 
 		// Publish the structure


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101591

## What Is Being Fixed

The Playwright test `Structures can be saved with all type of fields` started failing on the `[master] ci:test:cms` routine on 2026-08-05, timing out while waiting for the `published successfully` alert.

LPD-95548 added `Select Related Content` to the shared `FIELD_TYPES` constant in `StructureBuilderPage.ts` so its own specs could pass that value to `addField`. This test iterates `FIELD_TYPES`, so it began adding a Select Related Content field and leaving its mandatory Related Content setting empty, which correctly blocks Publish. The product behavior is right — `validateRelatedContent` has required `relatedStructureERC` since LPD-77584 — so the test was the thing out of date.

## How It Is Being Fixed

The test now configures the field, relating it to the built-in `Basic Document` structure, mirroring how the loop already configures the picklist field for `Select from List`. The `add-related-content` reducer selects the new child on insert, so `changeFieldSettings` applies to it directly without an extra `selectFields` call.

Configuring the field is preferable to dropping it from `FIELD_TYPES`, since it keeps the new field type inside the all-field-types coverage. Publish succeeding is itself proof the field was configured, because an empty `relatedStructureERC` blocks it.

## PR Check

**pr-check: PASS** — tested on `10f7940aa4e3d88051a870bea3ad3a4dabd4e418`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

Per-Module Compile and JavaScript Unit Tests matched their triggers but selected no work: `modules/test/playwright` has no `bnd.bnd`, so it deploys no bundle, and its only `test` script is `playwright test`, which is out of pr-check scope. The affected Playwright test was run separately and passed.

<!-- pr-check {"result": "success", "sha": "10f7940aa4e3d88051a870bea3ad3a4dabd4e418"} -->
