### PR TITLE
LPD-101791 Allow custom portlet decorators in applicationDecorator- #166

### DIFF
--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/GeneralConfig.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/dto/v1_0/GeneralConfig.java
@@ -5,12 +5,9 @@
 
 package com.liferay.headless.admin.site.dto.v1_0;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFilter;
-import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 
 import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.petra.string.StringBundler;
@@ -52,9 +49,7 @@ public class GeneralConfig implements Serializable {
 	}
 
 	@io.swagger.v3.oas.annotations.media.Schema
-	@JsonGetter("applicationDecorator")
-	@Valid
-	public ApplicationDecorator getApplicationDecorator() {
+	public String getApplicationDecorator() {
 		if (_applicationDecoratorSupplier != null) {
 			applicationDecorator = _applicationDecoratorSupplier.get();
 
@@ -64,20 +59,7 @@ public class GeneralConfig implements Serializable {
 		return applicationDecorator;
 	}
 
-	@JsonIgnore
-	public String getApplicationDecoratorAsString() {
-		ApplicationDecorator applicationDecorator = getApplicationDecorator();
-
-		if (applicationDecorator == null) {
-			return null;
-		}
-
-		return applicationDecorator.toString();
-	}
-
-	public void setApplicationDecorator(
-		ApplicationDecorator applicationDecorator) {
-
+	public void setApplicationDecorator(String applicationDecorator) {
 		this.applicationDecorator = applicationDecorator;
 
 		_applicationDecoratorSupplier = null;
@@ -85,8 +67,7 @@ public class GeneralConfig implements Serializable {
 
 	@JsonIgnore
 	public void setApplicationDecorator(
-		UnsafeSupplier<ApplicationDecorator, Exception>
-			applicationDecoratorUnsafeSupplier) {
+		UnsafeSupplier<String, Exception> applicationDecoratorUnsafeSupplier) {
 
 		_applicationDecoratorSupplier = () -> {
 			try {
@@ -103,10 +84,10 @@ public class GeneralConfig implements Serializable {
 
 	@GraphQLField
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected ApplicationDecorator applicationDecorator;
+	protected String applicationDecorator;
 
 	@JsonIgnore
-	private Supplier<ApplicationDecorator> _applicationDecoratorSupplier;
+	private Supplier<String> _applicationDecoratorSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
 		description = "The localized custom titles."
@@ -223,7 +204,7 @@ public class GeneralConfig implements Serializable {
 
 		sb.append("{");
 
-		ApplicationDecorator applicationDecorator = getApplicationDecorator();
+		String applicationDecorator = getApplicationDecorator();
 
 		if (applicationDecorator != null) {
 			if (sb.length() > 1) {
@@ -233,7 +214,9 @@ public class GeneralConfig implements Serializable {
 			sb.append("\"applicationDecorator\": ");
 
 			sb.append("\"");
-			sb.append(applicationDecorator);
+
+			sb.append(_escape(applicationDecorator));
+
 			sb.append("\"");
 		}
 
@@ -272,44 +255,6 @@ public class GeneralConfig implements Serializable {
 		name = "x-class-name"
 	)
 	public String xClassName;
-
-	@GraphQLName("ApplicationDecorator")
-	public static enum ApplicationDecorator {
-
-		BAREBONE("Barebone"), BORDERLESS("Borderless"), DECORATE("Decorate");
-
-		@JsonCreator
-		public static ApplicationDecorator create(String value) {
-			if ((value == null) || value.equals("")) {
-				return null;
-			}
-
-			for (ApplicationDecorator applicationDecorator : values()) {
-				if (Objects.equals(applicationDecorator.getValue(), value)) {
-					return applicationDecorator;
-				}
-			}
-
-			throw new IllegalArgumentException("Invalid enum value: " + value);
-		}
-
-		@JsonValue
-		public String getValue() {
-			return _value;
-		}
-
-		@Override
-		public String toString() {
-			return _value;
-		}
-
-		private ApplicationDecorator(String value) {
-			_value = value;
-		}
-
-		private final String _value;
-
-	}
 
 	private static String _escape(Object object) {
 		return StringUtil.replace(
@@ -400,4 +345,4 @@ public class GeneralConfig implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:709702621
+// LIFERAY-REST-BUILDER-HASH:1033317385

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/resources/com/liferay/headless/admin/site/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/resources/com/liferay/headless/admin/site/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 24.7.0
+version 25.0.0

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/GeneralConfig.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/dto/v1_0/GeneralConfig.java
@@ -26,27 +26,16 @@ public class GeneralConfig implements Cloneable, Serializable {
 		return GeneralConfigSerDes.toDTO(json);
 	}
 
-	public ApplicationDecorator getApplicationDecorator() {
+	public String getApplicationDecorator() {
 		return applicationDecorator;
 	}
 
-	public String getApplicationDecoratorAsString() {
-		if (applicationDecorator == null) {
-			return null;
-		}
-
-		return applicationDecorator.toString();
-	}
-
-	public void setApplicationDecorator(
-		ApplicationDecorator applicationDecorator) {
-
+	public void setApplicationDecorator(String applicationDecorator) {
 		this.applicationDecorator = applicationDecorator;
 	}
 
 	public void setApplicationDecorator(
-		UnsafeSupplier<ApplicationDecorator, Exception>
-			applicationDecoratorUnsafeSupplier) {
+		UnsafeSupplier<String, Exception> applicationDecoratorUnsafeSupplier) {
 
 		try {
 			applicationDecorator = applicationDecoratorUnsafeSupplier.get();
@@ -56,7 +45,7 @@ public class GeneralConfig implements Cloneable, Serializable {
 		}
 	}
 
-	protected ApplicationDecorator applicationDecorator;
+	protected String applicationDecorator;
 
 	public Map<String, String> getCustomTitle_i18n() {
 		return customTitle_i18n;
@@ -132,38 +121,5 @@ public class GeneralConfig implements Cloneable, Serializable {
 		return GeneralConfigSerDes.toJSON(this);
 	}
 
-	public static enum ApplicationDecorator {
-
-		BAREBONE("Barebone"), BORDERLESS("Borderless"), DECORATE("Decorate");
-
-		public static ApplicationDecorator create(String value) {
-			for (ApplicationDecorator applicationDecorator : values()) {
-				if (Objects.equals(applicationDecorator.getValue(), value) ||
-					Objects.equals(applicationDecorator.name(), value)) {
-
-					return applicationDecorator;
-				}
-			}
-
-			return null;
-		}
-
-		public String getValue() {
-			return _value;
-		}
-
-		@Override
-		public String toString() {
-			return _value;
-		}
-
-		private ApplicationDecorator(String value) {
-			_value = value;
-		}
-
-		private final String _value;
-
-	}
-
 }
-// LIFERAY-REST-BUILDER-HASH:-351304785
+// LIFERAY-REST-BUILDER-HASH:244313465

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/GeneralConfigSerDes.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-client/src/main/java/com/liferay/headless/admin/site/client/serdes/v1_0/GeneralConfigSerDes.java
@@ -54,7 +54,9 @@ public class GeneralConfigSerDes {
 			sb.append("\"applicationDecorator\": ");
 
 			sb.append("\"");
-			sb.append(generalConfig.getApplicationDecorator());
+
+			sb.append(_escape(generalConfig.getApplicationDecorator()));
+
 			sb.append("\"");
 		}
 
@@ -163,8 +165,7 @@ public class GeneralConfigSerDes {
 			if (Objects.equals(jsonParserFieldName, "applicationDecorator")) {
 				if (jsonParserFieldValue != null) {
 					generalConfig.setApplicationDecorator(
-						GeneralConfig.ApplicationDecorator.create(
-							(String)jsonParserFieldValue));
+						(String)jsonParserFieldValue);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "customTitle_i18n")) {
@@ -260,4 +261,4 @@ public class GeneralConfigSerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1886678178
+// LIFERAY-REST-BUILDER-HASH:-277377798

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-openapi.yaml
@@ -4644,7 +4644,6 @@ components:
                 generalConfig:
                     properties:
                         applicationDecorator:
-                            enum: [Barebone, Borderless, Decorate]
                             type: string
                         customTitle_i18n:
                             additionalProperties:

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/WidgetPageWidgetInstanceDTOConverter.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/dto/v1_0/converter/WidgetPageWidgetInstanceDTOConverter.java
@@ -16,6 +16,7 @@ import com.liferay.headless.admin.site.internal.resource.v1_0.util.LayoutUtil;
 import com.liferay.layout.exporter.PortletPermissionsExporter;
 import com.liferay.layout.exporter.PortletPreferencesPortletConfigurationExporter;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
@@ -26,7 +27,6 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
@@ -243,20 +243,8 @@ public class WidgetPageWidgetInstanceDTOConverter
 					() -> new GeneralConfig() {
 						{
 							setApplicationDecorator(
-								() -> {
-									String value = GetterUtil.getString(
-										portletPreferences.getValue(
-											"portletSetupPortletDecoratorId",
-											null),
-										null);
-
-									if (value == null) {
-										return null;
-									}
-
-									return ApplicationDecorator.create(
-										StringUtil.upperCaseFirstLetter(value));
-								});
+								() -> portletPreferences.getValue(
+									"portletSetupPortletDecoratorId", null));
 							setCustomTitle_i18n(
 								() -> _getCustomTitleMap(
 									layout.getGroupId(), portletPreferences));
@@ -281,8 +269,7 @@ public class WidgetPageWidgetInstanceDTOConverter
 		String column, DTOConverterContext dtoConverterContext, Layout layout) {
 
 		return TransformUtil.transformToArray(
-			com.liferay.petra.string.StringUtil.split(
-				layout.getTypeSettingsProperty(column)),
+			StringUtil.split(layout.getTypeSettingsProperty(column)),
 			portletId -> {
 				dtoConverterContext.setAttribute("portletId", portletId);
 

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/src/main/java/com/liferay/headless/admin/site/internal/resource/v1_0/util/LayoutUtil.java
@@ -647,8 +647,8 @@ public class LayoutUtil {
 		if (generalConfig.getApplicationDecorator() != null) {
 			map.put(
 				"portletSetupPortletDecoratorId",
-				StringUtil.lowerCase(
-					generalConfig.getApplicationDecoratorAsString()));
+				_getPortletDecoratorId(
+					generalConfig.getApplicationDecorator()));
 		}
 
 		Map<String, String> customTitleI18n =
@@ -774,6 +774,17 @@ public class LayoutUtil {
 		}
 
 		return itemExternalReference.getExternalReferenceCode();
+	}
+
+	private static String _getPortletDecoratorId(String applicationDecorator) {
+		if (applicationDecorator.equals("Barebone") ||
+			applicationDecorator.equals("Borderless") ||
+			applicationDecorator.equals("Decorate")) {
+
+			return StringUtil.lowerCase(applicationDecorator);
+		}
+
+		return applicationDecorator;
 	}
 
 	private static StyleBookEntryReference _getStyleBookEntryReference(

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/SitePageResourceTest.java
@@ -13,6 +13,7 @@ import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.asset.publisher.constants.AssetPublisherPortletKeys;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.test.util.DLTestUtil;
@@ -39,6 +40,7 @@ import com.liferay.headless.admin.site.client.dto.v1_0.FragmentImage;
 import com.liferay.headless.admin.site.client.dto.v1_0.FragmentImageValue;
 import com.liferay.headless.admin.site.client.dto.v1_0.FragmentInstance;
 import com.liferay.headless.admin.site.client.dto.v1_0.FriendlyUrlHistory;
+import com.liferay.headless.admin.site.client.dto.v1_0.GeneralConfig;
 import com.liferay.headless.admin.site.client.dto.v1_0.ImageFragmentEditableElementValue;
 import com.liferay.headless.admin.site.client.dto.v1_0.ItemExternalReference;
 import com.liferay.headless.admin.site.client.dto.v1_0.LinkToPagePageSettings;
@@ -59,8 +61,11 @@ import com.liferay.headless.admin.site.client.dto.v1_0.SitePageNavigationSetting
 import com.liferay.headless.admin.site.client.dto.v1_0.SitemapSettings;
 import com.liferay.headless.admin.site.client.dto.v1_0.TaxonomyCategoryBrief;
 import com.liferay.headless.admin.site.client.dto.v1_0.WidgetInstancePageElementDefinition;
+import com.liferay.headless.admin.site.client.dto.v1_0.WidgetLookAndFeelConfig;
+import com.liferay.headless.admin.site.client.dto.v1_0.WidgetPageSection;
 import com.liferay.headless.admin.site.client.dto.v1_0.WidgetPageSettings;
 import com.liferay.headless.admin.site.client.dto.v1_0.WidgetPageSpecification;
+import com.liferay.headless.admin.site.client.dto.v1_0.WidgetPageWidgetInstance;
 import com.liferay.headless.admin.site.client.http.HttpInvoker;
 import com.liferay.headless.admin.site.client.pagination.Page;
 import com.liferay.headless.admin.site.client.pagination.Pagination;
@@ -313,6 +318,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 					LayoutTypePortletConstants.COLUMN_PREFIX + "1",
 					RandomTestUtil.randomString()
 				).buildString()));
+
+		_testGetSiteSitePageWithCustomApplicationDecorator();
 	}
 
 	@Override
@@ -384,6 +391,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 				SitePage.Type.CONTENT_PAGE,
 				StringUtil.toLowerCase(RandomTestUtil.randomString())));
 
+		_testPostSiteSitePageWithApplicationDecorator();
 		_testPostSiteSitePageWithPageElements();
 		_testPostSiteSitePageWithPageSpecifications();
 		_testPostSiteSitePageWithContentPageSpecification();
@@ -2036,6 +2044,29 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 		};
 	}
 
+	private List<WidgetPageWidgetInstance> _getWidgetPageWidgetInstances(
+		SitePage sitePage) {
+
+		List<WidgetPageWidgetInstance> widgetPageWidgetInstances =
+			new ArrayList<>();
+
+		PageSpecification[] pageSpecifications =
+			sitePage.getPageSpecifications();
+
+		WidgetPageSpecification widgetPageSpecification =
+			(WidgetPageSpecification)pageSpecifications[0];
+
+		for (WidgetPageSection widgetPageSection :
+				widgetPageSpecification.getWidgetPageSections()) {
+
+			Collections.addAll(
+				widgetPageWidgetInstances,
+				widgetPageSection.getWidgetPageWidgetInstances());
+		}
+
+		return widgetPageWidgetInstances;
+	}
+
 	private SitePage _postSiteSitePageWithPageSpecificationsWithCustomFields(
 			SitePage.Type type)
 		throws Exception {
@@ -2205,6 +2236,43 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 		_assertSitePage(layout, sitePage);
 		_testGetSiteSitePageWithNestedFields(sitePage);
+	}
+
+	private void _testGetSiteSitePageWithCustomApplicationDecorator()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(testGroup);
+
+		LayoutTestUtil.addPortletToLayout(
+			layout, AssetPublisherPortletKeys.ASSET_PUBLISHER,
+			HashMapBuilder.put(
+				"portletSetupPortletDecoratorId", new String[] {"encadre"}
+			).build());
+
+		SitePageResource sitePageResource = _getSitePageResource(
+			"pageSpecifications");
+
+		SitePage sitePage = sitePageResource.getSiteSitePage(
+			testGroup.getExternalReferenceCode(),
+			layout.getExternalReferenceCode());
+
+		List<WidgetPageWidgetInstance> widgetPageWidgetInstances =
+			_getWidgetPageWidgetInstances(sitePage);
+
+		Assert.assertEquals(
+			widgetPageWidgetInstances.toString(), 1,
+			widgetPageWidgetInstances.size());
+
+		WidgetPageWidgetInstance widgetPageWidgetInstance =
+			widgetPageWidgetInstances.get(0);
+
+		WidgetLookAndFeelConfig widgetLookAndFeelConfig =
+			widgetPageWidgetInstance.getWidgetLookAndFeelConfig();
+
+		GeneralConfig generalConfig =
+			widgetLookAndFeelConfig.getGeneralConfig();
+
+		Assert.assertEquals("encadre", generalConfig.getApplicationDecorator());
 	}
 
 	private void _testGetSiteSitePageWithNestedFields(SitePage sitePage)
@@ -2936,6 +3004,72 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			_layoutLocalService.getLayoutByExternalReferenceCode(
 				sitePage.getExternalReferenceCode(), testGroup.getGroupId()),
 			postSitePage);
+	}
+
+	private void _testPostSiteSitePageWithApplicationDecorator()
+		throws Exception {
+
+		_testPostSiteSitePageWithApplicationDecorator("decorate", "decorate");
+		_testPostSiteSitePageWithApplicationDecorator("Decorate", "decorate");
+		_testPostSiteSitePageWithApplicationDecorator("encadre", "encadre");
+	}
+
+	private void _testPostSiteSitePageWithApplicationDecorator(
+			String applicationDecorator, String expectedApplicationDecorator)
+		throws Exception {
+
+		SitePage randomSitePage = _getRandomSitePage(SitePage.Type.WIDGET_PAGE);
+
+		WidgetPageSettings widgetPageSettings =
+			(WidgetPageSettings)randomSitePage.getPageSettings();
+
+		widgetPageSettings.setLayoutTemplateId("1_column");
+
+		randomSitePage.setPageSpecifications(
+			PageSpecificationsTestUtil.getWidgetPageSpecifications(
+				null, widgetPageSettings.getLayoutTemplateId(),
+				randomSitePage.getExternalReferenceCode()));
+
+		for (WidgetPageWidgetInstance widgetPageWidgetInstance :
+				_getWidgetPageWidgetInstances(randomSitePage)) {
+
+			WidgetLookAndFeelConfig widgetLookAndFeelConfig =
+				new WidgetLookAndFeelConfig();
+
+			GeneralConfig generalConfig = new GeneralConfig();
+
+			generalConfig.setApplicationDecorator(applicationDecorator);
+
+			widgetLookAndFeelConfig.setGeneralConfig(generalConfig);
+
+			widgetPageWidgetInstance.setWidgetLookAndFeelConfig(
+				widgetLookAndFeelConfig);
+		}
+
+		SitePageResource sitePageResource = _getSitePageResource(
+			"pageSpecifications");
+
+		SitePage sitePage = sitePageResource.postSiteSitePage(
+			testGroup.getExternalReferenceCode(), false, randomSitePage);
+
+		List<WidgetPageWidgetInstance> widgetPageWidgetInstances =
+			_getWidgetPageWidgetInstances(sitePage);
+
+		Assert.assertFalse(widgetPageWidgetInstances.isEmpty());
+
+		for (WidgetPageWidgetInstance widgetPageWidgetInstance :
+				widgetPageWidgetInstances) {
+
+			WidgetLookAndFeelConfig widgetLookAndFeelConfig =
+				widgetPageWidgetInstance.getWidgetLookAndFeelConfig();
+
+			GeneralConfig generalConfig =
+				widgetLookAndFeelConfig.getGeneralConfig();
+
+			Assert.assertEquals(
+				expectedApplicationDecorator,
+				generalConfig.getApplicationDecorator());
+		}
 	}
 
 	private void _testPostSiteSitePageWithContentPageSpecification()

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageSpecificationsTestUtil.java
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-test/src/testIntegration/java/com/liferay/headless/admin/site/resource/v1_0/test/util/PageSpecificationsTestUtil.java
@@ -1126,9 +1126,7 @@ public class PageSpecificationsTestUtil {
 		return pageSpecification;
 	}
 
-	private static GeneralConfig.ApplicationDecorator
-		_getRandomApplicationDecorator() {
-
+	private static String _getRandomApplicationDecorator() {
 		int random = RandomTestUtil.randomInt(0, 3);
 
 		if (random == 0) {
@@ -1136,14 +1134,14 @@ public class PageSpecificationsTestUtil {
 		}
 
 		if (random == 1) {
-			return GeneralConfig.ApplicationDecorator.BAREBONE;
+			return "barebone";
 		}
 
 		if (random == 2) {
-			return GeneralConfig.ApplicationDecorator.BORDERLESS;
+			return "borderless";
 		}
 
-		return GeneralConfig.ApplicationDecorator.DECORATE;
+		return "decorate";
 	}
 
 	private static Map<String, Object> _getWidgetConfig(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101791

## What is this trying to solve?

Creating a site from a site template fails when a widget page widget uses a theme-defined (custom) portlet decorator. The site template merge runs a SitePage batch export that converts each widget's look and feel into the `GeneralConfig` DTO, whose `applicationDecorator` property was a closed enum containing only the classic theme's decorators (`Barebone`, `Borderless`, `Decorate`). A custom decorator id such as `encadre` made the converter throw `IllegalArgumentException: Invalid enum value: Encadre`, aborting the export, so the new site was created without any of the template pages. Reported through customer escalation LPP-65080.

## How am I fixing it?

The `enum` constraint is removed from `applicationDecorator` in `rest-openapi.yaml`, making the property a plain string that carries the raw portlet decorator ID, following the precedent of LPD-69118 (the `resolution` enum in this same module). The export now emits the stored `portletSetupPortletDecoratorId` verbatim and the import writes the received value verbatim, mapping only the three legacy capitalized names to their lowercase IDs for backward compatibility with existing clients. Removing the public nested enum from the exported `dto.v1_0` package is a breaking Java API change, covered by the major `packageinfo` bump in the baseline commit (the bundle major bump had already landed on master through LPD-101009).

## How can you verify that it works?

Run `SitePageResourceTest` in `headless-admin-site-test`: `testGetSiteSitePage` now covers reading a widget page whose widget has `portletSetupPortletDecoratorId=encadre` (previously a 400), and `testPostSiteSitePage` covers the `encadre`/`decorate`/`Decorate` round trips. Manually: deploy a theme defining a custom portlet decorator, set it on a widget in a site template's widget page, and create a site from that template — the pages are created and the widget keeps the decorator. `SitePageResourceTest`, `PageSpecificationResourceTest`, `WidgetPageWidgetInstanceResourceTest`, and `PageTemplateResourceTest` all pass locally against a Postgres bundle.

## PR Check

**pr-check: PASS** — tested on `5f7ffb49c17745b6d0752a4c0ad1e128de1297b5`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5f7ffb49c17745b6d0752a4c0ad1e128de1297b5"} -->
