### PR TITLE
LPD-90026 Support restoring a previous page version from the UI

### DIFF
--- a/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/components/VersionHistory.tsx
+++ b/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/components/VersionHistory.tsx
@@ -115,6 +115,38 @@ export default function VersionHistory({config}: Props) {
 		}
 	};
 
+	const handleRestore = async (version: PageVersion) => {
+		if (!version.actions?.restore) {
+			return;
+		}
+
+		const confirmed = await openConfirmModal({
+			buttonLabel: Liferay.Language.get('restore'),
+			center: true,
+			status: 'warning',
+			text: Liferay.Language.get(
+				'you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost'
+			),
+			title: Liferay.Language.get('restore-version'),
+		});
+
+		if (!confirmed) {
+			return;
+		}
+
+		const {error} = await PageVersionService.restorePageVersion(
+			version.actions.restore.href
+		);
+
+		if (error) {
+			openToast({message: error, type: 'danger'});
+
+			return;
+		}
+
+		window.location.reload();
+	};
+
 	const keywords = search.trim().toLowerCase();
 
 	const matches = (...names: Array<string | undefined>) =>
@@ -150,6 +182,7 @@ export default function VersionHistory({config}: Props) {
 					<VersionList
 						items={items}
 						onDelete={handleDelete}
+						onRestore={handleRestore}
 						onSelect={setSelectedKey}
 						searching={Boolean(keywords)}
 						selectedKey={selectedKey}

--- a/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/components/VersionList.tsx
+++ b/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/components/VersionList.tsx
@@ -43,12 +43,14 @@ export type ListItem = {
 export default function VersionList({
 	items,
 	onDelete,
+	onRestore,
 	onSelect,
 	searching,
 	selectedKey,
 }: {
 	items: ListItem[];
 	onDelete?: (version: PageVersion) => void;
+	onRestore?: (version: PageVersion) => void;
 	onSelect: (key: string) => void;
 	searching: boolean;
 	selectedKey?: string;
@@ -93,7 +95,11 @@ export default function VersionList({
 
 				const {displayType, label} = STATUSES[status];
 
-				const actionItems = buildActionItems({onDelete, version});
+				const actionItems = buildActionItems({
+					onDelete,
+					onRestore,
+					version,
+				});
 
 				return (
 					<ClayList.Item
@@ -198,9 +204,11 @@ export default function VersionList({
 
 function buildActionItems({
 	onDelete,
+	onRestore,
 	version,
 }: {
 	onDelete?: (version: PageVersion) => void;
+	onRestore?: (version: PageVersion) => void;
 	version?: PageVersion;
 }) {
 	const items: ActionItems = [];
@@ -214,6 +222,18 @@ function buildActionItems({
 				onDelete?.(version);
 			},
 			symbolLeft: 'trash',
+		});
+	}
+
+	if (version?.actions?.restore) {
+		items.push({
+			label: Liferay.Language.get('restore-version'),
+			onClick: (event) => {
+				event.stopPropagation();
+
+				onRestore?.(version);
+			},
+			symbolLeft: 'undo',
 		});
 	}
 

--- a/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/services/ApiHelper.ts
+++ b/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/services/ApiHelper.ts
@@ -82,4 +82,18 @@ async function get<T>(url: string, signal?: AbortSignal) {
 	);
 }
 
-export default {del, get};
+async function post<T>(url: string, signal?: AbortSignal) {
+	return handleRequest<T>(() =>
+		fetch(url, {
+			headers: new Headers({
+				'Accept': 'application/json',
+				'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
+				'Content-Type': 'application/json',
+			}),
+			method: 'POST',
+			signal,
+		})
+	);
+}
+
+export default {del, get, post};

--- a/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/services/PageVersionService.ts
+++ b/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/services/PageVersionService.ts
@@ -32,4 +32,8 @@ async function getPageVersions(signal?: AbortSignal) {
 	};
 }
 
-export default {deletePageVersion, getPageVersions};
+async function restorePageVersion(url: string) {
+	return ApiHelper.post<void>(url);
+}
+
+export default {deletePageVersion, getPageVersions, restorePageVersion};

--- a/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/types/PageVersion.ts
+++ b/modules/apps/layout/layout-content-web/src/main/resources/META-INF/resources/js/types/PageVersion.ts
@@ -11,7 +11,7 @@ type Action = {
 };
 
 export type PageVersion = {
-	actions?: Partial<Record<'delete', Action>>;
+	actions?: Partial<Record<'delete' | 'restore', Action>>;
 	creator?: {
 		externalReferenceCode?: string;
 		image?: string;

--- a/modules/apps/layout/layout-content-web/test/js/components/VersionHistory.test.tsx
+++ b/modules/apps/layout/layout-content-web/test/js/components/VersionHistory.test.tsx
@@ -10,6 +10,7 @@ import {
 } from '@liferay/layout-js-components-web';
 import {render, screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {openToast} from 'frontend-js-components-web';
 import {fetch} from 'frontend-js-web';
 import React from 'react';
 
@@ -81,9 +82,18 @@ const DELETABLE_VERSIONS = [
 	VERSIONS[1],
 ];
 
+const RESTORABLE_VERSIONS = [
+	{
+		...VERSIONS[0],
+		actions: {restore: {href: '/restore/HOME_V_2', method: 'POST'}},
+	},
+	VERSIONS[1],
+];
+
 const mockFetch = fetch as jest.Mock;
 const mockHideProductMenu = hideProductMenuIfPresent as jest.Mock;
 const mockOpenConfirmModal = openConfirmModal as jest.Mock;
+const mockOpenToast = openToast as jest.Mock;
 const mockUseMediaQuery = useMediaQuery as jest.Mock;
 
 function mockLargeScreen() {
@@ -107,6 +117,12 @@ function queryCurrentItem() {
 	return document.querySelector('.lexicon-icon-sheets')?.closest('li');
 }
 
+async function openActions(item: HTMLElement) {
+	await userEvent.click(
+		within(item).getByRole('button', {name: 'show-options'})
+	);
+}
+
 function renderComponent({hasDraft = false} = {}) {
 	return render(
 		<VersionHistory
@@ -126,6 +142,18 @@ function renderComponent({hasDraft = false} = {}) {
 }
 
 describe('VersionHistory', () => {
+	const {location} = window;
+
+	beforeAll(() => {
+		delete (window as any).location;
+
+		(window as any).location = {...location, reload: jest.fn()};
+	});
+
+	afterAll(() => {
+		(window as any).location = location;
+	});
+
 	beforeEach(() => {
 		mockVersions([]);
 
@@ -546,5 +574,135 @@ describe('VersionHistory', () => {
 
 		expect(first).toBe(queryCurrentItem());
 		expect(first).toHaveClass('active');
+	});
+
+	it('only offers the restore action for versions with a restore action', async () => {
+		mockLargeScreen();
+		mockVersions(RESTORABLE_VERSIONS);
+
+		renderComponent();
+
+		await waitFor(() =>
+			expect(screen.getAllByRole('option')).toHaveLength(3)
+		);
+
+		const [current, restorable, notRestorable] =
+			screen.getAllByRole('option');
+
+		expect(
+			within(current).queryByRole('button', {name: 'show-options'})
+		).not.toBeInTheDocument();
+
+		expect(
+			within(notRestorable).queryByRole('button', {name: 'show-options'})
+		).not.toBeInTheDocument();
+
+		await openActions(restorable);
+
+		expect(
+			screen.getByRole('menuitem', {name: 'restore-version'})
+		).toBeInTheDocument();
+
+		expect(
+			screen.queryByRole('menuitem', {name: 'delete-version'})
+		).not.toBeInTheDocument();
+	});
+
+	it('restores the version once the confirmation is accepted', async () => {
+		mockLargeScreen();
+		mockVersions(RESTORABLE_VERSIONS);
+
+		renderComponent();
+
+		await waitFor(() =>
+			expect(screen.getAllByRole('option')).toHaveLength(3)
+		);
+
+		const [, restorable] = screen.getAllByRole('option');
+
+		await openActions(restorable);
+
+		await userEvent.click(
+			screen.getByRole('menuitem', {name: 'restore-version'})
+		);
+
+		expect(mockOpenConfirmModal).toHaveBeenCalledTimes(1);
+
+		await waitFor(() =>
+			expect(mockFetch).toHaveBeenCalledWith(
+				'/restore/HOME_V_2',
+				expect.objectContaining({method: 'POST'})
+			)
+		);
+	});
+
+	it('does not restore the version when the confirmation is dismissed', async () => {
+		mockLargeScreen();
+		mockVersions(RESTORABLE_VERSIONS);
+		mockOpenConfirmModal.mockResolvedValue(false);
+
+		renderComponent();
+
+		await waitFor(() =>
+			expect(screen.getAllByRole('option')).toHaveLength(3)
+		);
+
+		const [, restorable] = screen.getAllByRole('option');
+
+		await openActions(restorable);
+
+		await userEvent.click(
+			screen.getByRole('menuitem', {name: 'restore-version'})
+		);
+
+		await waitFor(() =>
+			expect(mockOpenConfirmModal).toHaveBeenCalledTimes(1)
+		);
+
+		expect(mockFetch).not.toHaveBeenCalledWith(
+			'/restore/HOME_V_2',
+			expect.anything()
+		);
+	});
+
+	it('shows an error toast when the restore fails', async () => {
+		mockLargeScreen();
+
+		mockFetch.mockImplementation((url: string) =>
+			Promise.resolve(
+				url === '/restore/HOME_V_2'
+					? {
+							json: () =>
+								Promise.resolve({title: 'restore-failed'}),
+							ok: false,
+						}
+					: {
+							json: () =>
+								Promise.resolve({items: RESTORABLE_VERSIONS}),
+							ok: true,
+						}
+			)
+		);
+
+		renderComponent();
+
+		await waitFor(() =>
+			expect(screen.getAllByRole('option')).toHaveLength(3)
+		);
+
+		const [, restorable] = screen.getAllByRole('option');
+
+		await openActions(restorable);
+
+		await userEvent.click(
+			screen.getByRole('menuitem', {name: 'restore-version'})
+		);
+
+		await waitFor(() =>
+			expect(mockOpenToast).toHaveBeenCalledWith({
+				message: 'restore-failed',
+				type: 'danger',
+			})
+		);
 	});
 });

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -25258,6 +25258,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue?
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue?
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore?
 you-are-already-unsubscribed=You are already unsubscribed.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=You are being redirected to an external editor to create this document.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=You are being redirected to an external editor to edit this document.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=أنت عل�
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=أنت على وشك حذف {0} بشكل نهائي. لا يمكن التراجع عن هذا الإجراء. هل تريد بالتأكيد الاستمرار؟
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=أنت على وشك إعادة حساب ملخص الطلب. لا يمكن التراجع عن هذا الإجراء. هل تريد بالتأكيد المتابعة؟
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=أنت على وشك الإبلاغ عن انتهاك {0} لدينا. جميع التقارير في غاية السرية.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=تم إلغاء اشتراكك بالفعل.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=ستتم إعادة توجيهك إلى محرر خارجي لإنشاء هذا المستند.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=ستتم إعادة توجيهك إلى محرر خارجي لتحرير هذا المستند.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Вече не сте се записал. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Вие сте пренасочени към външен редактор, за да създадете този документ. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Вие сте пренасочени към външен редактор, за да редактирате този документ. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -25254,6 +25254,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=va a realitz
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=Esteu a punt de suprimir permanentment "{0}". Aquesta acció no es pot desfer. Segur que voleu continuar?
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=Esteu a punt de recalcular el resum de la comanda. Aquesta acció no es pot desfer. Segur que voleu continuar?
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=Esteu a punt de denunciar una violació dels nostres {0}. Totes les denúncies són estrictament confidencials.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Ja us heu donat de baixa.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Se us està redirigint a un editor extern per crear aquest document.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Se us està redirigint a un editor extern per editar aquest document.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=You are already unsubscribed. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=You are being redirected to an external editor to create this document. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=You are being redirected to an external editor to edit this document. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Du er allerede afmeldt. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Du bliver omdirigeret til en ekstern editor for at oprette dette dokument. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Du bliver omdirigeret til en ekstern editor for at redigere dette dokument. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -25254,6 +25254,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Sie sind dab
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=Sie sind dabei, "{0}" dauerhaft zu löschen. Diese Aktion kann nicht rückgängig gemacht werden. Möchten Sie wirklich fortfahren?
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=Sie sind dabei, die Zusammenfassung der Bestellung neu zu berechnen. Dieser Vorgang kann nicht rückgängig gemacht werden. Möchten Sie wirklich fortfahren?
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=Sie sind dabei, einen Verstoß gegen unsere {0} zu melden. Alle Meldungen werden streng vertraulich behandelt.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Sie haben sich bereits abgemeldet.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Sie werden zur Bearbeitung dieses Dokuments zu einem externen Editor weitergeleitet.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Sie werden zur Bearbeitung dieses Dokuments zu einem externen Editor weitergeleitet.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
@@ -25254,6 +25254,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Sie sind dab
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=Sie sind dabei, "{0}" dauerhaft zu löschen. Diese Aktion kann nicht rückgängig gemacht werden. Möchten Sie wirklich fortfahren?
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=Sie sind dabei, die Zusammenfassung der Bestellung neu zu berechnen. Dieser Vorgang kann nicht rückgängig gemacht werden. Möchten Sie wirklich fortfahren?
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=Sie sind dabei, einen Verstoß gegen unsere {0} zu melden. Alle Meldungen werden streng vertraulich behandelt.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Sie haben sich bereits abgemeldet.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Sie werden zur Bearbeitung dieses Dokuments zu einem externen Editor weitergeleitet.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Sie werden zur Bearbeitung dieses Dokuments zu einem externen Editor weitergeleitet.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
@@ -25254,6 +25254,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Sie sind dab
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=Sie sind dabei, "{0}" dauerhaft zu löschen. Diese Aktion kann nicht rückgängig gemacht werden. Möchten Sie wirklich fortfahren?
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=Sie sind dabei, die Zusammenfassung der Bestellung neu zu berechnen. Dieser Vorgang kann nicht rückgängig gemacht werden. Möchten Sie wirklich fortfahren?
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=Sie sind dabei, einen Verstoß gegen unsere {0} zu melden. Alle Meldungen werden streng vertraulich behandelt.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Sie haben sich bereits abgemeldet.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Sie werden zur Bearbeitung dieses Dokuments zu einem externen Editor weitergeleitet.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Sie werden zur Bearbeitung dieses Dokuments zu einem externen Editor weitergeleitet.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Έχεις ήδη διαγραφεί. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Μπορείτε να ανακατευθυνθείτε σε ένα εξωτερικό πρόγραμμα επεξεργασίας για να δημιουργήσετε αυτό το έγγραφο. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Μπορείτε να ανακατευθυνθείτε σε ένα εξωτερικό πρόγραμμα επεξεργασίας για να επεξεργαστείτε αυτό το έγγραφο. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -25258,6 +25258,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue?
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue?
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore?
 you-are-already-unsubscribed=You are already unsubscribed.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=You are being redirected to an external editor to create this document.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=You are being redirected to an external editor to edit this document.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=You are already unsubscribed. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=You are being redirected to an external editor to create this document. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=You are being redirected to an external editor to edit this document. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=You are already unsubscribed. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=You are being redirected to an external editor to create this document. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=You are being redirected to an external editor to edit this document. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=You are already unsubscribed. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=You are being redirected to an external editor to create this document. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=You are being redirected to an external editor to edit this document. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_IE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_IE.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=You are already unsubscribed. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=You are being redirected to an external editor to create this document. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=You are being redirected to an external editor to edit this document. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -25254,6 +25254,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Está a punt
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=Está a punto de eliminar de forma permanente «{0}». Esta acción no se puede deshacer. ¿Seguro que quiere continuar?
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=Está a punto de recalcular el resumen del pedido. Esta acción no se puede deshacer. ¿Seguro que quiere continuar?
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=Va a denunciar una infracción de las {0}. Todas las denuncias son estrictamente confidenciales.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Su subscripción ya estaba cancelada.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Está siendo redirigido a un editor externo para crear este documento.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Está siendo redirigido a un editor externo para editar este documento.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -25254,6 +25254,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Está a punt
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=Está a punto de eliminar de forma permanente «{0}». Esta acción no se puede deshacer. ¿Seguro que quiere continuar?
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=Está a punto de recalcular el resumen del pedido. Esta acción no se puede deshacer. ¿Seguro que quiere continuar?
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=Va a denunciar una infracción de las {0}. Todas las denuncias son estrictamente confidenciales.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Su subscripción ya estaba cancelada.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Está siendo redirigido a un editor externo para crear este documento.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Está siendo redirigido a un editor externo para editar este documento.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -25254,6 +25254,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Está a punt
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=Está a punto de eliminar de forma permanente «{0}». Esta acción no se puede deshacer. ¿Seguro que quiere continuar?
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=Está a punto de recalcular el resumen del pedido. Esta acción no se puede deshacer. ¿Seguro que quiere continuar?
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=Va a denunciar una infracción de las {0}. Todas las denuncias son estrictamente confidenciales.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Su subscripción ya estaba cancelada.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Está siendo redirigido a un editor externo para crear este documento.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Está siendo redirigido a un editor externo para editar este documento.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -25254,6 +25254,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Está a punt
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=Está a punto de eliminar de forma permanente «{0}». Esta acción no se puede deshacer. ¿Seguro que quiere continuar?
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=Está a punto de recalcular el resumen del pedido. Esta acción no se puede deshacer. ¿Seguro que quiere continuar?
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=Va a denunciar una infracción de las {0}. Todas las denuncias son estrictamente confidenciales.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Su subscripción ya estaba cancelada.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Está siendo redirigido a un editor externo para crear este documento.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Está siendo redirigido a un editor externo para editar este documento.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Olete juba tellimata. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Selle dokumendi loomiseks suunatakse teid välisele redaktorile. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Dokumendi redigeerimiseks suunatakse teid välisele redaktorile. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=Gure {0}-(e)n urraketa baten berri ematera zoaz. Txosten guztiak erabat konfidentzialak dira.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=You are already unsubscribed. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=You are being redirected to an external editor to create this document. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=You are being redirected to an external editor to edit this document. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=شما تن�
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=تو قبلا ً لغو شدي. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=شما در حال هدایت به یک ویرایشگر خارجی برای ایجاد این سند هستید. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=شما در حال هدایت به یک ویرایشگر خارجی برای ویرایش این سند هستید. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -25250,6 +25250,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Olet tekemä
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=Olet poistamassa pysyvästi kohdetta {0}. Tätä toimintoa ei voi kumota. Haluatko varmasti jatkaa?
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=Olet laskemassa tilauksen yhteenvetoa uudelleen. Tätä toimintoa ei voi kumota. Haluatko varmasti jatkaa?
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=Olet raportoimassa {0} -rikkomuksen. Kaikki raportit ovat ehdottoman luottamuksellisia.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Olet jo peruuttanut tilauksen.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Sinut uudelleenohjataan ulkoiseen editoriin tämän asiakirjan luomiseksi.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Sinut uudelleenohjataan ulkoiseen editoriin tämän asiakirjan muokkaamiseksi.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -25254,6 +25254,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Vous êtes s
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=Vous êtes sur le point de supprimer définitivement « {0} ». Cette action est irréversible. Voulez-vous vraiment continuer ?
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=Vous êtes sur le point de recalculer le résumé de la commande. Cette action est irréversible. Voulez-vous vraiment continuer ?
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=Vous êtes sur le point d'enfreindre notre {0}. Tous les signalements restent strictement confidentiels.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Vous êtes déjà désabonné.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Vous êtes redirigé vers un éditeur externe pour créer ce document.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Vous êtes redirigé vers un éditeur externe pour éditer ce document.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
@@ -25254,6 +25254,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Vous êtes s
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=Vous êtes sur le point de supprimer définitivement « {0} ». Cette action est irréversible. Voulez-vous vraiment continuer ?
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=Vous êtes sur le point de recalculer le résumé de la commande. Cette action est irréversible. Voulez-vous vraiment continuer ?
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=Vous êtes sur le point d'enfreindre notre {0}. Tous les signalements restent strictement confidentiels.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Vous êtes déjà désabonné.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Vous êtes redirigé vers un éditeur externe pour créer ce document.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Vous êtes redirigé vers un éditeur externe pour éditer ce document.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Vous êtes s
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=Vous êtes sur le point d'enfreindre notre {0}. Tous les signalements restent strictement confidentiels.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Vous êtes déjà désabonné.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Vous êtes redirigé vers un éditeur externe pour créer ce document.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Vous êtes redirigé vers un éditeur externe pour éditer ce document.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
@@ -25254,6 +25254,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Vous êtes s
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=Vous êtes sur le point de supprimer définitivement « {0} ». Cette action est irréversible. Voulez-vous vraiment continuer ?
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=Vous êtes sur le point de recalculer le résumé de la commande. Cette action est irréversible. Voulez-vous vraiment continuer ?
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=Vous êtes sur le point d'enfreindre notre {0}. Tous les signalements restent strictement confidentiels.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Vous êtes déjà désabonné.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Vous êtes redirigé vers un éditeur externe pour créer ce document.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Vous êtes redirigé vers un éditeur externe pour éditer ce document.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Está a piqu
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=Está a piques de informar dunha violación do noso {0}. Todos os informes son estrictamente confidenciais.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Xa estás de baixa.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Está a ser redirixido a un editor externo para crear este documento.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Está a ser redirixido a un editor externo para editar este documento.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=आप प�
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=आप पहले से ही सदस्यता से बाहर हैं। (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=इस दस्तावेज़ को बनाने के लिए आपको बाहरी संपादक के पास रीडायरेक्ट किया जा रहा है। (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=इस दस्तावेज़ को संपादित करने के लिए आपको किसी बाहरी संपादक को पुनः निर्देशित किया जा रहा है. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=You are already unsubscribed. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=You are being redirected to an external editor to create this document. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=You are being redirected to an external editor to edit this document. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr_BA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr_BA.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=You are already unsubscribed. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=You are being redirected to an external editor to create this document. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=You are being redirected to an external editor to edit this document. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -25255,6 +25255,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Olyan válto
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=Véglegesen törli: "{0}". A művelet nem vonható vissza. Biztosan szeretné folytatni?
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=A rendelés összefoglalóját készül újraszámítani. A művelet nem vonható vissza. Biztosan szeretné folytatni?
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=Be kívánja jelenteni a {0} megsértését. Minden bejelentés szigorúan bizalmas.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Már leiratkozott.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=A dokumentum létrehozásához egy külső szerkesztőre irányítjuk.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=A dokumentum szerkesztéséhez egy külső szerkesztőre irányítjuk.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Anda sudah berhenti berlangganan. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Anda dialihkan ke editor eksternal untuk membuat dokumen ini. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Anda dialihkan ke editor eksternal untuk mengedit dokumen ini. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -25253,6 +25253,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Stai per app
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=Stai per segnalare una violazione del nostro {0}. Tutte le segnalazioni saranno strettamente confidenziali.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Hai già annullato l'iscrizione.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Si sta reindirizzando a un editor esterno per creare questo documento. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Si sta reindirizzando a un editor esterno per modificare questo documento. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
@@ -25254,6 +25254,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Stai per app
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=Stai per segnalare una violazione del nostro {0}. Tutte le segnalazioni saranno strettamente confidenziali.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Hai già annullato l'iscrizione.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Si sta reindirizzando a un editor esterno per creare questo documento. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Si sta reindirizzando a un editor esterno per modificare questo documento. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=אתה עו�
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=אתה עומד לדווח על הפרה של {0} שלנו. כל הדיווחים סודיים ביותר.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=כבר אינך מנוי.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=אתה מנותב מחדש לעורך חיצוני כדי ליצור מסמך זה. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=אתה מופנה למחולל תמלילים חיצוני לעריכת המסמך הזה.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -25254,6 +25254,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x={0}のカレ
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone="{0}" を完全に削除しようとしています。この操作は取り消せません。続行しますか？
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=注文概要を再計算しようとしています。この操作は取り消せません。続行しますか？
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential={0}違反を報告します。報告内容が公開されることはありません。
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=購読を解除しました。
 you-are-being-redirected-to-an-external-editor-to-create-this-document=このドキュメントを作成するため、外部のドキュメントにリダイレクトしています。
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=このドキュメントを編集するため、外部のドキュメントにリダイレクトしています。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=You are already unsubscribed. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=You are being redirected to an external editor to create this document. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=You are being redirected to an external editor to edit this document. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -25258,6 +25258,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=You are already unsubscribed.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=You are being redirected to an external editor to create this document.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=You are being redirected to an external editor to edit this document.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -25251,6 +25251,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=캘린더({0
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential={0} 위반을 신고하려고 합니다. 모든 보고서는 엄격하게 기밀로 유지됩니다.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=이미 구독이 취소되었습니다.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=이 문서를 만들기 위해 외부 편집자에게 리디렉션됩니다.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=이 문서를 편집하기 위해 외부 편집자로 리디렉션됩니다.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=ທ່ານ
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=ທ່ານກຳລັງຈະລຶບ "{0}" ແບບຖາວອນ. ການດຳເນີນການນີ້ບໍ່ສາມາດກັບຄືນໄດ້. ທ່ານແນ່ໃຈບໍ່ວ່າຕ້ອງການດຳເນີນການຕໍ່?
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=ທ່ານກຳລັງຈະຄິດໄລ່ສັງລວມລາຍການສັ່ງຊື້ຄືນໃໝ່. ການດຳເນີນການນີ້ບໍ່ສາມາດຍົກເລີກຄືນໄດ້. ທ່ານແນ່ໃຈຫຼືບໍ່ວ່າຕ້ອງການດຳເນີນການຕໍ່?
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=ທ່ານກຳລັງຈະລາຍງານການລະເມີດ {0} ຂອງພວກເຮົາ. ທຸກໆການລາຍງານຈະຖືກເກັບເປັນຄວາມລັບຢ່າງເຄັ່ງຄັດ.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=ທ່ານໄດ້ຍົກເລີກການຕິດຕາມແລ້ວ.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=ທ່ານກຳລັງຖືກປ່ຽນທິດທາງໄປຫາຕົວແກ້ໄຂພາຍນອກເພື່ອສ້າງເອກະສານນີ້.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=ທ່ານກຳລັງຖືກປ່ຽນທິດທາງໄປຫາຕົວແກ້ໄຂພາຍນອກເພື່ອແກ້ໄຂເອກະສານນີ້.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Jūs jau atsisakėte prenumeratos. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Norėdami sukurti šį dokumentą, būsite nukreipti į išorinį rengyklę. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Būsite nukreipti į išorinį rengyklę, kad galėtumėte redaguoti šį dokumentą. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=You are already unsubscribed. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=You are being redirected to an external editor to create this document. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=You are being redirected to an external editor to edit this document. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Anda sudah langganan. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Anda sedang diarahkan semula ke editor luaran untuk mencipta dokumen ini. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Anda sedang diarahkan semula ke editor luaran untuk mengedit dokumen ini. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_my.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_my.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=You are already unsubscribed. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=You are being redirected to an external editor to create this document. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=You are being redirected to an external editor to edit this document. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Du vil nå g
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=Du skal til å rapportere et brudd på vår {0}. Alle rapporter er strengt konfidensielle.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Du er allerede avmeldt. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Du blir omdirigert til en ekstern editor for å opprette dette dokumentet.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Du blir omdirigert til en ekstern editor for å redigere dette dokumentet.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -25255,6 +25255,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Deze wiijzin
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=U staat op het punt "{0}" definitief te verwijderen. Deze actie kan niet ongedaan worden gemaakt. Weet u zeker dat u wilt doorgaan?
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=U staat op het punt het besteloverzicht te herberekenen. Deze actie kan niet ongedaan worden gemaakt. Weet u zeker dat u wilt doorgaan?
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=U staat op het punt om een schending van onze {0} te melden. Alle meldingen zijn vertrouwelijk.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=U bent al uitgeschreven.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=U wordt omgeleid naar een externe editor om dit document te maken.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=U wordt omgeleid naar een externe editor om dit document te bewerken.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -25255,6 +25255,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Deze wiijzin
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=U staat op het punt "{0}" definitief te verwijderen. Deze actie kan niet ongedaan worden gemaakt. Weet u zeker dat u wilt doorgaan?
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=U staat op het punt het besteloverzicht te herberekenen. Deze actie kan niet ongedaan worden gemaakt. Weet u zeker dat u wilt doorgaan?
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=U staat op het punt om een schending van onze {0} te melden. Alle meldingen zijn vertrouwelijk.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=U bent al uitgeschreven.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=U wordt omgeleid naar een externe editor om dit document te maken.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=U wordt omgeleid naar een externe editor om dit document te bewerken.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Du vil nå g
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=Du skal til å rapportere et brudd på vår {0}. Alle rapporter er strengt konfidensielle.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Du er allerede avmeldt. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Du blir omdirigert til en ekstern editor for å opprette dette dokumentet.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Du blir omdirigert til en ekstern editor for å redigere dette dokumentet.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Jesteś już anulowany. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Użytkownik jest przekierowywany do edytora zewnętrznego w celu utworzenia tego dokumentu. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Użytkownik jest przekierowywany do edytora zewnętrznego w celu edycji tego dokumentu. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Você está 
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=Você está prestes a excluir permanentemente "{0}". Esta ação é irreversível. Tem certeza de que deseja continuar?
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=Você está prestes a recalcular o resumo do pedido. Esta ação não pode ser desfeita. Tem certeza de que deseja continuar?
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=Você está prestes a denunciar uma violência de nosso {0}. Todas as denuncias são confidências.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Você já está inscrito.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Você está sendo redirecionado para um editor externo para criar este documento.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Você está sendo redirecionado para um editor externo para editar este documento.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -25254,6 +25254,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Está preste
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=Você está prestes a excluir permanentemente "{0}". Esta ação é irreversível. Tem certeza de que deseja continuar?
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=Você está prestes a recalcular o resumo do pedido. Esta ação não pode ser desfeita. Tem certeza de que deseja continuar?
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=Você está prestes a denunciar uma violência de nosso {0}. Todas as denuncias são confidências.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Você já está inscrito.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Você está sendo redirecionado para um editor externo para criar este documento.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Você está sendo redirecionado para um editor externo para editar este documento.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Ești deja dezabonat. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Sunteți redirecționat către un editor extern pentru a crea acest document. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Sunteți redirecționat către un editor extern pentru a edita acest document. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Вы уже отписались. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Для создания этого документа вы перенаправляетесь во внешний редактор. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Для редактирования этого документа вы перенаправляетесь во внешний редактор. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Idete robiť
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Odber sa už odhlási. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Ste presmerovaní na externý editor na vytvorenie tohto dokumentu. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Ste presmerovaní na externý editor na úpravu tohto dokumentu. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Že zdaj si odjavnjena. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Če želite ustvariti ta dokument, boste preusmerjeni v zunanji urejevalnik. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Preusmerjeni ste v zunanji urejevalnik, da uredite ta dokument. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=You are already unsubscribed. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=You are being redirected to an external editor to create this document. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=You are being redirected to an external editor to edit this document. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=You are already unsubscribed. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=You are being redirected to an external editor to create this document. (Automatic Copy)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=You are being redirected to an external editor to edit this document. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=Du håller p
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=Du kommer att ta bort "{0}" permanent. Det går inte att ångra åtgärden. Vill du verkligen fortsätta?
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=Du kommer att räkna om ordersammanfattningen. Det går inte att ångra åtgärden. Vill du verkligen fortsätta?
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=Du kommer att anmäla en överträdelse av våra {0}. Alla anmälningar är strikt konfidentiella.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Du har redan avbrutit prenumerationen.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Du omdirigeras till ett externt redigeringsprogram för att skapa det här dokumentet.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Du omdirigeras till ett externt redigeringsprogram för att redigera det här dokumentet.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=உங்க
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=நீங்கள் எங்கள் {0} மீறலைப் பற்றி புகார் செய்கிறீர்கள். அனைத்து அறிக்கைகளும் கண்டிப்பாக ரகசியமாக உள்ளன.
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=நீங்கள் ஏற்கனவே unsubscribed செய்து இருக்கிறீர்கள்.
 you-are-being-redirected-to-an-external-editor-to-create-this-document=இந்த ஆவணத்தை உருவாக்க நீங்கள் External Editor-ற்கு ரீடைரக்ட் செய்யப்படுகின்றீர்கள்.
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=இந்த ஆவணத்தை திருத்த நீங்கள் External Editor-ற்கு ரீடைரக்ட் செய்யப்படுகின்றீர்கள்.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=การเ
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=คุณกำลังจะรายงานการละเมิด {0} ของเรา รายงานทั้งหมดเป็นความลับอย่างเคร่งครัด
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=คุณยกเลิกการสมัครแล้ว
 you-are-being-redirected-to-an-external-editor-to-create-this-document=คุณกำลังถูกนำไปยังโปรแกรมแก้ไขภายนอกเพื่อสร้างเอกสารนี้
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=คุณกำลังถูกนำไปยังโปรแกรมแก้ไขภายนอกเพื่อแก้ไขเอกสารนี้

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Zaten aboneliğiniz iptal edildi. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Bu belgeyi oluşturmak için harici bir düzenleyiciye yönlendiriliyorsunuz. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Bu belgeyi düzenlemek için harici bir düzenleyiciye yönlendiriliyorsunuz. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Ви вже відписані. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Ви перенаправлені до зовнішнього редактора для створення цього документа. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Ви перенаправлені до зовнішнього редактора для редагування цього документа. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -25252,6 +25252,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=You are abou
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=You are about to report a violation of our {0}. All reports are strictly confidential. (Automatic Copy)
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=Bạn đã hủy đăng ký. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-create-this-document=Bạn đang được chuyển hướng đến trình soạn thảo bên ngoài để tạo tài liệu này. (Automatic Translation)
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=Bạn đang được chuyển hướng đến một trình soạn thảo bên ngoài để chỉnh sửa tài liệu này. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -25254,6 +25254,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=您做出的
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=您即将永久删除"{0}"。此操作无法撤消。确定要继续吗？
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=您即将重新计算订单摘要。此操作无法撤消。确定要继续吗？
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=您即将举报违反我们 {0} 的行为。所有举报都将被严格保密。
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=您已经取消订阅。
 you-are-being-redirected-to-an-external-editor-to-create-this-document=您将重定向至外部编辑器来创建此文档。
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=您将重定向至外部编辑器来编辑此文档。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -25253,6 +25253,7 @@ you-are-about-to-make-changes-that-will-only-affect-your-calendar-x=您要進行
 you-are-about-to-permanently-delete-x-this-action-cannot-be-undone=You are about to permanently delete "{0}". This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-recalculate-the-order-summary-this-action-cannot-be-undone=You are about to recalculate the order summary. This action cannot be undone. Are you sure you want to continue? (Automatic Copy)
 you-are-about-to-report-a-violation-of-our-x.-all-reports-are-strictly-confidential=您即將舉報違反我們 {0} 的行為。 所有舉報都是嚴格保密的。
+you-are-about-to-restore-an-older-version-of-the-page.-all-your-unsaved-changes-will-be-lost=You are about to restore an older version of the page. All your unsaved changes will be lost. Do you want to restore? (Automatic Copy)
 you-are-already-unsubscribed=您已經取消訂閱。
 you-are-being-redirected-to-an-external-editor-to-create-this-document=將會重導向至外部編輯器以建立此文件。
 you-are-being-redirected-to-an-external-editor-to-edit-this-document=將會重導向至外部編輯器以編輯此文件。


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90026

## What Is Being Fixed

The version history panel of a content page listed every stored version and
allowed deleting them, but there was no way to go back to an older one. The
REST endpoint that restores a page specification version already exists, so the
capability was there but unreachable from the editor.

## How It Is Being Fixed

The service layer gains the missing piece first: `ApiHelper` learns to issue
`POST` requests, and `PageVersionService` exposes `restorePageVersion`, which
posts to the `restore` action href the backend advertises on each version. The
`PageVersion` type is widened accordingly, so the available actions drive what
the UI offers rather than the component guessing.

On top of that, `VersionList` renders a "Restore version" entry in the actions
menu of every version that carries a `restore` action, mirroring how the delete
action is already handled, and `VersionHistory` implements the handler. Because
restoring discards whatever is not saved yet, the handler asks for confirmation
before calling the service and surfaces a danger toast when the request fails.
Once the restore succeeds the page is reloaded, which is a provisional way of
picking up the restored content and is expected to be replaced once the editor
can refresh its state in place.

The confirmation copy is added as a new language key.

## PR Check

**pr-check: PASS** — tested on `6d4cb1ac6a105f7eaf2e63f981077382305070ed`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "6d4cb1ac6a105f7eaf2e63f981077382305070ed"} -->
