### PR TITLE
LPD-99950 Prevent page loss from duplicate layout reference codes

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutDuplicateExternalReferenceCodeUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/LayoutDuplicateExternalReferenceCodeUpgradeProcessTest.java
@@ -1,0 +1,273 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.upgrade.v7_4_x.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.change.tracking.test.util.BaseCTUpgradeProcessTestCase;
+import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.portal.db.index.IndexUpdaterUtil;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.IndexMetadata;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.change.tracking.CTModel;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.change.tracking.CTService;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.v7_4_x.LayoutDuplicateExternalReferenceCodeUpgradeProcess;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Georgel Pop
+ */
+@RunWith(Arquillian.class)
+public class LayoutDuplicateExternalReferenceCodeUpgradeProcessTest
+	extends BaseCTUpgradeProcessTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_connection = DataAccess.getConnection();
+
+		_dbInspector = new DBInspector(_connection);
+
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		try {
+			for (IndexMetadata indexMetadata : _indexMetadatas) {
+				if (!_dbInspector.hasIndex(
+						"Layout", indexMetadata.getIndexName())) {
+
+					IndexUpdaterUtil.updatePortalIndexes();
+
+					break;
+				}
+			}
+		}
+		finally {
+			DataAccess.cleanUp(_connection);
+		}
+	}
+
+	@Override
+	@Test
+	public void testMissingCtCollectionId() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				IndexUpdaterUtil.class.getName(), LoggerTestUtil.OFF)) {
+
+			super.testMissingCtCollectionId();
+		}
+	}
+
+	@Test
+	@TestInfo("LPD-99950")
+	public void testUpgrade() throws Exception {
+		String externalReferenceCode = PortalUUIDUtil.generate();
+
+		Layout renamedExternalReferenceCodeLayout1 = _addLayout(
+			_group, externalReferenceCode, false);
+		Layout renamedExternalReferenceCodeLayout2 = _addLayout(
+			_group, externalReferenceCode, true);
+		Layout keptExternalReferenceCodeLayout = _addLayout(
+			_group, externalReferenceCode, false);
+		Layout sharedExternalReferenceCodeLayout = _addLayout(
+			GroupTestUtil.addGroup(), externalReferenceCode, false);
+
+		Layout reservedExternalReferenceCodeLayout = _addLayout(
+			_group,
+			String.valueOf(renamedExternalReferenceCodeLayout1.getPlid()),
+			false);
+
+		String uniqueExternalReferenceCode = PortalUUIDUtil.generate();
+
+		Layout uniqueExternalReferenceCodeLayout = _addLayout(
+			_group, uniqueExternalReferenceCode, false);
+
+		long plid = CounterLocalServiceUtil.increment(Layout.class.getName());
+
+		runUpgrade();
+
+		Assert.assertEquals(
+			String.valueOf(plid + 1),
+			_getExternalReferenceCode(
+				renamedExternalReferenceCodeLayout1.getPlid()));
+		Assert.assertEquals(
+			String.valueOf(renamedExternalReferenceCodeLayout2.getPlid()),
+			_getExternalReferenceCode(
+				renamedExternalReferenceCodeLayout2.getPlid()));
+		Assert.assertEquals(
+			externalReferenceCode,
+			_getExternalReferenceCode(
+				keptExternalReferenceCodeLayout.getPlid()));
+		Assert.assertEquals(
+			String.valueOf(renamedExternalReferenceCodeLayout1.getPlid()),
+			_getExternalReferenceCode(
+				reservedExternalReferenceCodeLayout.getPlid()));
+		Assert.assertEquals(
+			externalReferenceCode,
+			_getExternalReferenceCode(
+				sharedExternalReferenceCodeLayout.getPlid()));
+		Assert.assertEquals(
+			uniqueExternalReferenceCode,
+			_getExternalReferenceCode(
+				uniqueExternalReferenceCodeLayout.getPlid()));
+
+		IndexUpdaterUtil.updatePortalIndexes();
+
+		for (IndexMetadata indexMetadata : _indexMetadatas) {
+			Assert.assertTrue(
+				_dbInspector.hasIndex("Layout", indexMetadata.getIndexName()));
+		}
+	}
+
+	@Override
+	protected CTModel<?> addCTModel() throws Exception {
+		String externalReferenceCode = PortalUUIDUtil.generate();
+
+		Layout layout = _addLayout(_group, externalReferenceCode, false);
+
+		_addLayout(_group, externalReferenceCode, true);
+
+		_entityCache.clearCache();
+		_multiVMPool.clear();
+
+		return _layoutLocalService.getLayout(layout.getPlid());
+	}
+
+	@Override
+	protected void deleteCTModel(long primaryKey) throws Exception {
+		_layoutLocalService.deleteLayout(
+			_layoutLocalService.getLayout(primaryKey));
+	}
+
+	@Override
+	protected CTService<?> getCTService() {
+		return _layoutLocalService;
+	}
+
+	@Override
+	protected void runUpgrade() throws Exception {
+		UpgradeProcess upgradeProcess =
+			new LayoutDuplicateExternalReferenceCodeUpgradeProcess();
+
+		upgradeProcess.upgrade();
+
+		_entityCache.clearCache();
+		_multiVMPool.clear();
+	}
+
+	@Override
+	protected CTModel<?> updateCTModel(CTModel<?> ctModel) throws Exception {
+		Layout layout = (Layout)ctModel;
+
+		layout.setPriority(RandomTestUtil.randomInt());
+
+		return _layoutLocalService.updateLayout(layout);
+	}
+
+	private Layout _addLayout(
+			Group group, String externalReferenceCode, boolean privateLayout)
+		throws Exception {
+
+		if (_indexMetadatas.isEmpty()) {
+			_indexMetadatas = _dropUniqueIndexes(
+				"Layout", "externalReferenceCode");
+		}
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(
+			group, privateLayout);
+
+		try (PreparedStatement preparedStatement = _connection.prepareStatement(
+				"update Layout set externalReferenceCode = ? where plid = ?")) {
+
+			preparedStatement.setString(1, externalReferenceCode);
+			preparedStatement.setLong(2, layout.getPlid());
+
+			preparedStatement.executeUpdate();
+		}
+
+		return layout;
+	}
+
+	private List<IndexMetadata> _dropUniqueIndexes(
+			String tableName, String columnName)
+		throws Exception {
+
+		DB db = DBManagerUtil.getDB();
+
+		List<IndexMetadata> indexMetadatas = db.getIndexMetadatas(
+			_connection, tableName, columnName, true);
+
+		for (IndexMetadata indexMetadata : indexMetadatas) {
+			db.runSQL(_connection, indexMetadata.getDropSQL());
+		}
+
+		return indexMetadatas;
+	}
+
+	private String _getExternalReferenceCode(long plid) throws Exception {
+		Layout layout = _layoutLocalService.getLayout(plid);
+
+		return layout.getExternalReferenceCode();
+	}
+
+	private Connection _connection;
+	private DBInspector _dbInspector;
+
+	@Inject
+	private EntityCache _entityCache;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private List<IndexMetadata> _indexMetadatas = Collections.emptyList();
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/LayoutDuplicateExternalReferenceCodeUpgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/LayoutDuplicateExternalReferenceCodeUpgradeProcess.java
@@ -1,0 +1,109 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.upgrade.v7_4_x;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Georgel Pop
+ */
+public class LayoutDuplicateExternalReferenceCodeUpgradeProcess
+	extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		Map<Long, Set<String>> externalReferenceCodesMap =
+			_getExternalReferenceCodesMap();
+
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+				StringBundler.concat(
+					"select distinct Layout1.externalReferenceCode, ",
+					"Layout1.plid, Layout1.groupId from Layout Layout1 inner ",
+					"join (select ctCollectionId, externalReferenceCode, ",
+					"groupId, max(plid) maxPlid from Layout group by ",
+					"ctCollectionId, externalReferenceCode, groupId having ",
+					"count(*) > 1) Layout2 on Layout2.ctCollectionId = ",
+					"Layout1.ctCollectionId and Layout2.externalReferenceCode ",
+					"= Layout1.externalReferenceCode and Layout2.groupId = ",
+					"Layout1.groupId where Layout1.plid != Layout2.maxPlid ",
+					"order by Layout1.plid"));
+
+			ResultSet resultSet = preparedStatement1.executeQuery();
+
+			PreparedStatement preparedStatement2 =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"update Layout set externalReferenceCode = ? where " +
+						"externalReferenceCode = ? and plid = ?")) {
+
+			while (resultSet.next()) {
+				long plid = resultSet.getLong("plid");
+
+				Set<String> externalReferenceCodes =
+					externalReferenceCodesMap.get(resultSet.getLong("groupId"));
+
+				String externalReferenceCode = String.valueOf(plid);
+
+				while (externalReferenceCodes.contains(externalReferenceCode)) {
+					externalReferenceCode = String.valueOf(
+						increment(Layout.class.getName()));
+				}
+
+				externalReferenceCodes.add(externalReferenceCode);
+
+				preparedStatement2.setString(1, externalReferenceCode);
+
+				preparedStatement2.setString(
+					2, resultSet.getString("externalReferenceCode"));
+				preparedStatement2.setLong(3, plid);
+
+				preparedStatement2.addBatch();
+			}
+
+			preparedStatement2.executeBatch();
+		}
+	}
+
+	private Map<Long, Set<String>> _getExternalReferenceCodesMap()
+		throws Exception {
+
+		Map<Long, Set<String>> externalReferenceCodesMap = new HashMap<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select Layout1.externalReferenceCode, Layout1.groupId ",
+					"from Layout Layout1 inner join (select distinct groupId ",
+					"from Layout group by ctCollectionId, ",
+					"externalReferenceCode, groupId having count(*) > 1) ",
+					"Layout2 on Layout2.groupId = Layout1.groupId"));
+
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				Set<String> externalReferenceCodes =
+					externalReferenceCodesMap.computeIfAbsent(
+						resultSet.getLong("groupId"), key -> new HashSet<>());
+
+				externalReferenceCodes.add(
+					resultSet.getString("externalReferenceCode"));
+			}
+		}
+
+		return externalReferenceCodesMap;
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -820,6 +820,10 @@ public class PortalUpgradeProcessRegistryImpl
 			UpgradeModulesFactory.create(
 				new String[] {"com.liferay.portal.security.audit.router"},
 				null));
+
+		upgradeVersionTreeMap.put(
+			new Version(38, 7, 8),
+			new LayoutDuplicateExternalReferenceCodeUpgradeProcess());
 	}
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99950

## What Is Being Fixed

Layouts propagated from a `layoutSetPrototype` reuse the source layout's `uuid_`, so a public and a private layout in the same group can share one. The `uuid_` index includes `privateLayout` but the external reference code index does not, so codes derived from that shared uuid collide within the group. Building the unique external reference code index then deletes every row of the duplicate group except the highest plid, which silently loses pages.

## How It Is Being Fixed

A new upgrade process rewrites the external reference code of the rows that are not the highest plid of their duplicate group, which is exactly the set the index cleaner would have deleted. Each such row takes its own plid as its new code, or a counter value when that plid is already in use as a code elsewhere in the group. The rewrite matches on `ctCollectionId` as well as group, so it also renames the row's copies in open publications and publishing a draft that contains one cannot reintroduce the duplicate.

The upgrade registers at `38.7.8`. LPD-98544 claimed `38.7.7` on master while this branch was in review, and `upgradeVersionTreeMap` is a `TreeMap`, so leaving both at the same key would have silently dropped one of the two upgrades.

An integration test drives the upgrade over six layouts covering each branch: the kept highest-plid row, a rename that takes its own plid, a rename forced onto the counter because another row in the group already holds that plid as its code, the same code in a second group that must not be touched, and a unique row inside a duplicate group. The counter case asserts the exact value the upgrade must take, read from the plid counter right before the run. It then rebuilds the unique external reference code index to prove no duplicate is left behind.

## PR Check

**pr-check: PASS** — tested on `782b5f83912a5b355c2c3f633ed16e4f9897eb38`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

Full Portal Build was not run. It matched only on a new self-contained `portal-impl` class and one added registry line, with no changed signature and no external consumer of the new type, and `portal-impl` is compiled by the Baseline and Per-Module Compile steps above.

<!-- pr-check {"result": "success", "sha": "782b5f83912a5b355c2c3f633ed16e4f9897eb38"} -->

