### PR TITLE
LPD-102350 Fix flaky Friendly URLs Only Display Locale Once test

### DIFF
--- a/modules/test/playwright/tests/layout-admin-web/main/pages/PageConfigurationPage.ts
+++ b/modules/test/playwright/tests/layout-admin-web/main/pages/PageConfigurationPage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Locator, Page} from '@playwright/test';
+import {Locator, Page, expect} from '@playwright/test';
 
 import {PagesAdminPage} from '../../../../pages/layout-admin-web/PagesAdminPage';
 import {clickAndExpectToBeHidden} from '../../../../utils/clickAndExpectToBeHidden';
@@ -89,6 +89,8 @@ export class PageConfigurationPage {
 	}
 
 	async setFriendlyURL(friendlyURL: string, language: 'spanish' | 'english') {
+		const languageIds = {english: 'en_US', spanish: 'es_ES'};
+
 		const selectLanguage = async (name: string) => {
 			const toggle = this.page.locator(
 				'.form-group.friendly-url .input-localized-trigger'
@@ -113,6 +115,16 @@ export class PageConfigurationPage {
 		await selectLanguage(language);
 
 		await this.friendlyURL.fill(friendlyURL);
+
+		// The localized input debounces copying the typed value into the hidden
+		// input of the selected language, so switching back to the default
+		// language too early discards it
+
+		await expect(
+			this.page.locator(
+				`input[name$="friendlyURL_${languageIds[language]}"]`
+			)
+		).toHaveValue(friendlyURL);
 
 		await selectLanguage('default');
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102350

## What Is Being Fixed

The Playwright test `layout-admin-web/main/pageFriendlyURL.spec.ts > Friendly URLs Only Display Locale Once` flakes intermittently. `PageConfigurationPage.setFriendlyURL` fills the localized friendly URL input and immediately switches the locale selector back to default. The localized input in `input_localized.js` debounces copying the typed value into the hidden per-locale input by 100ms, so the locale switch resets the visible field before the debounced handler commits the value, silently discarding the localized friendly URL the test relies on.

## How It Is Being Fixed

`setFriendlyURL` now waits for the hidden `friendlyURL_<locale>` input to reflect the typed value before switching the locale selector back to default, so the helper no longer races the debounce.

## Test Plan

- Reproduced the failure locally: 3/3 failed before the fix, 3/3 passed after.
- Ran the full `pageFriendlyURL.spec.ts` suite: 4/4 pass.
- Ran `friendlyURLHistory.spec.ts` (the other consumer of `setFriendlyURL`) before and after the fix: same 4 pass / 2 fail result in both cases — those two pre-existing failures are unrelated to this change.

## Why Are There No Tests?

This PR fixes a flaky Playwright test helper, not production code, so there is no separate test to add. Correctness was verified by re-running the affected specs directly: `pageFriendlyURL.spec.ts` failed 3/3 times before the fix and passed 3/3 after.

## PR Check

**pr-check: PASS** — tested on `3a4e19b3be8a2df310284650c554a31467ad6b8a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "3a4e19b3be8a2df310284650c554a31467ad6b8a"} -->
