### PR TITLE
LPD-101993 Skip orphaned element variations when copying layout content

### DIFF
--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutLocalServiceWrapper.java
@@ -572,25 +572,43 @@ public class LayoutLocalServiceWrapper
 				sourceLayoutPageTemplateStructureRelElementVariation.
 					getAudienceEntryERCs();
 
-			_layoutPageTemplateStructureRelElementVariationLocalService.
-				addOrUpdateLayoutPageTemplateStructureRelElementVariation(
-					PortalUUIDUtil.generate(), user.getUserId(),
-					targetLayout.getGroupId(),
-					sourceLayoutPageTemplateStructureRelElementVariation.
-						isActive(),
-					sourceLayoutPageTemplateStructureRelElementVariation.
-						getHide(),
-					sourceLayoutPageTemplateStructureRelElementVariation.
-						getHtmlMap(),
-					sourceLayoutPageTemplateStructureRelElementVariation.
-						getJsMap(),
-					sourceLayoutPageTemplateStructureRelElementVariation.
-						getName(),
-					targetLayout.getPlid(), segmentsExperienceERC,
-					sourceLayoutPageTemplateStructureRelElementVariation.
-						getTargetElement(),
-					audienceEntryERCs.toArray(new String[0]),
-					ServiceContextThreadLocal.getServiceContext());
+			if (ListUtil.isEmpty(audienceEntryERCs)) {
+				continue;
+			}
+
+			try {
+				_layoutPageTemplateStructureRelElementVariationLocalService.
+					addOrUpdateLayoutPageTemplateStructureRelElementVariation(
+						PortalUUIDUtil.generate(), user.getUserId(),
+						targetLayout.getGroupId(),
+						sourceLayoutPageTemplateStructureRelElementVariation.
+							isActive(),
+						sourceLayoutPageTemplateStructureRelElementVariation.
+							getHide(),
+						sourceLayoutPageTemplateStructureRelElementVariation.
+							getHtmlMap(),
+						sourceLayoutPageTemplateStructureRelElementVariation.
+							getJsMap(),
+						sourceLayoutPageTemplateStructureRelElementVariation.
+							getName(),
+						targetLayout.getPlid(), segmentsExperienceERC,
+						sourceLayoutPageTemplateStructureRelElementVariation.
+							getTargetElement(),
+						audienceEntryERCs.toArray(new String[0]),
+						ServiceContextThreadLocal.getServiceContext());
+			}
+			catch (Exception exception) {
+				if (_log.isWarnEnabled()) {
+					String externalReferenceCode =
+						sourceLayoutPageTemplateStructureRelElementVariation.
+							getExternalReferenceCode();
+
+					_log.warn(
+						"Unable to copy element variation " +
+							externalReferenceCode,
+						exception);
+				}
+			}
 		}
 	}
 

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceCopyLayoutContentTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceCopyLayoutContentTest.java
@@ -40,6 +40,7 @@ import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRelElem
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelElementVariationLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelLocalService;
 import com.liferay.layout.provider.LayoutStructureProvider;
@@ -1187,6 +1188,64 @@ public class LayoutLocalServiceCopyLayoutContentTest {
 	}
 
 	@Test
+	public void testCopyLayoutPageTemplateStructureRelElementVariationsWithDeletedAudiencesEntry()
+		throws Exception {
+
+		Layout targetLayout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Layout sourceLayout = targetLayout.fetchDraftLayout();
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_layoutPageTemplateStructureLocalService.
+				fetchLayoutPageTemplateStructure(
+					_group.getGroupId(), sourceLayout.getPlid());
+
+		SegmentsExperience sourceSegmentsExperience =
+			SegmentsTestUtil.addSegmentsExperience(
+				_group.getGroupId(), sourceLayout.getPlid());
+
+		_layoutPageTemplateStructureRelLocalService.
+			addLayoutPageTemplateStructureRel(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				layoutPageTemplateStructure.getLayoutPageTemplateStructureId(),
+				sourceSegmentsExperience.getSegmentsExperienceId(),
+				layoutPageTemplateStructure.getDefaultSegmentsExperienceData(),
+				ServiceContextTestUtil.getServiceContext(
+					_group.getGroupId(), TestPropsValues.getUserId()));
+
+		String audienceEntryERC = RandomTestUtil.randomString();
+
+		_layoutPageTemplateStructureRelElementVariationLocalService.
+			addOrUpdateLayoutPageTemplateStructureRelElementVariation(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				sourceLayout.getGroupId(), RandomTestUtil.randomBoolean(),
+				RandomTestUtil.randomString(),
+				Collections.<Locale, String>emptyMap(),
+				Collections.<Locale, String>emptyMap(),
+				RandomTestUtil.randomString(), sourceLayout.getPlid(),
+				sourceSegmentsExperience.getExternalReferenceCode(),
+				RandomTestUtil.randomString(), new String[] {audienceEntryERC},
+				ServiceContextTestUtil.getServiceContext(
+					sourceLayout.getGroupId(), TestPropsValues.getUserId()));
+
+		_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService.
+			deleteLayoutPageTemplateStructureRelElementVariationAudienceEntryRelsByAudienceEntryERC(
+				_group.getCompanyId(), audienceEntryERC);
+
+		_layoutLocalService.copyLayoutContent(sourceLayout, targetLayout);
+
+		List<LayoutPageTemplateStructureRelElementVariation>
+			targetLayoutPageTemplateStructureRelElementVariations =
+				_layoutPageTemplateStructureRelElementVariationLocalService.
+					getLayoutPageTemplateStructureRelElementVariations(
+						targetLayout.getPlid());
+
+		Assert.assertEquals(
+			targetLayoutPageTemplateStructureRelElementVariations.toString(), 0,
+			targetLayoutPageTemplateStructureRelElementVariations.size());
+	}
+
+	@Test
 	public void testCopyLayoutPortletPreferences() throws Exception {
 		String portletId = LayoutPortletKeys.LAYOUT_TEST_PORTLET;
 
@@ -1997,6 +2056,11 @@ public class LayoutLocalServiceCopyLayoutContentTest {
 	@Inject
 	private LayoutPageTemplateStructureLocalService
 		_layoutPageTemplateStructureLocalService;
+
+	@Inject
+	private
+		LayoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService
+			_layoutPageTemplateStructureRelElementVariationAudienceEntryRelLocalService;
 
 	@Inject
 	private LayoutPageTemplateStructureRelElementVariationLocalService


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101993

## What Is Being Fixed

In the page editor an element variation can be bound to an audience. When
that audience is deleted, the audience-delete model listener removes the
relation rows company-wide but leaves the parent element variation behind.
Because the variation's audience external reference codes are derived live
from the relation table, the orphaned variation now reports an empty list.
On the next publish the copy routine re-added the variation with empty
audience external reference codes, validation threw
AudienceEntryERCsException, and the whole CopyLayoutCallable aborted, so the
page could no longer be published. Every page whose variation referenced the
deleted audience was affected.

## How It Is Being Fixed

When copying layout content, element variations with no audiences are now
skipped instead of re-added with an empty audience list that fails
validation. The per-variation copy is also wrapped so that a failure on a
single variation is logged and skipped rather than aborting the entire
publish, keeping one bad variation from blocking the whole page.

## PR Check

**pr-check: PASS** — tested on `b30d0050770a052c407b6a921067cdccee13dfc4`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b30d0050770a052c407b6a921067cdccee13dfc4"} -->
