### PR TITLE
LPD-101984 Publish the page before asserting it in view mode

### DIFF
--- a/modules/test/playwright/tests/layout-page-template-admin-web/main/pageTemplatesAdmin.spec.ts
+++ b/modules/test/playwright/tests/layout-page-template-admin-web/main/pageTemplatesAdmin.spec.ts
@@ -476,6 +476,10 @@ test.describe('General', () => {
 			template: pageTemplateName,
 		});
 
+		// Publish the page so it can be reached through its live friendly URL
+
+		await pageEditorPage.publishPage();
+
 		// Assert new content page in view mode
 
 		await page.goto(`/web${site.friendlyUrlPath}/${layoutTitle}`);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101984

## What Is Being Fixed

`layout-page-template-admin-web/main/pageTemplatesAdmin.spec.ts > General › Create a page based on a page template` fails.

Since `bbf8708f99a37` (LPD-100303 Skip unpublished layouts in `_getViewableLayoutComposite`) the live friendly URL of an unpublished content page no longer resolves — the portal serves the site's first published page instead. LPD-101553 confirmed that as expected behavior: the draft layout's friendly URL is the entry point for a page that has never been published.

This test creates a page from a page template through the Pages admin UI, which leaves it unpublished, and then asserts the page template's content in view mode through that page's live friendly URL. The navigation landed on the site home page instead, so `Edited` was never visible. The trace of the local reproduction shows the served page as `p_r_p_selPlid=96` with the `Home` heading.

This is the view mode counterpart of LPD-101567, which covered the edit mode navigations through `PageEditorPage.goto`. A draft URL is the wrong tool here, because the test needs a page it can actually view.

## How It Is Being Fixed

The page is published before the view mode assertion, following the pattern already used by `PagesAdminPage.createNewPage`, which publishes through `pageEditorPage.publishPage()` unless the caller asks for a draft. Creating a page from the Pages admin redirects into the page editor, so the publish button is on screen at that point.

## Why Are There No Tests?

This is a Playwright spec fix; there is no production code to cover. The change is validated by the suite it repairs.

## Verification

Run against a bundle carrying the `isPublished()` gate, so the failure reproduces:

- Before the change, the target test fails and the trace shows the site home page being served.
- After the change, all 9 tests in `pageTemplatesAdmin.spec.ts` pass.

I also swept the rest of the suite for the same pattern. The other live URL navigations are safe: `customElement.spec.ts`, `navigate.spec.ts` and `portalSmoke.spec.ts` publish before navigating; `pageConfiguration.spec.ts` and `pagesSearch.spec.ts` use portlet layouts, for which `Layout.isPublished()` is always `true`; and the commerce, segments and template-web specs get their layouts from `headlessDelivery.createSitePage`, which publishes them.

## PR Check

**pr-check: PASS** — tested on `da2404a313f289d2d253a44070e8a5f1344e5c27`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | N/A |
| JavaScript Unit Tests | N/A |

Per-Module Compile is not applicable: `:test:playwright` is not a project in the Gradle build — `gradlew :test:playwright:deploy --dry-run` fails with `project 'playwright' not found in project ':test'` — so there is no module to deploy. The compile equivalent signal is the TypeScript check inside the source formatter, which passed.

JavaScript Unit Tests is not applicable: this module's `npm test` is `playwright test` and there is no jest config or suite, and Playwright tests are out of pr-check scope. See the verification runs above.

<!-- pr-check {"result": "success", "sha": "da2404a313f289d2d253a44070e8a5f1344e5c27"} -->
