### PR TITLE
LPD-101781 Retry the Select File click until the file chooser opens

### DIFF
--- a/modules/test/playwright/tests/layout-content-page-editor-web/form-container/uploadInputFragments.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/form-container/uploadInputFragments.spec.ts
@@ -4,7 +4,7 @@
  */
 
 import {ObjectDefinitionAPI} from '@liferay/object-admin-rest-client-js';
-import {expect, mergeTests} from '@playwright/test';
+import {FileChooser, expect, mergeTests} from '@playwright/test';
 import path from 'path';
 
 import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
@@ -442,17 +442,23 @@ test.describe('File Upload Fragment', () => {
 
 			// Select file from computer
 
-			const fileChooserPromise = page.waitForEvent('filechooser');
-
 			const fileUploadInput = page.locator('.file-upload');
 
-			await fileUploadInput
-				.getByText('Select File', {exact: true})
-				.click();
+			let fileChooser: FileChooser;
 
-			const fileChooser = await fileChooserPromise;
+			await expect(async () => {
+				const fileChooserPromise = page.waitForEvent('filechooser', {
+					timeout: 1000,
+				});
 
-			await fileChooser.setFiles(
+				await fileUploadInput
+					.getByText('Select File', {exact: true})
+					.click({timeout: 1000});
+
+				fileChooser = await fileChooserPromise;
+			}).toPass();
+
+			await fileChooser!.setFiles(
 				path.join(
 					__dirname,
 					'../main/dependencies/file_upload_image_2.jpg'


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101781

## What Is Being Fixed

`File Upload Fragment › Upload file from computer` failed on `[master] ci:test:page-management` build 350 (`d2fe10b8`):

```
Error: page.waitForEvent: Test timeout of 90000ms exceeded.
waiting for event "filechooser"
```

The Select File control in the File Upload fragment is a plain `<button>`, not a `<label for>`, so it opens a file chooser only once the fragment's script attaches its click handler. That attachment happens inside `import('@liferay/fragment-impl/api').then(...)`, so until the dynamic import resolves, clicking the button does nothing at all. The test clicked once immediately after `page.goto` and then waited, so a click that landed early was silently lost and the wait could never be satisfied.

This is not a product regression. Nothing in the `9bc377c5..d2fe10b8` range touches the fragment or the spec, the handler-inside-import structure predates that range, and the case had failed once in 69 runs on the routine.

## How It Is Being Fixed

The click is now retried until the file chooser actually opens, using the `expect(async () => {...}).toPass()` form that `.claude/rules/playwright.md` prescribes for a click that can miss its handler after a navigation. Each attempt opens its own short `waitForEvent` window and passes an explicit timeout to both the wait and the click, so an attempt cycles in about a second instead of consuming Playwright's 30 second default; the enclosing `toPass()` is bounded by the project's 90 second test timeout.

The sibling test `Upload file from document library` already guards the same button this way through `clickAndExpectToBeVisible`, which is why it does not flake. That helper does not fit here because a native file chooser is not in the DOM, so there is no target Locator to poll and no way to hand the `FileChooser` back to the caller.

Verified by delaying only the `fragment-impl` module response by 10 seconds: before the change that reproduces the CI trace byte for byte on every run, and after it the test passes under the same delay. It also passes clean, and all 11 tests in the file pass.

## PR Check

**pr-check: PASS** — tested on `a5aa769fe733d3d05b98db6bb19821a7b548ab45`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

Source Format ran `ant setup-sdk` then `ant format-source-current-branch -Dvalidate.commit.messages=true`; the formatter reported no changes and the commit message validated, so no `SF` autocommit was needed.

Per-Module Compile ran its setup step (`ant compile install-portal-snapshots`, BUILD SUCCESSFUL). The deploy step produced no signal: `modules/test/playwright` carries no `.lfrbuild-portal` marker, so it is not a discovered Gradle project and `:test:playwright:deploy` does not exist.

JavaScript Unit Tests matched the diff but was trimmed by developer decision: that module's `test` script is `playwright test`, not Jest, so `npm test` would run the entire e2e suite. The changed test itself was executed directly 4 times, including once under an injected 10s delay of `@liferay/fragment-impl/api` that reproduces the CI failure 100% of the time without the fix.

<!-- pr-check {"result": "success", "sha": "a5aa769fe733d3d05b98db6bb19821a7b548ab45"} -->
