### PR TITLE
LPD-99742 Fix disappearing referenced structure field

### DIFF
--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
@@ -142,6 +142,7 @@ public class UpdateStructureStrutsActionTest {
 	public void testExecuteDeletesObjectRelationships() throws Exception {
 		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
 		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition();
+
 		_objectDefinition3 = ObjectDefinitionTestUtil.publishObjectDefinition();
 
 		com.liferay.object.model.ObjectRelationship objectRelationship1 =
@@ -279,7 +280,7 @@ public class UpdateStructureStrutsActionTest {
 			com.liferay.object.model.ObjectRelationship objectRelationship)
 		throws Exception {
 
-		com.liferay.object.model.ObjectRelationship nonEdgeObjectRelationship =
+		com.liferay.object.model.ObjectRelationship updatedObjectRelationship =
 			_objectRelationshipLocalService.updateObjectRelationship(
 				objectRelationship.getExternalReferenceCode(),
 				objectRelationship.getObjectRelationshipId(),
@@ -288,7 +289,7 @@ public class UpdateStructureStrutsActionTest {
 				objectRelationship.getLabelMap(), null);
 
 		_objectRelationshipLocalService.deleteObjectRelationship(
-			nonEdgeObjectRelationship);
+			updatedObjectRelationship);
 	}
 
 	private MockHttpServletRequest _getMockHttpServletRequest(

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
@@ -170,6 +170,129 @@ public class UpdateStructureStrutsActionTest {
 				objectRelationship.getObjectRelationshipId()));
 	}
 
+	@Test
+	@TestInfo("LPD-99742")
+	public void testExecuteDoesNotDeleteRelationshipWhenSavingReferencedStructure()
+		throws Exception {
+
+		// Mirrors buildObjectDefinition.ts's buildRelationships(), which is
+		// what a "Referenced Content Structure" field actually builds:
+		// objectDefinitionId1 is the structure that owns the field
+		// (_objectDefinition1), objectDefinitionId2 is the referenced/target
+		// structure (_objectDefinition2), and deletionType is cascade. This
+		// is the opposite side assignment from a plain, non-multiselect
+		// related-content field, which buildObjectRelationships.ts builds
+		// with objectDefinitionId1 as the referenced/target structure.
+
+		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
+		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		com.liferay.object.model.ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				null, TestPropsValues.getUserId(),
+				_objectDefinition1.getObjectDefinitionId(),
+				_objectDefinition2.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_CASCADE, true,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				StringUtil.randomId(), false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+
+		Assert.assertTrue(objectRelationship.isEdge());
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		// Simulate editing and republishing the referenced/target structure
+		// (_objectDefinition2), not the owner - exactly the LPD-99742 repro
+		// steps ("go to Edit mode in Referenced Structure and simply publish
+		// it again").
+
+		_updateStructureStrutsAction.execute(
+			_getMockHttpServletRequest(_objectDefinition2),
+			mockHttpServletResponse);
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject(
+			mockHttpServletResponse.getContentAsString());
+
+		Assert.assertEquals(jsonObject.toString(), 0, jsonObject.length());
+
+		Assert.assertNotNull(
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				objectRelationship.getObjectRelationshipId()));
+	}
+
+	@Test
+	@TestInfo("LPD-99742")
+	public void testExecuteRecreatesOwnedEdgeRelationshipWhenSavingOwner()
+		throws Exception {
+
+		// Mirrors buildObjectRelationships.ts's convention for a
+		// non-multiselect related-content field: objectDefinitionId1 is the
+		// referenced/target structure, objectDefinitionId2 is the owner.
+		// Saving the owner (_objectDefinition2) while resending this same
+		// relationship's name must still replace it with a fresh row, not
+		// leave the stale one in place.
+
+		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
+		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		String name = StringUtil.randomId();
+
+		com.liferay.object.model.ObjectRelationship objectRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				null, TestPropsValues.getUserId(),
+				_objectDefinition1.getObjectDefinitionId(),
+				_objectDefinition2.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE, true,
+				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+				name, false, ObjectRelationshipConstants.TYPE_ONE_TO_MANY,
+				null);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			(MockHttpServletRequest)_getMockHttpServletRequest(
+				_objectDefinition2);
+
+		mockHttpServletRequest.setParameter(
+			"objectRelationships",
+			JSONUtil.putAll(
+				JSONUtil.put(
+					"deletionType", "disassociate"
+				).put(
+					"edge", true
+				).put(
+					"name", name
+				).put(
+					"objectDefinitionExternalReferenceCode1",
+					_objectDefinition1.getExternalReferenceCode()
+				).put(
+					"objectDefinitionExternalReferenceCode2",
+					_objectDefinition2.getExternalReferenceCode()
+				).put(
+					"type", "oneToMany"
+				)
+			).toString());
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		_updateStructureStrutsAction.execute(
+			mockHttpServletRequest, mockHttpServletResponse);
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject(
+			mockHttpServletResponse.getContentAsString());
+
+		Assert.assertEquals(jsonObject.toString(), 0, jsonObject.length());
+
+		Assert.assertNull(
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				objectRelationship.getObjectRelationshipId()));
+
+		Assert.assertNotNull(
+			_objectRelationshipLocalService.
+				fetchObjectRelationshipByObjectDefinitionId(
+					_objectDefinition2.getObjectDefinitionId(), name));
+	}
+
 	private HttpServletRequest _getMockHttpServletRequest(
 			com.liferay.object.model.ObjectDefinition objectDefinition)
 		throws Exception {

--- a/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
+++ b/modules/apps/site/site-cms-site-initializer-test/src/testIntegration/java/com/liferay/site/cms/site/initializer/internal/struts/test/UpdateStructureStrutsActionTest.java
@@ -34,8 +34,6 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
-import jakarta.servlet.http.HttpServletRequest;
-
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -140,6 +138,92 @@ public class UpdateStructureStrutsActionTest {
 	}
 
 	@Test
+	@TestInfo("LPD-99742")
+	public void testExecuteDeletesObjectRelationships() throws Exception {
+		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
+		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition();
+		_objectDefinition3 = ObjectDefinitionTestUtil.publishObjectDefinition();
+
+		com.liferay.object.model.ObjectRelationship objectRelationship1 =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, _objectDefinition1,
+				_objectDefinition3,
+				ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE,
+				StringUtil.randomId(),
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		com.liferay.object.model.ObjectRelationship objectRelationship2 =
+			_addEdgeObjectRelationship(_objectDefinition1, _objectDefinition3);
+
+		com.liferay.object.model.ObjectRelationship objectRelationship3 =
+			_addEdgeObjectRelationship(_objectDefinition3, _objectDefinition2);
+
+		com.liferay.object.model.ObjectRelationship objectRelationship4 =
+			ObjectRelationshipTestUtil.addObjectRelationship(
+				_objectRelationshipLocalService, _objectDefinition1,
+				_objectDefinition3,
+				ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE,
+				StringUtil.randomId(),
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY);
+
+		String name = StringUtil.randomId();
+
+		MockHttpServletRequest mockHttpServletRequest =
+			_getMockHttpServletRequest(_objectDefinition3);
+
+		mockHttpServletRequest.setParameter(
+			"objectRelationships",
+			JSONUtil.putAll(
+				JSONUtil.put(
+					"deletionType",
+					ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE
+				).put(
+					"name", name
+				).put(
+					"objectDefinitionExternalReferenceCode1",
+					_objectDefinition2.getExternalReferenceCode()
+				).put(
+					"objectDefinitionExternalReferenceCode2",
+					_objectDefinition3.getExternalReferenceCode()
+				).put(
+					"type", ObjectRelationshipConstants.TYPE_ONE_TO_MANY
+				)
+			).toString());
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		_updateStructureStrutsAction.execute(
+			mockHttpServletRequest, mockHttpServletResponse);
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject(
+			mockHttpServletResponse.getContentAsString());
+
+		Assert.assertEquals(jsonObject.toString(), 0, jsonObject.length());
+
+		Assert.assertNull(
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				objectRelationship1.getObjectRelationshipId()));
+
+		Assert.assertNotNull(
+			_objectRelationshipLocalService.
+				fetchObjectRelationshipByObjectDefinitionId(
+					_objectDefinition3.getObjectDefinitionId(), name));
+		Assert.assertNotNull(
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				objectRelationship2.getObjectRelationshipId()));
+		Assert.assertNotNull(
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				objectRelationship4.getObjectRelationshipId()));
+		Assert.assertNotNull(
+			_objectRelationshipLocalService.fetchObjectRelationship(
+				objectRelationship3.getObjectRelationshipId()));
+
+		_deleteEdgeObjectRelationship(objectRelationship2);
+		_deleteEdgeObjectRelationship(objectRelationship3);
+	}
+
+	@Test
 	@TestInfo("LPD-92696")
 	public void testExecuteDoesNotDeleteObjectRelationships() throws Exception {
 		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
@@ -170,28 +254,17 @@ public class UpdateStructureStrutsActionTest {
 				objectRelationship.getObjectRelationshipId()));
 	}
 
-	@Test
-	@TestInfo("LPD-99742")
-	public void testExecuteDoesNotDeleteRelationshipWhenSavingReferencedStructure()
+	private com.liferay.object.model.ObjectRelationship
+			_addEdgeObjectRelationship(
+				com.liferay.object.model.ObjectDefinition objectDefinition1,
+				com.liferay.object.model.ObjectDefinition objectDefinition2)
 		throws Exception {
-
-		// Mirrors buildObjectDefinition.ts's buildRelationships(), which is
-		// what a "Referenced Content Structure" field actually builds:
-		// objectDefinitionId1 is the structure that owns the field
-		// (_objectDefinition1), objectDefinitionId2 is the referenced/target
-		// structure (_objectDefinition2), and deletionType is cascade. This
-		// is the opposite side assignment from a plain, non-multiselect
-		// related-content field, which buildObjectRelationships.ts builds
-		// with objectDefinitionId1 as the referenced/target structure.
-
-		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
-		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition();
 
 		com.liferay.object.model.ObjectRelationship objectRelationship =
 			_objectRelationshipLocalService.addObjectRelationship(
 				null, TestPropsValues.getUserId(),
-				_objectDefinition1.getObjectDefinitionId(),
-				_objectDefinition2.getObjectDefinitionId(), 0,
+				objectDefinition1.getObjectDefinitionId(),
+				objectDefinition2.getObjectDefinitionId(), 0,
 				ObjectRelationshipConstants.DELETION_TYPE_CASCADE, true,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 				StringUtil.randomId(), false,
@@ -199,101 +272,26 @@ public class UpdateStructureStrutsActionTest {
 
 		Assert.assertTrue(objectRelationship.isEdge());
 
-		MockHttpServletResponse mockHttpServletResponse =
-			new MockHttpServletResponse();
-
-		// Simulate editing and republishing the referenced/target structure
-		// (_objectDefinition2), not the owner - exactly the LPD-99742 repro
-		// steps ("go to Edit mode in Referenced Structure and simply publish
-		// it again").
-
-		_updateStructureStrutsAction.execute(
-			_getMockHttpServletRequest(_objectDefinition2),
-			mockHttpServletResponse);
-
-		JSONObject jsonObject = _jsonFactory.createJSONObject(
-			mockHttpServletResponse.getContentAsString());
-
-		Assert.assertEquals(jsonObject.toString(), 0, jsonObject.length());
-
-		Assert.assertNotNull(
-			_objectRelationshipLocalService.fetchObjectRelationship(
-				objectRelationship.getObjectRelationshipId()));
+		return objectRelationship;
 	}
 
-	@Test
-	@TestInfo("LPD-99742")
-	public void testExecuteRecreatesOwnedEdgeRelationshipWhenSavingOwner()
+	private void _deleteEdgeObjectRelationship(
+			com.liferay.object.model.ObjectRelationship objectRelationship)
 		throws Exception {
 
-		// Mirrors buildObjectRelationships.ts's convention for a
-		// non-multiselect related-content field: objectDefinitionId1 is the
-		// referenced/target structure, objectDefinitionId2 is the owner.
-		// Saving the owner (_objectDefinition2) while resending this same
-		// relationship's name must still replace it with a fresh row, not
-		// leave the stale one in place.
+		com.liferay.object.model.ObjectRelationship nonEdgeObjectRelationship =
+			_objectRelationshipLocalService.updateObjectRelationship(
+				objectRelationship.getExternalReferenceCode(),
+				objectRelationship.getObjectRelationshipId(),
+				objectRelationship.getParameterObjectFieldId(),
+				objectRelationship.getDeletionType(), false,
+				objectRelationship.getLabelMap(), null);
 
-		_objectDefinition1 = ObjectDefinitionTestUtil.publishObjectDefinition();
-		_objectDefinition2 = ObjectDefinitionTestUtil.publishObjectDefinition();
-
-		String name = StringUtil.randomId();
-
-		com.liferay.object.model.ObjectRelationship objectRelationship =
-			_objectRelationshipLocalService.addObjectRelationship(
-				null, TestPropsValues.getUserId(),
-				_objectDefinition1.getObjectDefinitionId(),
-				_objectDefinition2.getObjectDefinitionId(), 0,
-				ObjectRelationshipConstants.DELETION_TYPE_DISASSOCIATE, true,
-				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
-				name, false, ObjectRelationshipConstants.TYPE_ONE_TO_MANY,
-				null);
-
-		MockHttpServletRequest mockHttpServletRequest =
-			(MockHttpServletRequest)_getMockHttpServletRequest(
-				_objectDefinition2);
-
-		mockHttpServletRequest.setParameter(
-			"objectRelationships",
-			JSONUtil.putAll(
-				JSONUtil.put(
-					"deletionType", "disassociate"
-				).put(
-					"edge", true
-				).put(
-					"name", name
-				).put(
-					"objectDefinitionExternalReferenceCode1",
-					_objectDefinition1.getExternalReferenceCode()
-				).put(
-					"objectDefinitionExternalReferenceCode2",
-					_objectDefinition2.getExternalReferenceCode()
-				).put(
-					"type", "oneToMany"
-				)
-			).toString());
-
-		MockHttpServletResponse mockHttpServletResponse =
-			new MockHttpServletResponse();
-
-		_updateStructureStrutsAction.execute(
-			mockHttpServletRequest, mockHttpServletResponse);
-
-		JSONObject jsonObject = _jsonFactory.createJSONObject(
-			mockHttpServletResponse.getContentAsString());
-
-		Assert.assertEquals(jsonObject.toString(), 0, jsonObject.length());
-
-		Assert.assertNull(
-			_objectRelationshipLocalService.fetchObjectRelationship(
-				objectRelationship.getObjectRelationshipId()));
-
-		Assert.assertNotNull(
-			_objectRelationshipLocalService.
-				fetchObjectRelationshipByObjectDefinitionId(
-					_objectDefinition2.getObjectDefinitionId(), name));
+		_objectRelationshipLocalService.deleteObjectRelationship(
+			nonEdgeObjectRelationship);
 	}
 
-	private HttpServletRequest _getMockHttpServletRequest(
+	private MockHttpServletRequest _getMockHttpServletRequest(
 			com.liferay.object.model.ObjectDefinition objectDefinition)
 		throws Exception {
 
@@ -365,6 +363,9 @@ public class UpdateStructureStrutsActionTest {
 
 	@DeleteAfterTestRun
 	private com.liferay.object.model.ObjectDefinition _objectDefinition2;
+
+	@DeleteAfterTestRun
+	private com.liferay.object.model.ObjectDefinition _objectDefinition3;
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
@@ -38,9 +38,11 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 import org.osgi.service.component.annotations.Component;
@@ -120,8 +122,28 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 		return null;
 	}
 
-	private void _deleteRelationships(long objectDefinitionId)
+	private void _deleteRelationships(
+			long objectDefinitionId,
+			List<ObjectRelationship> objectRelationships)
 		throws Exception {
+
+		// Only relationships whose name is about to be recreated from
+		// objectRelationships are deleted here. A blanket delete of every
+		// edge where this structure is objectDefinitionId2 also catches
+		// relationships this structure never owns in the first place - a
+		// "Referenced Content Structure" field's edge has the *referenced*
+		// structure as objectDefinitionId2 (see buildObjectDefinition.ts's
+		// buildRelationships), so simply republishing the referenced
+		// structure with no changes of its own would otherwise delete the
+		// referencing structure's field, with nothing to recreate it, since
+		// that edge is never part of this structure's own
+		// objectRelationships.
+
+		Set<String> names = new HashSet<>();
+
+		for (ObjectRelationship objectRelationship : objectRelationships) {
+			names.add(objectRelationship.getName());
+		}
 
 		for (com.liferay.object.model.ObjectRelationship
 				serviceBuilderObjectRelationship :
@@ -129,7 +151,9 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 						getObjectRelationshipsByObjectDefinitionId2(
 							objectDefinitionId, true)) {
 
-			if (serviceBuilderObjectRelationship.isReverse()) {
+			if (serviceBuilderObjectRelationship.isReverse() ||
+				!names.contains(serviceBuilderObjectRelationship.getName())) {
+
 				continue;
 			}
 
@@ -408,7 +432,8 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 
 			if (serviceBuilderObjectDefinition != null) {
 				_deleteRelationships(
-					serviceBuilderObjectDefinition.getObjectDefinitionId());
+					serviceBuilderObjectDefinition.getObjectDefinitionId(),
+					_objectRelationships);
 			}
 
 			if (ListUtil.isNotEmpty(_objectRelationships)) {

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/struts/UpdateStructureStrutsAction.java
@@ -9,6 +9,7 @@ import com.liferay.object.admin.rest.dto.v1_0.ObjectDefinition;
 import com.liferay.object.admin.rest.dto.v1_0.ObjectRelationship;
 import com.liferay.object.admin.rest.resource.v1_0.ObjectDefinitionResource;
 import com.liferay.object.admin.rest.resource.v1_0.ObjectRelationshipResource;
+import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectDefinitionService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
@@ -38,11 +39,9 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Callable;
 
 import org.osgi.service.component.annotations.Component;
@@ -122,53 +121,20 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 		return null;
 	}
 
-	private void _deleteRelationships(
-			long objectDefinitionId,
-			List<ObjectRelationship> objectRelationships)
+	private void _deleteRelationships(long objectDefinitionId)
 		throws Exception {
-
-		// Only relationships whose name is about to be recreated from
-		// objectRelationships are deleted here. A blanket delete of every
-		// edge where this structure is objectDefinitionId2 also catches
-		// relationships this structure never owns in the first place - a
-		// "Referenced Content Structure" field's edge has the *referenced*
-		// structure as objectDefinitionId2 (see buildObjectDefinition.ts's
-		// buildRelationships), so simply republishing the referenced
-		// structure with no changes of its own would otherwise delete the
-		// referencing structure's field, with nothing to recreate it, since
-		// that edge is never part of this structure's own
-		// objectRelationships.
-
-		Set<String> names = new HashSet<>();
-
-		for (ObjectRelationship objectRelationship : objectRelationships) {
-			names.add(objectRelationship.getName());
-		}
 
 		for (com.liferay.object.model.ObjectRelationship
 				serviceBuilderObjectRelationship :
 					_objectRelationshipLocalService.
 						getObjectRelationshipsByObjectDefinitionId2(
-							objectDefinitionId, true)) {
+							objectDefinitionId, false)) {
 
 			if (serviceBuilderObjectRelationship.isReverse() ||
-				!names.contains(serviceBuilderObjectRelationship.getName())) {
+				!serviceBuilderObjectRelationship.compareType(
+					ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
 
 				continue;
-			}
-
-			if (serviceBuilderObjectRelationship.isEdge()) {
-				serviceBuilderObjectRelationship =
-					_objectRelationshipLocalService.updateObjectRelationship(
-						serviceBuilderObjectRelationship.
-							getExternalReferenceCode(),
-						serviceBuilderObjectRelationship.
-							getObjectRelationshipId(),
-						serviceBuilderObjectRelationship.
-							getParameterObjectFieldId(),
-						serviceBuilderObjectRelationship.getDeletionType(),
-						false, serviceBuilderObjectRelationship.getLabelMap(),
-						null);
 			}
 
 			_objectRelationshipLocalService.deleteObjectRelationship(
@@ -432,8 +398,7 @@ public class UpdateStructureStrutsAction implements StrutsAction {
 
 			if (serviceBuilderObjectDefinition != null) {
 				_deleteRelationships(
-					serviceBuilderObjectDefinition.getObjectDefinitionId(),
-					_objectRelationships);
+					serviceBuilderObjectDefinition.getObjectDefinitionId());
 			}
 
 			if (ListUtil.isNotEmpty(_objectRelationships)) {

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/contexts/StateContext.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/contexts/StateContext.tsx
@@ -74,6 +74,7 @@ export type State = {
 	invalids: Map<Uuid, ErrorMap>;
 	publishedChildren: Set<Uuid>;
 	renamingItemUuid: Uuid | null;
+	savedChildren: Set<Uuid>;
 	selection: Uuid[];
 	structure: Structure;
 	unsavedChanges: boolean;
@@ -91,6 +92,7 @@ const INITIAL_STATE: State = {
 	invalids: new Map(),
 	publishedChildren: new Set(),
 	renamingItemUuid: null,
+	savedChildren: new Set(),
 	selection: [],
 	structure: {
 		children: new Map(),
@@ -170,6 +172,8 @@ type RenameItemAction = {
 	type: 'rename-item';
 	uuid: Uuid;
 };
+
+type SaveStructureAction = {type: 'save-structure'};
 
 type SetRenamingItemUuidAction = {
 	type: 'set-renaming-item-uuid';
@@ -258,6 +262,7 @@ export type Action =
 	| PublishStructureAction
 	| RefreshReferencedStructuresAction
 	| RenameItemAction
+	| SaveStructureAction
 	| SetRenamingItemUuidAction
 	| SetSelectionAction
 	| SetStructureStatusAction
@@ -316,10 +321,11 @@ function reducer(state: State, action: Action): State {
 		case 'add-referenced-structures': {
 			const {referencedStructures} = action;
 
-			const {publishedChildren, structure} = state;
+			const {publishedChildren, savedChildren, structure} = state;
 
 			let children = new Map(structure.children);
 
+			let nextSavedChildren = new Set(savedChildren);
 			let nextPublishedChildren = new Set(publishedChildren);
 
 			let selection: State['selection'] = [];
@@ -333,9 +339,17 @@ function reducer(state: State, action: Action): State {
 					root: {...structure, children},
 				});
 
+				const referencedStructureChildrenUuids = getChildrenUuids({
+					root: referencedStructure,
+				});
+
+				nextSavedChildren = new Set([
+					...nextSavedChildren,
+					...referencedStructureChildrenUuids,
+				]);
 				nextPublishedChildren = new Set([
 					...nextPublishedChildren,
-					...getChildrenUuids({root: referencedStructure}),
+					...referencedStructureChildrenUuids,
 				]);
 
 				if (i === 0) {
@@ -348,6 +362,7 @@ function reducer(state: State, action: Action): State {
 			return {
 				...state,
 				publishedChildren: nextPublishedChildren,
+				savedChildren: nextSavedChildren,
 				selection,
 				structure: {...structure, children: sortedChildren},
 			};
@@ -371,7 +386,7 @@ function reducer(state: State, action: Action): State {
 			};
 		}
 		case 'add-repeatable-group': {
-			const {history, publishedChildren, structure} = state;
+			const {history, savedChildren, structure} = state;
 
 			const {uuids} = action;
 
@@ -391,7 +406,7 @@ function reducer(state: State, action: Action): State {
 			const deletedChildrenUuids = new Set<Uuid>();
 
 			for (const item of items) {
-				if (publishedChildren.has(item.uuid)) {
+				if (savedChildren.has(item.uuid)) {
 					deletedChildrenUuids.add(item.uuid);
 				}
 			}
@@ -402,7 +417,7 @@ function reducer(state: State, action: Action): State {
 					? updateHistory({
 							deletedChildrenUuids,
 							initialHistory: history,
-							publishedChildren,
+							savedChildren,
 							structure,
 						})
 					: history,
@@ -482,7 +497,7 @@ function reducer(state: State, action: Action): State {
 				history: updateHistory({
 					deletedChildrenUuids,
 					initialHistory: state.history,
-					publishedChildren: state.publishedChildren,
+					savedChildren: state.savedChildren,
 					structure,
 				}),
 				invalids,
@@ -538,7 +553,7 @@ function reducer(state: State, action: Action): State {
 		case 'move-children': {
 			const {items, targetUuid} = action;
 
-			const {history, publishedChildren, structure} = state;
+			const {history, savedChildren, structure} = state;
 
 			const children = moveChildren({
 				items,
@@ -549,7 +564,7 @@ function reducer(state: State, action: Action): State {
 			const deletedChildrenUuids = new Set<Uuid>();
 
 			for (const item of items) {
-				if (publishedChildren.has(item.uuid)) {
+				if (savedChildren.has(item.uuid)) {
 					deletedChildrenUuids.add(item.uuid);
 				}
 			}
@@ -560,7 +575,7 @@ function reducer(state: State, action: Action): State {
 					? updateHistory({
 							deletedChildrenUuids,
 							initialHistory: history,
-							publishedChildren,
+							savedChildren,
 							structure,
 						})
 					: history,
@@ -624,7 +639,22 @@ function reducer(state: State, action: Action): State {
 				history: INITIAL_STATE.history,
 				invalids: new Map(),
 				publishedChildren: getChildrenUuids({root: structure}),
+				savedChildren: getChildrenUuids({root: structure}),
 				structure: nextStructure,
+				unsavedChanges: false,
+			};
+		}
+		case 'save-structure': {
+			const {structure} = state;
+
+			return {
+				...state,
+				history: INITIAL_STATE.history,
+				savedChildren: getChildrenUuids({root: structure}),
+				structure: {
+					...structure,
+					status: 'draft' as Structure['status'],
+				},
 				unsavedChanges: false,
 			};
 		}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/actionGeneratesChanges.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/actionGeneratesChanges.ts
@@ -29,6 +29,7 @@ export default function actionGeneratesChanges(actionType: Action['type']) {
 		case 'create-structure':
 		case 'publish-structure':
 		case 'refresh-referenced-structures':
+		case 'save-structure':
 		case 'set-renaming-item-uuid':
 		case 'set-selection':
 		case 'set-structure-status':

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/buildState.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/buildState.ts
@@ -42,6 +42,7 @@ export default function buildState({
 				? getChildrenUuids({root: structure})
 				: new Set(),
 		renamingItemUuid: null,
+		savedChildren: getChildrenUuids({root: structure}),
 		selection: [],
 		structure,
 		unsavedChanges: false,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/handleSaveStructure.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/handleSaveStructure.ts
@@ -110,7 +110,7 @@ export default async function handleSaveStructure({
 			return;
 		}
 		else {
-			dispatch({status: 'draft', type: 'set-structure-status'});
+			dispatch({type: 'save-structure'});
 			dispatch({type: 'clear-errors'});
 		}
 	}

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/state/updateHistory.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/structure_builder/utils/state/updateHistory.ts
@@ -11,12 +11,12 @@ import findChild from '../findChild';
 export default function updateHistory({
 	deletedChildrenUuids,
 	initialHistory,
-	publishedChildren,
+	savedChildren,
 	structure,
 }: {
 	deletedChildrenUuids: Set<Uuid>;
 	initialHistory: State['history'];
-	publishedChildren: State['publishedChildren'];
+	savedChildren: State['savedChildren'];
 	structure: Structure;
 }) {
 	let nextHistory = {...initialHistory};
@@ -31,7 +31,7 @@ export default function updateHistory({
 			continue;
 		}
 
-		if (publishedChildren.has(deletedChildUuid)) {
+		if (savedChildren.has(deletedChildUuid)) {
 			nextHistory = {
 				...nextHistory,
 				deletedChildren: [...nextHistory.deletedChildren, child],

--- a/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/components/RelatedContentSettings.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/components/RelatedContentSettings.test.tsx
@@ -63,6 +63,7 @@ const DEFAULT_STATE: State = {
 	invalids: new Map(),
 	publishedChildren: new Set(),
 	renamingItemUuid: null,
+	savedChildren: new Set(),
 	selection: [],
 	structure: {
 		children: new Map([[RELATED_CONTENT_UUID, RELATED_CONTENT]]),

--- a/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/components/StructureFieldSettings.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/components/StructureFieldSettings.test.tsx
@@ -57,6 +57,7 @@ const DEFAULT_STATE: State = {
 	invalids: new Map(),
 	publishedChildren: new Set(),
 	renamingItemUuid: null,
+	savedChildren: new Set(),
 	selection: [],
 	structure: {
 		children: new Map([[TEXT_FIELD_UUID, FIELD]]),

--- a/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/contexts/StateContext.reducer.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/contexts/StateContext.reducer.test.tsx
@@ -15,6 +15,7 @@ import {
 	useStateDispatch,
 } from '../../../../src/main/resources/META-INF/resources/js/structure_builder/contexts/StateContext';
 import {
+	RelatedContent,
 	RepeatableGroup,
 	Structure,
 } from '../../../../src/main/resources/META-INF/resources/js/structure_builder/types/Structure';
@@ -22,6 +23,19 @@ import getUuid from '../../../../src/main/resources/META-INF/resources/js/struct
 
 const STRUCTURE_UUID = getUuid();
 const CHILD_UUID = getUuid();
+
+const RELATED_CONTENT_UUID = getUuid();
+
+const RELATED_CONTENT: RelatedContent = {
+	erc: 'related-content-erc',
+	label: {},
+	multiselection: false,
+	name: 'relatedContent',
+	parent: STRUCTURE_UUID,
+	relatedStructureERC: 'target-structure-erc',
+	type: 'related-content',
+	uuid: RELATED_CONTENT_UUID,
+};
 
 function buildInitialState({
 	childLabel,
@@ -317,5 +331,61 @@ describe('StateContext reducer — update-structure friendly URL', () => {
 		});
 
 		expect(refs.state!.structure.slug).toBe('product-categories');
+	});
+});
+
+describe('StateContext reducer — move-children', () => {
+	function buildStateWithRelatedContent(
+		savedChildren: State['savedChildren']
+	): State {
+		const state = buildInitialState({
+			childLabel: {},
+			structureLabel: {},
+		});
+
+		const children = new Map(state.structure.children);
+
+		children.set(RELATED_CONTENT_UUID, RELATED_CONTENT);
+
+		return {
+			...state,
+			savedChildren,
+			structure: {...state.structure, children},
+		};
+	}
+
+	it('Records the relationship of a saved but unpublished child moved into a group', () => {
+		const refs = renderWithState(
+			buildStateWithRelatedContent(new Set([RELATED_CONTENT_UUID]))
+		);
+
+		act(() => {
+			refs.dispatch!({
+				items: [RELATED_CONTENT],
+				targetUuid: CHILD_UUID,
+				type: 'move-children',
+			});
+		});
+
+		expect(refs.state!.history.deletedRelationships).toEqual([
+			{
+				relationshipERC: 'related-content-erc',
+				structureERC: 'target-structure-erc',
+			},
+		]);
+	});
+
+	it('Records nothing for a child that was never saved', () => {
+		const refs = renderWithState(buildStateWithRelatedContent(new Set()));
+
+		act(() => {
+			refs.dispatch!({
+				items: [RELATED_CONTENT],
+				targetUuid: CHILD_UUID,
+				type: 'move-children',
+			});
+		});
+
+		expect(refs.state!.history.deletedRelationships).toEqual([]);
 	});
 });

--- a/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/contexts/StateContext.reducer.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/contexts/StateContext.reducer.test.tsx
@@ -69,6 +69,7 @@ function buildInitialState({
 		invalids: new Map(),
 		publishedChildren: new Set(),
 		renamingItemUuid: null,
+		savedChildren: new Set(),
 		selection: [],
 		structure,
 		unsavedChanges: false,

--- a/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/contexts/StateContext.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/contexts/StateContext.test.tsx
@@ -63,6 +63,7 @@ function buildInitialState(child: StructureChild): State {
 		invalids: new Map(),
 		publishedChildren: new Set(),
 		renamingItemUuid: null,
+		savedChildren: new Set(),
 		selection: [],
 		structure: {
 			children,

--- a/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/mocks/MockStateProvider.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/mocks/MockStateProvider.tsx
@@ -42,6 +42,7 @@ const DEFAULT_STATE: State = {
 	invalids: new Map(),
 	publishedChildren: new Set(),
 	renamingItemUuid: null,
+	savedChildren: new Set(),
 	selection: [],
 	structure: DEFAULT_STRUCTURE,
 	unsavedChanges: false,

--- a/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/utils/buildState.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/utils/buildState.test.ts
@@ -117,6 +117,7 @@ describe('buildState', () => {
 			invalids: new Map(),
 			publishedChildren: new Set(),
 			renamingItemUuid: null,
+			savedChildren: new Set(),
 			selection: [],
 			structure,
 			unsavedChanges: false,
@@ -139,6 +140,7 @@ describe('buildState', () => {
 
 		const nextState = {
 			...initialState,
+			savedChildren: new Set(children.keys()),
 			structure: {
 				...structure,
 				children,
@@ -178,6 +180,7 @@ describe('buildState', () => {
 			invalids: new Map(),
 			publishedChildren: new Set(),
 			renamingItemUuid: null,
+			savedChildren: new Set(),
 			selection: [],
 			structure,
 			unsavedChanges: false,
@@ -203,11 +206,13 @@ describe('buildState', () => {
 
 		const {children, uuid} = result!.structure;
 
+		const savedChildren = new Set(children.keys());
 		const publishedChildren = new Set(children.keys());
 
 		const nextState = {
 			...initialState,
 			publishedChildren,
+			savedChildren,
 			structure: {
 				...structure,
 				children,
@@ -250,6 +255,7 @@ describe('buildState', () => {
 			invalids: new Map(),
 			publishedChildren: new Set(),
 			renamingItemUuid: null,
+			savedChildren: new Set(),
 			selection: [],
 			structure,
 			unsavedChanges: false,
@@ -276,11 +282,13 @@ describe('buildState', () => {
 
 		const {children, uuid} = result!.structure;
 
+		const savedChildren = new Set(children.keys());
 		const publishedChildren = new Set(children.keys());
 
 		const nextState = {
 			...initialState,
 			publishedChildren,
+			savedChildren,
 			structure: {
 				...structure,
 				children,

--- a/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/utils/handleSaveStructure.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/utils/handleSaveStructure.test.ts
@@ -49,7 +49,6 @@ it('resets the structure status to draft after a successful update save so the S
 	await handleSaveStructure({dispatch, state, validate: () => true});
 
 	expect(dispatch).toHaveBeenCalledWith({
-		status: 'draft',
-		type: 'set-structure-status',
+		type: 'save-structure',
 	});
 });

--- a/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/utils/state/updateHistory.test.ts
+++ b/modules/apps/site/site-cms-site-initializer/test/js/structure_builder/utils/state/updateHistory.test.ts
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {State} from '../../../../../src/main/resources/META-INF/resources/js/structure_builder/contexts/StateContext';
+import {
+	RelatedContent,
+	Structure,
+} from '../../../../../src/main/resources/META-INF/resources/js/structure_builder/types/Structure';
+import getUuid from '../../../../../src/main/resources/META-INF/resources/js/structure_builder/utils/getUuid';
+import updateHistory from '../../../../../src/main/resources/META-INF/resources/js/structure_builder/utils/state/updateHistory';
+
+const ROOT_UUID = getUuid();
+const RELATED_CONTENT_UUID = getUuid();
+
+const INITIAL_HISTORY: State['history'] = {
+	deletedChildren: [],
+	deletedGroupERCs: [],
+	deletedRelationships: [],
+	modifiedNames: new Set(),
+	modifiedSlugs: new Set(),
+};
+
+const RELATED_CONTENT: RelatedContent = {
+	erc: 'related-content-erc',
+	label: {},
+	multiselection: false,
+	name: 'relatedContent',
+	parent: ROOT_UUID,
+	relatedStructureERC: 'target-structure-erc',
+	type: 'related-content',
+	uuid: RELATED_CONTENT_UUID,
+};
+
+const STRUCTURE: Structure = {
+	children: new Map([[RELATED_CONTENT_UUID, RELATED_CONTENT]]),
+	erc: 'root-erc',
+	label: {},
+	name: 'Root',
+	path: '',
+	settings: {},
+	slug: '',
+	spaces: 'all',
+	status: 'draft',
+	system: false,
+	type: 'L_CMS_CONTENT_STRUCTURES',
+	uuid: ROOT_UUID,
+	workflows: {},
+};
+
+describe('updateHistory', () => {
+	it('Records the deleted relationship of a saved but unpublished child', () => {
+		const history = updateHistory({
+			deletedChildrenUuids: new Set([RELATED_CONTENT_UUID]),
+			initialHistory: INITIAL_HISTORY,
+			savedChildren: new Set([RELATED_CONTENT_UUID]),
+			structure: STRUCTURE,
+		});
+
+		expect(history.deletedRelationships).toEqual([
+			{
+				relationshipERC: 'related-content-erc',
+				structureERC: 'target-structure-erc',
+			},
+		]);
+		expect(history.deletedChildren).toEqual([RELATED_CONTENT]);
+	});
+
+	it('Records nothing for a child that was never saved', () => {
+		const history = updateHistory({
+			deletedChildrenUuids: new Set([RELATED_CONTENT_UUID]),
+			initialHistory: INITIAL_HISTORY,
+			savedChildren: new Set(),
+			structure: STRUCTURE,
+		});
+
+		expect(history.deletedChildren).toEqual([]);
+		expect(history.deletedRelationships).toEqual([]);
+	});
+});

--- a/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/pages/StructureBuilderPage.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/pages/StructureBuilderPage.ts
@@ -638,6 +638,25 @@ export class StructureBuilderPage {
 	async publishStructure() {
 		await this.publishButton.click();
 
+		// Publishing a change that may impact stored data, such as removing a
+		// field, raises a confirmation first
+
+		const confirmDialog = this.page.getByRole('dialog', {
+			name: 'Publish Content Structure Changes',
+		});
+
+		const successAlert = this.page
+			.locator('.alert-success')
+			.filter({hasText: 'published successfully'});
+
+		await expect(confirmDialog.or(successAlert)).toBeVisible({
+			timeout: 10000,
+		});
+
+		if (await confirmDialog.isVisible()) {
+			await confirmDialog.getByRole('button', {name: 'Publish'}).click();
+		}
+
 		await waitForAlert(this.page, 'published successfully', {
 			timeout: 10000,
 		});

--- a/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/relatedContent.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/structure-builder/relatedContent.spec.ts
@@ -70,3 +70,63 @@ test(
 		});
 	}
 );
+
+test(
+	'Removing a related content added before publishing deletes its relationship',
+	{
+		tag: '@LPD-99742',
+	},
+	async ({structureBuilderPage}) => {
+		const relatedLabel = getRandomString();
+		const relatedContentLabel = getRandomString();
+		const structureLabel = getRandomString();
+
+		// Publish the structure the related content will point at
+
+		await structureBuilderPage.createStructureFromData({
+			label: relatedLabel,
+			name: `StructureName${getRandomInt()}`,
+			page: structureBuilderPage,
+		});
+
+		// Add a related content and save without publishing
+
+		await structureBuilderPage.goToCreateStructure();
+
+		await structureBuilderPage.changeStructureSettings({
+			label: structureLabel,
+			name: `StructureName${getRandomInt()}`,
+		});
+
+		await structureBuilderPage.addRelatedContent(
+			relatedContentLabel,
+			relatedLabel
+		);
+
+		const id = await structureBuilderPage.saveStructure();
+
+		await structureBuilderPage.editStructure(id);
+
+		await expect(
+			structureBuilderPage.getTreeItem({
+				field: {label: relatedContentLabel},
+			})
+		).toBeVisible();
+
+		// Remove it and publish
+
+		await structureBuilderPage.deleteFields([{label: relatedContentLabel}]);
+
+		await structureBuilderPage.publishStructure();
+
+		// It must not come back from the relationship left behind
+
+		await structureBuilderPage.editStructure(id);
+
+		await expect(
+			structureBuilderPage.getTreeItem({
+				field: {label: relatedContentLabel},
+			})
+		).not.toBeVisible();
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99742

## What Is Being Fixed

A structure that is referenced by another one loses that reference when it is edited and republished. After the reload, the "Referenced Content Structure" field is gone from the referencing structure, with no error shown.

A second defect in the same area: a "Select Related Content" field added and saved before the structure is ever published comes back after being removed and published, because its relationship row is never deleted.

This branch keeps the two commits from #18843 at its base. Jan's analysis identified the root cause and the opposite side conventions between the two relationship builders; the commits on top change the approach rather than replace the diagnosis.

## How It Is Being Fixed

`UpdateStructureStrutsAction._deleteRelationships` runs a delete-then-recreate step, and the set it deletes has to match the set the next step re-posts. LPD-84614 flipped its finder from `edge=false` to `edge=true`, which pointed it at a different set entirely: every edge relationship whose target is the structure being saved. Those are the referenced content structure fields owned by *other* structures, and nothing recreates them. The same flip stopped it matching the select related content rows it actually exists to replace, since those are created non-edge. Scoping the query to non-edge `oneToMany` rows restores the pairing, leaves both multiselect directions alone, and never touches a relationship the structure does not own.

The frontend half is the tracking gate. `publishedChildren` answers whether a child was published, but pressing Save already creates the relationship rows and the repeatable group definitions, so a child saved before publishing exists server side while that set says it does not. Its removal was never recorded in `deletedObjectRelationships`, and since the LPD-92696 merge disabled the PUT diff for relationships, nothing else could delete it. A separate `savedChildren` set, seeded from everything read back at load and refreshed on save as well as publish, answers the question the backend actually asks, since it looks those rows up with `get` calls that throw when they are missing. `publishedChildren` keeps driving the five behaviours that genuinely are about publishing.

This supersedes #18866, which GitHub closed on a force push.

## PR Check

**pr-check: PASS** — tested on `5659a1fee43c4c8f94463e0ff4fc10ef49618e8e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5659a1fee43c4c8f94463e0ff4fc10ef49618e8e"} -->
