### PR TITLE
LPD-99652 Render the fragment usages with a missing layout and report them in the log

### DIFF
--- a/modules/apps/fragment/fragment-api/bnd.bnd
+++ b/modules/apps/fragment/fragment-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Fragment API
 Bundle-SymbolicName: com.liferay.fragment.api
-Bundle-Version: 62.2.1
+Bundle-Version: 62.3.0
 Export-Package:\
 	com.liferay.fragment.cache,\
 	com.liferay.fragment.configuration,\

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalService.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalService.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import java.io.Serializable;
 
 import java.util.List;
+import java.util.Map;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -466,6 +467,11 @@ public interface FragmentEntryLinkLocalService
 			int layoutPageTemplateType)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public Map<String, List<Long>> getMissingLayoutPlidsMap(
+			long fragmentCollectionId)
+		throws PortalException;
+
 	/**
 	 * Returns the OSGi service identifier.
 	 *
@@ -538,4 +544,4 @@ public interface FragmentEntryLinkLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1523302530
+// LIFERAY-SERVICE-BUILDER-HASH:2137562996

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceUtil.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceUtil.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import java.io.Serializable;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Provides the local service utility for FragmentEntryLink. This utility wraps
@@ -634,6 +635,13 @@ public class FragmentEntryLinkLocalServiceUtil {
 				groupId, fragmentEntry, layoutPageTemplateType);
 	}
 
+	public static Map<String, List<Long>> getMissingLayoutPlidsMap(
+			long fragmentCollectionId)
+		throws PortalException {
+
+		return getService().getMissingLayoutPlidsMap(fragmentCollectionId);
+	}
+
 	/**
 	 * Returns the OSGi service identifier.
 	 *
@@ -728,4 +736,4 @@ public class FragmentEntryLinkLocalServiceUtil {
 			FragmentEntryLinkLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1331238008
+// LIFERAY-SERVICE-BUILDER-HASH:1306778833

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceWrapper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceWrapper.java
@@ -726,6 +726,15 @@ public class FragmentEntryLinkLocalServiceWrapper
 				groupId, fragmentEntry, layoutPageTemplateType);
 	}
 
+	@Override
+	public java.util.Map<String, java.util.List<Long>> getMissingLayoutPlidsMap(
+			long fragmentCollectionId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _fragmentEntryLinkLocalService.getMissingLayoutPlidsMap(
+			fragmentCollectionId);
+	}
+
 	/**
 	 * Returns the OSGi service identifier.
 	 *
@@ -863,4 +872,4 @@ public class FragmentEntryLinkLocalServiceWrapper
 	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:564296629
+// LIFERAY-SERVICE-BUILDER-HASH:-1308641458

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
@@ -1,1 +1,1 @@
-version 17.1.0
+version 17.2.0

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -812,25 +812,30 @@ public class FragmentEntryLinkLocalServiceImpl
 			FragmentEntryLinkTable fragmentEntryLinkTable)
 		throws PortalException {
 
-		Group group = _groupLocalService.getGroup(fragmentEntry.getGroupId());
-
 		return fragmentEntryLinkTable.fragmentEntryERC.eq(
 			fragmentEntry.getExternalReferenceCode()
 		).and(
-			Predicate.withParentheses(
-				fragmentEntryLinkTable.fragmentEntryScopeERC.eq(
-					group.getExternalReferenceCode()
-				).or(
-					Predicate.withParentheses(
-						fragmentEntryLinkTable.fragmentEntryScopeERC.isNull(
-						).and(
-							fragmentEntryLinkTable.groupId.eq(
-								group.getGroupId())
-						))
-				))
+			_getFragmentEntryGroupScopePredicate(
+				fragmentEntryLinkTable,
+				_groupLocalService.getGroup(fragmentEntry.getGroupId()))
 		).and(
 			fragmentEntryLinkTable.deleted.eq(false)
 		);
+	}
+
+	private Predicate _getFragmentEntryGroupScopePredicate(
+		FragmentEntryLinkTable fragmentEntryLinkTable, Group group) {
+
+		return Predicate.withParentheses(
+			fragmentEntryLinkTable.fragmentEntryScopeERC.eq(
+				group.getExternalReferenceCode()
+			).or(
+				Predicate.withParentheses(
+					fragmentEntryLinkTable.fragmentEntryScopeERC.isNull(
+					).and(
+						fragmentEntryLinkTable.groupId.eq(group.getGroupId())
+					))
+			));
 	}
 
 	private Predicate _getFragmentEntryLinksByFragmentEntryPredicate(

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -13,6 +13,7 @@ import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.model.FragmentEntryLinkTable;
+import com.liferay.fragment.model.FragmentEntryTable;
 import com.liferay.fragment.processor.DefaultFragmentEntryProcessorContext;
 import com.liferay.fragment.processor.FragmentEntryProcessorContext;
 import com.liferay.fragment.processor.FragmentEntryProcessorRegistry;
@@ -41,6 +42,7 @@ import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutTable;
@@ -68,8 +70,11 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.regex.Matcher;
@@ -579,6 +584,69 @@ public class FragmentEntryLinkLocalServiceImpl
 				DSLQueryFactoryUtil.countDistinct(
 					FragmentEntryLinkTable.INSTANCE.plid),
 				layoutPageTemplateType, false, groupId));
+	}
+
+	@Override
+	public Map<String, List<Long>> getMissingLayoutPlidsMap(
+			long fragmentCollectionId)
+		throws PortalException {
+
+		Map<String, List<Long>> missingLayoutPlidsMap = new HashMap<>();
+
+		FragmentCollection fragmentCollection =
+			_fragmentCollectionPersistence.fetchByPrimaryKey(
+				fragmentCollectionId);
+
+		if ((fragmentCollection == null) ||
+			(fragmentCollection.getGroupId() == CompanyConstants.SYSTEM)) {
+
+			return missingLayoutPlidsMap;
+		}
+
+		List<Object[]> results = fragmentEntryLinkPersistence.dslQuery(
+			DSLQueryFactoryUtil.selectDistinct(
+				FragmentEntryLinkTable.INSTANCE.fragmentEntryERC,
+				FragmentEntryLinkTable.INSTANCE.plid
+			).from(
+				FragmentEntryLinkTable.INSTANCE
+			).innerJoinON(
+				FragmentEntryTable.INSTANCE,
+				FragmentEntryTable.INSTANCE.externalReferenceCode.eq(
+					FragmentEntryLinkTable.INSTANCE.fragmentEntryERC
+				).and(
+					FragmentEntryTable.INSTANCE.groupId.eq(
+						fragmentCollection.getGroupId())
+				)
+			).where(
+				FragmentEntryTable.INSTANCE.fragmentCollectionId.eq(
+					fragmentCollectionId
+				).and(
+					_getFragmentEntryGroupScopePredicate(
+						FragmentEntryLinkTable.INSTANCE,
+						_groupLocalService.getGroup(
+							fragmentCollection.getGroupId()))
+				).and(
+					FragmentEntryLinkTable.INSTANCE.deleted.eq(false)
+				).and(
+					FragmentEntryLinkTable.INSTANCE.plid.notIn(
+						DSLQueryFactoryUtil.select(
+							LayoutTable.INSTANCE.plid
+						).from(
+							LayoutTable.INSTANCE
+						))
+				)
+			).orderBy(
+				FragmentEntryLinkTable.INSTANCE.plid.ascending()
+			));
+
+		for (Object[] result : results) {
+			List<Long> plids = missingLayoutPlidsMap.computeIfAbsent(
+				(String)result[0], fragmentEntryERC -> new ArrayList<>());
+
+			plids.add((Long)result[1]);
+		}
+
+		return missingLayoutPlidsMap;
 	}
 
 	@Override

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLinkLocalServiceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLinkLocalServiceTest.java
@@ -66,8 +66,10 @@ import com.liferay.segments.service.SegmentsExperienceLocalService;
 
 import java.io.InputStream;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -415,18 +417,66 @@ public class FragmentEntryLinkLocalServiceTest {
 	}
 
 	@Test
+	@TestInfo("LPD-99652")
+	public void testDeleteFragmentEntryLinksByFragmentEntry() throws Exception {
+		FragmentEntryLink fragmentEntryLink1 = _addFragmentEntryLinkToLayout();
+		FragmentEntryLink fragmentEntryLink2 =
+			_addFragmentEntryLinkFromGlobalToLayout();
+		FragmentEntryLink fragmentEntryLink3 =
+			_addFragmentEntryLinkToMissingLayout();
+
+		_fragmentEntryLinkLocalService.deleteFragmentEntryLinksByFragmentEntry(
+			_fragmentEntry, true);
+
+		Assert.assertNotNull(
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				fragmentEntryLink1.getFragmentEntryLinkId()));
+		Assert.assertNotNull(
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				fragmentEntryLink2.getFragmentEntryLinkId()));
+		Assert.assertNotNull(
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				fragmentEntryLink3.getFragmentEntryLinkId()));
+
+		_fragmentEntryLinkLocalService.deleteFragmentEntryLinksByFragmentEntry(
+			_fragmentEntry, false);
+
+		Assert.assertNull(
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				fragmentEntryLink1.getFragmentEntryLinkId()));
+		Assert.assertNotNull(
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				fragmentEntryLink2.getFragmentEntryLinkId()));
+		Assert.assertNull(
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				fragmentEntryLink3.getFragmentEntryLinkId()));
+
+		_fragmentEntryLinkLocalService.deleteFragmentEntryLinksByFragmentEntry(
+			_globalFragmentEntry, false);
+
+		Assert.assertNull(
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				fragmentEntryLink2.getFragmentEntryLinkId()));
+	}
+
+	@Test
 	public void testFragmentEntryLinksDeleted() throws PortalException {
 		_assertFragmentEntryLinksDeleted(_fragmentEntry);
 		_assertFragmentEntryLinksDeleted(_globalFragmentEntry);
 	}
 
 	@Test
+	@TestInfo("LPD-99652")
 	public void testGetAllFragmentEntryLinksByFragmentEntry() throws Exception {
 		FragmentEntryLink fragmentEntryLink1 = _addFragmentEntryLinkToLayout();
 		FragmentEntryLink fragmentEntryLink2 =
 			_addFragmentEntryLinkToLayoutPageTemplateEntry();
 		FragmentEntryLink fragmentEntryLink3 =
 			_addFragmentEntryLinkFromGlobalToLayout();
+		FragmentEntryLink fragmentEntryLink4 =
+			_addFragmentEntryLinkToMissingLayout();
+		FragmentEntryLink fragmentEntryLink5 =
+			_addFragmentEntryLinkFromGlobalToMissingLayout();
 
 		List<FragmentEntryLink> fragmentEntryLinks =
 			_fragmentEntryLinkLocalService.
@@ -442,34 +492,42 @@ public class FragmentEntryLinkLocalServiceTest {
 		Assert.assertTrue(fragmentEntryLinks.contains(fragmentEntryLink1));
 		Assert.assertTrue(fragmentEntryLinks.contains(fragmentEntryLink2));
 		Assert.assertFalse(fragmentEntryLinks.contains(fragmentEntryLink3));
+		Assert.assertTrue(fragmentEntryLinks.contains(fragmentEntryLink4));
+		Assert.assertFalse(fragmentEntryLinks.contains(fragmentEntryLink5));
 		Assert.assertFalse(
 			globalFragmentEntryLinks.contains(fragmentEntryLink1));
 		Assert.assertFalse(
 			globalFragmentEntryLinks.contains(fragmentEntryLink2));
 		Assert.assertTrue(
 			globalFragmentEntryLinks.contains(fragmentEntryLink3));
+		Assert.assertTrue(
+			globalFragmentEntryLinks.contains(fragmentEntryLink5));
 	}
 
 	@Test
+	@TestInfo("LPD-99652")
 	public void testGetAllFragmentEntryLinksCountByFragmentEntry()
 		throws Exception {
 
 		_addFragmentEntryLinkToLayout();
 		_addFragmentEntryLinkToLayoutPageTemplateEntry();
 		_addFragmentEntryLinkFromGlobalToLayout();
+		_addFragmentEntryLinkToMissingLayout();
+		_addFragmentEntryLinkFromGlobalToMissingLayout();
 
 		Assert.assertEquals(
-			2,
+			3,
 			_fragmentEntryLinkLocalService.
 				getAllFragmentEntryLinksCountByFragmentEntry(_fragmentEntry));
 		Assert.assertEquals(
-			1,
+			2,
 			_fragmentEntryLinkLocalService.
 				getAllFragmentEntryLinksCountByFragmentEntry(
 					_globalFragmentEntry));
 	}
 
 	@Test
+	@TestInfo("LPD-99652")
 	public void testGetLayoutFragmentEntryLinksByFragmentEntry()
 		throws Exception {
 
@@ -478,6 +536,10 @@ public class FragmentEntryLinkLocalServiceTest {
 			_addFragmentEntryLinkToLayoutPageTemplateEntry();
 		FragmentEntryLink fragmentEntryLink3 =
 			_addFragmentEntryLinkFromGlobalToLayout();
+		FragmentEntryLink fragmentEntryLink4 =
+			_addFragmentEntryLinkToMissingLayout();
+		FragmentEntryLink fragmentEntryLink5 =
+			_addFragmentEntryLinkFromGlobalToMissingLayout();
 
 		List<FragmentEntryLink> fragmentEntryLinks =
 			_fragmentEntryLinkLocalService.
@@ -494,29 +556,36 @@ public class FragmentEntryLinkLocalServiceTest {
 		Assert.assertTrue(fragmentEntryLinks.contains(fragmentEntryLink1));
 		Assert.assertFalse(fragmentEntryLinks.contains(fragmentEntryLink2));
 		Assert.assertFalse(fragmentEntryLinks.contains(fragmentEntryLink3));
+		Assert.assertTrue(fragmentEntryLinks.contains(fragmentEntryLink4));
+		Assert.assertFalse(fragmentEntryLinks.contains(fragmentEntryLink5));
 		Assert.assertFalse(
 			globalFragmentEntryLinks.contains(fragmentEntryLink1));
 		Assert.assertFalse(
 			globalFragmentEntryLinks.contains(fragmentEntryLink2));
 		Assert.assertTrue(
 			globalFragmentEntryLinks.contains(fragmentEntryLink3));
+		Assert.assertTrue(
+			globalFragmentEntryLinks.contains(fragmentEntryLink5));
 	}
 
 	@Test
+	@TestInfo("LPD-99652")
 	public void testGetLayoutFragmentEntryLinksCountByFragmentEntry()
 		throws Exception {
 
 		_addFragmentEntryLinkToLayout();
 		_addFragmentEntryLinkToLayoutPageTemplateEntry();
 		_addFragmentEntryLinkFromGlobalToLayout();
+		_addFragmentEntryLinkToMissingLayout();
+		_addFragmentEntryLinkFromGlobalToMissingLayout();
 
 		Assert.assertEquals(
-			1,
+			2,
 			_fragmentEntryLinkLocalService.
 				getLayoutFragmentEntryLinksCountByFragmentEntry(
 					_group.getGroupId(), _fragmentEntry));
 		Assert.assertEquals(
-			1,
+			2,
 			_fragmentEntryLinkLocalService.
 				getLayoutFragmentEntryLinksCountByFragmentEntry(
 					_group.getGroupId(), _globalFragmentEntry));
@@ -577,6 +646,40 @@ public class FragmentEntryLinkLocalServiceTest {
 				getLayoutPageTemplateFragmentEntryLinksCountByFragmentEntry(
 					_group.getGroupId(), _globalFragmentEntry,
 					LayoutPageTemplateEntryTypeConstants.BASIC));
+	}
+
+	@Test
+	@TestInfo("LPD-99652")
+	public void testGetMissingLayoutPlidsMap() throws Exception {
+		_addFragmentEntryLinkToLayout();
+
+		FragmentEntryLink fragmentEntryLink =
+			_addFragmentEntryLinkToMissingLayout();
+
+		FragmentEntry draftFragmentEntry = _fragmentEntryLocalService.getDraft(
+			_fragmentEntry.getFragmentEntryId());
+
+		Assert.assertEquals(
+			_fragmentEntry.getExternalReferenceCode(),
+			draftFragmentEntry.getExternalReferenceCode());
+		Assert.assertEquals(
+			_fragmentEntry.getGroupId(), draftFragmentEntry.getGroupId());
+
+		Map<String, List<Long>> missingLayoutPlidsMap =
+			_fragmentEntryLinkLocalService.getMissingLayoutPlidsMap(
+				_fragmentCollection.getFragmentCollectionId());
+
+		Assert.assertEquals(
+			missingLayoutPlidsMap.toString(), 1, missingLayoutPlidsMap.size());
+		Assert.assertEquals(
+			Collections.singletonList(fragmentEntryLink.getPlid()),
+			missingLayoutPlidsMap.get(
+				_fragmentEntry.getExternalReferenceCode()));
+
+		Assert.assertEquals(
+			Collections.emptyMap(),
+			_fragmentEntryLinkLocalService.getMissingLayoutPlidsMap(
+				RandomTestUtil.randomLong()));
 	}
 
 	@Test
@@ -1023,6 +1126,14 @@ public class FragmentEntryLinkLocalServiceTest {
 			layout.getPlid(), StringPool.BLANK, 0, null);
 	}
 
+	private FragmentEntryLink _addFragmentEntryLinkFromGlobalToMissingLayout()
+		throws Exception {
+
+		return _addFragmentEntryLink(
+			_globalFragmentEntry, null, 0, RandomTestUtil.randomLong(),
+			StringPool.BLANK, 0, null);
+	}
+
 	private FragmentEntryLink _addFragmentEntryLinkToLayout() throws Exception {
 		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
 
@@ -1050,6 +1161,14 @@ public class FragmentEntryLinkLocalServiceTest {
 		return _addFragmentEntryLink(
 			_fragmentEntry, null, defaultSegmentsExperienceId,
 			layoutPageTemplateEntry.getPlid(), StringPool.BLANK, 0, null);
+	}
+
+	private FragmentEntryLink _addFragmentEntryLinkToMissingLayout()
+		throws Exception {
+
+		return _addFragmentEntryLink(
+			_fragmentEntry, null, 0, RandomTestUtil.randomLong(),
+			StringPool.BLANK, 0, null);
 	}
 
 	private void _assertDeleteFragmentEntryLink(FragmentEntry fragmentEntry)

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
@@ -18,6 +18,7 @@ import com.liferay.fragment.configuration.FragmentServiceConfiguration;
 import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.exception.DuplicateFragmentEntryExternalReferenceCodeException;
 import com.liferay.fragment.exception.NoSuchEntryException;
+import com.liferay.fragment.exception.RequiredFragmentEntryException;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.model.FragmentEntryLink;
@@ -126,11 +127,13 @@ public class FragmentEntryLocalServiceTest {
 	}
 
 	@Test
+	@TestInfo("LPD-99652")
 	public void testDeleteFragmentEntry() throws Exception {
 		_testDeleteFragmentEntry();
 		_testDeleteFragmentEntryByExternalReferenceCode();
 		_testDeleteFragmentEntryDraftByExternalReferenceCode();
 		_testDeleteFragmentEntryNonexistentByExternalReferenceCode();
+		_testDeleteFragmentEntryWithMissingLayoutFragmentEntryLink();
 	}
 
 	@Test
@@ -891,6 +894,30 @@ public class FragmentEntryLocalServiceTest {
 			NoSuchEntryException.class,
 			() -> _fragmentEntryLocalService.deleteFragmentEntry(
 				RandomTestUtil.randomString(), _group.getGroupId()));
+	}
+
+	private void _testDeleteFragmentEntryWithMissingLayoutFragmentEntryLink()
+		throws Exception {
+
+		FragmentEntry fragmentEntry = FragmentEntryTestUtil.addFragmentEntry(
+			_fragmentCollection.getFragmentCollectionId());
+
+		FragmentEntryLink fragmentEntryLink =
+			FragmentTestUtil.addFragmentEntryLink(
+				fragmentEntry, RandomTestUtil.randomLong());
+
+		Assert.assertThrows(
+			RequiredFragmentEntryException.class,
+			() -> _fragmentEntryLocalService.deleteFragmentEntry(
+				fragmentEntry.getFragmentEntryId()));
+
+		Assert.assertNotNull(
+			_fragmentEntryLocalService.fetchFragmentEntry(
+				fragmentEntry.getFragmentEntryId()));
+
+		Assert.assertNotNull(
+			_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+				fragmentEntryLink.getFragmentEntryLinkId()));
 	}
 
 	private void _testFetchFragmentEntryByFragmentEntryId() throws Exception {

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/test/util/FragmentDisplayContextTestUtil.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/test/util/FragmentDisplayContextTestUtil.java
@@ -1,0 +1,96 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.test.util;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.module.util.BundleUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletURL;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import jakarta.portlet.RenderRequest;
+import jakarta.portlet.RenderResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.lang.reflect.Constructor;
+
+import java.util.Map;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Georgel Pop
+ */
+public class FragmentDisplayContextTestUtil {
+
+	public static Object createDisplayContext(
+			Constructor<?> constructor, Group group,
+			Map<String, String> parameters)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			CompanyLocalServiceUtil.getCompany(group.getCompanyId()));
+		themeDisplay.setLocale(LocaleUtil.getDefault());
+		themeDisplay.setPermissionChecker(
+			PermissionThreadLocal.getPermissionChecker());
+		themeDisplay.setScopeGroupId(group.getGroupId());
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		for (Map.Entry<String, String> entry : parameters.entrySet()) {
+			mockHttpServletRequest.setParameter(
+				entry.getKey(), entry.getValue());
+		}
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			new MockLiferayPortletRenderRequest(mockHttpServletRequest);
+
+		mockLiferayPortletRenderRequest.setAttribute(
+			StringBundler.concat(
+				mockLiferayPortletRenderRequest.getPortletName(), "-",
+				WebKeys.CURRENT_PORTLET_URL),
+			new MockLiferayPortletURL());
+
+		return constructor.newInstance(
+			mockHttpServletRequest, mockLiferayPortletRenderRequest,
+			new MockLiferayPortletRenderResponse());
+	}
+
+	public static Constructor<?> getConstructor(String className)
+		throws Exception {
+
+		Bundle bundle = FrameworkUtil.getBundle(
+			FragmentDisplayContextTestUtil.class);
+
+		bundle = BundleUtil.getBundle(
+			bundle.getBundleContext(), "com.liferay.fragment.web");
+
+		Class<?> clazz = bundle.loadClass(className);
+
+		return clazz.getConstructor(
+			HttpServletRequest.class, RenderRequest.class,
+			RenderResponse.class);
+	}
+
+}

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/web/internal/display/context/test/FragmentDisplayContextTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/web/internal/display/context/test/FragmentDisplayContextTest.java
@@ -1,0 +1,137 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.web.internal.display.context.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.test.util.FragmentDisplayContextTestUtil;
+import com.liferay.fragment.test.util.FragmentEntryTestUtil;
+import com.liferay.fragment.test.util.FragmentTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.lang.reflect.Constructor;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Georgel Pop
+ */
+@RunWith(Arquillian.class)
+public class FragmentDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_constructor = FragmentDisplayContextTestUtil.getConstructor(
+			_CLASS_NAME);
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_fragmentCollection = FragmentTestUtil.addFragmentCollection(
+			_group.getGroupId());
+	}
+
+	@Test
+	@TestInfo("LPD-99652")
+	public void testLogMissingLayoutPlids() throws Exception {
+		FragmentEntry fragmentEntry1 = FragmentEntryTestUtil.addFragmentEntry(
+			_fragmentCollection.getFragmentCollectionId());
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		FragmentTestUtil.addFragmentEntryLink(fragmentEntry1, layout.getPlid());
+
+		FragmentEntry fragmentEntry2 = FragmentEntryTestUtil.addFragmentEntry(
+			_fragmentCollection.getFragmentCollectionId());
+
+		long missingLayoutPlid1 = RandomTestUtil.randomLong();
+
+		long missingLayoutPlid2 = missingLayoutPlid1 + 1;
+
+		FragmentTestUtil.addFragmentEntryLink(
+			fragmentEntry2, missingLayoutPlid2);
+
+		FragmentTestUtil.addFragmentEntryLink(
+			fragmentEntry2, missingLayoutPlid1);
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME, LoggerTestUtil.DEBUG)) {
+
+			ReflectionTestUtil.invoke(
+				_getFragmentDisplayContext(),
+				"getFragmentEntriesSearchContainer", new Class<?>[0]);
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(
+				StringBundler.concat(
+					"Fragment entry ",
+					fragmentEntry2.getExternalReferenceCode(),
+					" references missing layouts ", missingLayoutPlid1, ", ",
+					missingLayoutPlid2),
+				logEntry.getMessage());
+		}
+	}
+
+	private Object _getFragmentDisplayContext() throws Exception {
+		return FragmentDisplayContextTestUtil.createDisplayContext(
+			_constructor, _group,
+			HashMapBuilder.put(
+				"fragmentCollectionId",
+				String.valueOf(_fragmentCollection.getFragmentCollectionId())
+			).build());
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.fragment.web.internal.display.context." +
+			"FragmentDisplayContext";
+
+	private static Constructor<?> _constructor;
+
+	@DeleteAfterTestRun
+	private FragmentCollection _fragmentCollection;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/web/internal/display/context/test/FragmentEntryLinkDisplayContextTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/web/internal/display/context/test/FragmentEntryLinkDisplayContextTest.java
@@ -1,0 +1,270 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.web.internal.display.context.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.test.util.FragmentDisplayContextTestUtil;
+import com.liferay.fragment.test.util.FragmentEntryTestUtil;
+import com.liferay.fragment.test.util.FragmentTestUtil;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.test.util.LayoutPageTemplateTestUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.lang.reflect.Constructor;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Georgel Pop
+ */
+@RunWith(Arquillian.class)
+public class FragmentEntryLinkDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_constructor = FragmentDisplayContextTestUtil.getConstructor(
+			_CLASS_NAME);
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	@TestInfo("LPD-99652")
+	public void testGetFragmentEntryLinkName() throws Exception {
+		FragmentEntry fragmentEntry = _addFragmentEntry();
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		FragmentEntryLink fragmentEntryLink1 =
+			FragmentTestUtil.addFragmentEntryLink(
+				fragmentEntry, layout.getPlid());
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			LayoutPageTemplateTestUtil.addLayoutPageTemplateEntry(
+				_group.getGroupId(), LayoutPageTemplateEntryTypeConstants.BASIC,
+				WorkflowConstants.STATUS_APPROVED);
+
+		FragmentEntryLink fragmentEntryLink2 =
+			FragmentTestUtil.addFragmentEntryLink(
+				fragmentEntry, layoutPageTemplateEntry.getPlid());
+
+		FragmentEntryLink fragmentEntryLink3 =
+			FragmentTestUtil.addFragmentEntryLink(
+				fragmentEntry, RandomTestUtil.randomLong());
+
+		Object fragmentEntryLinkDisplayContext =
+			_getFragmentEntryLinkDisplayContext(fragmentEntry);
+
+		Assert.assertEquals(
+			layout.getName(LocaleUtil.getDefault()),
+			ReflectionTestUtil.invoke(
+				fragmentEntryLinkDisplayContext, "getFragmentEntryLinkName",
+				new Class<?>[] {FragmentEntryLink.class}, fragmentEntryLink1));
+		Assert.assertEquals(
+			layoutPageTemplateEntry.getName(),
+			ReflectionTestUtil.invoke(
+				fragmentEntryLinkDisplayContext, "getFragmentEntryLinkName",
+				new Class<?>[] {FragmentEntryLink.class}, fragmentEntryLink2));
+		Assert.assertEquals(
+			StringPool.BLANK,
+			ReflectionTestUtil.invoke(
+				fragmentEntryLinkDisplayContext, "getFragmentEntryLinkName",
+				new Class<?>[] {FragmentEntryLink.class}, fragmentEntryLink3));
+	}
+
+	@Test
+	@TestInfo("LPD-99652")
+	public void testGetFragmentEntryLinkTypeLabel() throws Exception {
+		FragmentEntry fragmentEntry = _addFragmentEntry();
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		FragmentEntryLink fragmentEntryLink1 =
+			FragmentTestUtil.addFragmentEntryLink(
+				fragmentEntry, layout.getPlid());
+
+		FragmentEntryLink fragmentEntryLink2 =
+			FragmentTestUtil.addFragmentEntryLink(
+				fragmentEntry,
+				_addLayoutPageTemplateEntryPlid(
+					LayoutPageTemplateEntryTypeConstants.BASIC));
+		FragmentEntryLink fragmentEntryLink3 =
+			FragmentTestUtil.addFragmentEntryLink(
+				fragmentEntry,
+				_addLayoutPageTemplateEntryPlid(
+					LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE));
+		FragmentEntryLink fragmentEntryLink4 =
+			FragmentTestUtil.addFragmentEntryLink(
+				fragmentEntry,
+				_addLayoutPageTemplateEntryPlid(
+					LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT));
+
+		FragmentEntryLink fragmentEntryLink5 =
+			FragmentTestUtil.addFragmentEntryLink(
+				fragmentEntry, RandomTestUtil.randomLong());
+
+		Object fragmentEntryLinkDisplayContext =
+			_getFragmentEntryLinkDisplayContext(fragmentEntry);
+
+		Assert.assertEquals(
+			"page",
+			_getFragmentEntryLinkTypeLabel(
+				fragmentEntryLinkDisplayContext, fragmentEntryLink1));
+		Assert.assertEquals(
+			"page-template",
+			_getFragmentEntryLinkTypeLabel(
+				fragmentEntryLinkDisplayContext, fragmentEntryLink2));
+		Assert.assertEquals(
+			"display-page-template",
+			_getFragmentEntryLinkTypeLabel(
+				fragmentEntryLinkDisplayContext, fragmentEntryLink3));
+		Assert.assertEquals(
+			"master-page",
+			_getFragmentEntryLinkTypeLabel(
+				fragmentEntryLinkDisplayContext, fragmentEntryLink4));
+		Assert.assertEquals(
+			StringPool.BLANK,
+			_getFragmentEntryLinkTypeLabel(
+				fragmentEntryLinkDisplayContext, fragmentEntryLink5));
+	}
+
+	@Test
+	@TestInfo("LPD-99652")
+	public void testGetSearchContainer() throws Exception {
+		FragmentEntry fragmentEntry = _addFragmentEntry();
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		FragmentEntryLink fragmentEntryLink1 =
+			FragmentTestUtil.addFragmentEntryLink(
+				fragmentEntry, layout.getPlid());
+
+		long missingLayoutPlid = RandomTestUtil.randomLong();
+
+		FragmentEntryLink fragmentEntryLink2 =
+			FragmentTestUtil.addFragmentEntryLink(
+				fragmentEntry, missingLayoutPlid);
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME, LoggerTestUtil.WARN)) {
+
+			SearchContainer<FragmentEntryLink> searchContainer =
+				ReflectionTestUtil.invoke(
+					_getFragmentEntryLinkDisplayContext(fragmentEntry),
+					"getSearchContainer", new Class<?>[0]);
+
+			List<FragmentEntryLink> fragmentEntryLinks =
+				searchContainer.getResults();
+
+			Assert.assertEquals(
+				fragmentEntryLinks.toString(), 2, fragmentEntryLinks.size());
+			Assert.assertTrue(fragmentEntryLinks.contains(fragmentEntryLink1));
+			Assert.assertTrue(fragmentEntryLinks.contains(fragmentEntryLink2));
+
+			Assert.assertEquals(2, searchContainer.getTotal());
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(
+				StringBundler.concat(
+					"Fragment entry ", fragmentEntry.getExternalReferenceCode(),
+					" references missing layouts ", missingLayoutPlid),
+				logEntry.getMessage());
+		}
+	}
+
+	private FragmentEntry _addFragmentEntry() throws Exception {
+		FragmentCollection fragmentCollection =
+			FragmentTestUtil.addFragmentCollection(_group.getGroupId());
+
+		return FragmentEntryTestUtil.addFragmentEntry(
+			fragmentCollection.getFragmentCollectionId());
+	}
+
+	private long _addLayoutPageTemplateEntryPlid(int type) throws Exception {
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			LayoutPageTemplateTestUtil.addLayoutPageTemplateEntry(
+				_group.getGroupId(), type, WorkflowConstants.STATUS_APPROVED);
+
+		return layoutPageTemplateEntry.getPlid();
+	}
+
+	private Object _getFragmentEntryLinkDisplayContext(
+			FragmentEntry fragmentEntry)
+		throws Exception {
+
+		return FragmentDisplayContextTestUtil.createDisplayContext(
+			_constructor, _group,
+			HashMapBuilder.put(
+				"fragmentEntryId",
+				String.valueOf(fragmentEntry.getFragmentEntryId())
+			).build());
+	}
+
+	private String _getFragmentEntryLinkTypeLabel(
+		Object fragmentEntryLinkDisplayContext,
+		FragmentEntryLink fragmentEntryLink) {
+
+		return ReflectionTestUtil.invoke(
+			fragmentEntryLinkDisplayContext, "getFragmentEntryLinkTypeLabel",
+			new Class<?>[] {FragmentEntryLink.class}, fragmentEntryLink);
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.fragment.web.internal.display.context." +
+			"FragmentEntryLinkDisplayContext";
+
+	private static Constructor<?> _constructor;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
@@ -13,6 +13,7 @@ import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentComposition;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.service.FragmentCollectionLocalServiceUtil;
+import com.liferay.fragment.service.FragmentEntryLinkLocalServiceUtil;
 import com.liferay.fragment.service.FragmentEntryServiceUtil;
 import com.liferay.fragment.util.comparator.FragmentCollectionContributorNameComparator;
 import com.liferay.fragment.util.comparator.FragmentCompositionFragmentEntryNameComparator;
@@ -28,6 +29,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemListBu
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemList;
 import com.liferay.marketplace.constants.MarketplaceActionKeys;
 import com.liferay.marketplace.constants.MarketplacePortletKeys;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
@@ -38,6 +40,8 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletURL;
@@ -579,6 +583,8 @@ public class FragmentDisplayContext {
 		fragmentEntriesSearchContainer.setRowChecker(
 			new EmptyOnClickRowChecker(_renderResponse));
 
+		_logMissingLayoutPlids();
+
 		_fragmentEntriesSearchContainer = fragmentEntriesSearchContainer;
 
 		return _fragmentEntriesSearchContainer;
@@ -1092,6 +1098,30 @@ public class FragmentDisplayContext {
 		return true;
 	}
 
+	private void _logMissingLayoutPlids() {
+		if (_log.isDebugEnabled()) {
+			try {
+				Map<String, List<Long>> missingLayoutPlidsMap =
+					FragmentEntryLinkLocalServiceUtil.getMissingLayoutPlidsMap(
+						getFragmentCollectionId());
+
+				for (Map.Entry<String, List<Long>> entry :
+						missingLayoutPlidsMap.entrySet()) {
+
+					_log.debug(
+						StringBundler.concat(
+							"Fragment entry ", entry.getKey(),
+							" references missing layouts ",
+							StringUtil.merge(
+								entry.getValue(), StringPool.COMMA_AND_SPACE)));
+				}
+			}
+			catch (Exception exception) {
+				_log.debug(exception);
+			}
+		}
+	}
+
 	private void _updatePortletDisplay() {
 		if (!DesignLibraryUtil.isDesignLibraryScope(
 				_themeDisplay.getScopeGroup())) {
@@ -1117,6 +1147,9 @@ public class FragmentDisplayContext {
 
 		portletDisplay.setURLBack(backURL);
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		FragmentDisplayContext.class);
 
 	private SearchContainer<Object> _contributedEntriesSearchContainer;
 	private FragmentCollection _fragmentCollection;

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentEntryLinkDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentEntryLinkDisplayContext.java
@@ -102,18 +102,11 @@ public class FragmentEntryLinkDisplayContext {
 	public String getFragmentEntryLinkName(
 		FragmentEntryLink fragmentEntryLink) {
 
-		long layoutPageTemplateEntryPlid = fragmentEntryLink.getPlid();
-
 		Layout layout = LayoutLocalServiceUtil.fetchLayout(
 			fragmentEntryLink.getPlid());
 
-		if (layout.isDraftLayout()) {
-			layoutPageTemplateEntryPlid = layout.getClassPK();
-		}
-
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
-			LayoutPageTemplateEntryLocalServiceUtil.
-				fetchLayoutPageTemplateEntryByPlid(layoutPageTemplateEntryPlid);
+			_fetchLayoutPageTemplateEntry(layout);
 
 		ThemeDisplay themeDisplay = _getThemeDisplay();
 
@@ -138,18 +131,11 @@ public class FragmentEntryLinkDisplayContext {
 	public String getFragmentEntryLinkTypeLabel(
 		FragmentEntryLink fragmentEntryLink) {
 
-		long layoutPageTemplateEntryPlid = fragmentEntryLink.getPlid();
-
 		Layout layout = LayoutLocalServiceUtil.fetchLayout(
 			fragmentEntryLink.getPlid());
 
-		if (layout.isDraftLayout()) {
-			layoutPageTemplateEntryPlid = layout.getClassPK();
-		}
-
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
-			LayoutPageTemplateEntryLocalServiceUtil.
-				fetchLayoutPageTemplateEntryByPlid(layoutPageTemplateEntryPlid);
+			_fetchLayoutPageTemplateEntry(layout);
 
 		if (layoutPageTemplateEntry != null) {
 			if (layoutPageTemplateEntry.getType() ==
@@ -460,6 +446,19 @@ public class FragmentEntryLinkDisplayContext {
 				verticalNavItem.setLabel(name);
 			}
 		).build();
+	}
+
+	private LayoutPageTemplateEntry _fetchLayoutPageTemplateEntry(
+		Layout layout) {
+
+		long layoutPageTemplateEntryPlid = layout.getPlid();
+
+		if (layout.isDraftLayout()) {
+			layoutPageTemplateEntryPlid = layout.getClassPK();
+		}
+
+		return LayoutPageTemplateEntryLocalServiceUtil.
+			fetchLayoutPageTemplateEntryByPlid(layoutPageTemplateEntryPlid);
 	}
 
 	private long _getScopeGroupId() {

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentEntryLinkDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentEntryLinkDisplayContext.java
@@ -105,6 +105,10 @@ public class FragmentEntryLinkDisplayContext {
 		Layout layout = LayoutLocalServiceUtil.fetchLayout(
 			fragmentEntryLink.getPlid());
 
+		if (layout == null) {
+			return StringPool.BLANK;
+		}
+
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
 			_fetchLayoutPageTemplateEntry(layout);
 
@@ -133,6 +137,10 @@ public class FragmentEntryLinkDisplayContext {
 
 		Layout layout = LayoutLocalServiceUtil.fetchLayout(
 			fragmentEntryLink.getPlid());
+
+		if (layout == null) {
+			return StringPool.BLANK;
+		}
 
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
 			_fetchLayoutPageTemplateEntry(layout);

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentEntryLinkDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentEntryLinkDisplayContext.java
@@ -24,12 +24,15 @@ import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.SearchOrderByUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -39,6 +42,8 @@ import jakarta.portlet.RenderResponse;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -364,6 +369,9 @@ public class FragmentEntryLinkDisplayContext {
 						fragmentEntry));
 		}
 
+		_logMissingLayoutPlids(
+			fragmentEntry, fragmentEntryLinksSearchContainer.getResults());
+
 		_searchContainer = fragmentEntryLinksSearchContainer;
 
 		return _searchContainer;
@@ -485,6 +493,37 @@ public class FragmentEntryLinkDisplayContext {
 
 		return _themeDisplay;
 	}
+
+	private void _logMissingLayoutPlids(
+		FragmentEntry fragmentEntry,
+		List<FragmentEntryLink> fragmentEntryLinks) {
+
+		if (_log.isWarnEnabled()) {
+			List<Long> missingLayoutPlids = new ArrayList<>();
+
+			for (FragmentEntryLink fragmentEntryLink : fragmentEntryLinks) {
+				Layout layout = LayoutLocalServiceUtil.fetchLayout(
+					fragmentEntryLink.getPlid());
+
+				if (layout == null) {
+					missingLayoutPlids.add(fragmentEntryLink.getPlid());
+				}
+			}
+
+			if (!missingLayoutPlids.isEmpty()) {
+				_log.warn(
+					StringBundler.concat(
+						"Fragment entry ",
+						fragmentEntry.getExternalReferenceCode(),
+						" references missing layouts ",
+						StringUtil.merge(
+							missingLayoutPlids, StringPool.COMMA_AND_SPACE)));
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		FragmentEntryLinkDisplayContext.class);
 
 	private Long _fragmentCollectionId;
 	private FragmentEntry _fragmentEntry;


### PR DESCRIPTION
Supersedes https://github.com/liferay-page-management/liferay-portal/pull/18848, which excluded the orphaned fragment entry links from the usage lists and deleted them on fragment deletion.

This one goes with the simpler solution: the usages screen tolerates a fragment entry link whose layout is gone and reports it in the log, at WARN for the screen and at DEBUG for a whole fragment collection. Nothing is deleted and no count changes, so a fragment whose only usages are orphaned stays undeletable exactly as it is today, and the user needs to run the cleanup step that deletes those rows, `LayoutDataCleanupPreupgradeProcess`.

The rest of the solution is split into two simpler pulls. The new one, https://liferay.atlassian.net/browse/LPD-101584, moves the group fragment entry usages query into the service.

**pr-check: PASS** — tested on `e033f82d8c6843d3285046c93dcb02b6783b0a79`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |
