### PR TITLE
LPD-102343 Prevent a resource request from rendering the view JSP

### DIFF
--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/DisplayPageManagementToolbarDisplayContext.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/DisplayPageManagementToolbarDisplayContext.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.LiferayPortletURL;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.portlet.url.builder.ResourceURLBuilder;
@@ -344,12 +345,17 @@ public class DisplayPageManagementToolbarDisplayContext
 	}
 
 	private String _getExportDisplayPageURL() {
-		return ResourceURLBuilder.createResourceURL(
-			liferayPortletResponse
-		).setResourceID(
-			"/layout_page_template_admin/export_layout_page_template_entries_" +
-				"and_layout_page_template_collections"
-		).buildString();
+		LiferayPortletURL exportDisplayPageURL =
+			(LiferayPortletURL)ResourceURLBuilder.createResourceURL(
+				liferayPortletResponse
+			).setResourceID(
+				"/layout_page_template_admin/export_layout_page_template_" +
+					"entries_and_layout_page_template_collections"
+			).buildResourceURL();
+
+		exportDisplayPageURL.setCopyCurrentRenderParameters(false);
+
+		return exportDisplayPageURL.toString();
 	}
 
 	private String _getItemSelectorURL() {

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/LayoutPageTemplateManagementToolbarDisplayContext.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/LayoutPageTemplateManagementToolbarDisplayContext.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.LiferayPortletURL;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.portlet.url.builder.ResourceURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
@@ -199,15 +200,21 @@ public class LayoutPageTemplateManagementToolbarDisplayContext
 			_layoutPageTemplateDisplayContext.
 				getLayoutPageTemplateCollectionId());
 
-		return ResourceURLBuilder.createResourceURL(
-			liferayPortletResponse
-		).setParameter(
-			"layoutPageTemplateCollectionId",
-			_layoutPageTemplateDisplayContext.
-				getLayoutPageTemplateCollectionId()
-		).setResourceID(
-			"/layout_page_template_admin/export_layout_page_template_entries"
-		).buildString();
+		LiferayPortletURL exportLayoutPageTemplateEntryURL =
+			(LiferayPortletURL)ResourceURLBuilder.createResourceURL(
+				liferayPortletResponse
+			).setParameter(
+				"layoutPageTemplateCollectionId",
+				_layoutPageTemplateDisplayContext.
+					getLayoutPageTemplateCollectionId()
+			).setResourceID(
+				"/layout_page_template_admin" +
+					"/export_layout_page_template_entries"
+			).buildResourceURL();
+
+		exportLayoutPageTemplateEntryURL.setCopyCurrentRenderParameters(false);
+
+		return exportLayoutPageTemplateEntryURL.toString();
 	}
 
 	private String _getSelectMasterLayoutURL() {

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/MasterLayoutManagementToolbarDisplayContext.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/MasterLayoutManagementToolbarDisplayContext.java
@@ -20,14 +20,13 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.LiferayPortletURL;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
-
-import jakarta.portlet.ResourceURL;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -187,9 +186,10 @@ public class MasterLayoutManagementToolbarDisplayContext
 	}
 
 	private String _getExportMasterLayoutURL() {
-		ResourceURL exportMasterLayoutURL =
-			liferayPortletResponse.createResourceURL();
+		LiferayPortletURL exportMasterLayoutURL =
+			(LiferayPortletURL)liferayPortletResponse.createResourceURL();
 
+		exportMasterLayoutURL.setCopyCurrentRenderParameters(false);
 		exportMasterLayoutURL.setResourceID(
 			"/layout_page_template_admin/export_master_layouts");
 

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/DisplayPageActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/DisplayPageActionDropdownItemsProvider.java
@@ -31,6 +31,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.LiferayPortletURL;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
@@ -464,16 +465,20 @@ public class DisplayPageActionDropdownItemsProvider {
 		_getExportDisplayPageActionUnsafeConsumer() {
 
 		return dropdownItem -> {
-			dropdownItem.setDisabled(_layoutPageTemplateEntry.isDraft());
-			dropdownItem.setHref(
-				ResourceURLBuilder.createResourceURL(
+			LiferayPortletURL exportDisplayPageURL =
+				(LiferayPortletURL)ResourceURLBuilder.createResourceURL(
 					_renderResponse
 				).setParameter(
 					"layoutPageTemplateEntryId",
 					_layoutPageTemplateEntry.getLayoutPageTemplateEntryId()
 				).setResourceID(
 					"/layout_page_template_admin/export_display_pages"
-				).buildString());
+				).buildResourceURL();
+
+			exportDisplayPageURL.setCopyCurrentRenderParameters(false);
+
+			dropdownItem.setDisabled(_layoutPageTemplateEntry.isDraft());
+			dropdownItem.setHref(exportDisplayPageURL.toString());
 			dropdownItem.setIcon("upload");
 			dropdownItem.setLabel(
 				LanguageUtil.get(_httpServletRequest, "export"));

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/LayoutPageTemplateCollectionActionDropdownItem.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/LayoutPageTemplateCollectionActionDropdownItem.java
@@ -17,6 +17,7 @@ import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.portlet.LiferayPortletURL;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
@@ -298,15 +299,22 @@ public class LayoutPageTemplateCollectionActionDropdownItem {
 	}
 
 	private String _getExportLayoutPageTemplateCollectionURL() {
-		return ResourceURLBuilder.createResourceURL(
-			_renderResponse
-		).setParameter(
-			"layoutPageTemplateCollectionsIds",
-			_layoutPageTemplateCollection.getLayoutPageTemplateCollectionId()
-		).setResourceID(
-			"/layout_page_template_admin/export_layout_page_template_" +
-				"entries_and_layout_page_template_collections"
-		).buildString();
+		LiferayPortletURL exportLayoutPageTemplateCollectionURL =
+			(LiferayPortletURL)ResourceURLBuilder.createResourceURL(
+				_renderResponse
+			).setParameter(
+				"layoutPageTemplateCollectionsIds",
+				_layoutPageTemplateCollection.
+					getLayoutPageTemplateCollectionId()
+			).setResourceID(
+				"/layout_page_template_admin/export_layout_page_template_" +
+					"entries_and_layout_page_template_collections"
+			).buildResourceURL();
+
+		exportLayoutPageTemplateCollectionURL.setCopyCurrentRenderParameters(
+			false);
+
+		return exportLayoutPageTemplateCollectionURL.toString();
 	}
 
 	private String _getItemSelectorURL() {

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/LayoutPageTemplateEntryActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/LayoutPageTemplateEntryActionDropdownItemsProvider.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutPrototype;
+import com.liferay.portal.kernel.portlet.LiferayPortletURL;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
@@ -370,9 +371,8 @@ public class LayoutPageTemplateEntryActionDropdownItemsProvider {
 		_getExportLayoutPageTemplateEntryActionUnsafeConsumer() {
 
 		return dropdownItem -> {
-			dropdownItem.setDisabled(_layoutPageTemplateEntry.isDraft());
-			dropdownItem.setHref(
-				ResourceURLBuilder.createResourceURL(
+			LiferayPortletURL exportLayoutPageTemplateEntryURL =
+				(LiferayPortletURL)ResourceURLBuilder.createResourceURL(
 					_renderResponse
 				).setParameter(
 					"layoutPageTemplateCollectionId",
@@ -383,7 +383,13 @@ public class LayoutPageTemplateEntryActionDropdownItemsProvider {
 				).setResourceID(
 					"/layout_page_template_admin" +
 						"/export_layout_page_template_entries"
-				).buildString());
+				).buildResourceURL();
+
+			exportLayoutPageTemplateEntryURL.setCopyCurrentRenderParameters(
+				false);
+
+			dropdownItem.setDisabled(_layoutPageTemplateEntry.isDraft());
+			dropdownItem.setHref(exportLayoutPageTemplateEntryURL.toString());
 			dropdownItem.setIcon("upload");
 			dropdownItem.setLabel(
 				LanguageUtil.get(_httpServletRequest, "export"));

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/MasterLayoutActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/MasterLayoutActionDropdownItemsProvider.java
@@ -23,6 +23,7 @@ import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.LiferayPortletURL;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
@@ -356,16 +357,20 @@ public class MasterLayoutActionDropdownItemsProvider {
 		_getExportMasterLayoutActionUnsafeConsumer() {
 
 		return dropdownItem -> {
-			dropdownItem.setDisabled(!_layout.isPublished());
-			dropdownItem.setHref(
-				ResourceURLBuilder.createResourceURL(
+			LiferayPortletURL exportMasterLayoutURL =
+				(LiferayPortletURL)ResourceURLBuilder.createResourceURL(
 					_renderResponse
 				).setParameter(
 					"layoutPageTemplateEntryId",
 					_layoutPageTemplateEntry.getLayoutPageTemplateEntryId()
 				).setResourceID(
 					"/layout_page_template_admin/export_master_layouts"
-				).buildString());
+				).buildResourceURL();
+
+			exportMasterLayoutURL.setCopyCurrentRenderParameters(false);
+
+			dropdownItem.setDisabled(!_layout.isPublished());
+			dropdownItem.setHref(exportMasterLayoutURL.toString());
 			dropdownItem.setIcon("upload");
 			dropdownItem.setLabel(
 				LanguageUtil.get(_httpServletRequest, "export"));

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -66,6 +66,7 @@ page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.model.Group" %><%@
 page import="com.liferay.portal.kernel.model.LayoutPrototype" %><%@
 page import="com.liferay.portal.kernel.model.ModelHintsUtil" %><%@
+page import="com.liferay.portal.kernel.portlet.LiferayPortletURL" %><%@
 page import="com.liferay.portal.kernel.portlet.LiferayWindowState" %><%@
 page import="com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder" %><%@
 page import="com.liferay.portal.kernel.portlet.url.builder.ResourceURLBuilder" %><%@

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_display_pages.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_display_pages.jsp
@@ -33,7 +33,9 @@ DisplayPageManagementToolbarDisplayContext displayPageManagementToolbarDisplayCo
 />
 
 <div class="closed sidenav-container sidenav-right" id="<portlet:namespace />infoPanelId">
-	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= true %>" id="/layout_page_template_admin/info_panel" var="sidebarPanelURL" />
+	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/layout_page_template_admin/info_panel" var="sidebarPanelURL">
+		<portlet:param name="layoutPageTemplateCollectionId" value="<%= String.valueOf(displayPageDisplayContext.getLayoutPageTemplateCollectionId()) %>" />
+	</liferay-portlet:resourceURL>
 
 	<liferay-frontend:sidebar-panel
 		resourceURL="<%= sidebarPanelURL %>"

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_import.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_import.jsp
@@ -13,6 +13,16 @@ portletDisplay.setURLBack(ParamUtil.getString(request, "backURL", String.valueOf
 portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
 
 renderResponse.setTitle(LanguageUtil.get(request, "import"));
+
+LiferayPortletURL importURL = (LiferayPortletURL)ResourceURLBuilder.createResourceURL(
+	renderResponse
+).setParameter(
+	"layoutPageTemplateCollectionId", ParamUtil.getString(request, "layoutPageTemplateCollectionId")
+).setResourceID(
+	"/layout_page_template_admin/import"
+).buildResourceURL();
+
+importURL.setCopyCurrentRenderParameters(false);
 %>
 
 <react:component
@@ -21,14 +31,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "import"));
 		HashMapBuilder.<String, Object>put(
 			"backURL", ParamUtil.getString(request, "backURL")
 		).put(
-			"importURL",
-			ResourceURLBuilder.createResourceURL(
-				renderResponse
-			).setParameter(
-				"layoutPageTemplateCollectionId", ParamUtil.getString(request, "layoutPageTemplateCollectionId")
-			).setResourceID(
-				"/layout_page_template_admin/import"
-			).buildString()
+			"importURL", importURL.toString()
 		).build()
 	%>'
 />

--- a/modules/apps/layout/layout-page-template-admin-web/src/test/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/DisplayPageActionDropdownItemsProviderTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/test/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/DisplayPageActionDropdownItemsProviderTest.java
@@ -13,11 +13,11 @@ import com.liferay.layout.page.template.admin.web.internal.configuration.LayoutP
 import com.liferay.layout.page.template.admin.web.internal.constants.LayoutPageTemplateAdminWebKeys;
 import com.liferay.layout.page.template.admin.web.internal.security.permission.resource.LayoutPageTemplateEntryPermission;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.LiferayPortletURL;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.portlet.url.builder.RenderURLBuilder;
 import com.liferay.portal.kernel.portlet.url.builder.ResourceURLBuilder;
@@ -319,9 +319,9 @@ public class DisplayPageActionDropdownItemsProviderTest {
 		);
 
 		Mockito.when(
-			afterResourceIDStep.buildString()
+			afterResourceIDStep.buildResourceURL()
 		).thenReturn(
-			StringPool.BLANK
+			Mockito.mock(LiferayPortletURL.class)
 		);
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102343

## What Is Being Fixed

Exporting a Display Page Template failed with a 500 once the list had been searched, sorted or paginated. Those actions build their URLs from `DisplayPageDisplayContext.getPortletURL`, which pins `mvcPath=/view_display_pages.jsp` into the render parameters, and a resource URL copies the current render parameters by default. `MVCPortlet.serveResource` includes whatever `mvcPath` resolves to before it delegates to the `MVCResourceCommand`, so the whole view JSP was rendered into the export response and threw a `NullPointerException` before the export command ever ran. The same failure reached the info panel and the import screen, since every resource URL on those screens carried the parameter too.

## How It Is Being Fixed

Every resource URL the module creates now omits the current render parameters, so `mvcPath` never reaches `serveResource` and only the resource command produces the response. The 7 Java call sites build the URL through `ResourceURLBuilder`, cast it to `LiferayPortletURL` and call `setCopyCurrentRenderParameters(false)`, following `SiteNavigationAdminDisplayContext`. The info panel URL in `view_display_pages.jsp` switches the tag to `copyCurrentRenderParameters="<%= false %>"` and passes `layoutPageTemplateCollectionId` explicitly, because `DisplayPageTemplateInfoPanelDisplayContext` reads that parameter and it previously arrived only through the copy. This matches how `journal-web` builds its own info panel URL. The import URL moves into a scriptlet in `view_import.jsp` so the same flag applies.

Every command behind these URLs was checked for inputs that the copy used to supply. The export commands read `layoutPageTemplateEntryId`, which each URL sets explicitly, or `rowIds`, `layoutPageTemplateEntriesIds` and `layoutPageTemplateCollectionsIds`, which the toolbar posts from the form. `ImportMVCResourceCommand` reads `layoutPageTemplateCollectionId`, already explicit, and `importType` from the upload.

## Why Are There No Tests?

The display contexts and dropdown item providers build their resource URLs through a mocked `ResourceURLBuilder` chain, so the only feasible unit test asserts that `setCopyCurrentRenderParameters(false)` was called on a mocked URL rather than that the emitted URL omits `mvcPath`. That pins the implementation shape instead of the behavior, and would fail on an equivalent fix through `setCacheability(FULL)`. The change is covered by the existing export and import integration tests.

## PR Check

**pr-check: PASS** — tested on `a9d65be9a16d95afc7e47da444d67b7137b0f0c8`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| JSP Compile | PASS |
| Java Unit Tests | PASS |

Source Format: the Java and JSP formatter reported no violations over the 11 changed files. The JS step (`node-scripts format --current-branch`) cannot run in this Windows checkout (ERR_UNSUPPORTED_ESM_URL_SCHEME); the branch changes no JS or TS files, so CI covers it.

<!-- pr-check {"result": "success", "sha": "a9d65be9a16d95afc7e47da444d67b7137b0f0c8"} -->
