### PR TITLE
LPD-102082 Do not allow selecting CMS structures outside of a CMS group

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web-test/build.gradle
+++ b/modules/apps/layout/layout-content-page-editor-web-test/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-api")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
+	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationImplementation project(":apps:portal:portal-props-test-util")
 	testIntegrationImplementation project(":apps:portlet-display-template:portlet-display-template-api")
 	testIntegrationImplementation project(":apps:product-navigation:product-navigation-control-menu-api")

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/util/test/MappingTypesUtilTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/util/test/MappingTypesUtilTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/util/test/MappingTypesUtilTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/util/test/MappingTypesUtilTest.java
@@ -1,0 +1,216 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.page.editor.web.internal.util.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.layout.page.template.info.item.capability.EditPageInfoItemCapability;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectDefinitionSettingConstants;
+import com.liferay.object.constants.ObjectFolderConstants;
+import com.liferay.object.definition.setting.builder.ObjectDefinitionSettingBuilder;
+import com.liferay.object.field.builder.TextObjectFieldBuilder;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectFolder;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectFolderLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+import jakarta.portlet.Portlet;
+
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Víctor Galán
+ */
+@RunWith(Arquillian.class)
+public class MappingTypesUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	@TestInfo("LPD-101984")
+	public void testGetMappingTypeJSONObject() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		ObjectFolder objectFolder =
+			_objectFolderLocalService.getOrAddEmptyObjectFolder(
+				ObjectFolderConstants.
+					EXTERNAL_REFERENCE_CODE_CONTENT_STRUCTURES,
+				TestPropsValues.getCompanyId(), TestPropsValues.getUserId());
+
+		ObjectDefinition cmsObjectDefinition = _publishObjectDefinition(
+			_addCMSObjectDefinition(objectFolder.getObjectFolderId()));
+
+		ObjectDefinition objectDefinition = _publishObjectDefinition(
+			ObjectDefinitionTestUtil.addCustomObjectDefinition(
+				ObjectDefinitionTestUtil.getRandomName()));
+
+		Assert.assertNull(
+			_getMappingTypeJSONObject(RandomTestUtil.randomString()));
+
+		JSONArray mappingTypesJSONArray = _getMappingTypesJSONArray();
+
+		Assert.assertFalse(
+			_hasClassName(
+				cmsObjectDefinition.getClassName(), mappingTypesJSONArray));
+		Assert.assertTrue(
+			_hasClassName(
+				objectDefinition.getClassName(), mappingTypesJSONArray));
+	}
+
+	private ObjectDefinition _addCMSObjectDefinition(long objectFolderId)
+		throws Exception {
+
+		return _objectDefinitionLocalService.addCustomObjectDefinition(
+			null, TestPropsValues.getUserId(), objectFolderId, null, true,
+			false, true, false, true, false, false, false, false, null,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			ObjectDefinitionTestUtil.getRandomName(), null, null,
+			LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
+			true, ObjectDefinitionConstants.SCOPE_DEPOT,
+			ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
+			Collections.singletonList(
+				new ObjectDefinitionSettingBuilder(
+				).name(
+					ObjectDefinitionSettingConstants.NAME_ACCEPT_ALL_GROUPS
+				).value(
+					StringPool.TRUE
+				).build()),
+			Collections.singletonList(
+				new TextObjectFieldBuilder(
+				).labelMap(
+					LocalizedMapUtil.getLocalizedMap(
+						RandomTestUtil.randomString())
+				).name(
+					"a" + RandomTestUtil.randomString()
+				).build()),
+			Collections.emptyList(), new ServiceContext());
+	}
+
+	private JSONObject _getMappingTypeJSONObject(String className)
+		throws Exception {
+
+		return ReflectionTestUtil.invoke(
+			_getMappingTypesUtilClass(), "getMappingTypeJSONObject",
+			new Class<?>[] {
+				String.class, InfoItemServiceRegistry.class, String.class,
+				ThemeDisplay.class
+			},
+			className, _infoItemServiceRegistry, EditPageInfoItemCapability.KEY,
+			_getThemeDisplay());
+	}
+
+	private JSONArray _getMappingTypesJSONArray() throws Exception {
+		return ReflectionTestUtil.invoke(
+			_getMappingTypesUtilClass(), "getMappingTypesJSONArray",
+			new Class<?>[] {
+				InfoItemServiceRegistry.class, String.class, ThemeDisplay.class
+			},
+			_infoItemServiceRegistry, EditPageInfoItemCapability.KEY,
+			_getThemeDisplay());
+	}
+
+	private Class<?> _getMappingTypesUtilClass() throws Exception {
+		Class<?> portletClass = _portlet.getClass();
+
+		return Class.forName(
+			"com.liferay.layout.content.page.editor.web.internal.util." +
+				"MappingTypesUtil",
+			true, portletClass.getClassLoader());
+	}
+
+	private ThemeDisplay _getThemeDisplay() throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
+		themeDisplay.setLocale(LocaleUtil.getSiteDefault());
+		themeDisplay.setPermissionChecker(
+			PermissionThreadLocal.getPermissionChecker());
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+		themeDisplay.setSiteGroupId(_group.getGroupId());
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		return themeDisplay;
+	}
+
+	private boolean _hasClassName(
+		String className, JSONArray mappingTypesJSONArray) {
+
+		for (int i = 0; i < mappingTypesJSONArray.length(); i++) {
+			JSONObject mappingTypeJSONObject =
+				mappingTypesJSONArray.getJSONObject(i);
+
+			if (className.equals(
+					mappingTypeJSONObject.getString("className"))) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private ObjectDefinition _publishObjectDefinition(
+			ObjectDefinition objectDefinition)
+		throws Exception {
+
+		return _objectDefinitionLocalService.publishCustomObjectDefinition(
+			TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId());
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	private Group _group;
+
+	@Inject
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectFolderLocalService _objectFolderLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.layout.content.page.editor.web.internal.portlet.ContentPageEditorPortlet"
+	)
+	private Portlet _portlet;
+
+}

--- a/modules/apps/layout/layout-content-page-editor-web/build.gradle
+++ b/modules/apps/layout/layout-content-page-editor-web/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 	compileOnly project(":apps:learn:learn-api")
 	compileOnly project(":apps:marketplace:marketplace-api")
 	compileOnly project(":apps:mentions:mentions-api")
+	compileOnly project(":apps:object:object-api")
 	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:portal:portal-aop-api")

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorLayoutPageTemplateDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorLayoutPageTemplateDisplayContext.java
@@ -39,8 +39,10 @@ import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalServ
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryService;
 import com.liferay.layout.page.template.util.LayoutPageTemplateEntryUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.PortletURLFactory;
@@ -72,6 +74,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author Jürgen Kappler
@@ -138,6 +141,9 @@ public class ContentPageEditorLayoutPageTemplateDisplayContext
 		Map<String, Object> configContext =
 			(Map<String, Object>)editorContext.get("config");
 
+		configContext.put(
+			"formTypes",
+			_addSelectedFormType((JSONArray)configContext.get("formTypes")));
 		configContext.put(
 			"infoItemPreviewSelectorURL", _getInfoItemPreviewSelectorURL());
 
@@ -245,6 +251,41 @@ public class ContentPageEditorLayoutPageTemplateDisplayContext
 		}
 
 		return mappingFieldsJSONObject;
+	}
+
+	private JSONArray _addSelectedFormType(JSONArray formTypesJSONArray) {
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_getLayoutPageTemplateEntry();
+
+		if ((layoutPageTemplateEntry == null) ||
+			(layoutPageTemplateEntry.getClassNameId() <= 0)) {
+
+			return formTypesJSONArray;
+		}
+
+		String className = layoutPageTemplateEntry.getClassName();
+
+		for (int i = 0; i < formTypesJSONArray.length(); i++) {
+			JSONObject formTypeJSONObject = formTypesJSONArray.getJSONObject(i);
+
+			if (Objects.equals(
+					formTypeJSONObject.getString("className"), className)) {
+
+				return formTypesJSONArray;
+			}
+		}
+
+		JSONObject formTypeJSONObject =
+			MappingTypesUtil.getMappingTypeJSONObject(
+				className, infoItemServiceRegistry,
+				EditPageInfoItemCapability.KEY, themeDisplay);
+
+		if (formTypeJSONObject == null) {
+			return formTypesJSONArray;
+		}
+
+		return JSONUtil.concat(
+			JSONUtil.put(formTypeJSONObject), formTypesJSONArray);
 	}
 
 	private Long _getClassTypeId() {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/MappingTypesUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/MappingTypesUtil.java
@@ -11,9 +11,13 @@ import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.info.item.provider.InfoItemFormVariationsProvider;
 import com.liferay.info.localized.InfoLocalizedValue;
 import com.liferay.info.permission.provider.InfoPermissionProvider;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.PortalUtil;
 
@@ -25,51 +29,50 @@ import java.util.Objects;
  */
 public class MappingTypesUtil {
 
+	public static JSONObject getMappingTypeJSONObject(
+		String className, InfoItemServiceRegistry infoItemServiceRegistry,
+		String itemCapabilityKey, ThemeDisplay themeDisplay) {
+
+		for (InfoItemClassDetails infoItemClassDetails :
+				infoItemServiceRegistry.getInfoItemClassDetails(
+					itemCapabilityKey)) {
+
+			if (Objects.equals(
+					infoItemClassDetails.getClassName(), className)) {
+
+				return _getMappingTypeJSONObject(
+					infoItemClassDetails, infoItemServiceRegistry,
+					themeDisplay);
+			}
+		}
+
+		return null;
+	}
+
 	public static JSONArray getMappingTypesJSONArray(
 		InfoItemServiceRegistry infoItemServiceRegistry,
 		String itemCapabilityKey, ThemeDisplay themeDisplay) {
 
 		JSONArray mappingTypesJSONArray = JSONFactoryUtil.createJSONArray();
 
+		Group scopeGroup = themeDisplay.getScopeGroup();
+
 		for (InfoItemClassDetails infoItemClassDetails :
 				infoItemServiceRegistry.getInfoItemClassDetails(
 					itemCapabilityKey)) {
 
+			if (!scopeGroup.isCMS() &&
+				_isCMS(
+					infoItemClassDetails.getClassName(),
+					themeDisplay.getCompanyId())) {
+
+				continue;
+			}
+
 			mappingTypesJSONArray.put(
-				JSONUtil.put(
-					"className", infoItemClassDetails.getClassName()
-				).put(
-					"isRestricted",
-					() -> {
-						InfoPermissionProvider infoPermissionProvider =
-							infoItemServiceRegistry.getFirstInfoItemService(
-								InfoPermissionProvider.class,
-								infoItemClassDetails.getClassName());
-
-						if ((infoPermissionProvider == null) ||
-							infoPermissionProvider.hasViewPermission(
-								null, themeDisplay.getScopeGroupId(),
-								themeDisplay.getPermissionChecker())) {
-
-							return false;
-						}
-
-						return true;
-					}
-				).put(
-					"label",
-					infoItemClassDetails.getLabel(themeDisplay.getLocale())
-				).put(
-					"subtypes",
-					_getMappingFormVariationsJSONArray(
-						infoItemClassDetails, infoItemServiceRegistry,
-						themeDisplay)
-				).put(
-					"value",
-					String.valueOf(
-						PortalUtil.getClassNameId(
-							infoItemClassDetails.getClassName()))
-				));
+				_getMappingTypeJSONObject(
+					infoItemClassDetails, infoItemServiceRegistry,
+					themeDisplay));
 		}
 
 		return mappingTypesJSONArray;
@@ -151,6 +154,56 @@ public class MappingTypesUtil {
 		}
 
 		return jsonArray;
+	}
+
+	private static JSONObject _getMappingTypeJSONObject(
+		InfoItemClassDetails infoItemClassDetails,
+		InfoItemServiceRegistry infoItemServiceRegistry,
+		ThemeDisplay themeDisplay) {
+
+		return JSONUtil.put(
+			"className", infoItemClassDetails.getClassName()
+		).put(
+			"isRestricted",
+			() -> {
+				InfoPermissionProvider infoPermissionProvider =
+					infoItemServiceRegistry.getFirstInfoItemService(
+						InfoPermissionProvider.class,
+						infoItemClassDetails.getClassName());
+
+				if ((infoPermissionProvider == null) ||
+					infoPermissionProvider.hasViewPermission(
+						null, themeDisplay.getScopeGroupId(),
+						themeDisplay.getPermissionChecker())) {
+
+					return false;
+				}
+
+				return true;
+			}
+		).put(
+			"label", infoItemClassDetails.getLabel(themeDisplay.getLocale())
+		).put(
+			"subtypes",
+			_getMappingFormVariationsJSONArray(
+				infoItemClassDetails, infoItemServiceRegistry, themeDisplay)
+		).put(
+			"value",
+			String.valueOf(
+				PortalUtil.getClassNameId(infoItemClassDetails.getClassName()))
+		);
+	}
+
+	private static boolean _isCMS(String className, long companyId) {
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionLocalServiceUtil.fetchObjectDefinitionByClassName(
+				companyId, className);
+
+		if (objectDefinition == null) {
+			return false;
+		}
+
+		return objectDefinition.isCMS();
 	}
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102082

## What Is Being Fixed

In the page editor, the form container content type selector lists CMS structures even when the page is being edited from a site that is not a CMS group. CMS structures are object definitions that live in the L_CMS_CONTENT_STRUCTURES and L_CMS_FILE_TYPES object folders and belong to the CMS asset library, so offering them from a regular site lets a user pick a content type whose entries cannot be created there, and creating an entry then fails.

## How It Is Being Fixed

`MappingTypesUtil.getMappingTypesJSONArray` now skips CMS object definitions when the scope group is not a CMS group. Whether a definition is CMS is resolved from its info item class name through `ObjectDefinition.isCMS()`, the same pattern `AssetListDisplayContext` already uses.

Filtering alone would break display pages. If a display page template is mapped to a CMS structure, dropping that type from the list leaves the editor holding a mapping that no longer resolves, and the front end does `formTypes.find(...)` in several places. To avoid that, `ContentPageEditorLayoutPageTemplateDisplayContext` adds the display page template's own selected type back at the front of the list, behind its existing display-page guard. The new `MappingTypesUtil.getMappingTypeJSONObject` builds that single entry by looking the class name up in the unfiltered capability list, so a class without the edit-page capability returns null and is never added, and the entry shape stays defined in one place.

## PR Check

**pr-check: PASS** — tested on `21c0f939e5d41813fb22645305163cbdaf60c50d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "21c0f939e5d41813fb22645305163cbdaf60c50d"} -->
