### PR TITLE
LPD-101994 Reload the variations preview on experience change

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariations.tsx
@@ -389,6 +389,10 @@ function ElementVariations({
 					languageId={languageId}
 					previewURL={previewURL}
 					ref={elementVariationsPreviewRef}
+					segmentsExperienceId={
+						selectedExperience?.segmentsExperienceId ??
+						selectedSegmentsExperienceId
+					}
 				/>
 			</div>
 		</div>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsPreview.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/element_variations/ElementVariationsPreview.tsx
@@ -32,6 +32,7 @@ interface Props {
 	itemNames: Record<string, string>;
 	languageId: string;
 	previewURL: string;
+	segmentsExperienceId: number;
 }
 
 const ElementVariationsPreview = forwardRef<ElementVariationsPreviewRef, Props>(
@@ -44,6 +45,7 @@ const ElementVariationsPreview = forwardRef<ElementVariationsPreviewRef, Props>(
 			itemNames,
 			languageId,
 			previewURL: initialPreviewURL,
+			segmentsExperienceId,
 		},
 		ref
 	) {
@@ -55,9 +57,16 @@ const ElementVariationsPreview = forwardRef<ElementVariationsPreviewRef, Props>(
 		} | null>(null);
 
 		const [previewReady, setPreviewReady] = useState(false);
-		const [previewURL, setPreviewURL] = useState(
-			() => `${initialPreviewURL}&languageId=${languageId}`
+
+		const url = new URL(initialPreviewURL, window.location.origin);
+
+		url.searchParams.set('languageId', languageId);
+		url.searchParams.set(
+			'segmentsExperienceId',
+			String(segmentsExperienceId)
 		);
+
+		const previewURL = url.toString();
 
 		useImperativeHandle(
 			ref,
@@ -198,9 +207,7 @@ const ElementVariationsPreview = forwardRef<ElementVariationsPreviewRef, Props>(
 
 		useEffect(() => {
 			setPreviewReady(false);
-
-			setPreviewURL(`${initialPreviewURL}&languageId=${languageId}`);
-		}, [initialPreviewURL, languageId]);
+		}, [previewURL]);
 
 		return (
 			<div className="d-flex flex-column flex-grow-1 position-relative">

--- a/modules/test/playwright/pages/layout-content-page-editor-web/ElementVariationsPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/ElementVariationsPage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Locator, Page} from '@playwright/test';
+import {FrameLocator, Locator, Page} from '@playwright/test';
 
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import {hoverAndExpectToBeVisible} from '../../utils/hoverAndExpectToBeVisible';
@@ -11,6 +11,8 @@ import {hoverAndExpectToBeVisible} from '../../utils/hoverAndExpectToBeVisible';
 export class ElementVariationsPage {
 	readonly audienceInput: Locator;
 	readonly audiencesPriorityModal: Locator;
+	readonly cancelButton: Locator;
+	readonly experiencePicker: Locator;
 	readonly hideToggle: Locator;
 	readonly htmlInput: Locator;
 	readonly javaScriptInput: Locator;
@@ -19,6 +21,7 @@ export class ElementVariationsPage {
 	readonly newVariationButton: Locator;
 	readonly page: Page;
 	readonly pageElementPicker: Locator;
+	readonly preview: FrameLocator;
 	readonly saveButton: Locator;
 	readonly sidebar: Locator;
 
@@ -27,6 +30,12 @@ export class ElementVariationsPage {
 		this.audiencesPriorityModal = page.locator(
 			'.element-variations__audiences-priority-modal'
 		);
+		this.sidebar = page.locator('.element-variations__sidebar');
+		this.cancelButton = page.getByRole('button', {
+			exact: true,
+			name: 'Cancel',
+		});
+		this.experiencePicker = this.sidebar.getByLabel('Experience');
 		this.hideToggle = page.getByText('Hide Page Element');
 		this.htmlInput = page.getByLabel('HTML', {exact: true});
 		this.javaScriptInput = page.getByLabel('JavaScript', {exact: true});
@@ -43,8 +52,8 @@ export class ElementVariationsPage {
 			);
 		this.page = page;
 		this.pageElementPicker = page.getByLabel('Page Element');
+		this.preview = page.frameLocator('iframe[title="Element Variations"]');
 		this.saveButton = page.getByRole('button', {exact: true, name: 'Save'});
-		this.sidebar = page.locator('.element-variations__sidebar');
 	}
 
 	async createElementVariation({
@@ -105,6 +114,12 @@ export class ElementVariationsPage {
 		await this.sidebar.getByText(name).waitFor();
 	}
 
+	async startElementVariationDraft() {
+		await this.newVariationButton.click();
+
+		await this.nameInput.waitFor();
+	}
+
 	async deleteElementVariation(name: string) {
 		await this.openVariationActions(name);
 
@@ -157,8 +172,24 @@ export class ElementVariationsPage {
 		await this.sidebar.getByText(newName ?? name).waitFor();
 	}
 
+	async cancelElementVariationDraft() {
+		await this.page.keyboard.press('Escape');
+
+		await this.cancelButton.click();
+
+		await this.experiencePicker.waitFor();
+	}
+
+	getPageElementOption(label: string): Locator {
+		return this.page.getByRole('option', {exact: true, name: label});
+	}
+
 	getVariationListItem(name: string): Locator {
 		return this.sidebar.getByRole('listitem').filter({hasText: name});
+	}
+
+	async openPageElementPicker() {
+		await this.pageElementPicker.click();
 	}
 
 	async openVariationActions(name: string) {
@@ -243,6 +274,14 @@ export class ElementVariationsPage {
 			.locator('.dropdown-menu')
 			.getByText(audienceName)
 			.click();
+	}
+
+	async selectExperience(label: string) {
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('option', {exact: true, name: label}),
+			trigger: this.experiencePicker,
+		});
 	}
 
 	async selectLanguage(languageId: string) {

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/elementVariations.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/elementVariations.spec.ts
@@ -750,6 +750,108 @@ test(
 );
 
 test(
+	'Reflects the selected experience content in the preview and page element picker',
+	{tag: '@LPD-101994'},
+	async ({
+		apiHelpers,
+		audiencesPage,
+		elementVariationsPage,
+		pageEditorPage,
+		site,
+	}) => {
+
+		// Create an audience so element variations can be built
+
+		const audienceName = 'Audience ' + getRandomString();
+
+		await audiencesPage.goto();
+
+		await audiencesPage.createAudience({
+			attributeName: 'Language',
+			name: audienceName,
+			value: 'English (United States)',
+			valueType: 'select',
+		});
+
+		// Create a page with a Paragraph fragment in the default experience
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				getFragmentDefinition({
+					id: getRandomString(),
+					key: 'BASIC_COMPONENT-paragraph',
+				}),
+			]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		// Create a second experience and add a Heading only to it
+
+		const experienceName = 'Experience ' + getRandomString();
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.createExperience(experienceName);
+
+		await pageEditorPage.addFragment('Basic Components', 'Heading');
+
+		// Open element variations from the second experience
+
+		await pageEditorPage.goToElementVariations();
+
+		const paragraphDefaultText =
+			'A paragraph is a self-contained unit of a discourse';
+
+		// The default experience preview excludes the heading, so it is neither
+		// rendered nor offered as a page element
+
+		await elementVariationsPage.selectExperience('Default');
+
+		await expect(
+			elementVariationsPage.preview.getByText(paragraphDefaultText)
+		).toBeVisible();
+
+		await expect(
+			elementVariationsPage.preview.getByText('Heading Example')
+		).not.toBeVisible();
+
+		await elementVariationsPage.startElementVariationDraft();
+
+		await elementVariationsPage.openPageElementPicker();
+
+		await expect(
+			elementVariationsPage.getPageElementOption(
+				'Paragraph (element-text)'
+			)
+		).toBeVisible();
+
+		await expect(
+			elementVariationsPage.getPageElementOption('Heading (element-text)')
+		).not.toBeVisible();
+
+		await elementVariationsPage.cancelElementVariationDraft();
+
+		// The second experience preview renders the heading and offers it as a
+		// page element
+
+		await elementVariationsPage.selectExperience(experienceName);
+
+		await expect(
+			elementVariationsPage.preview.getByText('Heading Example')
+		).toBeVisible();
+
+		await elementVariationsPage.startElementVariationDraft();
+
+		await elementVariationsPage.openPageElementPicker();
+
+		await expect(
+			elementVariationsPage.getPageElementOption('Heading (element-text)')
+		).toBeVisible();
+	}
+);
+
+test(
 	'Loads each page own variations when navigating between pages',
 	{tag: '@LPD-93951'},
 	async ({


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101994

## What Is Being Fixed

In the Element Variations screen, switching the experience in the picker did not update the preview. The preview iframe kept rendering whichever experience was active when the screen opened, so it showed stale content and the Page Element picker offered editable elements that did not exist in the selected experience.

## How It Is Being Fixed

The selected experience id is now passed into the preview component, which builds the preview URL with the current segmentsExperienceId (alongside languageId) so the iframe reloads whenever the picker changes. The URL is derived from props rather than duplicated across a state initializer and an effect, and the id falls back to the server-provided selected experience so it is always defined.

## PR Check

**pr-check: PASS** — tested on `3bed3cc6d6387a51522434865a7a6c4b1dc5b59f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "3bed3cc6d6387a51522434865a7a6c4b1dc5b59f"} -->
