### PR TITLE
LPD-101671 Delete orphan FragmentEntryLinks on layout content update

### DIFF
--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
@@ -94,6 +94,7 @@ import com.liferay.segments.service.SegmentsExperienceLocalService;
 import com.liferay.sites.kernel.util.Sites;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -236,10 +237,20 @@ public class LayoutLocalServiceWrapper
 			TransactionInvokerUtil.invoke(
 				_transactionConfig,
 				() -> {
+					LayoutPageTemplateStructure layoutPageTemplateStructure =
+						_layoutPageTemplateStructureLocalService.
+							fetchLayoutPageTemplateStructure(
+								layout.getGroupId(), layout.getPlid());
+
+					String oldData = layoutPageTemplateStructure.getData(
+						segmentsExperienceId);
+
 					_layoutPageTemplateStructureLocalService.
 						updateLayoutPageTemplateStructureData(
 							user.getUserId(), layout.getGroupId(),
 							layout.getPlid(), segmentsExperienceId, data);
+
+					_deleteOrphanFragmentEntryLinks(oldData, data);
 
 					return null;
 				});
@@ -846,6 +857,28 @@ public class LayoutLocalServiceWrapper
 		}
 	}
 
+	private void _deleteOrphanFragmentEntryLinks(
+		String oldData, String newData) {
+
+		Set<Long> oldFragmentEntryLinkIds = _getFragmentEntryLinkIds(oldData);
+		Set<Long> newFragmentEntryLinkIds = _getFragmentEntryLinkIds(newData);
+
+		for (Long fragmentEntryLinkId : oldFragmentEntryLinkIds) {
+			if (newFragmentEntryLinkIds.contains(fragmentEntryLinkId)) {
+				continue;
+			}
+
+			FragmentEntryLink fragmentEntryLink =
+				_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+					fragmentEntryLinkId);
+
+			if (fragmentEntryLink != null) {
+				_fragmentEntryLinkLocalService.deleteFragmentEntryLink(
+					fragmentEntryLink);
+			}
+		}
+	}
+
 	private List<String> _deletePortletPermissions(
 			Layout layout, long[] segmentsExperiencesIds)
 		throws Exception {
@@ -887,6 +920,19 @@ public class LayoutLocalServiceWrapper
 		}
 
 		return null;
+	}
+
+	private Set<Long> _getFragmentEntryLinkIds(String data) {
+		if (Validator.isNull(data)) {
+			return Collections.emptySet();
+		}
+
+		LayoutStructure layoutStructure = LayoutStructure.of(data);
+
+		Map<Long, LayoutStructureItem> fragmentLayoutStructureItems =
+			layoutStructure.getFragmentLayoutStructureItems();
+
+		return fragmentLayoutStructureItems.keySet();
 	}
 
 	private Map<Long, FragmentEntryLink> _getFragmentEntryLinksMap(

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceTest.java
@@ -10,13 +10,17 @@ import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.service.FragmentCollectionLocalService;
+import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.fragment.service.FragmentEntryLocalService;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalServiceUtil;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.function.UnsafeBiFunction;
@@ -58,6 +62,7 @@ import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ScopeUtil;
@@ -892,6 +897,78 @@ public class LayoutLocalServiceTest {
 	}
 
 	@Test
+	@TestInfo("LPD-101671")
+	public void testUpdateLayoutContent() throws Exception {
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		long segmentsExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				draftLayout.getPlid());
+
+		FragmentEntryLink fragmentEntryLink1 =
+			ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+				"{}", draftLayout, segmentsExperienceId);
+		FragmentEntryLink fragmentEntryLink2 =
+			ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+				"{}", draftLayout, segmentsExperienceId);
+
+		_assertFragmentEntryLinks(
+			ListUtil.fromArray(fragmentEntryLink1, fragmentEntryLink2),
+			draftLayout, segmentsExperienceId);
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_layoutPageTemplateStructureLocalService.
+				fetchLayoutPageTemplateStructure(
+					draftLayout.getGroupId(), draftLayout.getPlid());
+
+		String data = layoutPageTemplateStructure.getData(segmentsExperienceId);
+
+		_layoutLocalService.updateLayoutContent(
+			data, draftLayout, segmentsExperienceId);
+
+		_assertFragmentEntryLinks(
+			ListUtil.fromArray(fragmentEntryLink1, fragmentEntryLink2),
+			draftLayout, segmentsExperienceId);
+
+		FragmentEntryLink orphanFragmentEntryLink =
+			ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+				"{}", draftLayout, segmentsExperienceId);
+
+		_assertFragmentEntryLinks(
+			ListUtil.fromArray(
+				fragmentEntryLink1, fragmentEntryLink2,
+				orphanFragmentEntryLink),
+			draftLayout, segmentsExperienceId);
+
+		_layoutLocalService.updateLayoutContent(
+			data, draftLayout, segmentsExperienceId);
+
+		_assertFragmentEntryLinks(
+			ListUtil.fromArray(fragmentEntryLink1, fragmentEntryLink2),
+			draftLayout, segmentsExperienceId);
+
+		Assert.assertNull(
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				orphanFragmentEntryLink.getFragmentEntryLinkId()));
+
+		FragmentEntryLink deletedFragmentEntryLink =
+			ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
+				"{}", draftLayout, segmentsExperienceId);
+
+		_fragmentEntryLinkLocalService.deleteFragmentEntryLink(
+			deletedFragmentEntryLink);
+
+		_layoutLocalService.updateLayoutContent(
+			data, draftLayout, segmentsExperienceId);
+
+		_assertFragmentEntryLinks(
+			ListUtil.fromArray(fragmentEntryLink1, fragmentEntryLink2),
+			draftLayout, segmentsExperienceId);
+	}
+
+	@Test
 	public void testUpdateLayoutWithEmptyDefaultFriendlyURLAndAnotherLocaleAdded()
 		throws Exception {
 
@@ -1210,6 +1287,24 @@ public class LayoutLocalServiceTest {
 					LayoutConstants.EXTERNAL_REFERENCE_CODE_SUFFIX_DEFAULT));
 	}
 
+	private void _assertFragmentEntryLinks(
+		List<FragmentEntryLink> fragmentEntryLinks, Layout layout,
+		long segmentsExperienceId) {
+
+		for (FragmentEntryLink actualFragmentEntryLink :
+				_fragmentEntryLinkLocalService.
+					getFragmentEntryLinksBySegmentsExperienceId(
+						layout.getGroupId(), segmentsExperienceId,
+						layout.getPlid(), false)) {
+
+			Assert.assertTrue(
+				fragmentEntryLinks.remove(actualFragmentEntryLink));
+		}
+
+		Assert.assertTrue(
+			fragmentEntryLinks.toString(), fragmentEntryLinks.isEmpty());
+	}
+
 	private void _assertSearch(
 			String keyword, String name, boolean searchOnlyByName, int count)
 		throws Exception {
@@ -1270,6 +1365,9 @@ public class LayoutLocalServiceTest {
 	private FragmentCollectionLocalService _fragmentCollectionLocalService;
 
 	@Inject
+	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
+
+	@Inject
 	private FragmentEntryLocalService _fragmentEntryLocalService;
 
 	@Inject
@@ -1284,6 +1382,10 @@ public class LayoutLocalServiceTest {
 	@Inject
 	private LayoutPageTemplateEntryLocalService
 		_layoutPageTemplateEntryLocalService;
+
+	@Inject
+	private LayoutPageTemplateStructureLocalService
+		_layoutPageTemplateStructureLocalService;
 
 	@Inject
 	private Portal _portal;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101671

## What Is Being Fixed

`LayoutLocalServiceWrapper.updateLayoutContent` replaced the layout's structure JSON without cleaning up the `FragmentEntryLink` rows the previous structure referenced. Fragments removed from the layout stayed in the database and remained returned by `FragmentEntryLinkLocalService` lookups, leaving orphan rows attached to the layout.

## How It Is Being Fixed

Reads the previous layout data before the update, extracts the fragment identifier set from both the old and the new structures, and deletes every `FragmentEntryLink` that was in the old set but not in the new one. Integration tests cover the no-op update (same structure), the orphan-cleanup case (a fragment removed from the structure), and the full-clear case (empty structure).

## PR Check

**pr-check: PASS** — tested on `01e72cd8a3a3022a7421c183abec15405072c106`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "01e72cd8a3a3022a7421c183abec15405072c106"} -->
