### PR TITLE
LPD-101907 Deny element variations to users without view permission

### DIFF
--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/java/com/liferay/frontend/js/audiences/web/internal/servlet/FrontendJSAudiencesWebServlet.java
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/java/com/liferay/frontend/js/audiences/web/internal/servlet/FrontendJSAudiencesWebServlet.java
@@ -13,7 +13,14 @@ import com.liferay.frontend.js.audiences.web.internal.util.BootstrapJavaScriptUt
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.frontend.hashed.files.HashedFilesUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -55,6 +62,7 @@ public class FrontendJSAudiencesWebServlet extends HttpServlet {
 		String[] parts = StringUtil.split(
 			httpServletRequest.getPathInfo(), CharPool.SLASH);
 
+		String cacheControl = "immutable, max-age=31536000, public";
 		String content = null;
 		String contentType = null;
 		String hash = null;
@@ -83,12 +91,27 @@ public class FrontendJSAudiencesWebServlet extends HttpServlet {
 			hash = audiencesDefinition.getHash();
 		}
 		else if ((parts.length == 4) && parts[3].startsWith("variations.")) {
+			User user = _getUser(httpServletRequest);
+
+			if (user == null) {
+				httpServletResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
+
+				return;
+			}
+
+			PermissionThreadLocal.setPermissionChecker(
+				_permissionCheckerFactory.create(user));
+
 			ElementVariations elementVariations = _getElementVariations(parts);
 
 			if (elementVariations == null) {
 				httpServletResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
 
 				return;
+			}
+
+			if (!user.isGuestUser()) {
+				cacheControl = "immutable, max-age=31536000, private";
 			}
 
 			content = elementVariations.getContent();
@@ -124,8 +147,7 @@ public class FrontendJSAudiencesWebServlet extends HttpServlet {
 		}
 
 		httpServletResponse.setContentType(contentType);
-		httpServletResponse.setHeader(
-			HttpHeaders.CACHE_CONTROL, "immutable, max-age=31536000, public");
+		httpServletResponse.setHeader(HttpHeaders.CACHE_CONTROL, cacheControl);
 
 		PrintWriter printWriter = httpServletResponse.getWriter();
 
@@ -137,6 +159,27 @@ public class FrontendJSAudiencesWebServlet extends HttpServlet {
 			GetterUtil.getLong(parts[1]), GetterUtil.getLong(parts[2]));
 	}
 
+	private User _getUser(HttpServletRequest httpServletRequest) {
+		try {
+			User user = _portal.getUser(httpServletRequest);
+
+			if (user != null) {
+				return user;
+			}
+
+			return _userLocalService.getGuestUser(
+				_portal.getCompanyId(httpServletRequest));
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+
+			return null;
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		FrontendJSAudiencesWebServlet.class);
+
 	@Reference
 	private AudiencesDefinitionProvider _audiencesDefinitionProvider;
 
@@ -144,6 +187,12 @@ public class FrontendJSAudiencesWebServlet extends HttpServlet {
 	private ElementVariationsProvider _elementVariationsProvider;
 
 	@Reference
+	private PermissionCheckerFactory _permissionCheckerFactory;
+
+	@Reference
 	private Portal _portal;
+
+	@Reference
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/frontend-js/frontend-js-audiences-web/src/main/java/com/liferay/frontend/js/audiences/web/internal/servlet/FrontendJSAudiencesWebServlet.java
+++ b/modules/apps/frontend-js/frontend-js-audiences-web/src/main/java/com/liferay/frontend/js/audiences/web/internal/servlet/FrontendJSAudiencesWebServlet.java
@@ -18,10 +18,12 @@ import com.liferay.portal.kernel.frontend.hashed.files.HashedFilesUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
+import com.liferay.portal.kernel.servlet.PortalSessionThreadLocal;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -32,6 +34,7 @@ import jakarta.servlet.Servlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -159,16 +162,43 @@ public class FrontendJSAudiencesWebServlet extends HttpServlet {
 			GetterUtil.getLong(parts[1]), GetterUtil.getLong(parts[2]));
 	}
 
+	private User _getSessionUser(HttpServletRequest httpServletRequest)
+		throws PortalException {
+
+		HttpSession httpSession = httpServletRequest.getSession();
+
+		if (PortalSessionThreadLocal.getHttpSession() == null) {
+			PortalSessionThreadLocal.setHttpSession(httpSession);
+		}
+
+		String userIdString = (String)httpSession.getAttribute("j_username");
+		String password = (String)httpSession.getAttribute("j_password");
+
+		if ((userIdString == null) || (password == null)) {
+			return null;
+		}
+
+		return _userLocalService.getUser(GetterUtil.getLong(userIdString));
+	}
+
 	private User _getUser(HttpServletRequest httpServletRequest) {
 		try {
 			User user = _portal.getUser(httpServletRequest);
 
-			if (user != null) {
-				return user;
+			if (user == null) {
+				user = _getSessionUser(httpServletRequest);
 			}
 
-			return _userLocalService.getGuestUser(
-				_portal.getCompanyId(httpServletRequest));
+			if (user == null) {
+				return _userLocalService.getGuestUser(
+					_portal.getCompanyId(httpServletRequest));
+			}
+
+			PrincipalThreadLocal.setName(user.getUserId());
+			PrincipalThreadLocal.setPassword(
+				_portal.getUserPassword(httpServletRequest));
+
+			return user;
 		}
 		catch (PortalException portalException) {
 			_log.error(portalException);

--- a/modules/apps/layout/layout-content-page-editor-web-test/build.gradle
+++ b/modules/apps/layout/layout-content-page-editor-web-test/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")
 	testIntegrationImplementation project(":apps:fragment:fragment-api")
 	testIntegrationImplementation project(":apps:fragment:fragment-entry-processor:fragment-entry-processor-api")
+	testIntegrationImplementation project(":apps:frontend-js:frontend-js-audiences-api")
 	testIntegrationImplementation project(":apps:info:info-api")
 	testIntegrationImplementation project(":apps:info:info-list-provider-item-selector-api")
 	testIntegrationImplementation project(":apps:info:info-test-util")

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/frontend/js/audiences/test/ElementVariationsProviderTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/frontend/js/audiences/test/ElementVariationsProviderTest.java
@@ -1,0 +1,92 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.content.page.editor.web.internal.frontend.js.audiences.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.frontend.js.audiences.ElementVariationsProvider;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.segments.model.SegmentsExperience;
+import com.liferay.segments.test.util.SegmentsTestUtil;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Víctor Galán
+ */
+@FeatureFlag("LPD-85746")
+@RunWith(Arquillian.class)
+public class ElementVariationsProviderTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testGetElementVariations() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(group);
+
+		SegmentsExperience segmentsExperience =
+			SegmentsTestUtil.addSegmentsExperience(
+				group.getGroupId(), layout.getPlid());
+
+		User guestUser = _userLocalService.getGuestUser(
+			TestPropsValues.getCompanyId());
+
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(guestUser));
+
+		Assert.assertNotNull(
+			_elementVariationsProvider.getElementVariations(
+				layout.getPlid(),
+				segmentsExperience.getSegmentsExperienceId()));
+
+		RoleTestUtil.removeResourcePermission(
+			RoleConstants.GUEST, Layout.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(layout.getPlid()), ActionKeys.VIEW);
+
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(guestUser));
+
+		Assert.assertNull(
+			_elementVariationsProvider.getElementVariations(
+				layout.getPlid(),
+				segmentsExperience.getSegmentsExperienceId()));
+	}
+
+	@Inject
+	private ElementVariationsProvider _elementVariationsProvider;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/frontend/js/audiences/ElementVariationsProviderImpl.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/frontend/js/audiences/ElementVariationsProviderImpl.java
@@ -18,13 +18,20 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.cache.PortalCache;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.frontend.hashed.files.HashedFilesUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Localization;
@@ -59,7 +66,8 @@ public class ElementVariationsProviderImpl
 
 		if ((layout == null) ||
 			!FeatureFlagManagerUtil.isEnabled(
-				layout.getCompanyId(), "LPD-85746")) {
+				layout.getCompanyId(), "LPD-85746") ||
+			!_hasViewPermission(layout)) {
 
 			return null;
 		}
@@ -240,11 +248,38 @@ public class ElementVariationsProviderImpl
 			SegmentsExperienceAudienceEntryRel::getAudienceEntryERC);
 	}
 
+	private boolean _hasViewPermission(Layout layout) {
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (permissionChecker == null) {
+			return false;
+		}
+
+		try {
+			return _layoutModelResourcePermission.contains(
+				permissionChecker, layout, ActionKeys.VIEW);
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+
+			return false;
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ElementVariationsProviderImpl.class);
+
 	@Reference
 	private JSONFactory _jsonFactory;
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;
+
+	@Reference(
+		target = "(model.class.name=com.liferay.portal.kernel.model.Layout)"
+	)
+	private ModelResourcePermission<Layout> _layoutModelResourcePermission;
 
 	@Reference
 	private

--- a/modules/test/playwright/tests/layout-content-page-editor-web/main/elementVariations.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/main/elementVariations.spec.ts
@@ -976,3 +976,121 @@ test(
 		await expect(page.getByText(secondVariationText)).not.toBeVisible();
 	}
 );
+
+test(
+	'Does not serve the element variations of a page the guest cannot view',
+	{tag: '@LPD-101907'},
+	async ({
+		apiHelpers,
+		audiencesPage,
+		browser,
+		elementVariationsPage,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+
+		// Create an audience matching the browser language
+
+		const audienceName = 'Audience ' + getRandomString();
+
+		await audiencesPage.goto();
+
+		await audiencesPage.createAudience({
+			attributeName: 'Language',
+			name: audienceName,
+			value: 'English (United States)',
+			valueType: 'select',
+		});
+
+		// Create a page with a Heading fragment, replace its heading and
+		// publish
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				getFragmentDefinition({
+					id: getRandomString(),
+					key: 'BASIC_COMPONENT-heading',
+				}),
+			]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.goToElementVariations();
+
+		await elementVariationsPage.createElementVariation({
+			audienceName,
+			html: `<span>Variation ${getRandomString()}</span>`,
+			name: 'Replace heading',
+			pageElementLabel: 'Heading (element-text)',
+		});
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.publishPage();
+
+		// Read the element variations URL from the published page
+
+		await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`);
+
+		const metaContent = await page
+			.locator('meta[name="audiences-variations"]')
+			.getAttribute('content');
+
+		const [plid, segmentsExperienceId, hash] = metaContent.split(':');
+
+		const variationsPath = `/o/audiences/${plid}/${segmentsExperienceId}/variations.(${hash}).js`;
+
+		// The variations of a page the guest can view are served and publicly
+		// cacheable
+
+		const guestContext = await browser.newContext({
+			storageState: {cookies: [], origins: []},
+		});
+
+		const allowedResponse = await guestContext.request.get(variationsPath);
+
+		expect(allowedResponse.status()).toBe(200);
+
+		expect(allowedResponse.headers()['cache-control']).toContain('public');
+
+		// Revoke the guest view permission on the page
+
+		const companyId = String(
+			await page.evaluate(() => Liferay.ThemeDisplay.getCompanyId())
+		);
+
+		const guestRole = await apiHelpers.jsonWebServicesRole.getRole(
+			companyId,
+			'Guest'
+		);
+
+		await apiHelpers.jsonWebServicesResourcePermissionApiHelper.removeResourcePermission(
+			'VIEW',
+			companyId,
+			String(site.id),
+			'com.liferay.portal.kernel.model.Layout',
+			plid,
+			String(guestRole.roleId),
+			'4'
+		);
+
+		// The guest is denied and the response is not cacheable
+
+		const deniedResponse = await guestContext.request.get(variationsPath);
+
+		expect(deniedResponse.status()).toBe(404);
+
+		const deniedCacheControl =
+			deniedResponse.headers()['cache-control'] ?? '';
+
+		expect(deniedCacheControl).not.toContain('max-age');
+
+		expect(deniedCacheControl).not.toContain('public');
+
+		await guestContext.close();
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101907

## What Is Being Fixed

The `/o/audiences` servlet served the element variations of any content page to any caller. The element variation HTML and JavaScript of a page the Guest role cannot view was returned to unauthenticated requests with HTTP 200, and the servlet's own hash mismatch redirect handed those callers the canonical content hash first. Because the plid and the segments experience id are small sequential integers, they can be enumerated, so no prior knowledge of the page was needed to reach the content.

## How It Is Being Fixed

The view permission on the plid is checked in the element variations provider before the content is looked up in the cache and before the servlet compares the request hash, so an unauthorized caller receives a 404 and never sees the redirect that would disclose the canonical hash. The check reads the permission checker from the thread local, which the page render already populates, so the top head dynamic include keeps working unchanged.

The servlet has no theme display and no permission checker on a request under `/o`, since neither `ServicePreAction` nor `MainServlet` runs for that path, so it resolves the caller itself and installs the checker. It resolves the request user, falling back to the session credentials and then to the guest user, mirroring what the layout common styles and change tracking document servlets already do for the same reason.

The cache visibility follows from the response now depending on the caller. A response served to a guest is still publicly cacheable, because its content is genuinely public, while a response served to an authenticated caller is marked private so that no shared cache stores a response produced under someone's permissions.

## PR Check

**pr-check: PASS** — tested on `1099f9de8c3aa218d38647ac3ca57dfcf4ecda7b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "1099f9de8c3aa218d38647ac3ca57dfcf4ecda7b"} -->
